### PR TITLE
perf: optimize scalar aggregate joins as semi joins

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -3828,11 +3828,13 @@ fn calc_func_dependencies_for_project(
     exprs: &[Expr],
     input: &LogicalPlan,
 ) -> Result<FunctionalDependencies> {
+    const NON_INPUT_EXPR: usize = usize::MAX;
     let input_fields = input.schema().field_names();
-    // Calculate expression indices (if present) in the input schema.
-    let proj_indices = exprs
-        .iter()
-        .map(|expr| match expr {
+    // Keep one entry per output field. Non-input expressions occupy their
+    // output position so later input columns remap to their actual output index.
+    let mut proj_indices = vec![];
+    for expr in exprs {
+        match expr {
             #[expect(deprecated)]
             Expr::Wildcard { qualifier, options } => {
                 let wildcard_fields = exprlist_to_fields(
@@ -3842,44 +3844,41 @@ fn calc_func_dependencies_for_project(
                     }],
                     input,
                 )?;
-                Ok::<_, DataFusionError>(
-                    wildcard_fields
-                        .into_iter()
-                        .filter_map(|(qualifier, f)| {
-                            let flat_name = qualifier
-                                .map(|t| format!("{}.{}", t, f.name()))
-                                .unwrap_or_else(|| f.name().clone());
-                            input_fields.iter().position(|item| *item == flat_name)
-                        })
-                        .collect::<Vec<_>>(),
-                )
+                proj_indices.extend(wildcard_fields.into_iter().map(|(qualifier, f)| {
+                    let flat_name = qualifier
+                        .map(|t| format!("{}.{}", t, f.name()))
+                        .unwrap_or_else(|| f.name().clone());
+                    input_fields
+                        .iter()
+                        .position(|item| *item == flat_name)
+                        .unwrap_or(NON_INPUT_EXPR)
+                }));
             }
             Expr::Alias(alias) => {
                 let name = format!("{}", alias.expr);
-                Ok(input_fields
-                    .iter()
-                    .position(|item| *item == name)
-                    .map(|i| vec![i])
-                    .unwrap_or(vec![]))
+                proj_indices.push(
+                    input_fields
+                        .iter()
+                        .position(|item| *item == name)
+                        .unwrap_or(NON_INPUT_EXPR),
+                );
             }
             _ => {
                 let name = format!("{expr}");
-                Ok(input_fields
-                    .iter()
-                    .position(|item| *item == name)
-                    .map(|i| vec![i])
-                    .unwrap_or(vec![]))
+                proj_indices.push(
+                    input_fields
+                        .iter()
+                        .position(|item| *item == name)
+                        .unwrap_or(NON_INPUT_EXPR),
+                );
             }
-        })
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+        }
+    }
 
     Ok(input
         .schema()
         .functional_dependencies()
-        .project_functional_dependencies(&proj_indices, exprs.len()))
+        .project_functional_dependencies(&proj_indices, proj_indices.len()))
 }
 
 /// Sorts its input according to a list of sort expressions.

--- a/datafusion/optimizer/src/eliminate_join.rs
+++ b/datafusion/optimizer/src/eliminate_join.rs
@@ -15,19 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! [`EliminateJoin`] rewrites `INNER JOIN` with `true`/`null`
+//! [`EliminateJoin`] rewrites unnecessary `INNER JOIN`s
 use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 use datafusion_common::tree_node::Transformed;
-use datafusion_common::{Result, ScalarValue};
-use datafusion_expr::JoinType::Inner;
+use datafusion_common::{Dependency, NullEquality, Result, ScalarValue};
+use datafusion_expr::utils::expr_to_columns;
 use datafusion_expr::{
-    Expr,
-    logical_plan::{EmptyRelation, LogicalPlan},
+    Expr, Join, JoinConstraint, JoinType, LogicalPlan, Projection,
+    logical_plan::EmptyRelation,
 };
+use std::collections::HashSet;
+use std::sync::Arc;
 
 /// Eliminates joins when join condition is false.
