### PR TITLE
perf: Optimize `lower`, `upper` for ASCII inputs

### DIFF
--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -461,10 +461,11 @@ fn case_conversion_utf8view_ascii(
     }
 }
 
-/// Walks the views once: inline rows (length ≤ 12) convert their inline bytes
-/// in place; long rows copy their referenced bytes into a single packed output
-/// buffer while converting, then rewrite the view (`buffer_index = 0`, new
-/// offset, new 4-byte prefix) to point at it.
+/// Walks the views once and produces a new `StringViewArray` with
+/// case-converted bytes. Inline strings (<= 12 bytes) are converted in-place;
+/// long strings copy-and-convert into output buffers and have their view fields
+/// rewritten to address the new bytes. ASCII case conversion preserves is byte
+/// length, so no row migrates between the inline and long layouts.
 fn case_conversion_utf8view_ascii_inner<F: Fn(&u8) -> u8>(
     array: &StringViewArray,
     convert: F,
@@ -475,16 +476,22 @@ fn case_conversion_utf8view_ascii_inner<F: Fn(&u8) -> u8>(
     let nulls = array.nulls();
 
     let mut new_views: Vec<u128> = Vec::with_capacity(item_len);
+    // Long values are packed into `in_progress`; when full it is sealed into
+    // `completed` and a new, larger block is started — same block-doubling
+    // scheme as Arrow's `GenericByteViewBuilder`.
     let mut in_progress: Vec<u8> = Vec::new();
     let mut completed: Vec<Buffer> = Vec::new();
     let mut block_size: u32 = STRING_VIEW_INIT_BLOCK_SIZE;
 
     for i in 0..item_len {
         if nulls.is_some_and(|n| n.is_null(i)) {
+            // Zero view = empty, no buffer reference; the null buffer is what
+            // marks the row null, so the view's value is irrelevant.
             new_views.push(0);
             continue;
         }
         let view = views[i];
+        // Length is the low 32 bits; `as u32` discards the rest of the view.
         let len = view as u32 as usize;
         if len == 0 {
             new_views.push(0);
@@ -492,14 +499,18 @@ fn case_conversion_utf8view_ascii_inner<F: Fn(&u8) -> u8>(
         }
         let mut bytes = view.to_le_bytes();
         if len <= 12 {
-            // Inline row: convert the inline data bytes; layout unchanged.
+            // Inline: value is in bytes[4..4+len], no buffer reference. Convert
+            // in place; nothing else in the view needs to change.
             for b in &mut bytes[4..4 + len] {
                 *b = convert(b);
             }
             new_views.push(u128::from_le_bytes(bytes));
         } else {
-            // Make sure the current data block has room for this value;
-            // otherwise flush and start a new, larger block.
+            // Long: input view points into shared `data_buffers` we can't
+            // mutate, so copy-convert into our own buffer and rewrite the
+            // view's prefix/buffer_index/offset (length is preserved).
+
+            // Ensure the current block has room; otherwise flush and grow.
             let required_cap = in_progress.len() + len;
             if in_progress.capacity() < required_cap {
                 if !in_progress.is_empty() {
@@ -512,12 +523,16 @@ fn case_conversion_utf8view_ascii_inner<F: Fn(&u8) -> u8>(
                 in_progress.reserve(to_reserve);
             }
 
+            // The in-progress block will be sealed at index `completed.len()`,
+            // and our value starts at the current write position within it.
             let buffer_index: u32 = i32::try_from(completed.len())
                 .expect("buffer count exceeds i32::MAX")
                 as u32;
             let new_offset: u32 =
                 i32::try_from(in_progress.len()).expect("offset exceeds i32::MAX") as u32;
 
+            // Source location from the input view: bytes 8..12 are buffer
+            // index, bytes 12..16 are the offset within it.
             let src_buffer_index =
                 u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
             let src_offset =
@@ -528,7 +543,9 @@ fn case_conversion_utf8view_ascii_inner<F: Fn(&u8) -> u8>(
             let prefix_start = in_progress.len();
             in_progress.extend(src.iter().map(&convert));
 
-            // Prefix is the first 4 bytes of the converted data we just wrote.
+            // Rewrite the three long-view fields; bytes[0..4] (length) is
+            // left untouched. The prefix is read back from the bytes we just
+            // wrote so the converted value has a single source of truth.
             let prefix: [u8; 4] = in_progress[prefix_start..prefix_start + 4]
                 .try_into()
                 .unwrap();

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -19,7 +19,10 @@
 
 use std::sync::Arc;
 
-use crate::strings::{GenericStringArrayBuilder, StringViewArrayBuilder, append_view};
+use crate::strings::{
+    GenericStringArrayBuilder, STRING_VIEW_INIT_BLOCK_SIZE, STRING_VIEW_MAX_BLOCK_SIZE,
+    StringViewArrayBuilder, append_view,
+};
 use arrow::array::{
     Array, ArrayRef, GenericStringArray, NullBufferBuilder, OffsetSizeTrait,
     StringViewArray, new_null_array,
@@ -323,32 +326,42 @@ fn string_trim<T: OffsetSizeTrait, Tr: Trimmer>(args: &[ArrayRef]) -> Result<Arr
 }
 
 pub(crate) fn to_lower(args: &[ColumnarValue], name: &str) -> Result<ColumnarValue> {
-    case_conversion(args, |string| string.to_lowercase(), name)
+    case_conversion(args, true, name)
 }
 
 pub(crate) fn to_upper(args: &[ColumnarValue], name: &str) -> Result<ColumnarValue> {
-    case_conversion(args, |string| string.to_uppercase(), name)
+    case_conversion(args, false, name)
 }
 
-fn case_conversion<'a, F>(
-    args: &'a [ColumnarValue],
-    op: F,
+#[inline]
+fn unicode_case(s: &str, lower: bool) -> String {
+    if lower {
+        s.to_lowercase()
+    } else {
+        s.to_uppercase()
+    }
+}
+
+fn case_conversion(
+    args: &[ColumnarValue],
+    lower: bool,
     name: &str,
-) -> Result<ColumnarValue>
-where
-    F: Fn(&'a str) -> String,
-{
+) -> Result<ColumnarValue> {
     match &args[0] {
         ColumnarValue::Array(array) => match array.data_type() {
-            DataType::Utf8 => Ok(ColumnarValue::Array(case_conversion_array::<i32, _>(
-                array, op,
+            DataType::Utf8 => Ok(ColumnarValue::Array(case_conversion_array::<i32>(
+                array, lower,
             )?)),
-            DataType::LargeUtf8 => Ok(ColumnarValue::Array(case_conversion_array::<
-                i64,
-                _,
-            >(array, op)?)),
+            DataType::LargeUtf8 => Ok(ColumnarValue::Array(
+                case_conversion_array::<i64>(array, lower)?,
+            )),
             DataType::Utf8View => {
                 let string_array = as_string_view_array(array)?;
+                if string_array.is_ascii() {
+                    return Ok(ColumnarValue::Array(Arc::new(
+                        case_conversion_utf8view_ascii(string_array, lower),
+                    )));
+                }
                 let item_len = string_array.len();
                 // Null-preserving: reuse the input null buffer as the output null buffer.
                 let nulls = string_array.nulls().cloned();
@@ -361,14 +374,14 @@ where
                         } else {
                             // SAFETY: `n.is_null(i)` was false in the branch above.
                             let s = unsafe { string_array.value_unchecked(i) };
-                            builder.append_value(&op(s));
+                            builder.append_value(&unicode_case(s, lower));
                         }
                     }
                 } else {
                     for i in 0..item_len {
                         // SAFETY: no null buffer means every index is valid.
                         let s = unsafe { string_array.value_unchecked(i) };
-                        builder.append_value(&op(s));
+                        builder.append_value(&unicode_case(s, lower));
                     }
                 }
 
@@ -378,15 +391,15 @@ where
         },
         ColumnarValue::Scalar(scalar) => match scalar {
             ScalarValue::Utf8(a) => {
-                let result = a.as_ref().map(|x| op(x));
+                let result = a.as_ref().map(|x| unicode_case(x, lower));
                 Ok(ColumnarValue::Scalar(ScalarValue::Utf8(result)))
             }
             ScalarValue::LargeUtf8(a) => {
-                let result = a.as_ref().map(|x| op(x));
+                let result = a.as_ref().map(|x| unicode_case(x, lower));
                 Ok(ColumnarValue::Scalar(ScalarValue::LargeUtf8(result)))
             }
             ScalarValue::Utf8View(a) => {
-                let result = a.as_ref().map(|x| op(x));
+                let result = a.as_ref().map(|x| unicode_case(x, lower));
                 Ok(ColumnarValue::Scalar(ScalarValue::Utf8View(result)))
             }
             other => exec_err!("Unsupported data type {other:?} for function {name}"),
@@ -394,16 +407,15 @@ where
     }
 }
 
-fn case_conversion_array<'a, O, F>(array: &'a ArrayRef, op: F) -> Result<ArrayRef>
-where
-    O: OffsetSizeTrait,
-    F: Fn(&'a str) -> String,
-{
+fn case_conversion_array<O: OffsetSizeTrait>(
+    array: &ArrayRef,
+    lower: bool,
+) -> Result<ArrayRef> {
     const PRE_ALLOC_BYTES: usize = 8;
 
     let string_array = as_generic_string_array::<O>(array)?;
     if string_array.is_ascii() {
-        return case_conversion_ascii_array::<O, _>(string_array, op);
+        return case_conversion_ascii_array::<O>(string_array, lower);
     }
 
     // Values contain non-ASCII.
@@ -423,43 +435,147 @@ where
             } else {
                 // SAFETY: `n.is_null(i)` was false in the branch above.
                 let s = unsafe { string_array.value_unchecked(i) };
-                builder.append_value(&op(s));
+                builder.append_value(&unicode_case(s, lower));
             }
         }
     } else {
         for i in 0..item_len {
             // SAFETY: no null buffer means every index is valid.
             let s = unsafe { string_array.value_unchecked(i) };
-            builder.append_value(&op(s));
+            builder.append_value(&unicode_case(s, lower));
         }
     }
     Ok(Arc::new(builder.finish(nulls)?))
 }
 
+/// Fast path for case conversion on an all-ASCII `StringViewArray`.
+fn case_conversion_utf8view_ascii(
+    array: &StringViewArray,
+    lower: bool,
+) -> StringViewArray {
+    // Specialize per conversion so the byte call inlines in the hot loops below.
+    if lower {
+        case_conversion_utf8view_ascii_inner(array, u8::to_ascii_lowercase)
+    } else {
+        case_conversion_utf8view_ascii_inner(array, u8::to_ascii_uppercase)
+    }
+}
+
+/// Walks the views once: inline rows (length ≤ 12) convert their inline bytes
+/// in place; long rows copy their referenced bytes into a single packed output
+/// buffer while converting, then rewrite the view (`buffer_index = 0`, new
+/// offset, new 4-byte prefix) to point at it.
+fn case_conversion_utf8view_ascii_inner<F: Fn(&u8) -> u8>(
+    array: &StringViewArray,
+    convert: F,
+) -> StringViewArray {
+    let item_len = array.len();
+    let views = array.views();
+    let data_buffers = array.data_buffers();
+    let nulls = array.nulls();
+
+    let mut new_views: Vec<u128> = Vec::with_capacity(item_len);
+    let mut in_progress: Vec<u8> = Vec::new();
+    let mut completed: Vec<Buffer> = Vec::new();
+    let mut block_size: u32 = STRING_VIEW_INIT_BLOCK_SIZE;
+
+    for i in 0..item_len {
+        if nulls.is_some_and(|n| n.is_null(i)) {
+            new_views.push(0);
+            continue;
+        }
+        let view = views[i];
+        let len = view as u32 as usize;
+        if len == 0 {
+            new_views.push(0);
+            continue;
+        }
+        let mut bytes = view.to_le_bytes();
+        if len <= 12 {
+            // Inline row: convert the inline data bytes; layout unchanged.
+            for b in &mut bytes[4..4 + len] {
+                *b = convert(b);
+            }
+            new_views.push(u128::from_le_bytes(bytes));
+        } else {
+            // Make sure the current data block has room for this value;
+            // otherwise flush and start a new, larger block.
+            let required_cap = in_progress.len() + len;
+            if in_progress.capacity() < required_cap {
+                if !in_progress.is_empty() {
+                    completed.push(Buffer::from_vec(std::mem::take(&mut in_progress)));
+                }
+                if block_size < STRING_VIEW_MAX_BLOCK_SIZE {
+                    block_size = block_size.saturating_mul(2);
+                }
+                let to_reserve = len.max(block_size as usize);
+                in_progress.reserve(to_reserve);
+            }
+
+            let buffer_index: u32 = i32::try_from(completed.len())
+                .expect("buffer count exceeds i32::MAX")
+                as u32;
+            let new_offset: u32 =
+                i32::try_from(in_progress.len()).expect("offset exceeds i32::MAX") as u32;
+
+            let src_buffer_index =
+                u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+            let src_offset =
+                u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
+            let src =
+                &data_buffers[src_buffer_index].as_slice()[src_offset..src_offset + len];
+
+            let prefix_start = in_progress.len();
+            in_progress.extend(src.iter().map(&convert));
+
+            // Prefix is the first 4 bytes of the converted data we just wrote.
+            let prefix: [u8; 4] = in_progress[prefix_start..prefix_start + 4]
+                .try_into()
+                .unwrap();
+            bytes[4..8].copy_from_slice(&prefix);
+            bytes[8..12].copy_from_slice(&buffer_index.to_le_bytes());
+            bytes[12..16].copy_from_slice(&new_offset.to_le_bytes());
+            new_views.push(u128::from_le_bytes(bytes));
+        }
+    }
+
+    if !in_progress.is_empty() {
+        completed.push(Buffer::from_vec(in_progress));
+    }
+
+    // SAFETY: each long view's buffer_index addresses a buffer we wrote, and
+    // its offset addresses bytes within that buffer; prefixes were copied from
+    // those same bytes; inline views were rewritten from valid inline bytes;
+    // null/empty rows are zero views with no buffer reference; row count is
+    // unchanged.
+    unsafe {
+        StringViewArray::new_unchecked(
+            ScalarBuffer::from(new_views),
+            completed,
+            array.nulls().cloned(),
+        )
+    }
+}
+
 /// Fast path for case conversion on an all-ASCII string array. ASCII case
 /// conversion is byte-length-preserving, so we can convert the entire addressed
-/// range in one call and reuse the offsets and nulls buffers — rebasing the
-/// offsets when the input is a sliced array.
-fn case_conversion_ascii_array<'a, O, F>(
-    string_array: &'a GenericStringArray<O>,
-    op: F,
-) -> Result<ArrayRef>
-where
-    O: OffsetSizeTrait,
-    F: Fn(&'a str) -> String,
-{
+/// byte range in one pass over the value buffer and reuse the offsets and nulls
+/// buffers — rebasing the offsets when the input is a sliced array.
+fn case_conversion_ascii_array<O: OffsetSizeTrait>(
+    string_array: &GenericStringArray<O>,
+    lower: bool,
+) -> Result<ArrayRef> {
     let value_offsets = string_array.value_offsets();
     let start = value_offsets.first().unwrap().as_usize();
     let end = value_offsets.last().unwrap().as_usize();
     let relevant = &string_array.value_data()[start..end];
 
-    // SAFETY: `relevant` is a subslice of the string array's value buffer,
-    // which is valid UTF-8.
-    let str_values = unsafe { std::str::from_utf8_unchecked(relevant) };
-
-    let converted_values = op(str_values);
-    debug_assert_eq!(converted_values.len(), str_values.len());
-    let values = Buffer::from_vec(converted_values.into_bytes());
+    let converted: Vec<u8> = if lower {
+        relevant.iter().map(u8::to_ascii_lowercase).collect()
+    } else {
+        relevant.iter().map(u8::to_ascii_uppercase).collect()
+    };
+    let values = Buffer::from_vec(converted);
 
     // Shift offsets from `start`-based to 0-based so they index into `values`.
     let offsets = if start == 0 {
@@ -468,7 +584,7 @@ where
         let s = O::usize_as(start);
         let rebased: Vec<O> = value_offsets.iter().map(|&o| o - s).collect();
         // SAFETY: subtracting a constant from monotonic offsets preserves
-        // monotonicity, and `start` is the minimum offset so no underflow.
+        // monotonicity, and `start` is the minimum offset, so no underflow.
         unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(rebased)) }
     };
 

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -211,6 +211,146 @@ mod tests {
     }
 
     #[test]
+    fn lower_ascii_utf8view() -> Result<()> {
+        // Mix of inlined (≤12 bytes) and referenced (>12 bytes) strings, plus
+        // a null and an empty, to exercise the all-ASCII Utf8View fast path.
+        let input = Arc::new(StringViewArray::from(vec![
+            Some("ARROW"), // inlined short
+            None,
+            Some("HELLO WORLD 123"), // referenced (15 bytes)
+            Some(""),
+            Some("0123456789"),         // inlined, no case change
+            Some("DATAFUSION IS COOL"), // referenced
+        ])) as ArrayRef;
+
+        let expected = Arc::new(StringViewArray::from(vec![
+            Some("arrow"),
+            None,
+            Some("hello world 123"),
+            Some(""),
+            Some("0123456789"),
+            Some("datafusion is cool"),
+        ])) as ArrayRef;
+
+        to_lower(input, expected)
+    }
+
+    #[test]
+    fn lower_sliced_ascii_utf8view() -> Result<()> {
+        // Slice of a parent that contains a non-ASCII string outside the
+        // slice. The slice is all-ASCII, so the fast path must run and produce
+        // correct output while the parent's unaddressed non-ASCII bytes are
+        // irrelevant to the result.
+        let parent = Arc::new(StringViewArray::from(vec![
+            Some("农历新年LONG ENOUGH FOR BUFFER"),
+            Some("HELLO WORLD 123"),
+            Some("DATAFUSION ROCKS!"),
+            Some("ZZZZZZZZZZZZZZZZ"),
+        ])) as ArrayRef;
+        let sliced = parent.slice(1, 2);
+        let result = invoke_lower(sliced)?;
+        let result_sv = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        let expected = StringViewArray::from(vec![
+            Some("hello world 123"),
+            Some("datafusion rocks!"),
+        ]);
+        assert_eq!(result_sv, &expected);
+        // The slice's two long views address 15 + 17 = 32 bytes; the ASCII
+        // fast path must produce a single packed buffer of exactly that
+        // size, not one scaled to the parent's data buffer.
+        assert_eq!(result_sv.data_buffers().len(), 1);
+        assert_eq!(result_sv.data_buffers()[0].len(), 32);
+        Ok(())
+    }
+
+    #[test]
+    fn lower_utf8view_inline_only_no_buffers() -> Result<()> {
+        // An array whose values are all ≤ 12 bytes is fully inline; the ASCII
+        // fast path should produce no data buffers at all.
+        let input = Arc::new(StringViewArray::from(vec![
+            Some("HELLO"),
+            None,
+            Some(""),
+            Some("0123456789ab"), // 12 bytes — inline boundary
+        ])) as ArrayRef;
+        let result = invoke_lower(input)?;
+        let result_sv = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        let expected = StringViewArray::from(vec![
+            Some("hello"),
+            None,
+            Some(""),
+            Some("0123456789ab"),
+        ]);
+        assert_eq!(result_sv, &expected);
+        assert_eq!(
+            result_sv.data_buffers().len(),
+            0,
+            "inline-only Utf8View should produce no data buffers"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn lower_utf8view_long_packs_tight() -> Result<()> {
+        // Mix of long and inline values; the long values should be packed into
+        // a single tight output buffer whose size is exactly the sum of their
+        // lengths (inline values do not contribute).
+        let input = Arc::new(StringViewArray::from(vec![
+            Some("HELLO WORLD 123"), // 15 bytes (long)
+            Some("ABC"),             // inline
+            None,
+            Some("DATAFUSION ROCKS!"),   // 17 bytes (long)
+            Some("ANOTHER LONG STRING"), // 19 bytes (long)
+        ])) as ArrayRef;
+        let result = invoke_lower(input)?;
+        let result_sv = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        let expected = StringViewArray::from(vec![
+            Some("hello world 123"),
+            Some("abc"),
+            None,
+            Some("datafusion rocks!"),
+            Some("another long string"),
+        ]);
+        assert_eq!(result_sv, &expected);
+        assert_eq!(result_sv.data_buffers().len(), 1);
+        assert_eq!(result_sv.data_buffers()[0].len(), 15 + 17 + 19);
+        Ok(())
+    }
+
+    #[test]
+    fn lower_utf8view_splits_into_multiple_buffers() -> Result<()> {
+        // Produce enough long-string output to overflow the first data block
+        // (≈16 KiB after the initial doubling) and confirm the fast path
+        // splits across buffers rather than packing everything into one and
+        // risking the i32::MAX offset limit.
+        const STR_LEN: usize = 500;
+        const N: usize = 40; // 40 × 500 B = 20 KiB total — crosses the first block.
+        let value = "X".repeat(STR_LEN);
+        let inputs: Vec<Option<String>> = (0..N).map(|_| Some(value.clone())).collect();
+        let input = Arc::new(StringViewArray::from(inputs.clone())) as ArrayRef;
+        let result = invoke_lower(input)?;
+        let result_sv = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        let expected_value = "x".repeat(STR_LEN);
+        let expected: Vec<Option<&str>> =
+            (0..N).map(|_| Some(expected_value.as_str())).collect();
+        assert_eq!(result_sv, &StringViewArray::from(expected));
+        assert!(
+            result_sv.data_buffers().len() >= 2,
+            "expected the output to span more than one data buffer, got {}",
+            result_sv.data_buffers().len()
+        );
+        // Total bytes across buffers must equal total long-value bytes
+        // (no row was inlined since each value is > 12 bytes).
+        let total: usize = result_sv.data_buffers().iter().map(|b| b.len()).sum();
+        assert_eq!(total, N * STR_LEN);
+        Ok(())
+    }
+
+    #[test]
     fn lower_sliced_utf8() -> Result<()> {
         let parent = Arc::new(StringArray::from(vec![
             Some("AAAAAAAA"),

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -95,22 +95,24 @@ mod tests {
     use datafusion_common::config::ConfigOptions;
     use std::sync::Arc;
 
-    fn to_upper(input: ArrayRef, expected: ArrayRef) -> Result<()> {
+    fn invoke_upper(input: ArrayRef) -> Result<ArrayRef> {
         let func = UpperFunc::new();
-
-        let arg_field = Field::new("a", input.data_type().clone(), true).into();
+        let data_type = input.data_type().clone();
         let args = ScalarFunctionArgs {
             number_rows: input.len(),
             args: vec![ColumnarValue::Array(input)],
-            arg_fields: vec![arg_field],
-            return_field: Field::new("f", expected.data_type().clone(), true).into(),
+            arg_fields: vec![Field::new("a", data_type.clone(), true).into()],
+            return_field: Field::new("f", data_type, true).into(),
             config_options: Arc::new(ConfigOptions::default()),
         };
-
-        let result = match func.invoke_with_args(args)? {
-            ColumnarValue::Array(result) => result,
+        match func.invoke_with_args(args)? {
+            ColumnarValue::Array(r) => Ok(r),
             _ => unreachable!("upper"),
-        };
+        }
+    }
+
+    fn to_upper(input: ArrayRef, expected: ArrayRef) -> Result<()> {
+        let result = invoke_upper(input)?;
         assert_eq!(&expected, &result);
         Ok(())
     }
@@ -205,5 +207,166 @@ mod tests {
         ])) as ArrayRef;
 
         to_upper(input, expected)
+    }
+
+    #[test]
+    fn upper_ascii_utf8view() -> Result<()> {
+        // Mix of inlined (≤12 bytes) and referenced (>12 bytes) strings, plus
+        // a null and an empty, to exercise the all-ASCII Utf8View fast path.
+        let input = Arc::new(StringViewArray::from(vec![
+            Some("arrow"), // inlined short
+            None,
+            Some("hello world 123"), // referenced (15 bytes)
+            Some(""),
+            Some("0123456789"),         // inlined, no case change
+            Some("datafusion is cool"), // referenced
+        ])) as ArrayRef;
+
+        let expected = Arc::new(StringViewArray::from(vec![
+            Some("ARROW"),
+            None,
+            Some("HELLO WORLD 123"),
+            Some(""),
+            Some("0123456789"),
+            Some("DATAFUSION IS COOL"),
+        ])) as ArrayRef;
+
+        to_upper(input, expected)
+    }
+
+    #[test]
+    fn upper_sliced_ascii_utf8view() -> Result<()> {
+        // Slice of a parent that contains a non-ASCII string outside the
+        // slice. The slice is all-ASCII, so the fast path must run and produce
+        // correct output while the parent's unaddressed non-ASCII bytes are
+        // irrelevant to the result.
+        let parent = Arc::new(StringViewArray::from(vec![
+            Some("农历新年long enough for buffer"),
+            Some("hello world 123"),
+            Some("datafusion rocks!"),
+            Some("zzzzzzzzzzzzzzzz"),
+        ])) as ArrayRef;
+        let sliced = parent.slice(1, 2);
+        let result = invoke_upper(sliced)?;
+        let result_sv = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        let expected = StringViewArray::from(vec![
+            Some("HELLO WORLD 123"),
+            Some("DATAFUSION ROCKS!"),
+        ]);
+        assert_eq!(result_sv, &expected);
+        // The slice's two long views address 15 + 17 = 32 bytes; the ASCII
+        // fast path must produce a single packed buffer of exactly that
+        // size, not one scaled to the parent's data buffer.
+        assert_eq!(result_sv.data_buffers().len(), 1);
+        assert_eq!(result_sv.data_buffers()[0].len(), 32);
+        Ok(())
+    }
+
+    #[test]
+    fn upper_utf8view_inline_only_no_buffers() -> Result<()> {
+        // An array whose values are all ≤ 12 bytes is fully inline; the ASCII
+        // fast path should produce no data buffers at all.
+        let input = Arc::new(StringViewArray::from(vec![
+            Some("hello"),
+            None,
+            Some(""),
+            Some("0123456789AB"), // 12 bytes — inline boundary
+        ])) as ArrayRef;
+        let result = invoke_upper(input)?;
+        let result_sv = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        let expected = StringViewArray::from(vec![
+            Some("HELLO"),
+            None,
+            Some(""),
+            Some("0123456789AB"),
+        ]);
+        assert_eq!(result_sv, &expected);
+        assert_eq!(
+            result_sv.data_buffers().len(),
+            0,
+            "inline-only Utf8View should produce no data buffers"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn upper_utf8view_long_packs_tight() -> Result<()> {
+        // Mix of long and inline values; the long values should be packed into
+        // a single tight output buffer whose size is exactly the sum of their
+        // lengths (inline values do not contribute).
+        let input = Arc::new(StringViewArray::from(vec![
+            Some("hello world 123"), // 15 bytes (long)
+            Some("abc"),             // inline
+            None,
+            Some("datafusion rocks!"),   // 17 bytes (long)
+            Some("another long string"), // 19 bytes (long)
+        ])) as ArrayRef;
+        let result = invoke_upper(input)?;
+        let result_sv = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        let expected = StringViewArray::from(vec![
+            Some("HELLO WORLD 123"),
+            Some("ABC"),
+            None,
+            Some("DATAFUSION ROCKS!"),
+            Some("ANOTHER LONG STRING"),
+        ]);
+        assert_eq!(result_sv, &expected);
+        assert_eq!(result_sv.data_buffers().len(), 1);
+        assert_eq!(result_sv.data_buffers()[0].len(), 15 + 17 + 19);
+        Ok(())
+    }
+
+    #[test]
+    fn upper_utf8view_splits_into_multiple_buffers() -> Result<()> {
+        // Produce enough long-string output to overflow the first data block
+        // (≈16 KiB after the initial doubling) and confirm the fast path
+        // splits across buffers rather than packing everything into one and
+        // risking the i32::MAX offset limit.
+        const STR_LEN: usize = 500;
+        const N: usize = 40; // 40 × 500 B = 20 KiB total — crosses the first block.
+        let value = "x".repeat(STR_LEN);
+        let inputs: Vec<Option<String>> = (0..N).map(|_| Some(value.clone())).collect();
+        let input = Arc::new(StringViewArray::from(inputs.clone())) as ArrayRef;
+        let result = invoke_upper(input)?;
+        let result_sv = result.as_any().downcast_ref::<StringViewArray>().unwrap();
+
+        let expected_value = "X".repeat(STR_LEN);
+        let expected: Vec<Option<&str>> =
+            (0..N).map(|_| Some(expected_value.as_str())).collect();
+        assert_eq!(result_sv, &StringViewArray::from(expected));
+        assert!(
+            result_sv.data_buffers().len() >= 2,
+            "expected the output to span more than one data buffer, got {}",
+            result_sv.data_buffers().len()
+        );
+        // Total bytes across buffers must equal total long-value bytes
+        // (no row was inlined since each value is > 12 bytes).
+        let total: usize = result_sv.data_buffers().iter().map(|b| b.len()).sum();
+        assert_eq!(total, N * STR_LEN);
+        Ok(())
+    }
+
+    #[test]
+    fn upper_sliced_utf8() -> Result<()> {
+        let parent = Arc::new(StringArray::from(vec![
+            Some("aaaaaaaa"),
+            Some("hello"),
+            Some("world"),
+            Some(""),
+            Some("zzzzzzzz"),
+        ])) as ArrayRef;
+        let sliced = parent.slice(1, 3);
+        let result = invoke_upper(sliced)?;
+        let result_sa = result.as_any().downcast_ref::<StringArray>().unwrap();
+
+        let expected = StringArray::from(vec![Some("HELLO"), Some("WORLD"), Some("")]);
+        assert_eq!(result_sa, &expected);
+        // The slice's addressed bytes are "hello" + "world" = 10; the ASCII
+        // fast path must produce a tight output buffer (not the parent's).
+        assert_eq!(result_sa.value_data().len(), 10);
+        Ok(())
     }
 }

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -531,12 +531,12 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
     }
 }
 
-/// Starting size for the long-string data block; matches Arrow's
-/// `GenericByteViewBuilder` default.
-const STARTING_BLOCK_SIZE: u32 = 8 * 1024;
-/// Maximum size each long-string data block grows to; matches Arrow's
-/// `GenericByteViewBuilder` default.
-const MAX_BLOCK_SIZE: u32 = 2 * 1024 * 1024;
+/// Starting size for the long-string data block used by `StringView`-style
+/// arrays; matches Arrow's `GenericByteViewBuilder` default.
+pub(crate) const STRING_VIEW_INIT_BLOCK_SIZE: u32 = 8 * 1024;
+/// Maximum size each long-string data block in a `StringView`-style array
+/// grows to; matches Arrow's `GenericByteViewBuilder` default.
+pub(crate) const STRING_VIEW_MAX_BLOCK_SIZE: u32 = 2 * 1024 * 1024;
 
 /// Builder for a [`StringViewArray`] that defers null tracking to `finish`.
 ///
@@ -545,13 +545,11 @@ const MAX_BLOCK_SIZE: u32 = 2 * 1024 * 1024;
 /// Short strings (≤ 12 bytes) are inlined into the view itself; long strings
 /// are appended into an in-progress data block. When the in-progress block
 /// fills up it is flushed into `completed` and a new block — double the size
-/// of the last, capped at [`MAX_BLOCK_SIZE`] — is started.
+/// of the last, capped at [`STRING_VIEW_MAX_BLOCK_SIZE`] — is started.
 pub(crate) struct StringViewArrayBuilder {
     views: Vec<u128>,
     in_progress: Vec<u8>,
     completed: Vec<Buffer>,
-    /// Current block-size target; doubles each time a block is flushed, up to
-    /// [`MAX_BLOCK_SIZE`].
     block_size: u32,
     placeholder_count: usize,
 }
@@ -562,15 +560,14 @@ impl StringViewArrayBuilder {
             views: Vec::with_capacity(item_capacity),
             in_progress: Vec::new(),
             completed: Vec::new(),
-            block_size: STARTING_BLOCK_SIZE,
+            block_size: STRING_VIEW_INIT_BLOCK_SIZE,
             placeholder_count: 0,
         }
     }
 
-    /// Doubles the block-size target (capped at [`MAX_BLOCK_SIZE`]) and
-    /// returns the new size. The first call returns `2 * STARTING_BLOCK_SIZE`.
+    /// Doubles the block-size target and returns the new size.
     fn next_block_size(&mut self) -> u32 {
-        if self.block_size < MAX_BLOCK_SIZE {
+        if self.block_size < STRING_VIEW_MAX_BLOCK_SIZE {
             self.block_size = self.block_size.saturating_mul(2);
         }
         self.block_size
@@ -988,7 +985,7 @@ mod tests {
 
     #[test]
     fn string_view_array_builder_flushes_full_blocks() {
-        // Each value is 300 bytes. The first data block is 2 × STARTING_BLOCK_SIZE
+        // Each value is 300 bytes. The first data block is 2 × STRING_VIEW_INIT_BLOCK_SIZE
         // = 16 KiB, so ~50 values saturate it and the rest spill into additional
         // blocks.
         let value = "x".repeat(300);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21813.

## Rationale for this change

This PR implements two optimizations for `lower` and `upper` on ASCII strings:

1. For the `Utf8`/`LargeUtf8` code path, we previously did the case conversion via `str::to_uppercase` or `str::to_lowercase`. For ASCII inputs, it is faster to use `map(u8::to_ascii_lowercase).collect()` over the bytes of the string directly: although the stdlib functions are well-optimized, they need to check again on every string to see if it is ASCII. Since we know the input is all-ASCII, we can avoid that check.
2. The `Utf8View` code path previously wasn't optimized for ASCII strings; add a new code path that is. As with the `Utf8` code path, we can do case-conversion on bytes directly, which vectorizes well and avoids repeated ASCII checks. In addition, we can build the output `StringViewArray` directly, which avoids the intermediate strings and unnecessary allocations used in the previous approach.

Benchmarks (ARM64):

  upper

  - upper_all_values_are_ascii: 5.4 → 4.1 µs (−24.1%)

  lower — all-ASCII (the optimized paths)

  - lower_all_values_are_ascii: 1024: 5.4 → 4.0 µs (−25.9%)
  - lower_all_values_are_ascii: 4096: 22.6 → 15.6 µs (−31.0%)
  - lower_all_values_are_ascii: 8192: 41.9 → 30.8 µs (−26.5%)
  - string_views size:4096 str_len:10  null:0   mixed:false: 151.0 → 75.3 µs (−50.1%)
  - string_views size:4096 str_len:10  null:0   mixed:true:  175.9 → 134.6 µs (−23.5%)
  - string_views size:4096 str_len:10  null:0.1 mixed:false: 143.5 → 76.8 µs (−46.5%)
  - string_views size:4096 str_len:10  null:0.1 mixed:true:  166.6 → 125.0 µs (−25.0%)
  - string_views size:4096 str_len:64  null:0   mixed:false: 150.1 → 92.7 µs (−38.2%)
  - string_views size:4096 str_len:64  null:0   mixed:true:  185.2 → 140.1 µs (−24.4%)
  - string_views size:4096 str_len:64  null:0.1 mixed:false: 136.7 → 97.0 µs (−29.0%)
  - string_views size:4096 str_len:64  null:0.1 mixed:true:  173.7 → 131.2 µs (−24.5%)
  - string_views size:4096 str_len:128 null:0   mixed:false: 190.3 → 141.7 µs (−25.5%)
  - string_views size:4096 str_len:128 null:0   mixed:true:  197.0 → 153.7 µs (−22.0%)
  - string_views size:4096 str_len:128 null:0.1 mixed:false: 173.3 → 141.7 µs (−18.2%)
  - string_views size:4096 str_len:128 null:0.1 mixed:true:  184.0 → 142.8 µs (−22.4%)
  - string_views size:8192 str_len:10  null:0   mixed:false: 302.9 → 150.2 µs (−50.4%)
  - string_views size:8192 str_len:10  null:0   mixed:true:  352.9 → 279.0 µs (−20.9%)
  - string_views size:8192 str_len:10  null:0.1 mixed:false: 285.0 → 154.3 µs (−45.9%)
  - string_views size:8192 str_len:10  null:0.1 mixed:true:  334.2 → 266.4 µs (−20.3%)
  - string_views size:8192 str_len:64  null:0   mixed:false: 295.6 → 184.4 µs (−37.6%)
  - string_views size:8192 str_len:64  null:0   mixed:true:  371.4 → 290.7 µs (−21.7%)
  - string_views size:8192 str_len:64  null:0.1 mixed:false: 273.7 → 195.1 µs (−28.7%)
  - string_views size:8192 str_len:64  null:0.1 mixed:true:  347.0 → 279.6 µs (−19.4%)
  - string_views size:8192 str_len:128 null:0   mixed:false: 379.6 → 285.6 µs (−24.8%)
  - string_views size:8192 str_len:128 null:0   mixed:true:  397.1 → 317.4 µs (−20.1%)
  - string_views size:8192 str_len:128 null:0.1 mixed:false: 364.1 → 285.1 µs (−21.7%)
  - string_views size:8192 str_len:128 null:0.1 mixed:true:  379.3 → 302.3 µs (−20.3%)
  - lower_sliced_ascii parent=65536 slice=128 str_len=32: 980.2 → 797.9 ns (−18.6%)

  lower — some non-ASCII string_views (mostly noise)

  - size:4096 str_len:10  null:0   mixed:false: 374.5 → 362.2 µs (−3.3%)
  - size:4096 str_len:10  null:0   mixed:true:  374.6 → 380.5 µs (+1.6%)
  - size:4096 str_len:10  null:0.1 mixed:false: 340.8 → 356.5 µs (+4.6%)
  - size:4096 str_len:10  null:0.1 mixed:true:  344.0 → 352.5 µs (+2.5%)
  - size:4096 str_len:64  null:0   mixed:false: 377.5 → 373.5 µs (−1.1%)
  - size:4096 str_len:64  null:0   mixed:true:  380.6 → 375.0 µs (−1.5%)
  - size:4096 str_len:64  null:0.1 mixed:false: 330.7 → 341.8 µs (+3.4%)
  - size:4096 str_len:64  null:0.1 mixed:true:  341.8 → 354.2 µs (+3.6%)
  - size:4096 str_len:128 null:0   mixed:false: 371.8 → 356.2 µs (−4.2%)
  - size:4096 str_len:128 null:0   mixed:true:  378.9 → 386.0 µs (+1.9%)
  - size:4096 str_len:128 null:0.1 mixed:false: 350.5 → 350.3 µs (−0.1%)
  - size:4096 str_len:128 null:0.1 mixed:true:  351.0 → 337.9 µs (−3.7%)
  - size:8192 str_len:10  null:0   mixed:false: 740.0 → 757.2 µs (+2.3%)
  - size:8192 str_len:10  null:0   mixed:true:  781.3 → 750.2 µs (−4.0%)
  - size:8192 str_len:10  null:0.1 mixed:false: 693.7 → 693.7 µs (0.0%)
  - size:8192 str_len:10  null:0.1 mixed:true:  681.5 → 705.2 µs (+3.5%)
  - size:8192 str_len:64  null:0   mixed:false: 755.5 → 768.6 µs (+1.7%)
  - size:8192 str_len:64  null:0   mixed:true:  759.6 → 754.3 µs (−0.7%)
  - size:8192 str_len:64  null:0.1 mixed:false: 711.5 → 667.8 µs (−6.1%)
  - size:8192 str_len:64  null:0.1 mixed:true:  682.1 → 688.2 µs (+0.9%)
  - size:8192 str_len:128 null:0   mixed:false: 771.5 → 765.9 µs (−0.7%)
  - size:8192 str_len:128 null:0   mixed:true:  747.7 → 792.6 µs (+6.0%)
  - size:8192 str_len:128 null:0.1 mixed:false: 687.1 → 701.3 µs (+2.1%)
  - size:8192 str_len:128 null:0.1 mixed:true:  679.2 → 696.8 µs (+2.6%)

  lower — first/middle non-ASCII (flat)

  - lower_the_first_value_is_nonascii: 1024:  42.1 → 42.4 µs (+0.7%)
  - lower_the_first_value_is_nonascii: 4096:  173.9 → 173.3 µs (−0.3%)
  - lower_the_first_value_is_nonascii: 8192:  350.8 → 349.3 µs (−0.4%)
  - lower_the_middle_value_is_nonascii: 1024: 42.9 → 42.8 µs (−0.2%)
  - lower_the_middle_value_is_nonascii: 4096: 175.1 → 176.3 µs (+0.7%)
  - lower_the_middle_value_is_nonascii: 8192: 353.6 → 354.6 µs (+0.3%)

## What changes are included in this PR?

* Implement optimizations
* Share StringViewArray buffer size constants with the bulk-NULL builders

## Are these changes tested?

Covered by existing tests.

## Are there any user-facing changes?

No.
