### PR TITLE
Refactor unary filter pushdown logic for Aggregate and Window

### DIFF
--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1001,19 +1001,6 @@ impl OptimizerRule for PushDownFilter {
                     })
                     .collect::<HashSet<_>>();
 
-                let predicates = split_conjunction_owned(filter.predicate);
-
-                let mut keep_predicates = vec![];
-                let mut push_predicates = vec![];
-                for expr in predicates {
-                    let cols = expr.column_refs();
-                    if cols.iter().all(|c| group_expr_columns.contains(c)) {
-                        push_predicates.push(expr);
-                    } else {
-                        keep_predicates.push(expr);
-                    }
-                }
-
                 // As for plan Filter: Column(a+b) > 0 -- Agg: groupby:[Column(a)+Column(b)]
                 // After push, we need to replace `a+b` with Column(a)+Column(b)
                 // So we need create a replace_map, add {`a+b` --> Expr(Column(a)+Column(b))}
@@ -1021,31 +1008,23 @@ impl OptimizerRule for PushDownFilter {
                 for expr in &agg.group_expr {
                     replace_map.insert(expr.schema_name().to_string(), expr.clone());
                 }
-                let replaced_push_predicates = push_predicates
-                    .into_iter()
-                    .map(|expr| replace_cols_by_name(expr, &replace_map))
-                    .collect::<Result<Vec<_>>>()?;
 
                 let agg_input = Arc::clone(&agg.input);
-                Transformed::yes(LogicalPlan::Aggregate(agg))
-                    .transform_data(|new_plan| {
-                        // If we have a filter to push, we push it down to the input of the aggregate
-                        if let Some(predicate) = conjunction(replaced_push_predicates) {
-                            let new_filter = make_filter(predicate, agg_input)?;
-                            insert_below(new_plan, new_filter)
-                        } else {
-                            Ok(Transformed::no(new_plan))
-                        }
-                    })?
-                    .map_data(|child_plan| {
-                        // if there are any remaining predicates we can't push, add them
-                        // back as a filter
-                        if let Some(predicate) = conjunction(keep_predicates) {
-                            make_filter(predicate, Arc::new(child_plan))
-                        } else {
-                            Ok(child_plan)
-                        }
-                    })
+                push_down_filter_through_unary(
+                    filter.predicate,
+                    |expr| {
+                        let cols = expr.column_refs();
+                        cols.iter().all(|c| group_expr_columns.contains(c))
+                    },
+                    LogicalPlan::Aggregate(agg),
+                    agg_input,
+                    |push_predicates| {
+                        push_predicates
+                            .into_iter()
+                            .map(|expr| replace_cols_by_name(expr, &replace_map))
+                            .collect::<Result<Vec<_>>>()
+                    },
+                )
             }
             // Tries to push filters based on the partition key(s) of the window function(s) used.
             // Example:
@@ -1102,18 +1081,6 @@ impl OptimizerRule for PushDownFilter {
                     .reduce(|a, b| &a & &b)
                     .unwrap_or_default();
 
-                let predicates = split_conjunction_owned(filter.predicate);
-                let mut keep_predicates = vec![];
-                let mut push_predicates = vec![];
-                for expr in predicates {
-                    let cols = expr.column_refs();
-                    if cols.iter().all(|c| potential_partition_keys.contains(c)) {
-                        push_predicates.push(expr);
-                    } else {
-                        keep_predicates.push(expr);
-                    }
-                }
-
                 // Unlike with aggregations, there are no cases where we have to replace, e.g.,
                 // `a+b` with Column(a)+Column(b). This is because partition expressions are not
                 // available as standalone columns to the user. For example, while an aggregation on
@@ -1123,25 +1090,16 @@ impl OptimizerRule for PushDownFilter {
                 // optimizers, such as the one used by Postgres.
 
                 let window_input = Arc::clone(&window.input);
-                Transformed::yes(LogicalPlan::Window(window))
-                    .transform_data(|new_plan| {
-                        // If we have a filter to push, we push it down to the input of the window
-                        if let Some(predicate) = conjunction(push_predicates) {
-                            let new_filter = make_filter(predicate, window_input)?;
-                            insert_below(new_plan, new_filter)
-                        } else {
-                            Ok(Transformed::no(new_plan))
-                        }
-                    })?
-                    .map_data(|child_plan| {
-                        // if there are any remaining predicates we can't push, add them
-                        // back as a filter
-                        if let Some(predicate) = conjunction(keep_predicates) {
-                            make_filter(predicate, Arc::new(child_plan))
-                        } else {
-                            Ok(child_plan)
-                        }
-                    })
+                push_down_filter_through_unary(
+                    filter.predicate,
+                    |expr| {
+                        let cols = expr.column_refs();
+                        cols.iter().all(|c| potential_partition_keys.contains(c))
+                    },
+                    LogicalPlan::Window(window),
+                    window_input,
+                    Ok,
+                )
             }
             LogicalPlan::Join(join) => push_down_join(join, Some(&filter.predicate)),
             LogicalPlan::TableScan(scan) => {
@@ -1376,6 +1334,45 @@ fn rewrite_projection(
             conjunction(keep_predicates),
         )),
     }