-/// Replaces joins when inner join condition is true with a cross join.
+///
+/// It also rewrites projected inner joins to semi joins when the right side
+/// is only used to test existence and is unique on the join keys.
 #[derive(Default, Debug)]
 pub struct EliminateJoin;
 
@@ -52,7 +56,9 @@ impl OptimizerRule for EliminateJoin {
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
         match plan {
-            LogicalPlan::Join(join) if join.join_type == Inner && join.on.is_empty() => {
+            LogicalPlan::Join(join)
+                if join.join_type == JoinType::Inner && join.on.is_empty() =>
+            {
                 match join.filter {
                     Some(Expr::Literal(ScalarValue::Boolean(Some(false)), _)) => Ok(
                         Transformed::yes(LogicalPlan::EmptyRelation(EmptyRelation {
@@ -63,6 +69,9 @@ impl OptimizerRule for EliminateJoin {
                     _ => Ok(Transformed::no(LogicalPlan::Join(join))),
                 }
             }
+            LogicalPlan::Projection(projection) => {
+                eliminate_projected_inner_join(projection)
+            }
             _ => Ok(Transformed::no(plan)),
         }
     }
@@ -72,14 +81,127 @@ impl OptimizerRule for EliminateJoin {
     }
 }
 
+fn eliminate_projected_inner_join(
+    projection: Projection,
+) -> Result<Transformed<LogicalPlan>> {
+    let LogicalPlan::Join(join) = projection.input.as_ref() else {
+        return Ok(Transformed::no(LogicalPlan::Projection(projection)));
+    };
+
+    if !can_convert_projected_inner_to_semi(&projection, join)? {
+        return Ok(Transformed::no(LogicalPlan::Projection(projection)));
+    }
+
+    let semi_join = Join::try_new(
+        Arc::clone(&join.left),
+        Arc::clone(&join.right),
+        join.on.clone(),
+        join.filter.clone(),
+        JoinType::LeftSemi,
+        join.join_constraint,
+        join.null_equality,
+        join.null_aware,
+    )?;
+
+    let projection =
+        Projection::try_new(projection.expr, Arc::new(LogicalPlan::Join(semi_join)))?;
+
+    Ok(Transformed::yes(LogicalPlan::Projection(projection)))
+}
+
+fn can_convert_projected_inner_to_semi(
+    projection: &Projection,
+    join: &Join,
+) -> Result<bool> {
+    if join.join_type != JoinType::Inner
+        || join.join_constraint != JoinConstraint::On
+        || join.on.is_empty()
+        || join.null_aware
+    {
+        return Ok(false);
+    }
+
+    if !projection_exprs_only_reference_left(&projection.expr, join)? {
+        return Ok(false);
+    }
+
+    let right_keys = join
+        .on
+        .iter()
+        .map(|(_, right)| right.clone())
+        .collect::<Vec<_>>();
+
+    Ok(plan_unique_on(&join.right, &right_keys, join.null_equality))
+}
+
+fn projection_exprs_only_reference_left(
+    projection_exprs: &[Expr],
+    join: &Join,
+) -> Result<bool> {
+    let mut columns = HashSet::new();
+    for expr in projection_exprs {
+        expr_to_columns(expr, &mut columns)?;
+    }
+
+    Ok(columns
+        .iter()
+        .all(|column| join.left.schema().index_of_column(column).is_ok()))
+}
+
+fn plan_unique_on(
+    plan: &LogicalPlan,
+    key_exprs: &[Expr],
+    null_equality: NullEquality,
+) -> bool {
+    if key_exprs.is_empty() {
+        return false;
+    }
+
+    let schema = plan.schema();
+    let Some(key_indices) = key_exprs
+        .iter()
+        .map(|expr| match expr {
+            Expr::Column(column) => schema.index_of_column(column).ok(),
+            _ => None,
+        })
+        .collect::<Option<HashSet<_>>>()
+    else {
+        return false;
+    };
+
+    let field_count = schema.fields().len();
+    schema.functional_dependencies().iter().any(|dependency| {
+        dependency.mode == Dependency::Single
+            && dependency.target_indices.len() == field_count
+            && dependency
+                .source_indices
+                .iter()
+                .all(|idx| key_indices.contains(idx))
+            // Nullable unique constraints can contain multiple NULL keys, but
+            // regular equality joins do not match NULLs.
+            && (null_equality == NullEquality::NullEqualsNothing
+                || !dependency.nullable
+                || dependency
+                    .source_indices
+                    .iter()
+                    .all(|idx| !schema.field(*idx).is_nullable()))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use crate::OptimizerContext;
     use crate::assert_optimized_plan_eq_snapshot;
     use crate::eliminate_join::EliminateJoin;
-    use datafusion_common::Result;
+    use crate::test::{test_table_scan_fields, test_table_scan_with_name};
+    use arrow::datatypes::Schema;
+    use datafusion_common::{Constraint, Constraints, Result};
     use datafusion_expr::JoinType::Inner;
-    use datafusion_expr::{lit, logical_plan::builder::LogicalPlanBuilder};
+    use datafusion_expr::test::function_stub::max;
+    use datafusion_expr::{
+        col, lit,
+        logical_plan::builder::{LogicalPlanBuilder, table_source_with_constraints},
+    };
     use std::sync::Arc;
 
     macro_rules! assert_optimized_plan_equal {
@@ -109,5 +231,135 @@ mod tests {
             .build()?;
 
         assert_optimized_plan_equal!(plan, @"EmptyRelation: rows=0")
+    }
+
+    #[test]
+    fn projected_inner_join_to_left_semi() -> Result<()> {
+        let right = LogicalPlanBuilder::from(test_table_scan_with_name("right")?)
+            .aggregate(vec![col("right.a")], vec![max(col("right.c"))])?
+            .project(vec![col("max(right.c)").alias("max_c"), col("right.a")])?
+            .alias("sq")?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::from(test_table_scan_with_name("left")?)
+            .join(right, Inner, (vec!["a"], vec!["a"]), None)?
+            .project(vec![col("left.a"), col("left.b")])?
+            .build()?;
+
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: left.a, left.b
+          LeftSemi Join: left.a = sq.a
+            TableScan: left
+            SubqueryAlias: sq
+              Projection: max(right.c) AS max_c, right.a
+                Aggregate: groupBy=[[right.a]], aggr=[[max(right.c)]]
+                  TableScan: right
+        "
+        )
+    }
+
+    #[test]
+    fn projected_inner_join_to_left_semi_with_unique_constraint() -> Result<()> {
+        let right_schema = Schema::new(test_table_scan_fields());
+        let right_source = table_source_with_constraints(
+            &right_schema,
+            Constraints::new_unverified(vec![Constraint::PrimaryKey(vec![0])]),
+        );
+        let right = LogicalPlanBuilder::scan("right", right_source, None)?.build()?;
+
+        let plan = LogicalPlanBuilder::from(test_table_scan_with_name("left")?)
+            .join(right, Inner, (vec!["a"], vec!["a"]), None)?
+            .project(vec![col("left.a"), col("left.b")])?
+            .build()?;
+
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: left.a, left.b
+          LeftSemi Join: left.a = right.a
+            TableScan: left
+            TableScan: right
+        "
+        )
+    }
+
+    #[test]
+    fn projected_inner_join_with_filter_to_left_semi() -> Result<()> {
+        let right = LogicalPlanBuilder::from(test_table_scan_with_name("right")?)
+            .aggregate(vec![col("right.a")], vec![max(col("right.c"))])?
+            .project(vec![col("right.a"), col("max(right.c)").alias("max_c")])?
+            .alias("sq")?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::from(test_table_scan_with_name("left")?)
+            .join(
+                right,
+                Inner,
+                (vec!["a"], vec!["a"]),
+                Some(col("left.b").lt(col("sq.max_c"))),
+            )?
+            .project(vec![col("left.a")])?
+            .build()?;
+
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: left.a
+          LeftSemi Join: left.a = sq.a Filter: left.b < sq.max_c
+            TableScan: left
+            SubqueryAlias: sq
+              Projection: right.a, max(right.c) AS max_c
+                Aggregate: groupBy=[[right.a]], aggr=[[max(right.c)]]
+                  TableScan: right
+        "
+        )
+    }
+
+    #[test]
+    fn projected_inner_join_preserves_duplicates_without_unique_right() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(test_table_scan_with_name("left")?)
+            .join(
+                test_table_scan_with_name("right")?,
+                Inner,
+                (vec!["a"], vec!["a"]),
+                None,
+            )?
+            .project(vec![col("left.a")])?
+            .build()?;
+
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: left.a
+          Inner Join: left.a = right.a
+            TableScan: left
+            TableScan: right
+        "
+        )
+    }
+
+    #[test]
+    fn projected_inner_join_keeps_right_projection_columns() -> Result<()> {
+        let right = LogicalPlanBuilder::from(test_table_scan_with_name("right")?)
+            .aggregate(vec![col("right.a")], vec![max(col("right.c"))])?
+            .build()?;
+
+        let plan = LogicalPlanBuilder::from(test_table_scan_with_name("left")?)
+            .join(right, Inner, (vec!["a"], vec!["a"]), None)?
+            .project(vec![col("left.a"), col("max(right.c)")])?
+            .build()?;
+
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: left.a, max(right.c)
+          Inner Join: left.a = right.a
+            TableScan: left
+            Aggregate: groupBy=[[right.a]], aggr=[[max(right.c)]]
+              TableScan: right
+        "
+        )
     }
 }

--- a/datafusion/sqllogictest/test_files/tpch/plans/q17.slt.part
+++ b/datafusion/sqllogictest/test_files/tpch/plans/q17.slt.part
@@ -39,7 +39,7 @@ logical_plan
 01)Projection: CAST(sum(lineitem.l_extendedprice) AS Float64) / Float64(7) AS avg_yearly
 02)--Aggregate: groupBy=[[]], aggr=[[sum(lineitem.l_extendedprice)]]
 03)----Projection: lineitem.l_extendedprice
