### PR TITLE
fix(spark): ANSI-aware custom nullability for `make_interval`

### DIFF
--- a/datafusion/catalog/src/information_schema.rs
+++ b/datafusion/catalog/src/information_schema.rs
@@ -436,6 +436,7 @@ fn get_udf_args_and_return_types(
                     .return_field_from_args(ReturnFieldArgs {
                         arg_fields: &arg_fields,
                         scalar_arguments: &scalar_arguments,
+                        config_options: &ConfigOptions::default(),
                     })
                     .map(|f| {
                         remove_native_type_prefix(&NativeType::from(

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -31,6 +31,7 @@ use crate::{LogicalPlan, Projection, Subquery, WindowFunctionDefinition, utils};
 use arrow::compute::can_cast_types;
 use arrow::datatypes::FieldRef;
 use arrow::datatypes::{DataType, Field};
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::datatype::FieldExt;
 use datafusion_common::{
     Column, DataFusionError, ExprSchema, Result, ScalarValue, Spans, TableReference,
@@ -590,6 +591,7 @@ impl ExprSchemable for Expr {
                 let args = ReturnFieldArgs {
                     arg_fields: &new_fields,
                     scalar_arguments: &arguments,
+                    config_options: &ConfigOptions::default(),
                 };
 
                 func.return_field_from_args(args)

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -451,6 +451,17 @@ pub struct ReturnFieldArgs<'a> {
     /// For example, if a function is called like `my_function(column_a, 5)`
     /// this field will be `[None, Some(ScalarValue::Int32(Some(5)))]`
     pub scalar_arguments: &'a [Option<&'a ScalarValue>],
+    /// Session configuration options at planning time.
+    ///
+    /// UDFs whose return type or nullability depends on session settings (e.g.
+    /// `spark.sql.ansi.enabled`) should read from this field rather than
+    /// storing config as a struct field and relying on [`ScalarUDFImpl::with_updated_config`].
+    ///
+    /// When called from logical planning (e.g. [`ExprSchema::to_field`]) this
+    /// may reflect a default / unset configuration rather than the actual
+    /// session config.  The physical-planning call site always provides the
+    /// real session config.
+    pub config_options: &'a ConfigOptions,
 }
 
 /// Trait for implementing user defined scalar functions.

--- a/datafusion/ffi/src/udf/return_type_args.rs
+++ b/datafusion/ffi/src/udf/return_type_args.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use arrow_schema::FieldRef;
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::scalar::ScalarValue;
 use datafusion_common::{DataFusionError, ffi_datafusion_err};
 use datafusion_expr::ReturnFieldArgs;
@@ -74,11 +75,14 @@ impl TryFrom<ReturnFieldArgs<'_>> for FFI_ReturnFieldArgs {
 pub struct ForeignReturnFieldArgsOwned {
     arg_fields: Vec<FieldRef>,
     scalar_arguments: Vec<Option<ScalarValue>>,
+    // ConfigOptions cannot cross the FFI boundary; always holds the default.
+    config_options: ConfigOptions,
 }
 
 pub struct ForeignReturnFieldArgs<'a> {
     arg_fields: &'a [FieldRef],
     scalar_arguments: Vec<Option<&'a ScalarValue>>,
+    config_options: &'a ConfigOptions,
 }
 
 impl TryFrom<&FFI_ReturnFieldArgs> for ForeignReturnFieldArgsOwned {
@@ -105,6 +109,7 @@ impl TryFrom<&FFI_ReturnFieldArgs> for ForeignReturnFieldArgsOwned {
         Ok(Self {
             arg_fields,
             scalar_arguments,
+            config_options: ConfigOptions::default(),
         })
     }
 }
@@ -118,6 +123,7 @@ impl<'a> From<&'a ForeignReturnFieldArgsOwned> for ForeignReturnFieldArgs<'a> {
                 .iter()
                 .map(|opt| opt.as_ref())
                 .collect(),
+            config_options: &value.config_options,
         }
     }
 }
@@ -127,6 +133,7 @@ impl<'a> From<&'a ForeignReturnFieldArgs<'a>> for ReturnFieldArgs<'a> {
         ReturnFieldArgs {
             arg_fields: value.arg_fields,
             scalar_arguments: &value.scalar_arguments,
+            config_options: value.config_options,
         }
     }
 }

