### PR TITLE
Reduce primitive group equality code size

### DIFF
--- a/datafusion/physical-plan/benches/aggregate_vectorized.rs
+++ b/datafusion/physical-plan/benches/aggregate_vectorized.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::ArrayRef;
+use arrow::array::{ArrayRef, BooleanBufferBuilder};
 use arrow::datatypes::{Int32Type, StringViewType};
 use arrow::util::bench_util::{
     create_primitive_array, create_string_view_array_with_len,
@@ -291,11 +291,13 @@ fn vectorized_equal_to<GroupColumnBuilder: GroupColumn>(
         b.iter(|| {
             // Cloning is a must as `vectorized_equal_to` will modify the input vec
             // and without cloning all benchmarks after the first one won't be meaningful
-            let mut equal_to_results = equal_to_results.clone();
-            builder.vectorized_equal_to(rows, input, rows, &mut equal_to_results);
+            let mut equal_to_results_builder =
+                BooleanBufferBuilder::new(equal_to_results.len());
+            equal_to_results_builder.append_slice(&equal_to_results);
+            builder.vectorized_equal_to(rows, input, rows, &mut equal_to_results_builder);
 
             // Make sure that the compiler does not optimize away the call
-            black_box(equal_to_results);
+            black_box(equal_to_results_builder);
         });
     });
 }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -47,6 +47,50 @@ pub struct PrimitiveGroupValueBuilder<T: ArrowPrimitiveType, const NULLABLE: boo
     nulls: MaybeNullBufferBuilder,
 }
 
+#[inline(never)]
+fn vectorized_equal_to_non_nullable<T>(
+    group_values: &[T::Native],
+    lhs_rows: &[usize],
+    array: &ArrayRef,
+    rhs_rows: &[usize],
+    equal_to_results: &mut BooleanBufferBuilder,
+) where
+    T: ArrowPrimitiveType,
+{
+    let array_values = array.as_primitive::<T>().values();
+    let n = lhs_rows.len();
+
+    // Build a packed comparison bitmask, then AND it into equal_to_results
+    let num_bytes = n.div_ceil(8);
+    let mut cmp_buf = vec![0u8; num_bytes];
+
+    for (i, (&lhs_row, &rhs_row)) in lhs_rows.iter().zip(rhs_rows.iter()).enumerate() {
+        let left = if cfg!(debug_assertions) {
+            group_values[lhs_row]
+        } else {
+            unsafe { *group_values.get_unchecked(lhs_row) }
+        };
+        let right = if cfg!(debug_assertions) {
+            array_values[rhs_row]
+        } else {
+            unsafe { *array_values.get_unchecked(rhs_row) }
+        };
+        if left.is_eq(right) {
+            cmp_buf[i / 8] |= 1 << (i % 8);
+        }
+    }
+
+    // AND the comparison result into the existing equal_to_results bitmask
+    apply_bitwise_binary_op(
+        equal_to_results.as_slice_mut(),
+        0,
+        &cmp_buf,
+        0,
+        n,
+        |a, b| a & b,
+    );
+}
+
 impl<T, const NULLABLE: bool> PrimitiveGroupValueBuilder<T, NULLABLE>
 where
     T: ArrowPrimitiveType,
@@ -58,52 +102,6 @@ where
             group_values: vec![],
             nulls: MaybeNullBufferBuilder::new(),
         }
-    }
-
-    fn vectorized_equal_to_non_nullable(
-        &self,
-        lhs_rows: &[usize],
-        array: &ArrayRef,
-        rhs_rows: &[usize],
-        equal_to_results: &mut BooleanBufferBuilder,
-    ) {
-        assert!(
-            !NULLABLE || (array.null_count() == 0 && !self.nulls.might_have_nulls()),
-            "called with nullable input"
-        );
-        let array_values = array.as_primitive::<T>().values();
-        let n = lhs_rows.len();
-
-        // Build a packed comparison bitmask, then AND it into equal_to_results
-        let num_bytes = n.div_ceil(8);
-        let mut cmp_buf = vec![0u8; num_bytes];
-
-        for (i, (&lhs_row, &rhs_row)) in lhs_rows.iter().zip(rhs_rows.iter()).enumerate()
-        {
-            let left = if cfg!(debug_assertions) {
-                self.group_values[lhs_row]
-            } else {
-                unsafe { *self.group_values.get_unchecked(lhs_row) }
-            };
-            let right = if cfg!(debug_assertions) {
-                array_values[rhs_row]
-            } else {
-                unsafe { *array_values.get_unchecked(rhs_row) }
-            };
-            if left.is_eq(right) {
-                cmp_buf[i / 8] |= 1 << (i % 8);
-            }
-        }
-
-        // AND the comparison result into the existing equal_to_results bitmask
-        apply_bitwise_binary_op(
-            equal_to_results.as_slice_mut(),
-            0,
-            &cmp_buf,
-            0,
-            n,
-            |a, b| a & b,
-        );
     }
 
     pub fn vectorized_equal_nullable(
@@ -181,7 +179,8 @@ impl<T: ArrowPrimitiveType, const NULLABLE: bool> GroupColumn
         equal_to_results: &mut BooleanBufferBuilder,
     ) {
         if !NULLABLE || (array.null_count() == 0 && !self.nulls.might_have_nulls()) {
-            self.vectorized_equal_to_non_nullable(
+            vectorized_equal_to_non_nullable::<T>(
+                &self.group_values,
                 lhs_rows,
                 array,
                 rhs_rows,


### PR DESCRIPTION
## Which issue does this PR close?

- N/A.

## Rationale for this change

Primitive group-by vectorized equality had the same non-null comparison loop emitted for both nullable and non-nullable const-generic instantiations. Sharing that loop reduces generated code size and instruction-cache pressure in aggregation paths without changing behavior.

Measured with release-nonlto on this branch:

- libdatafusion_physical_plan.rlib: 18,068,448 -> 17,592,688 bytes, -475,760 bytes / -2.63%.
- rlib text from /usr/bin/size: 4,844,256 -> 4,612,079, -232,177 / -4.79%.
- cargo asm aggregate sample: 492,394 -> 464,167, -28,227 / -5.73%.
- datafusion-cli __text: 88,257,172 -> 88,249,760, -7,412 bytes.

Criterion vectorized_equal_to results across 48 cases showed no statistically significant regressions. Overall mean was -4.94% and median was -1.53%, with larger nullable cases seeing the clearest wins.

## What changes are included in this PR?

- Moves the primitive non-null vectorized equality helper out of the NULLABLE const-generic impl and marks it inline(never), so nullable and non-nullable builders share the same emitted helper per primitive type.
- Keeps the nullable slow path unchanged.
- Updates the aggregate_vectorized benchmark harness to use BooleanBufferBuilder, matching the current GroupColumn API.

## Are these changes tested?

- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p datafusion-physical-plan multi_group_by::primitive --profile release-nonlto
- cargo bench -p datafusion-physical-plan --features test_utils --bench aggregate_vectorized --profile release-nonlto -- PrimitiveGroupValueBuilder_vectorized_append.*vectorized_equal_to --sample-size 20 --measurement-time 2

## Are there any user-facing changes?

No.