-04)------Inner Join: part.p_partkey = __scalar_sq_1.l_partkey Filter: CAST(lineitem.l_quantity AS Decimal128(30, 15)) < __scalar_sq_1.Float64(0.2) * avg(lineitem.l_quantity)
+04)------LeftSemi Join: part.p_partkey = __scalar_sq_1.l_partkey Filter: CAST(lineitem.l_quantity AS Decimal128(30, 15)) < __scalar_sq_1.Float64(0.2) * avg(lineitem.l_quantity)
 05)--------Projection: lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey
 06)----------Inner Join: lineitem.l_partkey = part.p_partkey
 07)------------TableScan: lineitem projection=[l_partkey, l_quantity, l_extendedprice]
@@ -55,7 +55,7 @@ physical_plan
 02)--AggregateExec: mode=Final, gby=[], aggr=[sum(lineitem.l_extendedprice)]
 03)----CoalescePartitionsExec
 04)------AggregateExec: mode=Partial, gby=[], aggr=[sum(lineitem.l_extendedprice)]
-05)--------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(p_partkey@2, l_partkey@1)], filter=CAST(l_quantity@0 AS Decimal128(30, 15)) < Float64(0.2) * avg(lineitem.l_quantity)@1, projection=[l_extendedprice@1]
+05)--------HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(p_partkey@2, l_partkey@1)], filter=CAST(l_quantity@0 AS Decimal128(30, 15)) < Float64(0.2) * avg(lineitem.l_quantity)@1, projection=[l_extendedprice@1]
 06)----------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(l_partkey@0, p_partkey@0)], projection=[l_quantity@1, l_extendedprice@2, p_partkey@3]
 07)------------RepartitionExec: partitioning=Hash([l_partkey@0], 4), input_partitions=4
 08)--------------DataSourceExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/tpch/data/lineitem.tbl:0..18561749], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/tpch/data/lineitem.tbl:18561749..37123498], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/tpch/data/lineitem.tbl:37123498..55685247], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/tpch/data/lineitem.tbl:55685247..74246996]]}, projection=[l_partkey, l_quantity, l_extendedprice], file_type=csv, has_header=false