--- a/datafusion/functions-nested/src/map_values.rs
+++ b/datafusion/functions-nested/src/map_values.rs
@@ -149,6 +149,7 @@ mod tests {
     use crate::map_values::MapValuesFunc;
     use arrow::datatypes::{DataType, Field, FieldRef};
     use datafusion_common::ScalarValue;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ScalarUDFImpl;
     use std::sync::Arc;
 
@@ -196,6 +197,7 @@ mod tests {
             let args = datafusion_expr::ReturnFieldArgs {
                 arg_fields: &[field],
                 scalar_arguments: &[None::<&ScalarValue>],
+                config_options: &ConfigOptions::default(),
             };
 
             func.return_field_from_args(args).unwrap()

--- a/datafusion/functions-nested/src/remove.rs
+++ b/datafusion/functions-nested/src/remove.rs
@@ -476,6 +476,7 @@ mod tests {
     };
     use arrow::datatypes::{DataType, Field, Int32Type};
     use datafusion_common::ScalarValue;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_expr::{ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl};
     use datafusion_expr_common::columnar_value::ColumnarValue;
     use std::ops::Deref;
@@ -500,6 +501,7 @@ mod tests {
                     .return_field_from_args(ReturnFieldArgs {
                         arg_fields: &args_fields,
                         scalar_arguments: &scalar_args,
+                        config_options: &ConfigOptions::default(),
                     })
                     .unwrap();
 
@@ -532,6 +534,7 @@ mod tests {
                     .return_field_from_args(ReturnFieldArgs {
                         arg_fields: &args_fields,
                         scalar_arguments: &scalar_args,
+                        config_options: &ConfigOptions::default(),
                     })
                     .unwrap();
 
@@ -553,6 +556,7 @@ mod tests {
                     .return_field_from_args(ReturnFieldArgs {
                         arg_fields: &[Arc::clone(&input_field)],
                         scalar_arguments: &[None],
+                        config_options: &ConfigOptions::default(),
                     })
                     .unwrap();
 
@@ -656,6 +660,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &args_fields,
                 scalar_arguments: &scalar_args,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -763,6 +768,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &args_fields,
                 scalar_arguments: &scalar_args,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -867,6 +873,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &args_fields,
                 scalar_arguments: &scalar_args,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/functions/benches/date_trunc.rs
+++ b/datafusion/functions/benches/date_trunc.rs
@@ -60,6 +60,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &arg_fields,
                 scalar_arguments: &scalar_arguments,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
         let config_options = Arc::new(ConfigOptions::default());

--- a/datafusion/functions/src/core/with_metadata.rs
+++ b/datafusion/functions/src/core/with_metadata.rs
@@ -159,6 +159,7 @@ mod tests {
     use super::*;
     use arrow::datatypes::Field;
     use datafusion_common::ScalarValue;
+    use datafusion_common::config::ConfigOptions;
     use std::sync::Arc;
 
     fn field(name: &str, dt: DataType, nullable: bool) -> FieldRef {
@@ -185,6 +186,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &fields,
                 scalar_arguments: &scalars,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
         assert_eq!(ret.name(), "my_col");
@@ -218,6 +220,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &fields,
                 scalar_arguments: &scalars,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
         assert_eq!(ret.name(), "x");
@@ -246,6 +249,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &fields,
                 scalar_arguments: &scalars,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
         assert_eq!(ret.metadata().get("a").map(String::as_str), Some("1"));
@@ -271,6 +275,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &fields,
                 scalar_arguments: &scalars,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap_err();
         assert!(err.to_string().contains("odd number"));
@@ -287,6 +292,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &fields,
                 scalar_arguments: &scalars,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap_err();
         assert!(err.to_string().contains("at least one"));
@@ -308,6 +314,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &fields,
                 scalar_arguments: &scalars,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
         assert_eq!(ret.metadata().get("unit").map(String::as_str), Some(""));
@@ -328,6 +335,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &fields,
                 scalar_arguments: &scalars,
+                config_options: &ConfigOptions::default(),
             })
             .unwrap_err();
         assert!(err.to_string().contains("non-empty constant string"));

--- a/datafusion/functions/src/datetime/now.rs
+++ b/datafusion/functions/src/datetime/now.rs
@@ -174,6 +174,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &empty_fields,
                 scalar_arguments: &empty_scalars,
+                config_options: &ConfigOptions::default(),
             })
             .expect("legacy now() return field");
 
@@ -181,6 +182,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &empty_fields,
                 scalar_arguments: &empty_scalars,
+                config_options: &ConfigOptions::default(),
             })
             .expect("configured now() return field");
 

--- a/datafusion/functions/src/unicode/strpos.rs
+++ b/datafusion/functions/src/unicode/strpos.rs
@@ -336,6 +336,7 @@ mod tests {
     use arrow::datatypes::DataType::{Int32, Int64};
 
     use arrow::datatypes::{DataType, Field};
+    use datafusion_common::config::ConfigOptions;
     use datafusion_common::{Result, ScalarValue};
     use datafusion_expr::{ColumnarValue, ScalarUDFImpl};
 
@@ -434,6 +435,7 @@ mod tests {
                     Field::new("f2", DataType::Utf8, substring_nullable).into(),
                 ],
                 scalar_arguments: &[None::<&ScalarValue>, None::<&ScalarValue>],
+                config_options: &ConfigOptions::default(),
             };
 
             strpos.return_field_from_args(args).unwrap().is_nullable()

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -291,6 +291,7 @@ pub mod test {
         let return_field = func.return_field_from_args(datafusion_expr::ReturnFieldArgs {
             arg_fields: &field_array,
             scalar_arguments: &scalar_arguments_refs,
+        config_options: &ConfigOptions::default(),
         });
             let arg_fields = $ARGS.iter()
             .enumerate()

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -109,6 +109,7 @@ impl ScalarFunctionExpr {
         let ret_args = ReturnFieldArgs {
             arg_fields: &arg_fields,
             scalar_arguments: &arguments,
+            config_options: &config_options,
         };
         let return_field = fun.return_field_from_args(ret_args)?;
         Ok(Self {

--- a/datafusion/spark/src/function/array/shuffle.rs
+++ b/datafusion/spark/src/function/array/shuffle.rs
@@ -270,6 +270,7 @@ fn fixed_size_array_shuffle(
 mod tests {
     use super::*;
     use arrow::datatypes::Field;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ReturnFieldArgs;
 
     #[test]
@@ -287,6 +288,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&non_nullable_field)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -305,6 +307,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&nullable_field)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/array/slice.rs
+++ b/datafusion/spark/src/function/array/slice.rs
@@ -186,6 +186,7 @@ mod tests {
     use arrow::datatypes::Field;
     use datafusion_common::ScalarValue;
     use datafusion_common::cast::as_list_array;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ReturnFieldArgs;
 
     #[test]
@@ -200,6 +201,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &arg_fields,
                 scalar_arguments: &[],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
         assert_eq!(

--- a/datafusion/spark/src/function/bitmap/bitmap_count.rs
+++ b/datafusion/spark/src/function/bitmap/bitmap_count.rs
@@ -250,6 +250,7 @@ mod tests {
         let result = bitmap_count.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[Arc::clone(&non_nullable_field)],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         // The result should not be nullable (same as input)
@@ -262,6 +263,7 @@ mod tests {
         let result = bitmap_count.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[Arc::clone(&nullable_field)],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         // The result should be nullable (same as input)

--- a/datafusion/spark/src/function/bitwise/bit_count.rs
+++ b/datafusion/spark/src/function/bitwise/bit_count.rs
@@ -172,6 +172,7 @@ mod tests {
         UInt16Array, UInt32Array, UInt64Array,
     };
     use arrow::datatypes::Field;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_bit_count_basic() {
@@ -357,6 +358,7 @@ mod tests {
         let result = bit_count.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[Arc::clone(&non_nullable_field)],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         // The result should not be nullable (same as input)
@@ -369,6 +371,7 @@ mod tests {
         let result = bit_count.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[Arc::clone(&nullable_field)],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         // The result should be nullable (same as input)

--- a/datafusion/spark/src/function/bitwise/bit_get.rs
+++ b/datafusion/spark/src/function/bitwise/bit_get.rs
@@ -123,6 +123,7 @@ fn spark_bit_get(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_bit_get_nullability_non_nullable_inputs() {
@@ -134,6 +135,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[value_field, pos_field],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -151,6 +153,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[value_field, pos_field],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/bitwise/bit_shift.rs
+++ b/datafusion/spark/src/function/bitwise/bit_shift.rs
@@ -292,6 +292,7 @@ impl ScalarUDFImpl for SparkBitShift {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_bit_shift_nullability() -> Result<()> {
@@ -308,6 +309,7 @@ mod tests {
                 Arc::clone(&non_nullable_shift),
             ],
             scalar_arguments: &[None, None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         assert_eq!(out.data_type(), non_nullable_value.data_type());
@@ -321,6 +323,7 @@ mod tests {
         let out_nullable_value = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[Arc::clone(&nullable_value), Arc::clone(&non_nullable_shift)],
             scalar_arguments: &[None, None],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(
             out_nullable_value.is_nullable(),
@@ -332,6 +335,7 @@ mod tests {
         let out_nullable_shift = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[non_nullable_value, nullable_shift],
             scalar_arguments: &[None, None],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(
             out_nullable_shift.is_nullable(),

--- a/datafusion/spark/src/function/bitwise/bitwise_not.rs
+++ b/datafusion/spark/src/function/bitwise/bitwise_not.rs
@@ -119,6 +119,7 @@ pub fn spark_bitwise_not(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
     use std::sync::Arc;
 
     #[test]
@@ -132,6 +133,7 @@ mod tests {
                 arg_fields: &[Arc::clone(&non_nullable_i32)],
                 // single-argument function -> one scalar_argument slot (None)
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -145,6 +147,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&nullable_i32)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -158,6 +161,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&non_nullable_i64)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -169,6 +173,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&nullable_i64)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/conversion/cast.rs
+++ b/datafusion/spark/src/function/conversion/cast.rs
@@ -633,6 +633,7 @@ mod tests {
         let return_field_args = ReturnFieldArgs {
             arg_fields: &arg_fields,
             scalar_arguments: &scalar_arguments,
+            config_options: &ConfigOptions::default(),
         };
         let result = cast.return_field_from_args(return_field_args);
         assert!(result.is_err());

--- a/datafusion/spark/src/function/datetime/date_add.rs
+++ b/datafusion/spark/src/function/datetime/date_add.rs
@@ -131,6 +131,7 @@ fn spark_date_add(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_date_add_non_nullable_inputs() {
@@ -144,6 +145,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: args,
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -163,6 +165,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: args,
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/datetime/date_sub.rs
+++ b/datafusion/spark/src/function/datetime/date_sub.rs
@@ -129,6 +129,7 @@ fn spark_date_sub(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_date_sub_nullability_non_nullable_args() {
@@ -140,6 +141,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[date_field, days_field],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -157,6 +159,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[date_field, nullable_days_field],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/datetime/last_day.rs
+++ b/datafusion/spark/src/function/datetime/last_day.rs
@@ -139,6 +139,7 @@ mod tests {
     use super::*;
     use crate::function::utils::test::test_scalar_function;
     use arrow::array::Array;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_last_day_nullability_matches_input() {
@@ -151,6 +152,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&non_nullable_arg)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .expect("non-nullable arg should succeed");
         assert_eq!(non_nullable_out.data_type(), &DataType::Date32);
@@ -160,6 +162,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&nullable_arg)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .expect("nullable arg should succeed");
         assert_eq!(nullable_out.data_type(), &DataType::Date32);

--- a/datafusion/spark/src/function/datetime/make_dt_interval.rs
+++ b/datafusion/spark/src/function/datetime/make_dt_interval.rs
@@ -243,6 +243,7 @@ mod tests {
     use arrow::array::{DurationMicrosecondArray, Float64Array, Int32Array};
     use arrow::datatypes::DataType::Duration;
     use arrow::datatypes::TimeUnit::Microsecond;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_common::internal_datafusion_err;
 
     use super::*;
@@ -322,6 +323,7 @@ mod tests {
         let out = udf.return_field_from_args(ReturnFieldArgs {
             arg_fields: &arg_fields,
             scalar_arguments: &[None, None, None, None],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(out.is_nullable());
         assert_eq!(out.data_type(), &Duration(Microsecond));
@@ -337,6 +339,7 @@ mod tests {
         let out = udf.return_field_from_args(ReturnFieldArgs {
             arg_fields: &non_nullable_arg_fields,
             scalar_arguments: &[None, None, None, None],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(!out.is_nullable());
 
@@ -347,6 +350,7 @@ mod tests {
         let out = udf.return_field_from_args(ReturnFieldArgs {
             arg_fields: &non_nullable_arg_fields,
             scalar_arguments: &scalar_refs,
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(out.is_nullable());
 
@@ -354,6 +358,7 @@ mod tests {
         let out = udf.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[],
             scalar_arguments: &[],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(!out.is_nullable());
 

--- a/datafusion/spark/src/function/datetime/make_interval.rs
+++ b/datafusion/spark/src/function/datetime/make_interval.rs
@@ -139,9 +139,10 @@ impl ScalarUDFImpl for SparkMakeInterval {
     ///   - ANSI mode on  → nullable only when any input field is nullable
     ///   - ANSI mode off → always nullable (overflow silently produces NULL)
     fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        let ansi_mode = args.config_options.execution.enable_ansi_mode;
         let nullable = if args.arg_fields.is_empty() {
             false
-        } else if self.ansi_mode {
+        } else if ansi_mode {
             args.arg_fields.iter().any(|f| f.is_nullable())
         } else {
             true
@@ -672,6 +673,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[],
                 scalar_arguments: &[],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
         assert!(!field.is_nullable(), "nullary call must not be nullable");
@@ -687,6 +689,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[non_null_field],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
         assert!(field.is_nullable(), "non-ANSI must always be nullable");
@@ -695,12 +698,14 @@ mod tests {
     #[test]
     fn return_field_ansi_mode_not_nullable_when_inputs_not_null() {
         // ANSI mode: no overflow → null; nullable only if inputs are nullable.
+        // config_options carries ansi mode to return_field_from_args.
         let udf = SparkMakeInterval::new_with_config(&make_ansi_config());
         let non_null_field: FieldRef = Arc::new(Field::new("x", DataType::Int32, false));
         let field = udf
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[non_null_field],
                 scalar_arguments: &[None],
+                config_options: &make_ansi_config(),
             })
             .unwrap();
         assert!(
@@ -717,6 +722,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[nullable_field],
                 scalar_arguments: &[None],
+                config_options: &make_ansi_config(),
             })
             .unwrap();
         assert!(

--- a/datafusion/spark/src/function/datetime/make_interval.rs
+++ b/datafusion/spark/src/function/datetime/make_interval.rs
@@ -20,18 +20,25 @@ use std::sync::Arc;
 use arrow::array::{Array, ArrayRef, IntervalMonthDayNanoBuilder, PrimitiveArray};
 use arrow::datatypes::DataType::Interval;
 use arrow::datatypes::IntervalUnit::MonthDayNano;
-use arrow::datatypes::{DataType, IntervalMonthDayNano};
+use arrow::datatypes::{DataType, Field, FieldRef, IntervalMonthDayNano};
+use datafusion_common::config::ConfigOptions;
 use datafusion_common::types::{NativeType, logical_float64, logical_int32};
-use datafusion_common::{DataFusionError, Result, ScalarValue, plan_datafusion_err};
+use datafusion_common::{
+    DataFusionError, Result, ScalarValue, exec_err, plan_datafusion_err,
+};
 use datafusion_expr::{
-    Coercion, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
-    TypeSignatureClass, Volatility,
+    Coercion, ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF,
+    ScalarUDFImpl, Signature, TypeSignature, TypeSignatureClass, Volatility,
 };
 use datafusion_functions::utils::make_scalar_function;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkMakeInterval {
     signature: Signature,
+    /// Mirrors `spark.sql.ansi.enabled` / `enable_ansi_mode`.
+    /// When true (failOnError=true in Spark) arithmetic overflow returns an error;
+    /// when false (default) it returns NULL instead.
+    ansi_mode: bool,
 }
 
 impl Default for SparkMakeInterval {
@@ -42,6 +49,10 @@ impl Default for SparkMakeInterval {
 
 impl SparkMakeInterval {
     pub fn new() -> Self {
+        Self::new_with_config(&ConfigOptions::default())
+    }
+
+    pub fn new_with_config(config: &ConfigOptions) -> Self {
         let int32 = Coercion::new_implicit(
             TypeSignatureClass::Native(logical_int32()),
             vec![TypeSignatureClass::Integer],
@@ -100,6 +111,7 @@ impl SparkMakeInterval {
 
         Self {
             signature: Signature::one_of(variants, Volatility::Immutable),
+            ansi_mode: config.execution.enable_ansi_mode,
         }
     }
 }
@@ -114,7 +126,31 @@ impl ScalarUDFImpl for SparkMakeInterval {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        // return_field_from_args is the authoritative implementation
         Ok(Interval(MonthDayNano))
+    }
+
+    fn with_updated_config(&self, config: &ConfigOptions) -> Option<ScalarUDF> {
+        Some(ScalarUDF::from(Self::new_with_config(config)))
+    }
+
+    /// Spark nullability rule (mirrors `failOnError` in Spark source):
+    ///   - nullary call → never null (always returns zero interval)
+    ///   - ANSI mode on  → nullable only when any input field is nullable
+    ///   - ANSI mode off → always nullable (overflow silently produces NULL)
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        let nullable = if args.arg_fields.is_empty() {
+            false
+        } else if self.ansi_mode {
+            args.arg_fields.iter().any(|f| f.is_nullable())
+        } else {
+            true
+        };
+        Ok(Arc::new(Field::new(
+            self.name(),
+            Interval(MonthDayNano),
+            nullable,
+        )))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -123,11 +159,17 @@ impl ScalarUDFImpl for SparkMakeInterval {
                 Some(IntervalMonthDayNano::new(0, 0, 0)),
             )));
         }
-        make_scalar_function(make_interval_kernel, vec![])(&args.args)
+        let ansi_mode = self.ansi_mode;
+        make_scalar_function(move |cols| make_interval_kernel(cols, ansi_mode), vec![])(
+            &args.args,
+        )
     }
 }
 
-fn make_interval_kernel(args: &[ArrayRef]) -> Result<ArrayRef, DataFusionError> {
+fn make_interval_kernel(
+    args: &[ArrayRef],
+    ansi_mode: bool,
+) -> Result<ArrayRef, DataFusionError> {
     use arrow::array::AsArray;
     use arrow::datatypes::{Float64Type, Int32Type};
 
@@ -216,6 +258,11 @@ fn make_interval_kernel(args: &[ArrayRef]) -> Result<ArrayRef, DataFusionError> 
         match make_interval_month_day_nano(y, mo, w, d, h, mi, s) {
             Some(v) => builder.append_value(v),
             None => {
+                if ansi_mode {
+                    return exec_err!(
+                        "Arithmetic overflow in make_interval: result does not fit in IntervalMonthDayNano"
+                    );
+                }
                 builder.append_null();
                 continue;
             }
@@ -274,7 +321,7 @@ mod tests {
 
     use super::*;
     fn run_make_interval_month_day_nano(arrs: Vec<ArrayRef>) -> Result<ArrayRef> {
-        make_interval_kernel(&arrs)
+        make_interval_kernel(&arrs, false)
     }
 
     #[test]
@@ -538,6 +585,14 @@ mod tests {
         args: Vec<ColumnarValue>,
         number_rows: usize,
     ) -> Result<ColumnarValue, DataFusionError> {
+        invoke_make_interval_with_config(args, number_rows, &ConfigOptions::default())
+    }
+
+    fn invoke_make_interval_with_config(
+        args: Vec<ColumnarValue>,
+        number_rows: usize,
+        config: &ConfigOptions,
+    ) -> Result<ColumnarValue, DataFusionError> {
         let arg_fields = args
             .iter()
             .map(|arg| Field::new("a", arg.data_type(), true).into())
@@ -547,9 +602,9 @@ mod tests {
             arg_fields,
             number_rows,
             return_field: Field::new("f", Interval(MonthDayNano), true).into(),
-            config_options: Arc::new(ConfigOptions::default()),
+            config_options: Arc::new(config.clone()),
         };
-        SparkMakeInterval::new().invoke_with_args(args)
+        SparkMakeInterval::new_with_config(config).invoke_with_args(args)
     }
 
     #[test]
@@ -600,5 +655,115 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    // --- nullability / return_field_from_args tests ---
+
+    fn make_ansi_config() -> ConfigOptions {
+        let mut cfg = ConfigOptions::default();
+        cfg.execution.enable_ansi_mode = true;
+        cfg
+    }
+
+    #[test]
+    fn return_field_nullary_is_not_nullable() {
+        let udf = SparkMakeInterval::new();
+        let field = udf
+            .return_field_from_args(ReturnFieldArgs {
+                arg_fields: &[],
+                scalar_arguments: &[],
+            })
+            .unwrap();
+        assert!(!field.is_nullable(), "nullary call must not be nullable");
+    }
+
+    #[test]
+    fn return_field_non_ansi_always_nullable() {
+        // Even with all non-null inputs, non-ANSI mode is always nullable
+        // because overflow silently returns NULL.
+        let udf = SparkMakeInterval::new(); // ansi_mode = false
+        let non_null_field: FieldRef = Arc::new(Field::new("x", DataType::Int32, false));
+        let field = udf
+            .return_field_from_args(ReturnFieldArgs {
+                arg_fields: &[non_null_field],
+                scalar_arguments: &[None],
+            })
+            .unwrap();
+        assert!(field.is_nullable(), "non-ANSI must always be nullable");
+    }
+
+    #[test]
+    fn return_field_ansi_mode_not_nullable_when_inputs_not_null() {
+        // ANSI mode: no overflow → null; nullable only if inputs are nullable.
+        let udf = SparkMakeInterval::new_with_config(&make_ansi_config());
+        let non_null_field: FieldRef = Arc::new(Field::new("x", DataType::Int32, false));
+        let field = udf
+            .return_field_from_args(ReturnFieldArgs {
+                arg_fields: &[non_null_field],
+                scalar_arguments: &[None],
+            })
+            .unwrap();
+        assert!(
+            !field.is_nullable(),
+            "ANSI mode with non-null inputs must not be nullable"
+        );
+    }
+
+    #[test]
+    fn return_field_ansi_mode_nullable_when_any_input_nullable() {
+        let udf = SparkMakeInterval::new_with_config(&make_ansi_config());
+        let nullable_field: FieldRef = Arc::new(Field::new("x", DataType::Int32, true));
+        let field = udf
+            .return_field_from_args(ReturnFieldArgs {
+                arg_fields: &[nullable_field],
+                scalar_arguments: &[None],
+            })
+            .unwrap();
+        assert!(
+            field.is_nullable(),
+            "ANSI mode with nullable inputs must be nullable"
+        );
+    }
+
+    // --- ANSI mode overflow error tests ---
+
+    #[test]
+    fn ansi_mode_overflow_returns_error() {
+        let ansi_cfg = make_ansi_config();
+        let year = ColumnarValue::Array(Arc::new(Int32Array::from(vec![Some(i32::MAX)])));
+        let month = ColumnarValue::Array(Arc::new(Int32Array::from(vec![Some(1)])));
+        let week = ColumnarValue::Array(Arc::new(Int32Array::from(vec![Some(0)])));
+        let day = ColumnarValue::Array(Arc::new(Int32Array::from(vec![Some(0)])));
+        let hour = ColumnarValue::Array(Arc::new(Int32Array::from(vec![Some(0)])));
+        let min = ColumnarValue::Array(Arc::new(Int32Array::from(vec![Some(0)])));
+        let sec = ColumnarValue::Array(Arc::new(Float64Array::from(vec![Some(0.0)])));
+
+        let result = invoke_make_interval_with_config(
+            vec![year, month, week, day, hour, min, sec],
+            1,
+            &ansi_cfg,
+        );
+        assert!(
+            result.is_err(),
+            "ANSI mode overflow must return an error, not NULL"
+        );
+    }
+
+    #[test]
+    fn non_ansi_overflow_returns_null() {
+        // Existing behavior must be preserved: overflow → NULL in non-ANSI mode.
+        let year = Arc::new(Int32Array::from(vec![Some(i32::MAX)])) as ArrayRef;
+        let month = Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef;
+        let week = Arc::new(Int32Array::from(vec![Some(0)])) as ArrayRef;
+        let day = Arc::new(Int32Array::from(vec![Some(0)])) as ArrayRef;
+        let hour = Arc::new(Int32Array::from(vec![Some(0)])) as ArrayRef;
+        let min = Arc::new(Int32Array::from(vec![Some(0)])) as ArrayRef;
+        let sec = Arc::new(Float64Array::from(vec![Some(0.0)])) as ArrayRef;
+
+        let out = run_make_interval_month_day_nano(vec![
+            year, month, week, day, hour, min, sec,
+        ])
+        .unwrap();
+        assert_eq!(out.null_count(), 1, "non-ANSI overflow must produce NULL");
     }
 }

--- a/datafusion/spark/src/function/datetime/next_day.rs
+++ b/datafusion/spark/src/function/datetime/next_day.rs
@@ -248,6 +248,7 @@ fn spark_next_day(days: i32, day_of_week: &str) -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn return_type_is_not_used() {
@@ -273,6 +274,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&date_field), Arc::clone(&day_field)],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/hash/crc32.rs
+++ b/datafusion/spark/src/function/hash/crc32.rs
@@ -126,6 +126,7 @@ fn spark_crc32(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_crc32_nullability() -> Result<()> {
@@ -136,6 +137,7 @@ mod tests {
         let result = crc32_func.return_field_from_args(ReturnFieldArgs {
             arg_fields: std::slice::from_ref(&field_not_null),
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(!result.is_nullable());
         assert_eq!(result.data_type(), &DataType::Int64);
@@ -145,6 +147,7 @@ mod tests {
         let result = crc32_func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[field_nullable],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(result.is_nullable());
         assert_eq!(result.data_type(), &DataType::Int64);

--- a/datafusion/spark/src/function/hash/sha1.rs
+++ b/datafusion/spark/src/function/hash/sha1.rs
@@ -140,6 +140,7 @@ fn spark_sha1(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_sha1_nullability() -> Result<()> {
@@ -150,6 +151,7 @@ mod tests {
         let out = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[Arc::clone(&non_nullable)],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(!out.is_nullable());
         assert_eq!(out.data_type(), &DataType::Utf8);
@@ -159,6 +161,7 @@ mod tests {
         let out = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[Arc::clone(&nullable)],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
         assert!(out.is_nullable());
         assert_eq!(out.data_type(), &DataType::Utf8);

--- a/datafusion/spark/src/function/json/json_tuple.rs
+++ b/datafusion/spark/src/function/json/json_tuple.rs
@@ -191,6 +191,7 @@ fn json_tuple_inner(args: &[ArrayRef], return_type: &DataType) -> Result<ArrayRe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_return_field_shape() {
@@ -204,6 +205,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &fields,
                 scalar_arguments: &[None, None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -226,6 +228,7 @@ mod tests {
         let result = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &fields,
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         });
         assert!(result.is_err());
         assert!(

--- a/datafusion/spark/src/function/map/map_from_arrays.rs
+++ b/datafusion/spark/src/function/map/map_from_arrays.rs
@@ -111,6 +111,7 @@ fn map_from_arrays_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_map_from_arrays_nullability_and_type() {
@@ -131,6 +132,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&keys_field), Arc::clone(&values_field)],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .expect("return_field_from_args should succeed");
 
@@ -152,6 +154,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[nullable_keys, values_field],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .expect("return_field_from_args should succeed");
 

--- a/datafusion/spark/src/function/map/map_from_entries.rs
+++ b/datafusion/spark/src/function/map/map_from_entries.rs
@@ -155,6 +155,7 @@ fn map_from_entries_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 mod tests {
     use super::*;
     use arrow::datatypes::Fields;
+    use datafusion_common::config::ConfigOptions;
 
     fn make_entries_field(array_nullable: bool, element_nullable: bool) -> FieldRef {
         let struct_type = DataType::Struct(Fields::from(vec![
@@ -180,6 +181,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&non_nullable_field)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .expect("should infer field");
         assert!(!result.is_nullable());
@@ -191,6 +193,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&element_nullable_field)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .expect("should infer field");
         assert!(result.is_nullable());
@@ -202,6 +205,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&array_nullable_field)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .expect("should infer field");
         assert!(result.is_nullable());

--- a/datafusion/spark/src/function/math/abs.rs
+++ b/datafusion/spark/src/function/math/abs.rs
@@ -230,6 +230,7 @@ pub fn spark_abs(
 mod tests {
     use super::*;
     use arrow::datatypes::i256;
+    use datafusion_common::config::ConfigOptions;
 
     macro_rules! eval_array_legacy_mode {
         ($INPUT:expr, $OUTPUT:expr, $FUNC:ident) => {{
@@ -518,6 +519,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&non_nullable_i32)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -531,6 +533,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&nullable_i32)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -544,6 +547,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&non_nullable_f64)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -556,6 +560,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&nullable_f64)],
                 scalar_arguments: &[None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/string/ascii.rs
+++ b/datafusion/spark/src/function/string/ascii.rs
@@ -89,6 +89,7 @@ impl ScalarUDFImpl for SparkAscii {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_return_field_nullable_input() {
@@ -99,6 +100,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[nullable_field],
                 scalar_arguments: &[],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -118,6 +120,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[non_nullable_field],
                 scalar_arguments: &[],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/string/char.rs
+++ b/datafusion/spark/src/function/string/char.rs
@@ -138,6 +138,7 @@ fn chr(args: &[ArrayRef]) -> Result<ArrayRef> {
 #[test]
 fn test_char_nullability() -> Result<()> {
     use arrow::datatypes::{DataType::Utf8, Field, FieldRef};
+    use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ReturnFieldArgs;
     use std::sync::Arc;
 
@@ -148,6 +149,7 @@ fn test_char_nullability() -> Result<()> {
     let out_nullable = func.return_field_from_args(ReturnFieldArgs {
         arg_fields: &[nullable_field],
         scalar_arguments: &[None],
+        config_options: &ConfigOptions::default(),
     })?;
 
     assert!(
@@ -165,6 +167,7 @@ fn test_char_nullability() -> Result<()> {
     let out_non_nullable = func.return_field_from_args(ReturnFieldArgs {
         arg_fields: &[non_nullable_field],
         scalar_arguments: &[None],
+        config_options: &ConfigOptions::default(),
     })?;
 
     assert!(

--- a/datafusion/spark/src/function/string/concat.rs
+++ b/datafusion/spark/src/function/string/concat.rs
@@ -162,6 +162,7 @@ mod tests {
     use super::*;
     use crate::function::utils::test::test_scalar_function;
     use arrow::array::{Array, StringArray};
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_concat_basic() -> Result<()> {
@@ -208,6 +209,7 @@ mod tests {
         let args = ReturnFieldArgs {
             arg_fields: &fields,
             scalar_arguments: &[],
+            config_options: &ConfigOptions::default(),
         };
 
         let field = func.return_field_from_args(args)?;
@@ -231,6 +233,7 @@ mod tests {
         let args = ReturnFieldArgs {
             arg_fields: &fields,
             scalar_arguments: &[],
+            config_options: &ConfigOptions::default(),
         };
 
         let field = func.return_field_from_args(args)?;

--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -2412,6 +2412,7 @@ mod tests {
     use crate::function::utils::test::test_scalar_function;
     use arrow::array::StringArray;
     use arrow::datatypes::DataType::Utf8;
+    use datafusion_common::config::ConfigOptions;
 
     #[test]
     fn test_format_string_nullability() -> Result<()> {
@@ -2421,6 +2422,7 @@ mod tests {
         let out_nullable = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[nullable_format],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         assert!(
@@ -2432,6 +2434,7 @@ mod tests {
         let out_non_nullable = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[non_nullable_format],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         assert!(

--- a/datafusion/spark/src/function/string/ilike.rs
+++ b/datafusion/spark/src/function/string/ilike.rs
@@ -89,6 +89,7 @@ mod tests {
     use arrow::array::{Array, BooleanArray};
     use arrow::datatypes::DataType::Boolean;
     use datafusion_common::ScalarValue;
+    use datafusion_common::config::ConfigOptions;
 
     macro_rules! test_ilike_string_invoke {
         ($INPUT1:expr, $INPUT2:expr, $EXPECTED:expr) => {
@@ -189,6 +190,7 @@ mod tests {
                     Arc::clone(&non_nullable_field2),
                 ],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -206,6 +208,7 @@ mod tests {
                     Arc::clone(&non_nullable_field2),
                 ],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -223,6 +226,7 @@ mod tests {
                     Arc::clone(&nullable_field2),
                 ],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -235,6 +239,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&nullable_field1), Arc::clone(&nullable_field2)],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/string/length.rs
+++ b/datafusion/spark/src/function/string/length.rs
@@ -200,6 +200,7 @@ mod tests {
     use crate::function::utils::test::test_scalar_function;
     use arrow::array::Int32Array;
     use arrow::datatypes::DataType::Int32;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_common::{Result, ScalarValue};
 
     macro_rules! test_spark_length_string {
@@ -295,6 +296,7 @@ mod tests {
         let out_nullable = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[nullable_field],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         assert!(
@@ -308,6 +310,7 @@ mod tests {
         let out_non_nullable = func.return_field_from_args(ReturnFieldArgs {
             arg_fields: &[non_nullable_field],
             scalar_arguments: &[None],
+            config_options: &ConfigOptions::default(),
         })?;
 
         assert!(

--- a/datafusion/spark/src/function/string/like.rs
+++ b/datafusion/spark/src/function/string/like.rs
@@ -91,6 +91,7 @@ mod tests {
     use arrow::array::{Array, BooleanArray};
     use arrow::datatypes::DataType::Boolean;
     use datafusion_common::ScalarValue;
+    use datafusion_common::config::ConfigOptions;
 
     macro_rules! test_like_string_invoke {
         ($INPUT1:expr, $INPUT2:expr, $EXPECTED:expr) => {
@@ -196,6 +197,7 @@ mod tests {
                     Arc::clone(&non_nullable_field2),
                 ],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -213,6 +215,7 @@ mod tests {
                     Arc::clone(&non_nullable_field2),
                 ],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -230,6 +233,7 @@ mod tests {
                     Arc::clone(&nullable_field2),
                 ],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 
@@ -242,6 +246,7 @@ mod tests {
             .return_field_from_args(ReturnFieldArgs {
                 arg_fields: &[Arc::clone(&nullable_field1), Arc::clone(&nullable_field2)],
                 scalar_arguments: &[None, None],
+                config_options: &ConfigOptions::default(),
             })
             .unwrap();
 

--- a/datafusion/spark/src/function/utils.rs
+++ b/datafusion/spark/src/function/utils.rs
@@ -60,7 +60,8 @@ pub mod test {
 
             let return_field = func.return_field_from_args(datafusion_expr::ReturnFieldArgs {
                 arg_fields: &arg_fields,
-                scalar_arguments: &scalar_arguments_refs
+                scalar_arguments: &scalar_arguments_refs,
+            config_options: &ConfigOptions::default(),
             });
 
             match expected {


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #19155

## Rationale for this change
Spark's `make_interval` nullability follows this rule (from Spark source):
```scala
nullable = if (failOnError) children.exists(_.nullable) else true
Where failOnError maps to DataFusion's enable_ansi_mode. The previous
default implementation always reports nullable = true, which is correct
for non-ANSI mode (overflow silently returns NULL) but too pessimistic for
ANSI mode (overflow throws, so output is only nullable when inputs are).
```

Previous attempts ([#19248](https://github.com/EshwarCVS/datafusion/issues/19248), [#19606](https://github.com/EshwarCVS/datafusion/issues/19606)) tried to derive nullability from input
fields inside return_field_from_args, but ReturnFieldArgs carries no
ConfigOptions, so ANSI mode was inaccessible.

### What changes are included in this PR?
Add ansi_mode: bool field to SparkMakeInterval, populated via a new
new_with_config(config) constructor.
Implement with_updated_config so the planner keeps the UDF in sync with
session config (same pattern as SparkCast).
Implement return_field_from_args with Spark's exact rule:
nullary call → nullable = false (always returns zero interval)
ANSI mode on → nullable = any input field is nullable
ANSI mode off (default) → nullable = true
In ANSI mode, make_interval_kernel now returns exec_err! on arithmetic
overflow instead of silently appending NULL.

### Are these changes tested?
Yes. Six new unit tests cover all branches:

```
return_field_nullary_is_not_nullable — zero-arg call is never nullable
return_field_non_ansi_always_nullable — non-ANSI: always nullable even with non-null inputs
return_field_ansi_mode_not_nullable_when_inputs_not_null — ANSI + non-null inputs → not nullable
return_field_ansi_mode_nullable_when_any_input_nullable — ANSI + nullable input → nullable
ansi_mode_overflow_returns_error — ANSI mode overflow is an error, not NULL
non_ansi_overflow_returns_null — non-ANSI overflow is still NULL (regression guard)
All 14 tests (8 existing + 6 new) pass.
```

### Are there any user-facing changes?
Non-ANSI mode (default): no behavior change.
ANSI mode: make_interval with non-nullable inputs now correctly
reports a non-nullable output field, and arithmetic overflow raises an
error instead of silently returning NULL.