### PR TITLE
Consolidate and document SQL AST shims

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -50,7 +50,7 @@ pub use sqlparser::ast::{
     ExceptSelectItem, ExcludeSelectItem, IlikeSelectItem, RenameSelectItem,
     ReplaceSelectElement,
 };
-// Use sqlparser shims when sql feature disabled
+// Use shims for sqlparser types when the sql feature is disabled.
 #[cfg(not(feature = "sql"))]
 pub use crate::sql::{
     ExceptSelectItem, ExcludeSelectItem, IlikeSelectItem, RenameSelectItem,

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -46,7 +46,13 @@ use datafusion_common::{
 use datafusion_expr_common::placement::ExpressionPlacement;
 use datafusion_functions_window_common::field::WindowUDFFieldArgs;
 #[cfg(feature = "sql")]
-use sqlparser::ast::{
+pub use sqlparser::ast::{
+    ExceptSelectItem, ExcludeSelectItem, IlikeSelectItem, RenameSelectItem,
+    ReplaceSelectElement,
+};
+// Use sqlparser shims when sql feature disabled
+#[cfg(not(feature = "sql"))]
+pub use crate::sql::{
     ExceptSelectItem, ExcludeSelectItem, IlikeSelectItem, RenameSelectItem,
     ReplaceSelectElement,
 };
@@ -1416,62 +1422,6 @@ impl Lambda {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
-#[cfg(not(feature = "sql"))]
-pub struct IlikeSelectItem {
-    pub pattern: String,
-}
-#[cfg(not(feature = "sql"))]
-impl Display for IlikeSelectItem {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "ILIKE '{}'", &self.pattern)?;
-        Ok(())
-    }
-}
-#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
-#[cfg(not(feature = "sql"))]
-pub enum ExcludeSelectItem {
-    Single(Ident),
-    Multiple(Vec<Ident>),
-}
-#[cfg(not(feature = "sql"))]
-impl Display for ExcludeSelectItem {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "EXCLUDE")?;
-        match self {
-            Self::Single(column) => {
-                write!(f, " {column}")?;
-            }
-            Self::Multiple(columns) => {
-                write!(f, " ({})", display_comma_separated(columns))?;
-            }
-        }
-        Ok(())
-    }
-}
-#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
-#[cfg(not(feature = "sql"))]
-pub struct ExceptSelectItem {
-    pub first_element: Ident,
-    pub additional_elements: Vec<Ident>,
-}
-#[cfg(not(feature = "sql"))]
-impl Display for ExceptSelectItem {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "EXCEPT ")?;
-        if self.additional_elements.is_empty() {
-            write!(f, "({})", self.first_element)?;
-        } else {
-            write!(
-                f,
-                "({}, {})",
-                self.first_element,
-                display_comma_separated(&self.additional_elements)
-            )?;
-        }
-        Ok(())
-    }
-}
 
 pub fn display_comma_separated<T>(slice: &[T]) -> String
 where
@@ -1479,64 +1429,6 @@ where
 {
     use itertools::Itertools;
     slice.iter().map(|v| format!("{v}")).join(", ")
-}
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
-#[cfg(not(feature = "sql"))]
-pub enum RenameSelectItem {
-    Single(String),
-    Multiple(Vec<String>),
-}
-#[cfg(not(feature = "sql"))]
-impl Display for RenameSelectItem {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "RENAME")?;
-        match self {
-            Self::Single(column) => {
-                write!(f, " {column}")?;
-            }
-            Self::Multiple(columns) => {
-                write!(f, " ({})", display_comma_separated(columns))?;
-            }
-        }
-        Ok(())
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
-#[cfg(not(feature = "sql"))]
-pub struct Ident {
-    /// The value of the identifier without quotes.
-    pub value: String,
-    /// The starting quote if any. Valid quote characters are the single quote,
-    /// double quote, backtick, and opening square bracket.
-    pub quote_style: Option<char>,
-    /// The span of the identifier in the original SQL string.
-    pub span: String,
-}
-#[cfg(not(feature = "sql"))]
-impl Display for Ident {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "[{}]", self.value)
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
-#[cfg(not(feature = "sql"))]
-pub struct ReplaceSelectElement {
-    pub expr: String,
-    pub column_name: Ident,
-    pub as_keyword: bool,
-}
-#[cfg(not(feature = "sql"))]
-impl Display for ReplaceSelectElement {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if self.as_keyword {
-            write!(f, "{} AS {}", self.expr, self.column_name)
-        } else {
-            write!(f, "{} {}", self.expr, self.column_name)
-        }
-    }
 }
 
 /// Additional options for wildcards, e.g. Snowflake `EXCLUDE`/`RENAME` and Bigquery `EXCEPT`.

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -1422,7 +1422,6 @@ impl Lambda {
     }
 }
 