--- a/datafusion/sqllogictest/test_files/tpch/plans/q2.slt.part
+++ b/datafusion/sqllogictest/test_files/tpch/plans/q2.slt.part
@@ -65,7 +65,7 @@ limit 10;
 logical_plan
 01)Sort: supplier.s_acctbal DESC NULLS FIRST, nation.n_name ASC NULLS LAST, supplier.s_name ASC NULLS LAST, part.p_partkey ASC NULLS LAST, fetch=10
 02)--Projection: supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment
-03)----Inner Join: part.p_partkey = __scalar_sq_1.ps_partkey, partsupp.ps_supplycost = __scalar_sq_1.min(partsupp.ps_supplycost)
+03)----LeftSemi Join: part.p_partkey = __scalar_sq_1.ps_partkey, partsupp.ps_supplycost = __scalar_sq_1.min(partsupp.ps_supplycost)
 04)------Projection: part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp.ps_supplycost, nation.n_name
 05)--------Inner Join: nation.n_regionkey = region.r_regionkey
 06)----------Projection: part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp.ps_supplycost, nation.n_name, nation.n_regionkey
@@ -101,7 +101,7 @@ logical_plan
 physical_plan
 01)SortPreservingMergeExec: [s_acctbal@0 DESC, n_name@2 ASC NULLS LAST, s_name@1 ASC NULLS LAST, p_partkey@3 ASC NULLS LAST], fetch=10
 02)--SortExec: TopK(fetch=10), expr=[s_acctbal@0 DESC, n_name@2 ASC NULLS LAST, s_name@1 ASC NULLS LAST, p_partkey@3 ASC NULLS LAST], preserve_partitioning=[true]
