### PR TITLE
fix: use datafusion_expr instead of datafusion crate

### DIFF
--- a/datafusion/spark/src/function/string/is_valid_utf8.rs
+++ b/datafusion/spark/src/function/string/is_valid_utf8.rs
@@ -16,9 +16,11 @@
 // under the License.
 
 use arrow::datatypes::{DataType, Field, FieldRef};
-use datafusion::logical_expr::{ColumnarValue, Signature, Volatility};
 use datafusion_common::{Result, internal_err};
-use datafusion_expr::{ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl};
+use datafusion_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    Volatility,
+};
 
 use arrow::array::{Array, ArrayRef, BooleanArray};
 use arrow::buffer::BooleanBuffer;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

 - Building the `datafusion-spark` crate in isolation, e.g. `cargo clippy -p datafusion-spark` fails as indicated by https://github.com/apache/datafusion/pull/21043
 
```Shell
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `datafusion`
  --> datafusion/spark/src/function/string/is_valid_utf8.rs:19:5
   |
19 | use datafusion::logical_expr::{ColumnarValue, Signature, Volatility};
   |     ^^^^^^^^^^ use of unresolved module or unlinked crate `datafusion`
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix import statement. No code changes.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, building `datafusion-spark` crate works now.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

N/A