-
 pub fn display_comma_separated<T>(slice: &[T]) -> String
 where
     T: Display,

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -80,6 +80,8 @@ pub mod statistics {
 mod predicate_bounds;
 pub mod preimage;
 pub mod ptr_eq;
+#[cfg(not(feature = "sql"))]
+pub mod sql;
 pub mod test;
 pub mod tree_node;
 pub mod type_coercion;

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -24,8 +24,6 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-#[cfg(not(feature = "sql"))]
-use crate::expr::Ident;
 use crate::expr::Sort;
 use arrow::datatypes::DataType;
 use datafusion_common::tree_node::{Transformed, TreeNodeContainer, TreeNodeRecursion};
@@ -34,6 +32,8 @@ use datafusion_common::{
 };
 #[cfg(feature = "sql")]
 use sqlparser::ast::Ident;
+#[cfg(not(feature = "sql"))]
+use crate::sql::Ident;
 
 /// Various types of DDL  (CREATE / DROP) catalog manipulation
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]

--- a/datafusion/expr/src/logical_plan/ddl.rs
+++ b/datafusion/expr/src/logical_plan/ddl.rs
@@ -25,6 +25,8 @@ use std::{
 };
 
 use crate::expr::Sort;
+#[cfg(not(feature = "sql"))]
+use crate::sql::Ident;
 use arrow::datatypes::DataType;
 use datafusion_common::tree_node::{Transformed, TreeNodeContainer, TreeNodeRecursion};
 use datafusion_common::{
@@ -32,8 +34,6 @@ use datafusion_common::{
 };
 #[cfg(feature = "sql")]
 use sqlparser::ast::Ident;
-#[cfg(not(feature = "sql"))]
-use crate::sql::Ident;
 
 /// Various types of DDL  (CREATE / DROP) catalog manipulation
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]

--- a/datafusion/expr/src/sql.rs
+++ b/datafusion/expr/src/sql.rs
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Local copies of [`sqlparser::ast`] structures
+//!
+//! These types are used when the `sql` feature is disabled. When `sql` is
+//! enabled, the upstream types from [`sqlparser`] are used instead.
+//!
+//! These definitions should be structurally compatible with the upstream
+//! `sqlparser` types, so that code which switches between them via `cfg` keeps
+//! compiling.
+//!
+//! See [#17332](https://github.com/apache/datafusion/pull/17332) for
+//! more detail.
+
+use crate::expr::display_comma_separated;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
+pub struct IlikeSelectItem {
+    pub pattern: String,
+}
+
+impl Display for IlikeSelectItem {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "ILIKE '{}'", &self.pattern)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
+pub enum ExcludeSelectItem {
+    Single(Ident),
+    Multiple(Vec<Ident>),
+}
+
+impl Display for ExcludeSelectItem {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "EXCLUDE")?;
+        match self {
+            Self::Single(column) => {
+                write!(f, " {column}")?;
+            }
+            Self::Multiple(columns) => {
+                write!(f, " ({})", display_comma_separated(columns))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
+pub struct ExceptSelectItem {
+    pub first_element: Ident,
+    pub additional_elements: Vec<Ident>,
+}
+
+impl Display for ExceptSelectItem {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "EXCEPT ")?;
+        if self.additional_elements.is_empty() {
+            write!(f, "({})", self.first_element)?;
+        } else {
+            write!(
+                f,
+                "({}, {})",
+                self.first_element,
+                display_comma_separated(&self.additional_elements)
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
+pub enum RenameSelectItem {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl Display for RenameSelectItem {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "RENAME")?;
+        match self {
+            Self::Single(column) => {
+                write!(f, " {column}")?;
+            }
+            Self::Multiple(columns) => {
+                write!(f, " ({})", display_comma_separated(columns))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
+pub struct Ident {
+    /// The value of the identifier without quotes.
+    pub value: String,
+    /// The starting quote if any. Valid quote characters are the single quote,
+    /// double quote, backtick, and opening square bracket.
+    pub quote_style: Option<char>,
+    /// The span of the identifier in the original SQL string.
+    pub span: String,
+}
+
+impl Display for Ident {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "[{}]", self.value)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Hash, Debug)]
+pub struct ReplaceSelectElement {
+    pub expr: String,
+    pub column_name: Ident,
+    pub as_keyword: bool,
+}
+
+impl Display for ReplaceSelectElement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.as_keyword {
+            write!(f, "{} AS {}", self.expr, self.column_name)
+        } else {
+            write!(f, "{} {}", self.expr, self.column_name)
+        }
+    }
+}

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -39,7 +39,7 @@ use datafusion_common::{
 };
 
 #[cfg(not(feature = "sql"))]
-use crate::expr::{ExceptSelectItem, ExcludeSelectItem};
+use crate::sql::{ExceptSelectItem, ExcludeSelectItem};
 use indexmap::IndexSet;
 #[cfg(feature = "sql")]
 use sqlparser::ast::{ExceptSelectItem, ExcludeSelectItem};


### PR DESCRIPTION
## Which issue does this PR close?

- Related to https://github.com/apache/datafusion/pull/22069

## Rationale for this change

While upgrading sqlparser, it was not clear why there were feature gates for the `sql` feature: https://github.com/apache/datafusion/pull/22069/changes#r3204705488

There is a mode to avoid the `sqlparser` dependency, added by @timsaucer in
- #17332

I think this feature makes sense but it is a little hard to understand because it is implemented with a bunch of `#[cfg(not(feature = "sql"))]` and there is no central place that explains the design.

## What changes are included in this PR?

1. Consolidate the SQL AST shim structures in a separate module
2. Document the design so it is easier to understand

## Are these changes tested?

Yes by CI

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->