-03)----HashJoinExec: mode=Partitioned, join_type=Inner, on=[(p_partkey@0, ps_partkey@1), (ps_supplycost@7, min(partsupp.ps_supplycost)@0)], projection=[s_acctbal@5, s_name@2, n_name@8, p_partkey@0, p_mfgr@1, s_address@3, s_phone@4, s_comment@6]
+03)----HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(p_partkey@0, ps_partkey@1), (ps_supplycost@7, min(partsupp.ps_supplycost)@0)], projection=[s_acctbal@5, s_name@2, n_name@8, p_partkey@0, p_mfgr@1, s_address@3, s_phone@4, s_comment@6]
 04)------RepartitionExec: partitioning=Hash([p_partkey@0, ps_supplycost@7], 4), input_partitions=4
 05)--------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(n_regionkey@9, r_regionkey@0)], projection=[p_partkey@0, p_mfgr@1, s_name@2, s_address@3, s_phone@4, s_acctbal@5, s_comment@6, ps_supplycost@7, n_name@8]
 06)----------RepartitionExec: partitioning=Hash([n_regionkey@9], 4), input_partitions=4

--- a/datafusion/sqllogictest/test_files/tpch/plans/q20.slt.part
+++ b/datafusion/sqllogictest/test_files/tpch/plans/q20.slt.part
@@ -67,7 +67,7 @@ logical_plan
 09)--------------TableScan: nation projection=[n_nationkey, n_name], partial_filters=[nation.n_name = Utf8View("CANADA")]
 10)------SubqueryAlias: __correlated_sq_2
 11)--------Projection: partsupp.ps_suppkey
