### PR TITLE
Minor: Disallow async function in lambdas

### DIFF
--- a/datafusion/physical-expr/src/expressions/lambda.rs
+++ b/datafusion/physical-expr/src/expressions/lambda.rs
@@ -224,8 +224,9 @@ fn check_async_udf(body: &Arc<dyn PhysicalExpr>) -> Result<()> {
             .downcast_ref::<ScalarFunctionExpr>()
             .is_some_and(|udf| udf.fun().as_async().is_some()))
     })? {
-        // https://github.com/apache/datafusion/issues/22091
-        return plan_err!("Async functions in lambdas aren't supported");
+        return plan_err!(
+            "Async functions in lambdas aren't supported, see https://github.com/apache/datafusion/issues/22091"
+        );
     }
 
     Ok(())

--- a/datafusion/physical-expr/src/expressions/lambda.rs
+++ b/datafusion/physical-expr/src/expressions/lambda.rs
@@ -21,6 +21,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use crate::{
+    ScalarFunctionExpr,
     expressions::{Column, LambdaVariable},
     physical_expr::PhysicalExpr,
 };
@@ -61,11 +62,16 @@ impl Hash for LambdaExpr {
 impl LambdaExpr {
     /// Create a new lambda expression with the given parameters and body
     pub fn try_new(params: Vec<String>, body: Arc<dyn PhysicalExpr>) -> Result<Self> {
-        if all_unique(&params) {
-            Ok(Self::new(params, body))
-        } else {
-            plan_err!("lambda params must be unique, got ({})", params.join(", "))
+        if !all_unique(&params) {
+            return plan_err!(
+                "lambda params must be unique, got ({})",
+                params.join(", ")
+            );
         }
+
+        check_async_udf(&body)?;
+
+        Ok(Self::new(params, body))
     }
 
     fn new(params: Vec<String>, body: Arc<dyn PhysicalExpr>) -> Self {
@@ -179,6 +185,8 @@ impl PhysicalExpr for LambdaExpr {
             );
         };
 
+        check_async_udf(body)?;
+
         Ok(Arc::new(Self::new(self.params.clone(), Arc::clone(body))))
     }
 
@@ -208,6 +216,19 @@ fn all_unique(params: &[String]) -> bool {
             params.iter().all(|p| set.insert(p.as_str()))
         }
     }
+}
+
+fn check_async_udf(body: &Arc<dyn PhysicalExpr>) -> Result<()> {
+    if body.exists(|expr| {
+        Ok(expr
+            .downcast_ref::<ScalarFunctionExpr>()
+            .is_some_and(|udf| udf.fun().as_async().is_some()))
+    })? {
+        // https://github.com/apache/datafusion/issues/22091
+        return plan_err!("Async functions in lambdas aren't supported");
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/datafusion/sqllogictest/test_files/async_udf.slt
+++ b/datafusion/sqllogictest/test_files/async_udf.slt
@@ -99,3 +99,9 @@ physical_plan
 01)ProjectionExec: expr=[__async_fn_0@1 as async_abs(data.x)]
 02)--AsyncFuncExec: async_expr=[async_expr(name=__async_fn_0, expr=async_abs(x@0))]
 03)----DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Async udf can't be used in lambdas
+query error
+select array_transform([1], v -> async_abs(v));
+----
+DataFusion error: Error during planning: Async functions in lambdas aren't supported

--- a/datafusion/sqllogictest/test_files/async_udf.slt
+++ b/datafusion/sqllogictest/test_files/async_udf.slt
@@ -104,4 +104,4 @@ physical_plan
 query error
 select array_transform([1], v -> async_abs(v));
 ----
-DataFusion error: Error during planning: Async functions in lambdas aren't supported
+DataFusion error: Error during planning: Async functions in lambdas aren't supported, see https://github.com/apache/datafusion/issues/22091

--- a/datafusion/sqllogictest/test_files/async_udf.slt
+++ b/datafusion/sqllogictest/test_files/async_udf.slt
@@ -100,8 +100,12 @@ physical_plan
 02)--AsyncFuncExec: async_expr=[async_expr(name=__async_fn_0, expr=async_abs(x@0))]
 03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
+statement ok
+set datafusion.sql_parser.dialect = databricks;
+
 # Async udf can't be used in lambdas
-query error
+query error DataFusion error: Error during planning: Async functions in lambdas aren't supported, see https://github\.com/apache/datafusion/issues/22091
 select array_transform([1], v -> async_abs(v));
-----
-DataFusion error: Error during planning: Async functions in lambdas aren't supported, see https://github.com/apache/datafusion/issues/22091
+
+statement ok
+set datafusion.sql_parser.dialect = generic;


### PR DESCRIPTION
## Which issue does this PR close?

Part of #22091.

## Rationale for this change

Current async udfs in lambdas fail with generic errors

## What changes are included in this PR?

Report an explicit error when trying to create a lambda with async functions

## Are these changes tested?

One sqllogictest added to assert the friendly error

## Are there any user-facing changes?

What failed before still fail but with a better error
