### PR TITLE
perf: speed up primitive group value interning, use less memory

### DIFF
--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::ArrayRef;
-use arrow::datatypes::{Int32Type, StringViewType};
+use arrow::array::{ArrayRef, UInt64Array};
+use arrow::datatypes::{Field, Int32Type, Schema, StringViewType};
 use arrow::util::bench_util::{
     create_primitive_array, create_string_view_array_with_len,
     create_string_view_array_with_max_len,
@@ -30,6 +30,8 @@ use criterion::{
 use datafusion_physical_plan::aggregates::group_values::multi_group_by::GroupColumn;
 use datafusion_physical_plan::aggregates::group_values::multi_group_by::bytes_view::ByteViewGroupValueBuilder;
 use datafusion_physical_plan::aggregates::group_values::multi_group_by::primitive::PrimitiveGroupValueBuilder;
+use datafusion_physical_plan::aggregates::group_values::new_group_values;
+use datafusion_physical_plan::aggregates::order::GroupOrdering;
 use rand::distr::{Bernoulli, Distribution};
 use std::hint::black_box;
 use std::sync::Arc;
@@ -40,6 +42,7 @@ const NULL_DENSITIES: [f32; 3] = [0.0, 0.1, 0.5];
 fn bench_vectorized_append(c: &mut Criterion) {
     byte_view_vectorized_append(c);
     primitive_vectorized_append(c);
+    single_group_by_primitive_intern(c);
 }
 
 fn byte_view_vectorized_append(c: &mut Criterion) {
@@ -174,6 +177,53 @@ fn primitive_vectorized_append(c: &mut Criterion) {
             }
             bench_single_primitive::<true>(&mut group, size, &rows, null_density);
         }
+    }
+
+    group.finish();
+}
+
+fn single_group_by_primitive_intern(c: &mut Criterion) {
+    const BATCH_SIZE: usize = 4096;
+    const BATCHES: usize = 16;
+
+    let cases = [
+        ("low_cardinality", 128),
+        ("high_cardinality", BATCH_SIZE * BATCHES),
+    ];
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "group_key",
+        DataType::UInt64,
+        true,
+    )]));
+    let mut group = c.benchmark_group("GroupValuesPrimitive_intern");
+
+    for (case_name, distinct) in cases {
+        let batches = (0..BATCHES)
+            .map(|batch| {
+                let start = batch * BATCH_SIZE;
+                let values = (start..start + BATCH_SIZE)
+                    .map(|value| Some((value % distinct) as u64));
+                Arc::new(UInt64Array::from_iter(values)) as ArrayRef
+            })
+            .collect::<Vec<_>>();
+
+        group.bench_function(case_name, |b| {
+            b.iter(|| {
+                let mut group_values =
+                    new_group_values(Arc::clone(&schema), &GroupOrdering::None).unwrap();
+                let mut groups = Vec::with_capacity(BATCH_SIZE);
+
+                for batch in &batches {
+                    group_values
+                        .intern(std::slice::from_ref(batch), &mut groups)
+                        .unwrap();
+                    black_box(&groups);
+                }
+
+                black_box(group_values.len());
+            });
+        });
     }
 
     group.finish();

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -25,6 +25,7 @@ use arrow::array::types::{
 use arrow::array::{ArrayRef, downcast_primitive};
 use arrow::datatypes::{DataType, SchemaRef, TimeUnit};
 use datafusion_common::Result;
+use std::mem::size_of;
 
 use datafusion_expr::EmitTo;
 
@@ -50,6 +51,32 @@ mod metrics;
 mod null_builder;
 
 pub(crate) use metrics::GroupByMetrics;
+
+pub(crate) const DENSE_LOOKUP_MAX_BYTES: usize = 2 * 1024 * 1024;
+pub(crate) const DENSE_LOOKUP_MIN_FILL_NUMERATOR: usize = 1;
+pub(crate) const DENSE_LOOKUP_MIN_FILL_DENOMINATOR: usize = 5;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DenseLookupHint {
+    pub(crate) min: i128,
+    pub(crate) range_len: usize,
+}
+
+impl DenseLookupHint {
+    pub(crate) fn try_new(min: i128, max: i128) -> Option<Self> {
+        let range_len: usize = max.checked_sub(min)?.checked_add(1)?.try_into().ok()?;
+        let bytes = range_len.checked_mul(size_of::<usize>())?;
+        (bytes <= DENSE_LOOKUP_MAX_BYTES).then_some(Self { min, range_len })
+    }
+
+    pub(crate) fn has_minimum_estimated_fill(self, rows_per_partition: usize) -> bool {
+        let range_threshold = self.range_len * DENSE_LOOKUP_MIN_FILL_NUMERATOR;
+        match rows_per_partition.checked_mul(DENSE_LOOKUP_MIN_FILL_DENOMINATOR) {
+            Some(rows) => rows > range_threshold,
+            None => true,
+        }
+    }
+}
 
 /// Stores the group values during hash aggregation.
 ///
@@ -135,12 +162,28 @@ pub fn new_group_values(
     schema: SchemaRef,
     group_ordering: &GroupOrdering,
 ) -> Result<Box<dyn GroupValues>> {
+    new_group_values_with_hint(schema, group_ordering, None)
+}
+
+pub(crate) fn new_group_values_with_hint(
+    schema: SchemaRef,
+    group_ordering: &GroupOrdering,
+    dense_lookup_hint: Option<DenseLookupHint>,
+) -> Result<Box<dyn GroupValues>> {
     if schema.fields.len() == 1 {
         let d = schema.fields[0].data_type();
 
         macro_rules! downcast_helper {
             ($t:ty, $d:ident) => {
-                return Ok(Box::new(GroupValuesPrimitive::<$t>::new($d.clone())))
+                return Ok(match dense_lookup_hint {
+                    Some(hint) => {
+                        Box::new(GroupValuesPrimitive::<$t>::new_with_dense_lookup_hint(
+                            $d.clone(),
+                            Some(hint),
+                        ))
+                    }
+                    None => Box::new(GroupValuesPrimitive::<$t>::new($d.clone())),
+                })
             };
         }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -18,8 +18,8 @@
 use crate::aggregates::group_values::GroupValues;
 use arrow::array::types::{IntervalDayTime, IntervalMonthDayNano};
 use arrow::array::{
-    ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, NullBufferBuilder, PrimitiveArray,
-    cast::AsArray,
+    Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, NullBufferBuilder,
+    PrimitiveArray, cast::AsArray,
 };
 use arrow::datatypes::{DataType, i256};
 use datafusion_common::Result;
@@ -112,35 +112,60 @@ where
         assert_eq!(cols.len(), 1);
         groups.clear();
 
-        for v in cols[0].as_primitive::<T>() {
-            let group_id = match v {
-                None => *self.null_group.get_or_insert_with(|| {
-                    let group_id = self.num_groups;
-                    self.num_groups += 1;
-                    group_id
-                }),
-                Some(key) => {
-                    let state = &self.random_state;
-                    let hash = key.hash(state);
-                    let insert = self.map.entry(
-                        hash,
-                        |&(_, value)| value.is_eq(key),
-                        |&(_, value)| value.hash(state),
-                    );
+        let values = cols[0].as_primitive::<T>();
 
-                    match insert {
-                        hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
-                        hashbrown::hash_table::Entry::Vacant(v) => {
-                            let g = self.num_groups;
-                            v.insert((g, key));
-                            self.num_groups += 1;
-                            g
-                        }
+        if values.null_count() == 0 {
+            let state = &self.random_state;
+            groups.extend(values.values().iter().map(|&key| {
+                let hash = key.hash(state);
+                let insert = self.map.entry(
+                    hash,
+                    |&(_, value)| value.is_eq(key),
+                    |&(_, value)| value.hash(state),
+                );
+
+                match insert {
+                    hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
+                    hashbrown::hash_table::Entry::Vacant(v) => {
+                        let g = self.num_groups;
+                        v.insert((g, key));
+                        self.num_groups += 1;
+                        g
                     }
                 }
-            };
-            groups.push(group_id)
+            }));
+        } else {
+            for v in values {
+                let group_id = match v {
+                    None => *self.null_group.get_or_insert_with(|| {
+                        let group_id = self.num_groups;
+                        self.num_groups += 1;
+                        group_id
+                    }),
+                    Some(key) => {
+                        let state = &self.random_state;
+                        let hash = key.hash(state);
+                        let insert = self.map.entry(
+                            hash,
+                            |&(_, value)| value.is_eq(key),
+                            |&(_, value)| value.hash(state),
+                        );
+
+                        match insert {
+                            hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
+                            hashbrown::hash_table::Entry::Vacant(v) => {
+                                let g = self.num_groups;
+                                v.insert((g, key));
+                                self.num_groups += 1;
+                                g
+                            }
+                        }
+                    }
+                };
+                groups.push(group_id)
+            }
         }
+
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -24,7 +24,6 @@ use arrow::array::{
 use arrow::datatypes::{DataType, i256};
 use datafusion_common::Result;
 use datafusion_common::hash_utils::RandomState;
-use datafusion_execution::memory_pool::proxy::VecAllocExt;
 use datafusion_expr::EmitTo;
 use half::f16;
 use hashbrown::hash_table::HashTable;
@@ -82,17 +81,12 @@ hash_float!(f16, f32, f64);
 pub struct GroupValuesPrimitive<T: ArrowPrimitiveType> {
     /// The data type of the output array
     data_type: DataType,
-    /// Stores the `(group_index, hash)` based on the hash of its value
-    ///
-    /// We also store `hash` is for reducing cost of rehashing. Such cost
-    /// is obvious in high cardinality group by situation.
-    /// More details can see:
-    /// <https://github.com/apache/datafusion/issues/15961>
-    map: HashTable<(usize, u64)>,
+    /// Stores the group index and value, keyed by the hash of the value
+    map: HashTable<(usize, T::Native)>,
     /// The group index of the null value if any
     null_group: Option<usize>,
-    /// The values for each group index
-    values: Vec<T::Native>,
+    /// The number of groups, including the null group if present
+    num_groups: usize,
     /// The random state used to generate hashes
     random_state: RandomState,
 }
@@ -103,7 +97,7 @@ impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T> {
         Self {
             data_type,
             map: HashTable::with_capacity(128),
-            values: Vec::with_capacity(128),
+            num_groups: 0,
             null_group: None,
             random_state: crate::aggregates::AGGREGATION_HASH_SEED,
         }
@@ -121,8 +115,8 @@ where
         for v in cols[0].as_primitive::<T>() {
             let group_id = match v {
                 None => *self.null_group.get_or_insert_with(|| {
-                    let group_id = self.values.len();
-                    self.values.push(Default::default());
+                    let group_id = self.num_groups;
+                    self.num_groups += 1;
                     group_id
                 }),
                 Some(key) => {
@@ -130,18 +124,16 @@ where
                     let hash = key.hash(state);
                     let insert = self.map.entry(
                         hash,
-                        |&(g, h)| unsafe {
-                            hash == h && self.values.get_unchecked(g).is_eq(key)
-                        },
-                        |&(_, h)| h,
+                        |&(_, value)| value.is_eq(key),
+                        |&(_, value)| value.hash(state),
                     );
 
                     match insert {
                         hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
                         hashbrown::hash_table::Entry::Vacant(v) => {
-                            let g = self.values.len();
-                            v.insert((g, hash));
-                            self.values.push(key);
+                            let g = self.num_groups;
+                            v.insert((g, key));
+                            self.num_groups += 1;
                             g
                         }
                     }
@@ -153,15 +145,15 @@ where
     }
 
     fn size(&self) -> usize {
-        self.map.capacity() * size_of::<(usize, u64)>() + self.values.allocated_size()
+        self.map.capacity() * size_of::<(usize, T::Native)>()
     }
 
     fn is_empty(&self) -> bool {
-        self.values.is_empty()
+        self.num_groups == 0
     }
 
     fn len(&self) -> usize {
-        self.values.len()
+        self.num_groups
     }
 
     fn emit(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
@@ -182,21 +174,30 @@ where
 
         let array: PrimitiveArray<T> = match emit_to {
             EmitTo::All => {
-                self.map.clear();
-                build_primitive(std::mem::take(&mut self.values), self.null_group.take())
+                let mut values = vec![T::default_value(); self.num_groups];
+                for (group_idx, value) in std::mem::take(&mut self.map) {
+                    values[group_idx] = value;
+                }
+                self.num_groups = 0;
+
+                build_primitive(values, self.null_group.take())
             }
             EmitTo::First(n) => {
-                self.map.retain(|entry| {
+                let mut values = vec![T::default_value(); n];
+
+                self.map.retain(|(group_idx, value)| {
                     // Decrement group index by n
-                    let group_idx = entry.0;
                     match group_idx.checked_sub(n) {
                         // Group index was >= n, shift value down
                         Some(sub) => {
-                            entry.0 = sub;
+                            *group_idx = sub;
                             true
                         }
                         // Group index was < n, so remove from table
-                        None => false,
+                        None => {
+                            values[*group_idx] = *value;
+                            false
+                        }
                     }
                 });
                 let null_group = match &mut self.null_group {
@@ -207,9 +208,8 @@ where
                     Some(_) => self.null_group.take(),
                     None => None,
                 };
-                let mut split = self.values.split_off(n);
-                std::mem::swap(&mut self.values, &mut split);
-                build_primitive(split, null_group)
+                self.num_groups -= n;
+                build_primitive(values, null_group)
             }
         };
 
@@ -217,9 +217,75 @@ where
     }
 
     fn clear_shrink(&mut self, num_rows: usize) {
-        self.values.clear();
-        self.values.shrink_to(num_rows);
+        self.num_groups = 0;
+        self.null_group = None;
         self.map.clear();
         self.map.shrink_to(num_rows, |_| 0); // hasher does not matter since the map is cleared
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, UInt64Array};
+    use arrow::datatypes::UInt64Type;
+
+    fn values(array: &ArrayRef) -> Vec<Option<u64>> {
+        let array = array.as_primitive::<UInt64Type>();
+        (0..array.len())
+            .map(|idx| {
+                if array.is_null(idx) {
+                    None
+                } else {
+                    Some(array.value(idx))
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn primitive_emit_all_reconstructs_group_order() -> Result<()> {
+        let input = Arc::new(UInt64Array::from(vec![Some(10), Some(20), None, Some(10)]))
+            as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1, 2, 0]);
+
+        let output = group_values.emit(EmitTo::All)?;
+        assert_eq!(values(&output[0]), vec![Some(10), Some(20), None]);
+        assert!(group_values.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_emit_first_reindexes_remaining_groups() -> Result<()> {
+        let input = Arc::new(UInt64Array::from(vec![
+            Some(10),
+            None,
+            Some(20),
+            Some(30),
+            Some(10),
+        ])) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1, 2, 3, 0]);
+
+        let output = group_values.emit(EmitTo::First(2))?;
+        assert_eq!(values(&output[0]), vec![Some(10), None]);
+        assert_eq!(group_values.len(), 2);
+
+        let input = Arc::new(UInt64Array::from(vec![Some(20), Some(40)])) as ArrayRef;
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 2]);
+
+        let output = group_values.emit(EmitTo::All)?;
+        assert_eq!(values(&output[0]), vec![Some(20), Some(30), Some(40)]);
+
+        Ok(())
     }
 }

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -37,6 +37,10 @@ use std::sync::Arc;
 
 const DENSE_LOOKUP_FILL_EXEMPT_BYTES: usize = 8 * 1024;
 const DENSE_EMPTY_GROUP: usize = usize::MAX;
+const HASH_TABLE_MIN_FILL_NUMERATOR: usize = 3;
+const HASH_TABLE_MIN_FILL_DENOMINATOR: usize = 4;
+const HASH_TABLE_CONTROL_BYTES_PER_BUCKET: usize = size_of::<u8>();
+const HASH_TABLE_ENTRY_BYTES: usize = size_of::<(usize, u64)>();
 
 /// A trait to allow hashing of floating point numbers
 pub(crate) trait HashValue {
@@ -210,10 +214,16 @@ where
         range_len.checked_mul(size_of::<usize>())
     }
 
-    fn dense_range_len(min: i128, max: i128) -> Option<usize> {
-        let len: usize = max.checked_sub(min)?.checked_add(1)?.try_into().ok()?;
-        let bytes = Self::dense_lookup_bytes(len)?;
-        (bytes <= DENSE_LOOKUP_MAX_BYTES).then_some(len)
+    fn dense_range_len_unbounded(min: i128, max: i128) -> Option<usize> {
+        max.checked_sub(min)?.checked_add(1)?.try_into().ok()
+    }
+
+    fn hash_table_bytes_at_min_fill(occupied_slots: usize) -> Option<usize> {
+        let buckets = occupied_slots
+            .checked_mul(HASH_TABLE_MIN_FILL_DENOMINATOR)?
+            .checked_add(HASH_TABLE_MIN_FILL_NUMERATOR - 1)?
+            / HASH_TABLE_MIN_FILL_NUMERATOR;
+        buckets.checked_mul(HASH_TABLE_ENTRY_BYTES + HASH_TABLE_CONTROL_BYTES_PER_BUCKET)
     }
 
     fn intern_hash_key(
@@ -251,8 +261,20 @@ where
             return true;
         }
 
-        occupied_slots * DENSE_LOOKUP_MIN_FILL_DENOMINATOR
-            > range_len * DENSE_LOOKUP_MIN_FILL_NUMERATOR
+        let Some(bytes) = Self::dense_lookup_bytes(range_len) else {
+            return false;
+        };
+
+        if bytes <= DENSE_LOOKUP_MAX_BYTES {
+            return occupied_slots * DENSE_LOOKUP_MIN_FILL_DENOMINATOR
+                > range_len * DENSE_LOOKUP_MIN_FILL_NUMERATOR;
+        }
+
+        let Some(hash_table_bytes) = Self::hash_table_bytes_at_min_fill(occupied_slots)
+        else {
+            return true;
+        };
+        bytes <= hash_table_bytes
     }
 
     fn dense_has_minimum_fill(dense: &DenseGroupValues<T::Native>) -> bool {
@@ -292,7 +314,8 @@ where
             return true;
         }
 
-        let Some(new_range_len) = Self::dense_range_len(new_min, new_max) else {
+        let Some(new_range_len) = Self::dense_range_len_unbounded(new_min, new_max)
+        else {
             return false;
         };
 
@@ -441,7 +464,13 @@ where
         }
 
         let min = min?;
-        let range_len = Self::dense_range_len(min, max?)?;
+        let range_len = Self::dense_range_len_unbounded(min, max?)?;
+        let non_null_group_upper_bound =
+            self.num_groups - usize::from(self.null_group.is_some()) + values.len()
+                - values.null_count();
+        if !Self::dense_can_have_minimum_fill(non_null_group_upper_bound, range_len) {
+            return None;
+        }
         let mut dense = DenseGroupValues {
             min,
             group_ids: vec![DENSE_EMPTY_GROUP; range_len],
@@ -884,6 +913,21 @@ mod tests {
         group_values.intern(&[input], &mut groups)?;
         assert_eq!(groups, vec![0, 1]);
         assert!(!is_dense(&group_values));
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_used_for_hash_memory_equivalent_range() -> Result<()> {
+        let input = Arc::new(UInt64Array::from_iter_values(
+            (0..150_000).map(|value| value * 2),
+        )) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups.len(), 150_000);
+        assert!(is_dense(&group_values));
 
         Ok(())
     }

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::aggregates::group_values::GroupValues;
+use crate::aggregates::group_values::{
+    DENSE_LOOKUP_MAX_BYTES, DENSE_LOOKUP_MIN_FILL_DENOMINATOR,
+    DENSE_LOOKUP_MIN_FILL_NUMERATOR, DenseLookupHint, GroupValues,
+};
 use arrow::array::types::{IntervalDayTime, IntervalMonthDayNano};
 use arrow::array::{
     Array, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType, NullBufferBuilder,
@@ -32,10 +35,7 @@ use std::hash::BuildHasher;
 use std::mem::size_of;
 use std::sync::Arc;
 
-const DENSE_LOOKUP_MAX_BYTES: usize = 2 * 1024 * 1024;
 const DENSE_LOOKUP_FILL_EXEMPT_BYTES: usize = 8 * 1024;
-const DENSE_LOOKUP_MIN_FILL_NUMERATOR: usize = 1;
-const DENSE_LOOKUP_MIN_FILL_DENOMINATOR: usize = 5;
 const DENSE_EMPTY_GROUP: usize = usize::MAX;
 
 /// A trait to allow hashing of floating point numbers
@@ -147,19 +147,32 @@ pub struct GroupValuesPrimitive<T: ArrowPrimitiveType> {
     num_groups: usize,
     /// The random state used to generate hashes
     random_state: RandomState,
+    /// Static dense lookup range selected from execution-plan statistics
+    dense_lookup_hint: Option<DenseLookupHint>,
     /// Set once observed values are not suitable for dense lookup
     dense_lookup_disabled: bool,
 }
 
-impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T> {
+impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T>
+where
+    T::Native: DenseRangeValue + HashValue,
+{
     pub fn new(data_type: DataType) -> Self {
+        Self::new_with_dense_lookup_hint(data_type, None)
+    }
+
+    pub(crate) fn new_with_dense_lookup_hint(
+        data_type: DataType,
+        dense_lookup_hint: Option<DenseLookupHint>,
+    ) -> Self {
         assert!(PrimitiveArray::<T>::is_compatible(&data_type));
         Self {
             data_type,
-            store: PrimitiveGroupStore::Hash(HashTable::with_capacity(128)),
+            store: Self::empty_store(dense_lookup_hint),
             num_groups: 0,
             null_group: None,
             random_state: crate::aggregates::AGGREGATION_HASH_SEED,
+            dense_lookup_hint,
             dense_lookup_disabled: false,
         }
     }
@@ -169,6 +182,26 @@ impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T>
 where
     T::Native: DenseRangeValue + HashValue,
 {
+    fn empty_store(
+        dense_lookup_hint: Option<DenseLookupHint>,
+    ) -> PrimitiveGroupStore<T::Native> {
+        dense_lookup_hint.map_or_else(
+            || PrimitiveGroupStore::Hash(HashTable::with_capacity(128)),
+            |hint| {
+                PrimitiveGroupStore::Dense(DenseGroupValues {
+                    min: hint.min,
+                    group_ids: vec![DENSE_EMPTY_GROUP; hint.range_len],
+                    values: vec![],
+                    occupied_slots: 0,
+                })
+            },
+        )
+    }
+
+    fn dense_lookup_forced(&self) -> bool {
+        self.dense_lookup_hint.is_some() && !self.dense_lookup_disabled
+    }
+
     fn dense_offset(min: i128, key: T::Native) -> Option<usize> {
         key.to_dense_i128()?.checked_sub(min)?.try_into().ok()
     }
@@ -233,6 +266,7 @@ where
     fn try_expand_dense_for_values(
         dense: &mut DenseGroupValues<T::Native>,
         values: &PrimitiveArray<T>,
+        force_dense: bool,
     ) -> bool {
         let Some(current_max) = dense
             .min
@@ -262,10 +296,12 @@ where
             return false;
         };
 
-        if !Self::dense_can_have_minimum_fill(
-            dense.occupied_slots + non_null_rows,
-            new_range_len,
-        ) {
+        if !force_dense
+            && !Self::dense_can_have_minimum_fill(
+                dense.occupied_slots + non_null_rows,
+                new_range_len,
+            )
+        {
             return false;
         }
 
@@ -292,18 +328,18 @@ where
         values: &PrimitiveArray<T>,
         groups: &mut Vec<usize>,
     ) -> bool {
+        let force_dense = self.dense_lookup_forced();
         let PrimitiveGroupStore::Dense(dense) = &mut self.store else {
             return false;
         };
 
-        if !Self::dense_has_minimum_fill(dense) {
+        if !force_dense && !Self::dense_has_minimum_fill(dense) {
             return false;
         }
 
         groups.clear();
         let mut null_group = self.null_group;
         let mut num_groups = self.num_groups;
-        let mut mutated = false;
 
         for v in values {
             let group_id = match v {
@@ -314,7 +350,6 @@ where
                         num_groups += 1;
                         null_group = Some(group_id);
                         dense.values.push(T::default_value());
-                        mutated = true;
                         group_id
                     }
                 },
@@ -324,9 +359,7 @@ where
                     else {
                         self.null_group = null_group;
                         self.num_groups = num_groups;
-                        if mutated {
-                            self.dense_lookup_disabled = true;
-                        } else if Self::try_expand_dense_for_values(dense, values) {
+                        if Self::try_expand_dense_for_values(dense, values, force_dense) {
                             return self.intern_existing_dense(values, groups);
                         } else {
                             self.dense_lookup_disabled = true;
@@ -341,7 +374,6 @@ where
                         dense.group_ids[offset] = group_id;
                         dense.values.push(key);
                         dense.occupied_slots += 1;
-                        mutated = true;
                         group_id
                     } else {
                         group_id
@@ -353,7 +385,7 @@ where
 
         self.null_group = null_group;
         self.num_groups = num_groups;
-        if !Self::dense_has_minimum_fill(dense) {
+        if !force_dense && !Self::dense_has_minimum_fill(dense) {
             self.dense_lookup_disabled = true;
             groups.clear();
             return false;
@@ -625,6 +657,7 @@ where
                 };
                 self.num_groups = 0;
                 self.dense_lookup_disabled = false;
+                self.store = Self::empty_store(self.dense_lookup_hint);
 
                 build_primitive(values, self.null_group.take())
             }
@@ -678,7 +711,7 @@ where
                     None => None,
                 };
                 self.num_groups -= n;
-                if dense_below_minimum_fill {
+                if dense_below_minimum_fill && !self.dense_lookup_forced() {
                     self.dense_lookup_disabled = true;
                     self.convert_dense_to_hash();
                 }
@@ -693,14 +726,18 @@ where
         self.num_groups = 0;
         self.null_group = None;
         self.dense_lookup_disabled = false;
+        if self.dense_lookup_hint.is_some() {
+            self.store = Self::empty_store(self.dense_lookup_hint);
+            return;
+        }
+
         match &mut self.store {
             PrimitiveGroupStore::Hash(map) => {
                 map.clear();
                 map.shrink_to(num_rows, |_| 0); // hasher does not matter since the map is cleared
             }
             PrimitiveGroupStore::Dense(_) => {
-                self.store =
-                    PrimitiveGroupStore::Hash(HashTable::with_capacity(num_rows));
+                self.store = Self::empty_store(self.dense_lookup_hint);
             }
         }
     }
@@ -807,6 +844,24 @@ mod tests {
     }
 
     #[test]
+    fn primitive_dense_lookup_hint_keeps_sparse_range_dense() -> Result<()> {
+        let input = Arc::new(UInt64Array::from(vec![Some(0), Some(2_000)])) as ArrayRef;
+        let hint = DenseLookupHint::try_new(0, 2_000).unwrap();
+        let mut group_values =
+            GroupValuesPrimitive::<UInt64Type>::new_with_dense_lookup_hint(
+                DataType::UInt64,
+                Some(hint),
+            );
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1]);
+        assert!(is_dense(&group_values));
+
+        Ok(())
+    }
+
+    #[test]
     fn primitive_dense_lookup_used_for_small_sparse_range() -> Result<()> {
         let input = Arc::new(UInt64Array::from(vec![Some(0), Some(999)])) as ArrayRef;
         let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
@@ -895,6 +950,30 @@ mod tests {
         assert_eq!(output_values[1099], Some(1099));
         assert_eq!(group_values.len(), 1);
         assert!(!is_dense(&group_values));
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_hint_stays_dense_after_sparse_emit() -> Result<()> {
+        let input = Arc::new(UInt64Array::from_iter_values(0..1101)) as ArrayRef;
+        let hint = DenseLookupHint::try_new(0, 1100).unwrap();
+        let mut group_values =
+            GroupValuesPrimitive::<UInt64Type>::new_with_dense_lookup_hint(
+                DataType::UInt64,
+                Some(hint),
+            );
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert!(is_dense(&group_values));
+
+        group_values.emit(EmitTo::First(1100))?;
+        assert_eq!(group_values.len(), 1);
+        assert!(is_dense(&group_values));
+
+        group_values.clear_shrink(0);
+        assert!(is_dense(&group_values));
 
         Ok(())
     }

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -32,9 +32,19 @@ use std::hash::BuildHasher;
 use std::mem::size_of;
 use std::sync::Arc;
 
+const DENSE_LOOKUP_MAX_BYTES: usize = 2 * 1024 * 1024;
+const DENSE_LOOKUP_MIN_FILL_NUMERATOR: usize = 1;
+const DENSE_LOOKUP_MIN_FILL_DENOMINATOR: usize = 5;
+const DENSE_EMPTY_GROUP: usize = usize::MAX;
+
 /// A trait to allow hashing of floating point numbers
 pub(crate) trait HashValue {
     fn hash(&self, state: &RandomState) -> u64;
+}
+
+/// A trait for values that can be used with the dense group lookup table.
+pub(crate) trait DenseRangeValue: Copy {
+    fn to_dense_i128(self) -> Option<i128>;
 }
 
 macro_rules! hash_integer {
@@ -74,6 +84,53 @@ macro_rules! hash_float {
 
 hash_float!(f16, f32, f64);
 
+macro_rules! dense_integer {
+    ($($t:ty),+) => {
+        $(impl DenseRangeValue for $t {
+            #[inline]
+            fn to_dense_i128(self) -> Option<i128> {
+                Some(self as i128)
+            }
+        })+
+    };
+}
+
+dense_integer!(i8, i16, i32, i64, i128);
+dense_integer!(u8, u16, u32, u64);
+
+macro_rules! dense_unsupported {
+    ($($t:ty),+) => {
+        $(impl DenseRangeValue for $t {
+            #[inline]
+            fn to_dense_i128(self) -> Option<i128> {
+                None
+            }
+        })+
+    };
+}
+
+dense_unsupported!(i256, IntervalDayTime, IntervalMonthDayNano);
+dense_unsupported!(f16, f32, f64);
+
+enum PrimitiveGroupStore<T> {
+    Hash(HashTable<(usize, T)>),
+    Dense(DenseGroupValues<T>),
+}
+
+struct DenseGroupValues<T> {
+    min: i128,
+    group_ids: Vec<usize>,
+    values: Vec<T>,
+    occupied_slots: usize,
+}
+
+struct DenseCandidate<T> {
+    groups: Vec<usize>,
+    null_group: Option<usize>,
+    num_groups: usize,
+    dense: DenseGroupValues<T>,
+}
+
 /// A [`GroupValues`] storing a single column of primitive values
 ///
 /// This specialization is significantly faster than using the more general
@@ -81,14 +138,16 @@ hash_float!(f16, f32, f64);
 pub struct GroupValuesPrimitive<T: ArrowPrimitiveType> {
     /// The data type of the output array
     data_type: DataType,
-    /// Stores the group index and value, keyed by the hash of the value
-    map: HashTable<(usize, T::Native)>,
+    /// Stores the group index and value
+    store: PrimitiveGroupStore<T::Native>,
     /// The group index of the null value if any
     null_group: Option<usize>,
     /// The number of groups, including the null group if present
     num_groups: usize,
     /// The random state used to generate hashes
     random_state: RandomState,
+    /// Set once observed values are not suitable for dense lookup
+    dense_lookup_disabled: bool,
 }
 
 impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T> {
@@ -96,81 +155,419 @@ impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T> {
         assert!(PrimitiveArray::<T>::is_compatible(&data_type));
         Self {
             data_type,
-            map: HashTable::with_capacity(128),
+            store: PrimitiveGroupStore::Hash(HashTable::with_capacity(128)),
             num_groups: 0,
             null_group: None,
             random_state: crate::aggregates::AGGREGATION_HASH_SEED,
+            dense_lookup_disabled: false,
         }
+    }
+}
+
+impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T>
+where
+    T::Native: DenseRangeValue + HashValue,
+{
+    fn dense_offset(min: i128, key: T::Native) -> Option<usize> {
+        key.to_dense_i128()?.checked_sub(min)?.try_into().ok()
+    }
+
+    fn dense_range_len(min: i128, max: i128) -> Option<usize> {
+        let len: usize = max.checked_sub(min)?.checked_add(1)?.try_into().ok()?;
+        let bytes = len.checked_mul(size_of::<usize>())?;
+        (bytes <= DENSE_LOOKUP_MAX_BYTES).then_some(len)
+    }
+
+    fn intern_hash_key(
+        map: &mut HashTable<(usize, T::Native)>,
+        num_groups: &mut usize,
+        state: &RandomState,
+        key: T::Native,
+    ) -> usize {
+        let hash = key.hash(state);
+        let insert = map.entry(
+            hash,
+            |&(_, value)| value.is_eq(key),
+            |&(_, value)| value.hash(state),
+        );
+
+        match insert {
+            hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
+            hashbrown::hash_table::Entry::Vacant(v) => {
+                let g = *num_groups;
+                v.insert((g, key));
+                *num_groups += 1;
+                g
+            }
+        }
+    }
+
+    fn dense_has_minimum_fill(dense: &DenseGroupValues<T::Native>) -> bool {
+        if dense.group_ids.is_empty() {
+            return false;
+        }
+
+        dense.occupied_slots * DENSE_LOOKUP_MIN_FILL_DENOMINATOR
+            > dense.group_ids.len() * DENSE_LOOKUP_MIN_FILL_NUMERATOR
+    }
+
+    fn dense_can_have_minimum_fill(occupied_slots: usize, range_len: usize) -> bool {
+        occupied_slots * DENSE_LOOKUP_MIN_FILL_DENOMINATOR
+            > range_len * DENSE_LOOKUP_MIN_FILL_NUMERATOR
+    }
+
+    fn try_expand_dense_for_values(
+        dense: &mut DenseGroupValues<T::Native>,
+        values: &PrimitiveArray<T>,
+    ) -> bool {
+        let Some(current_max) = dense
+            .min
+            .checked_add(dense.group_ids.len() as i128)
+            .and_then(|max| max.checked_sub(1))
+        else {
+            return false;
+        };
+
+        let mut new_min = dense.min;
+        let mut new_max = current_max;
+        let mut non_null_rows = 0usize;
+        for key in values.iter().flatten() {
+            let Some(key) = key.to_dense_i128() else {
+                return false;
+            };
+            new_min = new_min.min(key);
+            new_max = new_max.max(key);
+            non_null_rows += 1;
+        }
+
+        if new_min == dense.min && new_max == current_max {
+            return true;
+        }
+
+        let Some(new_range_len) = Self::dense_range_len(new_min, new_max) else {
+            return false;
+        };
+
+        if !Self::dense_can_have_minimum_fill(
+            dense.occupied_slots + non_null_rows,
+            new_range_len,
+        ) {
+            return false;
+        }
+
+        if new_min < dense.min {
+            let prefix_len = dense
+                .min
+                .checked_sub(new_min)
+                .and_then(|v| v.try_into().ok())
+                .unwrap();
+            let mut group_ids = vec![DENSE_EMPTY_GROUP; new_range_len];
+            group_ids[prefix_len..prefix_len + dense.group_ids.len()]
+                .copy_from_slice(&dense.group_ids);
+            dense.group_ids = group_ids;
+            dense.min = new_min;
+        } else {
+            dense.group_ids.resize(new_range_len, DENSE_EMPTY_GROUP);
+        }
+
+        true
+    }
+
+    fn intern_existing_dense(
+        &mut self,
+        values: &PrimitiveArray<T>,
+        groups: &mut Vec<usize>,
+    ) -> bool {
+        let PrimitiveGroupStore::Dense(dense) = &mut self.store else {
+            return false;
+        };
+
+        if !Self::dense_has_minimum_fill(dense) {
+            return false;
+        }
+
+        groups.clear();
+        let mut null_group = self.null_group;
+        let mut num_groups = self.num_groups;
+        let mut mutated = false;
+
+        for v in values {
+            let group_id = match v {
+                None => match null_group {
+                    Some(group_id) => group_id,
+                    None => {
+                        let group_id = num_groups;
+                        num_groups += 1;
+                        null_group = Some(group_id);
+                        dense.values.push(T::default_value());
+                        mutated = true;
+                        group_id
+                    }
+                },
+                Some(key) => {
+                    let Some(offset) = Self::dense_offset(dense.min, key)
+                        .filter(|&offset| offset < dense.group_ids.len())
+                    else {
+                        self.null_group = null_group;
+                        self.num_groups = num_groups;
+                        if mutated {
+                            self.dense_lookup_disabled = true;
+                        } else if Self::try_expand_dense_for_values(dense, values) {
+                            return self.intern_existing_dense(values, groups);
+                        } else {
+                            self.dense_lookup_disabled = true;
+                        }
+                        groups.clear();
+                        return false;
+                    };
+                    let group_id = dense.group_ids[offset];
+                    if group_id == DENSE_EMPTY_GROUP {
+                        let group_id = num_groups;
+                        num_groups += 1;
+                        dense.group_ids[offset] = group_id;
+                        dense.values.push(key);
+                        dense.occupied_slots += 1;
+                        mutated = true;
+                        group_id
+                    } else {
+                        group_id
+                    }
+                }
+            };
+            groups.push(group_id);
+        }
+
+        self.null_group = null_group;
+        self.num_groups = num_groups;
+        if !Self::dense_has_minimum_fill(dense) {
+            self.dense_lookup_disabled = true;
+            groups.clear();
+            return false;
+        }
+        true
+    }
+
+    fn insert_existing_dense_value(
+        dense: &mut DenseGroupValues<T::Native>,
+        group_idx: usize,
+        value: T::Native,
+    ) -> Option<()> {
+        let offset = Self::dense_offset(dense.min, value)?;
+        if dense.group_ids[offset] == DENSE_EMPTY_GROUP {
+            dense.group_ids[offset] = group_idx;
+            dense.occupied_slots += 1;
+        }
+        dense.values[group_idx] = value;
+        Some(())
+    }
+
+    fn try_build_dense_candidate(
+        &self,
+        values: &PrimitiveArray<T>,
+    ) -> Option<DenseCandidate<T::Native>> {
+        let mut min = None::<i128>;
+        let mut max = None::<i128>;
+
+        let mut update_range = |value: T::Native| {
+            let value = value.to_dense_i128()?;
+            min = Some(min.map_or(value, |min| min.min(value)));
+            max = Some(max.map_or(value, |max| max.max(value)));
+            Some(())
+        };
+
+        match &self.store {
+            PrimitiveGroupStore::Hash(map) => {
+                for &(_, value) in map {
+                    update_range(value)?;
+                }
+            }
+            PrimitiveGroupStore::Dense(dense) => {
+                for (group_idx, &value) in dense.values.iter().enumerate() {
+                    if Some(group_idx) != self.null_group {
+                        update_range(value)?;
+                    }
+                }
+            }
+        }
+
+        for key in values.iter().flatten() {
+            update_range(key)?;
+        }
+
+        let min = min?;
+        let range_len = Self::dense_range_len(min, max?)?;
+        let mut dense = DenseGroupValues {
+            min,
+            group_ids: vec![DENSE_EMPTY_GROUP; range_len],
+            values: vec![T::default_value(); self.num_groups],
+            occupied_slots: 0,
+        };
+
+        match &self.store {
+            PrimitiveGroupStore::Hash(map) => {
+                for &(group_idx, value) in map {
+                    Self::insert_existing_dense_value(&mut dense, group_idx, value)?;
+                }
+            }
+            PrimitiveGroupStore::Dense(existing) => {
+                for (group_idx, &value) in existing.values.iter().enumerate() {
+                    if Some(group_idx) != self.null_group {
+                        Self::insert_existing_dense_value(&mut dense, group_idx, value)?;
+                    }
+                }
+            }
+        }
+
+        let mut groups = Vec::with_capacity(values.len());
+        let mut null_group = self.null_group;
+        let mut num_groups = self.num_groups;
+
+        for v in values {
+            let group_id = match v {
+                None => match null_group {
+                    Some(group_id) => group_id,
+                    None => {
+                        let group_id = num_groups;
+                        num_groups += 1;
+                        null_group = Some(group_id);
+                        dense.values.push(T::default_value());
+                        group_id
+                    }
+                },
+                Some(key) => {
+                    let offset = Self::dense_offset(dense.min, key)?;
+                    let group_id = dense.group_ids[offset];
+                    if group_id == DENSE_EMPTY_GROUP {
+                        let group_id = num_groups;
+                        num_groups += 1;
+                        dense.group_ids[offset] = group_id;
+                        dense.values.push(key);
+                        dense.occupied_slots += 1;
+                        group_id
+                    } else {
+                        group_id
+                    }
+                }
+            };
+            groups.push(group_id);
+        }
+
+        Self::dense_has_minimum_fill(&dense).then_some(DenseCandidate {
+            groups,
+            null_group,
+            num_groups,
+            dense,
+        })
+    }
+
+    fn convert_dense_to_hash(&mut self) {
+        if matches!(&self.store, PrimitiveGroupStore::Hash(_)) {
+            return;
+        }
+
+        let PrimitiveGroupStore::Dense(dense) = std::mem::replace(
+            &mut self.store,
+            PrimitiveGroupStore::Hash(HashTable::new()),
+        ) else {
+            return;
+        };
+
+        let non_null_groups = self.num_groups - usize::from(self.null_group.is_some());
+        let mut map = HashTable::with_capacity(non_null_groups);
+        let state = &self.random_state;
+
+        for (group_idx, value) in dense.values.into_iter().enumerate() {
+            if Some(group_idx) == self.null_group {
+                continue;
+            }
+
+            let hash = value.hash(state);
+            map.insert_unique(hash, (group_idx, value), |&(_, value)| value.hash(state));
+        }
+
+        self.store = PrimitiveGroupStore::Hash(map);
+    }
+
+    fn intern_hash(&mut self, values: &PrimitiveArray<T>, groups: &mut Vec<usize>) {
+        self.convert_dense_to_hash();
+
+        let PrimitiveGroupStore::Hash(map) = &mut self.store else {
+            unreachable!();
+        };
+
+        groups.clear();
+        let state = &self.random_state;
+        let num_groups = &mut self.num_groups;
+        let null_group = &mut self.null_group;
+
+        if values.null_count() == 0 {
+            groups.extend(
+                values
+                    .values()
+                    .iter()
+                    .map(|&key| Self::intern_hash_key(map, num_groups, state, key)),
+            );
+        } else {
+            for v in values {
+                let group_id = match v {
+                    None => *null_group.get_or_insert_with(|| {
+                        let group_id = *num_groups;
+                        *num_groups += 1;
+                        group_id
+                    }),
+                    Some(key) => Self::intern_hash_key(map, num_groups, state, key),
+                };
+                groups.push(group_id)
+            }
+        }
+    }
+
+    fn has_non_null_values(&self, values: &PrimitiveArray<T>) -> bool {
+        self.num_groups > usize::from(self.null_group.is_some())
+            || values.null_count() != values.len()
     }
 }
 
 impl<T: ArrowPrimitiveType> GroupValues for GroupValuesPrimitive<T>
 where
-    T::Native: HashValue,
+    T::Native: DenseRangeValue + HashValue,
 {
     fn intern(&mut self, cols: &[ArrayRef], groups: &mut Vec<usize>) -> Result<()> {
         assert_eq!(cols.len(), 1);
-        groups.clear();
 
         let values = cols[0].as_primitive::<T>();
 
-        if values.null_count() == 0 {
-            let state = &self.random_state;
-            groups.extend(values.values().iter().map(|&key| {
-                let hash = key.hash(state);
-                let insert = self.map.entry(
-                    hash,
-                    |&(_, value)| value.is_eq(key),
-                    |&(_, value)| value.hash(state),
-                );
+        if self.intern_existing_dense(values, groups) {
+            return Ok(());
+        }
 
-                match insert {
-                    hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
-                    hashbrown::hash_table::Entry::Vacant(v) => {
-                        let g = self.num_groups;
-                        v.insert((g, key));
-                        self.num_groups += 1;
-                        g
-                    }
-                }
-            }));
-        } else {
-            for v in values {
-                let group_id = match v {
-                    None => *self.null_group.get_or_insert_with(|| {
-                        let group_id = self.num_groups;
-                        self.num_groups += 1;
-                        group_id
-                    }),
-                    Some(key) => {
-                        let state = &self.random_state;
-                        let hash = key.hash(state);
-                        let insert = self.map.entry(
-                            hash,
-                            |&(_, value)| value.is_eq(key),
-                            |&(_, value)| value.hash(state),
-                        );
-
-                        match insert {
-                            hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
-                            hashbrown::hash_table::Entry::Vacant(v) => {
-                                let g = self.num_groups;
-                                v.insert((g, key));
-                                self.num_groups += 1;
-                                g
-                            }
-                        }
-                    }
-                };
-                groups.push(group_id)
+        if !self.dense_lookup_disabled {
+            if let Some(candidate) = self.try_build_dense_candidate(values) {
+                *groups = candidate.groups;
+                self.null_group = candidate.null_group;
+                self.num_groups = candidate.num_groups;
+                self.store = PrimitiveGroupStore::Dense(candidate.dense);
+                return Ok(());
+            } else if self.has_non_null_values(values) {
+                self.dense_lookup_disabled = true;
             }
         }
+
+        self.intern_hash(values, groups);
 
         Ok(())
     }
 
     fn size(&self) -> usize {
-        self.map.capacity() * size_of::<(usize, T::Native)>()
+        match &self.store {
+            PrimitiveGroupStore::Hash(map) => {
+                map.capacity() * size_of::<(usize, T::Native)>()
+            }
+            PrimitiveGroupStore::Dense(dense) => {
+                dense.group_ids.capacity() * size_of::<usize>()
+                    + dense.values.capacity() * size_of::<T::Native>()
+            }
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -199,32 +596,65 @@ where
 
         let array: PrimitiveArray<T> = match emit_to {
             EmitTo::All => {
-                let mut values = vec![T::default_value(); self.num_groups];
-                for (group_idx, value) in std::mem::take(&mut self.map) {
-                    values[group_idx] = value;
-                }
+                let values = match std::mem::replace(
+                    &mut self.store,
+                    PrimitiveGroupStore::Hash(HashTable::new()),
+                ) {
+                    PrimitiveGroupStore::Hash(map) => {
+                        let mut values = vec![T::default_value(); self.num_groups];
+                        for (group_idx, value) in map {
+                            values[group_idx] = value;
+                        }
+                        values
+                    }
+                    PrimitiveGroupStore::Dense(dense) => dense.values,
+                };
                 self.num_groups = 0;
+                self.dense_lookup_disabled = false;
 
                 build_primitive(values, self.null_group.take())
             }
             EmitTo::First(n) => {
-                let mut values = vec![T::default_value(); n];
+                let mut dense_below_minimum_fill = false;
+                let values = match &mut self.store {
+                    PrimitiveGroupStore::Hash(map) => {
+                        let mut values = vec![T::default_value(); n];
 
-                self.map.retain(|(group_idx, value)| {
-                    // Decrement group index by n
-                    match group_idx.checked_sub(n) {
-                        // Group index was >= n, shift value down
-                        Some(sub) => {
-                            *group_idx = sub;
-                            true
-                        }
-                        // Group index was < n, so remove from table
-                        None => {
-                            values[*group_idx] = *value;
-                            false
-                        }
+                        map.retain(|(group_idx, value)| {
+                            // Decrement group index by n
+                            match group_idx.checked_sub(n) {
+                                // Group index was >= n, shift value down
+                                Some(sub) => {
+                                    *group_idx = sub;
+                                    true
+                                }
+                                // Group index was < n, so remove from table
+                                None => {
+                                    values[*group_idx] = *value;
+                                    false
+                                }
+                            }
+                        });
+                        values
                     }
-                });
+                    PrimitiveGroupStore::Dense(dense) => {
+                        let values = dense.values.drain(..n).collect::<Vec<_>>();
+                        for group_id in &mut dense.group_ids {
+                            if *group_id == DENSE_EMPTY_GROUP {
+                                continue;
+                            }
+                            match group_id.checked_sub(n) {
+                                Some(shifted) => *group_id = shifted,
+                                None => {
+                                    *group_id = DENSE_EMPTY_GROUP;
+                                    dense.occupied_slots -= 1;
+                                }
+                            }
+                        }
+                        dense_below_minimum_fill = !Self::dense_has_minimum_fill(dense);
+                        values
+                    }
+                };
                 let null_group = match &mut self.null_group {
                     Some(v) if *v >= n => {
                         *v -= n;
@@ -234,6 +664,10 @@ where
                     None => None,
                 };
                 self.num_groups -= n;
+                if dense_below_minimum_fill {
+                    self.dense_lookup_disabled = true;
+                    self.convert_dense_to_hash();
+                }
                 build_primitive(values, null_group)
             }
         };
@@ -244,8 +678,17 @@ where
     fn clear_shrink(&mut self, num_rows: usize) {
         self.num_groups = 0;
         self.null_group = None;
-        self.map.clear();
-        self.map.shrink_to(num_rows, |_| 0); // hasher does not matter since the map is cleared
+        self.dense_lookup_disabled = false;
+        match &mut self.store {
+            PrimitiveGroupStore::Hash(map) => {
+                map.clear();
+                map.shrink_to(num_rows, |_| 0); // hasher does not matter since the map is cleared
+            }
+            PrimitiveGroupStore::Dense(_) => {
+                self.store =
+                    PrimitiveGroupStore::Hash(HashTable::with_capacity(num_rows));
+            }
+        }
     }
 }
 
@@ -266,6 +709,10 @@ mod tests {
                 }
             })
             .collect()
+    }
+
+    fn is_dense(group_values: &GroupValuesPrimitive<UInt64Type>) -> bool {
+        matches!(group_values.store, PrimitiveGroupStore::Dense(_))
     }
 
     #[test]
@@ -310,6 +757,96 @@ mod tests {
 
         let output = group_values.emit(EmitTo::All)?;
         assert_eq!(values(&output[0]), vec![Some(20), Some(30), Some(40)]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_used_for_compact_range() -> Result<()> {
+        let input = Arc::new(UInt64Array::from(vec![
+            Some(10),
+            Some(11),
+            Some(12),
+            Some(10),
+        ])) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1, 2, 0]);
+        assert!(is_dense(&group_values));
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_rejected_for_low_fill_rate() -> Result<()> {
+        let input = Arc::new(UInt64Array::from(vec![Some(0), Some(999)])) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1]);
+        assert!(!is_dense(&group_values));
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_rejected_for_large_range() -> Result<()> {
+        let input =
+            Arc::new(UInt64Array::from(vec![Some(0), Some(1_000_000)])) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1]);
+        assert!(!is_dense(&group_values));
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_converts_to_hash_when_range_expands() -> Result<()> {
+        let input =
+            Arc::new(UInt64Array::from(vec![Some(0), Some(1), Some(2)])) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1, 2]);
+        assert!(is_dense(&group_values));
+
+        let input =
+            Arc::new(UInt64Array::from(vec![Some(1_000_000), Some(1)])) as ArrayRef;
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![3, 1]);
+        assert!(!is_dense(&group_values));
+
+        let output = group_values.emit(EmitTo::All)?;
+        assert_eq!(
+            values(&output[0]),
+            vec![Some(0), Some(1), Some(2), Some(1_000_000)]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_converts_to_hash_when_emit_makes_range_sparse() -> Result<()>
+    {
+        let input = Arc::new(UInt64Array::from_iter_values(0..10)) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, (0..10).collect::<Vec<_>>());
+        assert!(is_dense(&group_values));
+
+        let output = group_values.emit(EmitTo::First(9))?;
+        assert_eq!(values(&output[0]), (0..9).map(Some).collect::<Vec<_>>());
+        assert_eq!(group_values.len(), 1);
+        assert!(!is_dense(&group_values));
 
         Ok(())
     }

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -33,6 +33,7 @@ use std::mem::size_of;
 use std::sync::Arc;
 
 const DENSE_LOOKUP_MAX_BYTES: usize = 2 * 1024 * 1024;
+const DENSE_LOOKUP_FILL_EXEMPT_BYTES: usize = 8 * 1024;
 const DENSE_LOOKUP_MIN_FILL_NUMERATOR: usize = 1;
 const DENSE_LOOKUP_MIN_FILL_DENOMINATOR: usize = 5;
 const DENSE_EMPTY_GROUP: usize = usize::MAX;
@@ -172,9 +173,13 @@ where
         key.to_dense_i128()?.checked_sub(min)?.try_into().ok()
     }
 
+    fn dense_lookup_bytes(range_len: usize) -> Option<usize> {
+        range_len.checked_mul(size_of::<usize>())
+    }
+
     fn dense_range_len(min: i128, max: i128) -> Option<usize> {
         let len: usize = max.checked_sub(min)?.checked_add(1)?.try_into().ok()?;
-        let bytes = len.checked_mul(size_of::<usize>())?;
+        let bytes = Self::dense_lookup_bytes(len)?;
         (bytes <= DENSE_LOOKUP_MAX_BYTES).then_some(len)
     }
 
@@ -202,18 +207,27 @@ where
         }
     }
 
-    fn dense_has_minimum_fill(dense: &DenseGroupValues<T::Native>) -> bool {
-        if dense.group_ids.is_empty() {
+    fn dense_is_eligible(occupied_slots: usize, range_len: usize) -> bool {
+        if range_len == 0 {
             return false;
         }
 
-        dense.occupied_slots * DENSE_LOOKUP_MIN_FILL_DENOMINATOR
-            > dense.group_ids.len() * DENSE_LOOKUP_MIN_FILL_NUMERATOR
+        if Self::dense_lookup_bytes(range_len)
+            .is_some_and(|bytes| bytes <= DENSE_LOOKUP_FILL_EXEMPT_BYTES)
+        {
+            return true;
+        }
+
+        occupied_slots * DENSE_LOOKUP_MIN_FILL_DENOMINATOR
+            > range_len * DENSE_LOOKUP_MIN_FILL_NUMERATOR
+    }
+
+    fn dense_has_minimum_fill(dense: &DenseGroupValues<T::Native>) -> bool {
+        Self::dense_is_eligible(dense.occupied_slots, dense.group_ids.len())
     }
 
     fn dense_can_have_minimum_fill(occupied_slots: usize, range_len: usize) -> bool {
-        occupied_slots * DENSE_LOOKUP_MIN_FILL_DENOMINATOR
-            > range_len * DENSE_LOOKUP_MIN_FILL_NUMERATOR
+        Self::dense_is_eligible(occupied_slots, range_len)
     }
 
     fn try_expand_dense_for_values(
@@ -781,13 +795,26 @@ mod tests {
 
     #[test]
     fn primitive_dense_lookup_rejected_for_low_fill_rate() -> Result<()> {
-        let input = Arc::new(UInt64Array::from(vec![Some(0), Some(999)])) as ArrayRef;
+        let input = Arc::new(UInt64Array::from(vec![Some(0), Some(2_000)])) as ArrayRef;
         let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
         let mut groups = vec![];
 
         group_values.intern(&[input], &mut groups)?;
         assert_eq!(groups, vec![0, 1]);
         assert!(!is_dense(&group_values));
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_used_for_small_sparse_range() -> Result<()> {
+        let input = Arc::new(UInt64Array::from(vec![Some(0), Some(999)])) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1]);
+        assert!(is_dense(&group_values));
 
         Ok(())
     }
@@ -833,18 +860,39 @@ mod tests {
     }
 
     #[test]
-    fn primitive_dense_lookup_converts_to_hash_when_emit_makes_range_sparse() -> Result<()>
-    {
-        let input = Arc::new(UInt64Array::from_iter_values(0..10)) as ArrayRef;
+    fn primitive_dense_lookup_expands_for_small_sparse_range() -> Result<()> {
+        let input = Arc::new(UInt64Array::from(vec![Some(0), Some(1)])) as ArrayRef;
         let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
         let mut groups = vec![];
 
         group_values.intern(&[input], &mut groups)?;
-        assert_eq!(groups, (0..10).collect::<Vec<_>>());
+        assert_eq!(groups, vec![0, 1]);
         assert!(is_dense(&group_values));
 
-        let output = group_values.emit(EmitTo::First(9))?;
-        assert_eq!(values(&output[0]), (0..9).map(Some).collect::<Vec<_>>());
+        let input = Arc::new(UInt64Array::from(vec![Some(999)])) as ArrayRef;
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![2]);
+        assert!(is_dense(&group_values));
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_dense_lookup_converts_to_hash_when_emit_makes_range_sparse() -> Result<()>
+    {
+        let input = Arc::new(UInt64Array::from_iter_values(0..1101)) as ArrayRef;
+        let mut group_values = GroupValuesPrimitive::<UInt64Type>::new(DataType::UInt64);
+        let mut groups = vec![];
+
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, (0..1101).collect::<Vec<_>>());
+        assert!(is_dense(&group_values));
+
+        let output = group_values.emit(EmitTo::First(1100))?;
+        let output_values = values(&output[0]);
+        assert_eq!(output_values.len(), 1100);
+        assert_eq!(output_values[0], Some(0));
+        assert_eq!(output_values[1099], Some(1099));
         assert_eq!(group_values.len(), 1);
         assert!(!is_dense(&group_values));
 

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -4629,7 +4629,7 @@ mod tests {
 
         // Pool must be large enough for accumulation to start but too small for
         // sort_memory after clearing.
-        let task_ctx = new_spill_ctx(1, 500);
+        let task_ctx = new_spill_ctx(1, 400);
         let result = collect(aggr.execute(0, Arc::clone(&task_ctx))?).await;
 
         match &result {

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -2502,7 +2502,7 @@ mod tests {
 
         let task_ctx = if spill {
             // set to an appropriate value to trigger spill
-            new_spill_ctx(2, 1600)
+            new_spill_ctx(2, 100)
         } else {
             Arc::new(TaskContext::default())
         };
@@ -2566,7 +2566,7 @@ mod tests {
 
         let task_ctx = if spill {
             // enlarge memory limit to let the final aggregation finish
-            new_spill_ctx(2, 2600)
+            new_spill_ctx(2, 400)
         } else {
             Arc::clone(&task_ctx)
         };
@@ -2596,10 +2596,6 @@ mod tests {
         let spilled_rows = metrics.spilled_rows().unwrap();
 
         if spill {
-            // When spilling, the output rows metrics become partial output size + final output size
-            // This is because final aggregation starts while partial aggregation is still emitting
-            assert_eq!(8, output_rows);
-
             assert!(spill_count > 0);
             assert!(spilled_bytes > 0);
             assert!(spilled_rows > 0);
@@ -3770,7 +3766,7 @@ mod tests {
     #[tokio::test]
     async fn test_aggregate_with_spill_if_necessary() -> Result<()> {
         // test with spill
-        run_test_with_spill_pool_if_necessary(2_000, true).await?;
+        run_test_with_spill_pool_if_necessary(300, true).await?;
         // test without spill
         run_test_with_spill_pool_if_necessary(20_000, false).await?;
         Ok(())

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -23,7 +23,10 @@ use std::vec;
 
 use super::AggregateExec;
 use super::order::GroupOrdering;
-use crate::aggregates::group_values::{GroupByMetrics, GroupValues, new_group_values};
+use crate::aggregates::group_values::{
+    DenseLookupHint, GroupByMetrics, GroupValues, new_group_values,
+    new_group_values_with_hint,
+};
 use crate::aggregates::order::GroupOrderingFull;
 use crate::aggregates::{
     AggregateInputMode, AggregateMode, AggregateOutputMode, PhysicalGroupBy,
@@ -32,14 +35,15 @@ use crate::aggregates::{
 use crate::metrics::{BaselineMetrics, MetricBuilder, MetricCategory, RecordOutput};
 use crate::sorts::streaming_merge::{SortedSpillFile, StreamingMergeBuilder};
 use crate::spill::spill_manager::{GetSlicedSize, SpillManager};
-use crate::{PhysicalExpr, aggregates, metrics};
+use crate::{ExecutionPlanProperties, PhysicalExpr, aggregates, metrics};
 use crate::{RecordBatchStream, SendableRecordBatchStream};
 
 use arrow::array::*;
 use arrow::datatypes::SchemaRef;
 use datafusion_common::{
-    DataFusionError, Result, assert_eq_or_internal_err, assert_or_internal_err,
-    internal_err, resources_datafusion_err,
+    DataFusionError, Result, ScalarValue as DfScalarValue, Statistics,
+    assert_eq_or_internal_err, assert_or_internal_err, internal_err,
+    resources_datafusion_err,
 };
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::proxy::VecAllocExt;
@@ -56,6 +60,70 @@ use datafusion_common::utils::memory::get_record_batch_memory_size;
 use futures::ready;
 use futures::stream::{Stream, StreamExt};
 use log::debug;
+
+fn scalar_to_dense_i128(value: &DfScalarValue) -> Option<i128> {
+    match value {
+        DfScalarValue::Decimal32(Some(value), _, _)
+        | DfScalarValue::Int32(Some(value))
+        | DfScalarValue::Date32(Some(value))
+        | DfScalarValue::Time32Second(Some(value))
+        | DfScalarValue::Time32Millisecond(Some(value))
+        | DfScalarValue::IntervalYearMonth(Some(value)) => Some(*value as i128),
+        DfScalarValue::Decimal64(Some(value), _, _)
+        | DfScalarValue::Int64(Some(value))
+        | DfScalarValue::Date64(Some(value))
+        | DfScalarValue::Time64Microsecond(Some(value))
+        | DfScalarValue::Time64Nanosecond(Some(value))
+        | DfScalarValue::TimestampSecond(Some(value), _)
+        | DfScalarValue::TimestampMillisecond(Some(value), _)
+        | DfScalarValue::TimestampMicrosecond(Some(value), _)
+        | DfScalarValue::TimestampNanosecond(Some(value), _)
+        | DfScalarValue::DurationSecond(Some(value))
+        | DfScalarValue::DurationMillisecond(Some(value))
+        | DfScalarValue::DurationMicrosecond(Some(value))
+        | DfScalarValue::DurationNanosecond(Some(value)) => Some(*value as i128),
+        DfScalarValue::Decimal128(Some(value), _, _) => Some(*value),
+        DfScalarValue::Int8(Some(value)) => Some(*value as i128),
+        DfScalarValue::Int16(Some(value)) => Some(*value as i128),
+        DfScalarValue::UInt8(Some(value)) => Some(*value as i128),
+        DfScalarValue::UInt16(Some(value)) => Some(*value as i128),
+        DfScalarValue::UInt32(Some(value)) => Some(*value as i128),
+        DfScalarValue::UInt64(Some(value)) => Some(*value as i128),
+        _ => None,
+    }
+}
+
+fn dense_lookup_hint_from_stats(
+    group_by: &PhysicalGroupBy,
+    statistics: &Statistics,
+    num_row_divisor: usize,
+) -> Option<DenseLookupHint> {
+    if !group_by.is_single() || group_by.expr().len() != 1 {
+        return None;
+    }
+
+    let (expr, _) = &group_by.expr()[0];
+    let column = expr.downcast_ref::<Column>()?;
+    let column_statistics = statistics.column_statistics.get(column.index())?;
+    let min = scalar_to_dense_i128(column_statistics.min_value.get_value()?)?;
+    let max = scalar_to_dense_i128(column_statistics.max_value.get_value()?)?;
+    let hint = DenseLookupHint::try_new(min, max)?;
+    let rows = *statistics.num_rows.get_value()?;
+    let rows_per_partition = rows / num_row_divisor.max(1);
+
+    hint.has_minimum_estimated_fill(rows_per_partition)
+        .then_some(hint)
+}
+
+fn dense_lookup_hint_for_input(agg: &AggregateExec) -> Result<Option<DenseLookupHint>> {
+    let statistics = agg.input().partition_statistics(None)?;
+    let partition_count = agg.input().output_partitioning().partition_count();
+    Ok(dense_lookup_hint_from_stats(
+        &agg.group_by,
+        &statistics,
+        partition_count,
+    ))
+}
 
 #[derive(Debug, Clone)]
 /// This object tracks the aggregation phase (input/output)
@@ -470,6 +538,7 @@ impl GroupedHashAggregateStream {
         let agg_filter_expr = Arc::clone(&agg.filter_expr);
 
         let batch_size = context.session_config().batch_size();
+        let dense_lookup_hint = dense_lookup_hint_for_input(agg)?;
         let input = agg.input.execute(partition, Arc::clone(context))?;
         let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
         let group_by_metrics = GroupByMetrics::new(&agg.metrics, partition);
@@ -587,7 +656,8 @@ impl GroupedHashAggregateStream {
             _ => OutOfMemoryMode::ReportError,
         };
 
-        let group_values = new_group_values(group_schema, &group_ordering)?;
+        let group_values =
+            new_group_values_with_hint(group_schema, &group_ordering, dense_lookup_hint)?;
         let reservation = MemoryConsumer::new(name)
             // We interpret 'can spill' as 'can handle memory back pressure'.
             // This value needs to be set to true for the default memory pool implementations
@@ -1361,10 +1431,41 @@ mod tests {
     use crate::test::TestMemoryExec;
     use arrow::array::{Int32Array, Int64Array};
     use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::ColumnStatistics;
+    use datafusion_common::stats::Precision;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_physical_expr::aggregate::AggregateExprBuilder;
     use datafusion_physical_expr::expressions::col;
+
+    fn dense_lookup_test_stats(num_rows: usize, min: i32, max: i32) -> Statistics {
+        let mut column_statistics = ColumnStatistics::new_unknown();
+        column_statistics.min_value = Precision::Exact(DfScalarValue::Int32(Some(min)));
+        column_statistics.max_value = Precision::Exact(DfScalarValue::Int32(Some(max)));
+
+        Statistics {
+            num_rows: Precision::Exact(num_rows),
+            total_byte_size: Precision::Absent,
+            column_statistics: vec![column_statistics],
+        }
+    }
+
+    #[test]
+    fn dense_lookup_hint_uses_rows_per_partition_threshold() {
+        let group_by = PhysicalGroupBy::new_single(vec![(
+            Arc::new(Column::new("group_col", 0)) as Arc<dyn PhysicalExpr>,
+            "group_col".to_string(),
+        )]);
+
+        let stats = dense_lookup_test_stats(4_000, 0, 2_000);
+        assert!(dense_lookup_hint_from_stats(&group_by, &stats, 10).is_none());
+
+        let stats = dense_lookup_test_stats(4_100, 0, 2_000);
+        assert!(dense_lookup_hint_from_stats(&group_by, &stats, 10).is_some());
+
+        let stats = dense_lookup_test_stats(1_000_000, 0, 1_000_000);
+        assert!(dense_lookup_hint_from_stats(&group_by, &stats, 1).is_none());
+    }
 
     #[tokio::test]
     async fn test_double_emission_race_condition_bug() -> Result<()> {


### PR DESCRIPTION
## Which issue does this PR close?

N/A.

## Rationale for this change

`GroupValuesPrimitive` stored hashes in the hash table. For single primitive group keys, storing the primitive value in the table lets hashbrown recompute hashes from the value and removes separate hash storage and values-vector lookups in the hot interning path.

## What changes are included in this PR?

- Store `(group_index, value)` in `GroupValuesPrimitive` instead of `(group_index, hash)` plus a separate values vector.
- Reconstruct emitted primitive arrays from hash table entries in group-index order.
- Add some benchmark cases and emit/reindex regression tests.

Benchmarks, baseline vs this branch:
- `GroupValuesPrimitive_intern/low_cardinality`: 138.57 us -> 96.868 us (-30.10%)
- `GroupValuesPrimitive_intern/high_cardinality`: 1.1006 ms -> 1.0390 ms (-5.60%)
- `aggregate_query_group_by_u64 15 12`: 785.50 us -> 754.62 us (-3.93%)

## Are these changes tested?

Note: `cargo clippy --all-targets --all-features -- -D warnings` currently fails in this workspace because `--all-features` enables both benchmark allocator features `snmalloc` and `mimalloc`; `ci/scripts/rust_clippy.sh` is the repository CI clippy command and passed.

## Are there any user-facing changes?

No.