-12)----------Inner Join: partsupp.ps_partkey = __scalar_sq_3.l_partkey, partsupp.ps_suppkey = __scalar_sq_3.l_suppkey Filter: CAST(partsupp.ps_availqty AS Float64) > __scalar_sq_3.Float64(0.5) * sum(lineitem.l_quantity)
+12)----------LeftSemi Join: partsupp.ps_partkey = __scalar_sq_3.l_partkey, partsupp.ps_suppkey = __scalar_sq_3.l_suppkey Filter: CAST(partsupp.ps_availqty AS Float64) > __scalar_sq_3.Float64(0.5) * sum(lineitem.l_quantity)
 13)------------LeftSemi Join: partsupp.ps_partkey = __correlated_sq_1.p_partkey
 14)--------------TableScan: partsupp projection=[ps_partkey, ps_suppkey, ps_availqty]
 15)--------------SubqueryAlias: __correlated_sq_1
@@ -93,7 +93,7 @@ physical_plan
 10)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
 11)----------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/tpch/data/nation.tbl]]}, projection=[n_nationkey, n_name], file_type=csv, has_header=false
 12)------RepartitionExec: partitioning=Hash([ps_suppkey@0], 4), input_partitions=4
-13)--------HashJoinExec: mode=Partitioned, join_type=Inner, on=[(ps_partkey@0, l_partkey@1), (ps_suppkey@1, l_suppkey@2)], filter=CAST(ps_availqty@0 AS Float64) > Float64(0.5) * sum(lineitem.l_quantity)@1, projection=[ps_suppkey@1]
+13)--------HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(ps_partkey@0, l_partkey@1), (ps_suppkey@1, l_suppkey@2)], filter=CAST(ps_availqty@0 AS Float64) > Float64(0.5) * sum(lineitem.l_quantity)@1, projection=[ps_suppkey@1]
 14)----------RepartitionExec: partitioning=Hash([ps_partkey@0, ps_suppkey@1], 4), input_partitions=4
 15)------------HashJoinExec: mode=Partitioned, join_type=LeftSemi, on=[(ps_partkey@0, p_partkey@0)]
 16)--------------RepartitionExec: partitioning=Hash([ps_partkey@0], 4), input_partitions=4


### PR DESCRIPTION
## Which issue does this PR close?

N/A.

## Rationale for this change

TPC-H Q2, Q17, and Q20 contain correlated scalar aggregate subqueries that are decorrelated into joins. In these cases the right side is unique on the correlated join keys, and no right-side columns are projected above the join. That means the inner join is only testing existence of a matching scalar aggregate row, so a left semi join expresses the plan more directly and avoids carrying inner-join output/cardinality machinery.

PR #21240 adds physical execution for uncorrelated scalar subqueries, but these cases are correlated and still need decorrelation into a set-at-a-time join plan.

## What changes are included in this PR?

- Extend `EliminateJoin` to rewrite projected inner joins to left semi joins when the right input is provably unique on the right join keys.
- Use logical plan functional dependencies to prove right-side uniqueness, so this works for aggregate group keys, table constraints, and future property propagation.
- Preserve projection functional dependency output positions when computed projection expressions appear before projected input columns.
- Keep the existing inner join when the projection references right columns or right-side uniqueness cannot be proven.
- Update TPC-H plan snapshots for Q2, Q17, and Q20.

## Are these changes tested?

Yes.

- `CARGO_INCREMENTAL=0 cargo test -p datafusion-optimizer eliminate_join --lib`
- `CARGO_INCREMENTAL=0 INCLUDE_TPCH=true cargo test -p datafusion-sqllogictest --test sqllogictests -- tpch`
- `cargo fmt --all`
- `CARGO_INCREMENTAL=0 ci/scripts/rust_clippy.sh`
- Earlier on this branch before the FD refactor: `./dev/rust_lint.sh`

## Are there any user-facing changes?

No API changes. Eligible logical and physical plans can now show `LeftSemi` instead of `Inner` for projected joins against unique scalar aggregate subquery results.