+}
+
+/// Pushes eligible conjunctive predicates below a single-input plan node and
+/// re-applies ineligible predicates above it.
+fn push_down_filter_through_unary<C, R>(
+    predicate: Expr,
+    mut can_push: C,
+    unary_plan: LogicalPlan,
+    unary_input: Arc<LogicalPlan>,
+    rewrite_push_predicates: R,
+) -> Result<Transformed<LogicalPlan>>
+where
+    C: FnMut(&Expr) -> bool,
+    R: FnOnce(Vec<Expr>) -> Result<Vec<Expr>>,
+{
+    let (push_predicates, keep_predicates): (Vec<_>, Vec<_>) =
+        split_conjunction_owned(predicate)
+            .into_iter()
+            .partition(|expr| can_push(expr));
+    let push_predicates = rewrite_push_predicates(push_predicates)?;
+
+    Transformed::yes(unary_plan)
+        .transform_data(|new_plan| {
+            // If we have a filter to push, push it down to the unary node's input.
+            if let Some(predicate) = conjunction(push_predicates) {
+                let new_filter = make_filter(predicate, unary_input)?;
+                insert_below(new_plan, new_filter)
+            } else {
+                Ok(Transformed::no(new_plan))
+            }
+        })?
+        .map_data(|child_plan| {
+            // If any predicates remain, add them back as a filter above the unary node.
+            if let Some(predicate) = conjunction(keep_predicates) {
+                make_filter(predicate, Arc::new(child_plan))
+            } else {
+                Ok(child_plan)
+            }
+        })
 }
 
 /// Creates a new LogicalPlan::Filter node.

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1004,16 +1004,18 @@ impl OptimizerRule for PushDownFilter {
                 // As for plan Filter: Column(a+b) > 0 -- Agg: groupby:[Column(a)+Column(b)]
                 // After push, we need to replace `a+b` with Column(a)+Column(b)
                 // So we need create a replace_map, add {`a+b` --> Expr(Column(a)+Column(b))}
-                let mut replace_map = HashMap::new();
-                for expr in &agg.group_expr {
-                    replace_map.insert(expr.schema_name().to_string(), expr.clone());
-                }
+                let replace_map = agg
+                    .group_expr
+                    .iter()
+                    .map(|expr| (expr.schema_name().to_string(), expr.clone()))
+                    .collect::<HashMap<_, _>>();
 
                 push_down_filter_through_unary(
                     filter.predicate,
                     |expr| {
-                        let cols = expr.column_refs();
-                        cols.iter().all(|c| group_expr_columns.contains(c))
+                        expr.column_refs()
+                            .iter()
+                            .all(|c| group_expr_columns.contains(c))
                     },
                     LogicalPlan::Aggregate(agg),
                     |push_predicates| {
@@ -1090,8 +1092,9 @@ impl OptimizerRule for PushDownFilter {
                 push_down_filter_through_unary(
                     filter.predicate,
                     |expr| {
-                        let cols = expr.column_refs();
-                        cols.iter().all(|c| potential_partition_keys.contains(c))
+                        expr.column_refs()
+                            .iter()
+                            .all(|c| potential_partition_keys.contains(c))
                     },
                     LogicalPlan::Window(window),
                     Ok,
@@ -1375,20 +1378,7 @@ fn insert_filter_below_unary(
     plan: LogicalPlan,
     predicate: Expr,
 ) -> Result<Transformed<LogicalPlan>> {
-    let mut predicate = Some(predicate);
-    let transformed_plan = plan.map_children(|child| {
-        if let Some(predicate) = predicate.take() {
-            make_filter(predicate, Arc::new(child)).map(Transformed::yes)
-        } else {
-            // already took the predicate
-            internal_err!("node had more than one input")
-        }
-    })?;
-
-    // make sure we did the actual replacement
-    assert_or_internal_err!(predicate.is_none(), "node had no inputs");
-
-    Ok(transformed_plan)
+    map_single_child(plan, |child| make_filter(predicate, Arc::new(child)))
 }
 
 /// Creates a new LogicalPlan::Filter node.
@@ -1413,18 +1403,28 @@ fn insert_below(
     plan: LogicalPlan,
     new_child: LogicalPlan,
 ) -> Result<Transformed<LogicalPlan>> {
-    let mut new_child = Some(new_child);
-    let transformed_plan = plan.map_children(|_child| {
-        if let Some(new_child) = new_child.take() {
-            Ok(Transformed::yes(new_child))
+    map_single_child(plan, |_child| Ok(new_child))
+}
+
+fn map_single_child<F>(
+    plan: LogicalPlan,
+    replace_child: F,
+) -> Result<Transformed<LogicalPlan>>
+where
+    F: FnOnce(LogicalPlan) -> Result<LogicalPlan>,
+{
+    let mut replace_child = Some(replace_child);
+    let transformed_plan = plan.map_children(|child| {
+        if let Some(replace_child) = replace_child.take() {
+            replace_child(child).map(Transformed::yes)
         } else {
-            // already took the new child
+            // already replaced the child
             internal_err!("node had more than one input")
         }
     })?;
 
     // make sure we did the actual replacement
-    assert_or_internal_err!(new_child.is_none(), "node had no inputs");
+    assert_or_internal_err!(replace_child.is_none(), "node had no inputs");
 
     Ok(transformed_plan)
 }

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1009,7 +1009,6 @@ impl OptimizerRule for PushDownFilter {
                     replace_map.insert(expr.schema_name().to_string(), expr.clone());
                 }
 
-                let agg_input = Arc::clone(&agg.input);
                 push_down_filter_through_unary(
                     filter.predicate,
                     |expr| {
@@ -1017,7 +1016,6 @@ impl OptimizerRule for PushDownFilter {
                         cols.iter().all(|c| group_expr_columns.contains(c))
                     },
                     LogicalPlan::Aggregate(agg),
-                    agg_input,
                     |push_predicates| {
                         push_predicates
                             .into_iter()
@@ -1089,7 +1087,6 @@ impl OptimizerRule for PushDownFilter {
                 // place, so we can use `push_predicates` directly. This is consistent with other
                 // optimizers, such as the one used by Postgres.
 
-                let window_input = Arc::clone(&window.input);
                 push_down_filter_through_unary(
                     filter.predicate,
                     |expr| {
@@ -1097,7 +1094,6 @@ impl OptimizerRule for PushDownFilter {
                         cols.iter().all(|c| potential_partition_keys.contains(c))
                     },
                     LogicalPlan::Window(window),
-                    window_input,
                     Ok,
                 )
             }
@@ -1342,7 +1338,6 @@ fn push_down_filter_through_unary<C, R>(
     predicate: Expr,
     mut can_push: C,
     unary_plan: LogicalPlan,
-    unary_input: Arc<LogicalPlan>,
     rewrite_push_predicates: R,
 ) -> Result<Transformed<LogicalPlan>>
 where
@@ -1359,8 +1354,7 @@ where
         .transform_data(|new_plan| {
             // If we have a filter to push, push it down to the unary node's input.
             if let Some(predicate) = conjunction(push_predicates) {
-                let new_filter = make_filter(predicate, unary_input)?;
-                insert_below(new_plan, new_filter)
+                insert_filter_below_unary(new_plan, predicate)
             } else {
                 Ok(Transformed::no(new_plan))
             }
@@ -1373,6 +1367,28 @@ where
                 Ok(child_plan)
             }
         })
+}
+
+/// Inserts a filter below a single-input plan node, using that node's existing
+/// child as the filter input.
+fn insert_filter_below_unary(
+    plan: LogicalPlan,
+    predicate: Expr,
+) -> Result<Transformed<LogicalPlan>> {
+    let mut predicate = Some(predicate);
+    let transformed_plan = plan.map_children(|child| {
+        if let Some(predicate) = predicate.take() {
+            make_filter(predicate, Arc::new(child)).map(Transformed::yes)
+        } else {
+            // already took the predicate
+            internal_err!("node had more than one input")
+        }
+    })?;
+
+    // make sure we did the actual replacement
+    assert_or_internal_err!(predicate.is_none(), "node had no inputs");
+
+    Ok(transformed_plan)
 }
 
 /// Creates a new LogicalPlan::Filter node.


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #22056

## Rationale for this change

`PushDownFilter` contained duplicated logic in the `Aggregate` and `Window` branches for:

* Splitting predicates into pushable and retained sets.
* Rebuilding unary plans with pushed filters below them.
* Re-applying retained predicates above the rebuilt plan.

This change extracts the shared unary pushdown/rebuild flow into reusable internal helpers to reduce duplication and improve maintainability, while preserving existing optimizer behavior.

## What changes are included in this PR?

* Added a new internal helper, `push_down_filter_through_unary`, to encapsulate the common unary filter pushdown pattern.
* Added `insert_filter_below_unary` helper for inserting filters beneath unary plan nodes.
* Refactored the `Aggregate` branch to use the shared helper while preserving aggregate-specific expression rewriting via `replace_cols_by_name`.
* Refactored the `Window` branch to use the shared helper while preserving existing partition-key eligibility checks.
* Extracted reusable single-child replacement logic into `map_single_child`.
* Simplified `insert_below` to reuse the new helper.

No intended SQL behavior changes are included in this PR.

## Are these changes tested?

No new tests were added in this PR.

This refactor is intended to preserve existing behavior and is expected to be covered by the existing optimizer test suite, including:

* `cargo test -p datafusion-optimizer push_down_filter`
* `cargo test -p datafusion-sqllogictest --test sqllogictests push_down_filter_regression`

## Are there any user-facing changes?

No. This change is limited to optimizer internals and does not intend to change SQL semantics or user-visible behavior.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
