### PR TITLE
ci: narrow macOS scope to datafusion-ffi, cover benchmarks on amd64

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -298,7 +298,6 @@ jobs:
             --profile ci \
             --exclude datafusion-examples \
             --exclude ffi_example_table_provider \
-            --exclude datafusion-benchmarks \
             --exclude datafusion-cli \
             --workspace \
             --lib \
@@ -557,6 +556,11 @@ jobs:
   #          export PATH=$PATH:$HOME/d/protoc/bin
   #          cargo test --lib --tests --bins --features avro,json,backtrace
 
+  # macOS scope is narrowed to `datafusion-ffi`: the only bug class amd64
+  # cannot reproduce is FFI cdylib loading (`.dylib` vs `.so` resolution in
+  # datafusion/ffi/src/tests/utils.rs). All other macos-only failures
+  # historically came from datafusion-benchmarks (now covered on amd64) or
+  # flaky sqllogictest metrics.
   macos-aarch64:
     name: cargo test (macos-aarch64)
     runs-on: macos-15
@@ -567,9 +571,9 @@ jobs:
           fetch-depth: 1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-macos-aarch64-builder
-      - name: Run tests (excluding doctests)
+      - name: Run datafusion-ffi tests
         shell: bash
-        run: cargo test --profile ci --exclude datafusion-cli --workspace --lib --tests --bins --features avro,json,backtrace,integration-tests,substrait
+        run: cargo test --profile ci -p datafusion-ffi --lib --tests --features integration-tests
 
   vendor:
     name: Verify Vendored Code


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

The `cargo test (macos-aarch64)` job is the slowest job in `Rust` CI (~22 min vs 1–6 min for everything else; ~68% of that is compile, ~25% is test execution). I audited 1000 failed PR runs over Mar–May 2026 to figure out what unique signal it actually provides.

**Findings (full breakdown of the 30 PR runs where macOS was the *sole* failing job):**

| Bucket | Count | Notes |
|---|---|---|
| `explain_analyze.slt` | 12 | flaky — platform-dependent scan_efficiency_ratio / pushdown_rows metrics |
| `push_down_filter_*.slt` | 8 | same — flaky metrics |
| `benchmark_runner::cli::tests` | 3 | real bugs, but live in `datafusion-benchmarks`, which amd64 was `--exclude`ing |
| `statistics::tpcds_*` | 2 | same PR, also in `datafusion-benchmarks` |
| `tests::test_ffi_udaf` etc. | 1 | real, **macOS-specific** — FFI cdylib loading (`.dylib` vs `.so` resolution in `datafusion/ffi/src/tests/utils.rs`) |
| Build / network / cancellation | 4 | environment noise |

So in 2 months on >1000 failed PR runs, exactly **one** real bug was caught only by macOS that amd64 couldn't have caught with the right scope. Everything else was either flake noise or `datafusion-benchmarks` coverage that amd64 was skipping.

## What changes are included in this PR?

1. **`linux-test` (amd64)**: drop `--exclude datafusion-benchmarks`. amd64 now runs benchmark crate tests, which historically only macOS was running.
2. **`macos-aarch64`**: scope down to `cargo test -p datafusion-ffi --features integration-tests`. This is the only place where the platform itself matters (cdylib path resolution).

Net effect:
- macOS job drops from ~22 min to an estimated ~10–13 min on a cold cache (compile of the `datafusion-ffi` dependency tree dominates; 9 test binaries run in <1 s combined).
- `datafusion-benchmarks` is now covered on the fast 16-CPU amd64 runner instead of the 3-core macos-15 runner.
- Required-checks list (`.asf.yaml`) is unchanged — same job names.

## Are these changes tested?

Verified locally that `cargo test --profile ci -p datafusion-ffi --lib --tests --features integration-tests` builds all 9 FFI test binaries and they pass. CI on this PR will exercise both the new amd64 scope and the new macOS scope.

## Are there any user-facing changes?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)