### PR TITLE
chore: Fix no-op Transformed flags

### DIFF
--- a/datafusion/core/tests/physical_optimizer/aggregate_statistics.rs
+++ b/datafusion/core/tests/physical_optimizer/aggregate_statistics.rs
@@ -117,6 +117,27 @@ fn check_batch(batch: RecordBatch, agg: &TestAggregate) {
     );
 }
 
+#[test]
+fn unchanged_plan_preserves_plan_arc() -> Result<()> {
+    let source = mock_data()?;
+    let schema = source.schema();
+    let plan: Arc<dyn ExecutionPlan> = Arc::new(FilterExec::try_new(
+        expressions::binary(
+            expressions::col("a", &schema)?,
+            Operator::Gt,
+            cast(expressions::lit(1u32), &schema, DataType::Int32)?,
+            &schema,
+        )?,
+        source,
+    )?);
+
+    let config = ConfigOptions::new();
+    let optimized = AggregateStatistics::new().optimize(Arc::clone(&plan), &config)?;
+    assert!(Arc::ptr_eq(&plan, &optimized));
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_count_partial_direct_child() -> Result<()> {
     // basic test case with the aggregation applied on a source with exact statistics
@@ -277,10 +298,12 @@ async fn test_count_inexact_stat() -> Result<()> {
     )?;
 
     let conf = ConfigOptions::new();
-    let optimized = AggregateStatistics::new().optimize(Arc::new(final_agg), &conf)?;
+    let plan: Arc<dyn ExecutionPlan> = Arc::new(final_agg);
+    let optimized = AggregateStatistics::new().optimize(Arc::clone(&plan), &conf)?;
 
     // check that the original ExecutionPlan was not replaced
     assert!(optimized.is::<AggregateExec>());
+    assert!(Arc::ptr_eq(&plan, &optimized));
 
     Ok(())
 }
@@ -321,10 +344,12 @@ async fn test_count_with_nulls_inexact_stat() -> Result<()> {
     )?;
 
     let conf = ConfigOptions::new();
-    let optimized = AggregateStatistics::new().optimize(Arc::new(final_agg), &conf)?;
+    let plan: Arc<dyn ExecutionPlan> = Arc::new(final_agg);
+    let optimized = AggregateStatistics::new().optimize(Arc::clone(&plan), &conf)?;
 
     // check that the original ExecutionPlan was not replaced
     assert!(optimized.is::<AggregateExec>());
+    assert!(Arc::ptr_eq(&plan, &optimized));
 
     Ok(())
 }

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -2228,11 +2228,14 @@ impl Expr {
     pub fn infer_placeholder_types(self, schema: &DFSchema) -> Result<(Expr, bool)> {
         let mut has_placeholder = false;
         self.transform(|mut expr| {
+            let mut transformed = false;
             match &mut expr {
                 // Default to assuming the arguments are the same type
                 Expr::BinaryExpr(BinaryExpr { left, op: _, right }) => {
-                    rewrite_placeholder(left.as_mut(), right.as_ref(), schema)?;
-                    rewrite_placeholder(right.as_mut(), left.as_ref(), schema)?;
+                    transformed |=
+                        rewrite_placeholder(left.as_mut(), right.as_ref(), schema)?;
+                    transformed |=
+                        rewrite_placeholder(right.as_mut(), left.as_ref(), schema)?;
                 }
                 Expr::Between(Between {
                     expr,
@@ -2240,8 +2243,10 @@ impl Expr {
                     low,
                     high,
                 }) => {
-                    rewrite_placeholder(low.as_mut(), expr.as_ref(), schema)?;
-                    rewrite_placeholder(high.as_mut(), expr.as_ref(), schema)?;
+                    transformed |=
+                        rewrite_placeholder(low.as_mut(), expr.as_ref(), schema)?;
+                    transformed |=
+                        rewrite_placeholder(high.as_mut(), expr.as_ref(), schema)?;
                 }
                 Expr::InList(InList {
                     expr,
@@ -2249,19 +2254,20 @@ impl Expr {
                     negated: _,
                 }) => {
                     for item in list.iter_mut() {
-                        rewrite_placeholder(item, expr.as_ref(), schema)?;
+                        transformed |= rewrite_placeholder(item, expr.as_ref(), schema)?;
                     }
                 }
                 Expr::Like(Like { expr, pattern, .. })
                 | Expr::SimilarTo(Like { expr, pattern, .. }) => {
-                    rewrite_placeholder(pattern.as_mut(), expr.as_ref(), schema)?;
+                    transformed |=
+                        rewrite_placeholder(pattern.as_mut(), expr.as_ref(), schema)?;
                 }
                 Expr::Placeholder(_) => {
                     has_placeholder = true;
                 }
                 _ => {}
             }
-            Ok(Transformed::yes(expr))
+            Ok(Transformed::new_transformed(expr, transformed))
         })
         .data()
         .map(|data| (data, has_placeholder))
@@ -2936,7 +2942,7 @@ impl HashNode for Expr {
 
 // Modifies expr to match the DataType, metadata, and nullability of other if it is
 // a placeholder with previously unspecified type information (i.e., most placeholders)
-fn rewrite_placeholder(expr: &mut Expr, other: &Expr, schema: &DFSchema) -> Result<()> {
+fn rewrite_placeholder(expr: &mut Expr, other: &Expr, schema: &DFSchema) -> Result<bool> {
     if let Expr::Placeholder(Placeholder { id: _, field }) = expr
         && field.is_none()
     {
@@ -2951,10 +2957,11 @@ fn rewrite_placeholder(expr: &mut Expr, other: &Expr, schema: &DFSchema) -> Resu
                 // We can't infer the nullability of the future parameter that might
                 // be bound, so ensure this is set to true
                 *field = Some(other_field.as_ref().clone().with_nullable(true).into());
+                return Ok(true);
             }
         }
     };
-    Ok(())
+    Ok(false)
 }
 
 #[macro_export]
@@ -3955,6 +3962,21 @@ mod test {
             },
             _ => panic!("Expected BinaryExpr"),
         }
+    }
+
+    #[test]
+    fn rewrite_placeholder_reports_no_change_when_type_already_known() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+        let df_schema = DFSchema::try_from(schema).unwrap();
+        let mut expr = Expr::Placeholder(Placeholder::new_with_field(
+            "$1".to_string(),
+            Some(Arc::new(Field::new("name", DataType::Utf8, true))),
+        ));
+
+        let transformed = rewrite_placeholder(&mut expr, &col("name"), &df_schema)
+            .expect("failed to rewrite placeholder");
+        assert!(!transformed);
     }
 
     #[test]

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -404,6 +404,10 @@ fn push_down_all_join(
     on_filter: Vec<Expr>,
 ) -> Result<Transformed<LogicalPlan>> {
     let is_inner_join = join.join_type == JoinType::Inner;
+    let original_left = Arc::clone(&join.left);
+    let original_right = Arc::clone(&join.right);
+    let original_filter = join.filter.clone();
+
     // Get pushable predicates from current optimizer state
     let (left_preserved, right_preserved) = lr_is_preserved(join.join_type);
 
@@ -510,6 +514,10 @@ fn push_down_all_join(
     join_conditions.extend(on_filter_join_conditions);
     join.filter = conjunction(join_conditions);
 
+    let transformed = !Arc::ptr_eq(&join.left, &original_left)
+        || !Arc::ptr_eq(&join.right, &original_right)
+        || join.filter != original_filter;
+
     // wrap the join on the filter whose predicates must be kept, if any
     let plan = LogicalPlan::Join(join);
     let plan = if let Some(predicate) = conjunction(keep_predicates) {
@@ -517,7 +525,7 @@ fn push_down_all_join(
     } else {
         plan
     };
-    Ok(Transformed::yes(plan))
+    Ok(Transformed::new_transformed(plan, transformed))
 }
 
 fn push_down_join(
@@ -1027,7 +1035,7 @@ impl OptimizerRule for PushDownFilter {
                     .collect::<Result<Vec<_>>>()?;
 
                 let agg_input = Arc::clone(&agg.input);
-                Transformed::yes(LogicalPlan::Aggregate(agg))
+                Transformed::no(LogicalPlan::Aggregate(agg))
                     .transform_data(|new_plan| {
                         // If we have a filter to push, we push it down to the input of the aggregate
                         if let Some(predicate) = conjunction(replaced_push_predicates) {
@@ -1123,7 +1131,7 @@ impl OptimizerRule for PushDownFilter {
                 // optimizers, such as the one used by Postgres.
 
                 let window_input = Arc::clone(&window.input);
-                Transformed::yes(LogicalPlan::Window(window))
+                Transformed::no(LogicalPlan::Window(window))
                     .transform_data(|new_plan| {
                         // If we have a filter to push, we push it down to the input of the window
                         if let Some(predicate) = conjunction(push_predicates) {
@@ -1199,18 +1207,19 @@ impl OptimizerRule for PushDownFilter {
                     .cloned()
                     .collect();
 
+                let scan_filters_changed = new_scan_filters != scan.filters;
                 let new_scan = LogicalPlan::TableScan(TableScan {
                     filters: new_scan_filters,
                     ..scan
                 });
 
-                Transformed::yes(new_scan).transform_data(|new_scan| {
-                    if let Some(predicate) = conjunction(new_predicate) {
-                        make_filter(predicate, Arc::new(new_scan)).map(Transformed::yes)
-                    } else {
-                        Ok(Transformed::no(new_scan))
-                    }
-                })
+                if let Some(predicate) = conjunction(new_predicate) {
+                    make_filter(predicate, Arc::new(new_scan)).map(|plan| {
+                        Transformed::new_transformed(plan, scan_filters_changed)
+                    })
+                } else {
+                    Ok(Transformed::yes(new_scan))
+                }
             }
             LogicalPlan::Extension(extension_plan) => {
                 // This check prevents the Filter from being removed when the extension node has no children,
@@ -1687,6 +1696,11 @@ mod tests {
             .aggregate(vec![col("a")], vec![sum(col("b")).alias("b")])?
             .filter(col("b").gt(lit(10i64)))?
             .build()?;
+        let transformed = PushDownFilter::new()
+            .rewrite(plan.clone(), &OptimizerContext::new())
+            .expect("failed to optimize plan");
+        assert!(!transformed.transformed);
+
         // filter of aggregate is after aggregation since they are non-commutative
         assert_optimized_plan_equal!(
             plan,
@@ -1879,6 +1893,10 @@ mod tests {
             .window(vec![window])?
             .filter(col("c").gt(lit(10i64)))?
             .build()?;
+        let transformed = PushDownFilter::new()
+            .rewrite(plan.clone(), &OptimizerContext::new())
+            .expect("failed to optimize plan");
+        assert!(!transformed.transformed);
 
         assert_optimized_plan_equal!(
             plan,
@@ -3104,6 +3122,10 @@ mod tests {
                 Some(filter),
             )?
             .build()?;
+        let transformed = PushDownFilter::new()
+            .rewrite(plan.clone(), &OptimizerContext::new())
+            .expect("failed to optimize plan");
+        assert!(!transformed.transformed);
 
         // not part of the test, just good to know:
         assert_snapshot!(plan,
@@ -3210,15 +3232,20 @@ mod tests {
         let plan =
             table_scan_with_pushdown_provider(TableProviderFilterPushDown::Inexact)?;
 
-        let optimized_plan = PushDownFilter::new()
+        let optimized = PushDownFilter::new()
             .rewrite(plan, &OptimizerContext::new())
-            .expect("failed to optimize plan")
-            .data;
+            .expect("failed to optimize plan");
+        assert!(optimized.transformed);
+
+        let optimized_again = PushDownFilter::new()
+            .rewrite(optimized.data.clone(), &OptimizerContext::new())
+            .expect("failed to optimize plan");
+        assert!(!optimized_again.transformed);
 
         // Optimizing the same plan multiple times should produce the same plan
         // each time.
         assert_optimized_plan_equal!(
-            optimized_plan,
+            optimized_again.data,
             @r"
         Filter: a = Int64(1)
           TableScan: test, partial_filters=[a = Int64(1)]
@@ -3230,6 +3257,11 @@ mod tests {
     fn filter_with_table_provider_unsupported() -> Result<()> {
         let plan =
             table_scan_with_pushdown_provider(TableProviderFilterPushDown::Unsupported)?;
+
+        let transformed = PushDownFilter::new()
+            .rewrite(plan.clone(), &OptimizerContext::new())
+            .expect("failed to optimize plan");
+        assert!(!transformed.transformed);
 
         assert_optimized_plan_equal!(
             plan,

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -566,7 +566,7 @@ impl TreeNodeRewriter for ConstEvaluator {
                     }
                     // For other expressions (like CASE, COALESCE), preserve the original
                     // to allow short-circuit evaluation at execution time
-                    Ok(Transformed::yes(expr))
+                    Ok(Transformed::no(expr))
                 }
             },
             Some(false) => Ok(Transformed::no(expr)),
@@ -2776,7 +2776,9 @@ mod tests {
         let expr = lit(0) / lit(0);
         let expected = expr.clone();
 
-        assert_eq!(simplify(expr), expected);
+        let (simplified, num_iter) = simplify_with_cycle_count(expr);
+        assert_eq!(simplified, expected);
+        assert_eq!(num_iter, 1);
     }
 
     #[test]

--- a/datafusion/physical-optimizer/src/aggregate_statistics.rs
+++ b/datafusion/physical-optimizer/src/aggregate_statistics.rs
@@ -86,13 +86,19 @@ impl PhysicalOptimizerRule for AggregateStatistics {
                 )?))
             } else {
                 plan.map_children(|child| {
-                    self.optimize(child, config).map(Transformed::yes)
+                    let optimized = self.optimize(Arc::clone(&child), config)?;
+                    let transformed = !Arc::ptr_eq(&child, &optimized);
+                    Ok(Transformed::new_transformed(optimized, transformed))
                 })
                 .data()
             }
         } else {
-            plan.map_children(|child| self.optimize(child, config).map(Transformed::yes))
-                .data()
+            plan.map_children(|child| {
+                let optimized = self.optimize(Arc::clone(&child), config)?;
+                let transformed = !Arc::ptr_eq(&child, &optimized);
+                Ok(Transformed::new_transformed(optimized, transformed))
+            })
+            .data()
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Just some cleanup.

## Rationale for this change

Some optimizer paths were returning `Transformed::yes` even when they preserved the original plan or expression. That can cause unnecessary follow-up optimizer work and makes the transformed flag less useful as a fixed-point signal.

## What changes are included in this PR?

- Reports `Transformed::no` when filter pushdown through joins, aggregates, windows, or table scans does not actually change the plan.
- Reports `Transformed::no` when constant simplification preserves an expression after a runtime simplification error.
- Tracks whether placeholder type inference actually fills in placeholder type information before reporting a transformation.
- Preserves `Transformed::no` in `AggregateStatistics` recursive child optimization when the optimized child is the same plan handle.

## Are these changes tested?

## Are there any user-facing changes?

No.
