### PR TITLE
chore: Fix broken build with `--benches --all-features`

### DIFF
--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -292,8 +292,7 @@ fn vectorized_equal_to<GroupColumnBuilder: GroupColumn>(
             // Rebuild the buffer each iteration as `vectorized_equal_to` mutates
             // it, and without a fresh buffer all iterations after the first one
             // would not be meaningful.
-            let mut equal_to_buffer =
-                BooleanBufferBuilder::new(equal_to_results.len());
+            let mut equal_to_buffer = BooleanBufferBuilder::new(equal_to_results.len());
             for &v in &equal_to_results {
                 equal_to_buffer.append(v);
             }

--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::ArrayRef;
+use arrow::array::{ArrayRef, BooleanBufferBuilder};
 use arrow::datatypes::{Int32Type, StringViewType};
 use arrow::util::bench_util::{
     create_primitive_array, create_string_view_array_with_len,
@@ -289,13 +289,18 @@ fn vectorized_equal_to<GroupColumnBuilder: GroupColumn>(
         builder.vectorized_append(input, rows).unwrap();
 
         b.iter(|| {
-            // Cloning is a must as `vectorized_equal_to` will modify the input vec
-            // and without cloning all benchmarks after the first one won't be meaningful
-            let mut equal_to_results = equal_to_results.clone();
-            builder.vectorized_equal_to(rows, input, rows, &mut equal_to_results);
+            // Rebuild the buffer each iteration as `vectorized_equal_to` mutates
+            // it, and without a fresh buffer all iterations after the first one
+            // would not be meaningful.
+            let mut equal_to_buffer =
+                BooleanBufferBuilder::new(equal_to_results.len());
+            for &v in &equal_to_results {
+                equal_to_buffer.append(v);
+            }
+            builder.vectorized_equal_to(rows, input, rows, &mut equal_to_buffer);
 
             // Make sure that the compiler does not optimize away the call
-            black_box(equal_to_results);
+            black_box(equal_to_buffer);
         });
     });
 }


### PR DESCRIPTION
```
$ cargo check -p datafusion-physical-plan --benches --all-features
    Checking tokio v1.52.2
   Compiling getrandom v0.2.17
    Checking arrow-string v58.2.0
    Checking console v0.16.3
    Checking arrow-csv v58.2.0
   Compiling rstest_macros v0.26.1
    Checking criterion v0.8.2
   Compiling rand_core v0.6.4
    Checking insta v1.47.2
   Compiling rand_chacha v0.3.1
   Compiling rand v0.8.6
    Checking arrow v58.2.0
   Compiling rstest_reuse v0.7.0
    Checking rstest v0.26.1
    Checking datafusion-common v53.1.0 (/Users/neilconway/df/review/datafusion/common)
    Checking object_store v0.13.2
    Checking datafusion-common-runtime v53.1.0 (/Users/neilconway/df/review/datafusion/common-runtime)
    Checking datafusion-expr-common v53.1.0 (/Users/neilconway/df/review/datafusion/expr-common)
    Checking datafusion-physical-expr-common v53.1.0 (/Users/neilconway/df/review/datafusion/physical-expr-common)
    Checking datafusion-functions-aggregate-common v53.1.0 (/Users/neilconway/df/review/datafusion/functions-aggregate-common)
    Checking datafusion-functions-window-common v53.1.0 (/Users/neilconway/df/review/datafusion/functions-window-common)
    Checking datafusion-expr v53.1.0 (/Users/neilconway/df/review/datafusion/expr)
    Checking datafusion-execution v53.1.0 (/Users/neilconway/df/review/datafusion/execution)
    Checking datafusion-physical-expr v53.1.0 (/Users/neilconway/df/review/datafusion/physical-expr)
    Checking datafusion-functions v53.1.0 (/Users/neilconway/df/review/datafusion/functions)
    Checking datafusion-functions-aggregate v53.1.0 (/Users/neilconway/df/review/datafusion/functions-aggregate)
    Checking datafusion-functions-window v53.1.0 (/Users/neilconway/df/review/datafusion/functions-window)
    Checking datafusion-physical-plan v53.1.0 (/Users/neilconway/df/review/datafusion/physical-plan)
error[E0308]: mismatched types
   --> datafusion/physical-plan/benches/aggregate_vectorized.rs:295:60
    |
295 |             builder.vectorized_equal_to(rows, input, rows, &mut equal_to_results);
    |                     -------------------                    ^^^^^^^^^^^^^^^^^^^^^ expected `&mut BooleanBufferBuilder`, found `&mut Vec<bool>`
    |                     |
    |                     arguments to this method are incorrect
    |
    = note: expected mutable reference `&mut BooleanBufferBuilder`
               found mutable reference `&mut Vec<bool>`
note: method defined here
   --> datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs:80:8
    |
 80 |     fn vectorized_equal_to(
    |        ^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `datafusion-physical-plan` (bench "aggregate_vectorized") due to 1 previous error
```