### PR TITLE
chore: Upgrade to newer `install-action`, unbreak CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install cargo-audit
-        uses: taiki-e/install-action@7ea35f098a7369cd23488403f58be9c491a6c55f  # v2.77.0
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8  # v2.77.6
         with:
           tool: cargo-audit
       - name: Run audit check

--- a/.github/workflows/breaking_changes_detector.yml
+++ b/.github/workflows/breaking_changes_detector.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install cargo-semver-checks
         if: steps.changed_crates.outputs.packages != ''
-        uses: taiki-e/install-action@7ea35f098a7369cd23488403f58be9c491a6c55f  # v2.77.0
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8  # v2.77.6
         with:
           tool: cargo-semver-checks
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -64,7 +64,7 @@ jobs:
           source ci/scripts/utils/tool_versions.sh
           echo "LYCHEE_VERSION=${LYCHEE_VERSION}" >> "$GITHUB_ENV"
       - name: Install lychee
-        uses: taiki-e/install-action@7ea35f098a7369cd23488403f58be9c491a6c55f  # v2.77.0
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8  # v2.77.6
         with:
           tool: lychee@${{ env.LYCHEE_VERSION }}
       - name: Run markdown link check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -429,7 +429,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq clang
       - name: Setup wasm-pack
-        uses: taiki-e/install-action@7ea35f098a7369cd23488403f58be9c491a6c55f  # v2.77.0
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8  # v2.77.6
         with:
           tool: wasm-pack
       - name: Run tests with headless mode
@@ -774,7 +774,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
       - name: Install cargo-msrv
-        uses: taiki-e/install-action@7ea35f098a7369cd23488403f58be9c491a6c55f  # v2.77.0
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8  # v2.77.6
         with:
           tool: cargo-msrv
 


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## Rationale for this change

The version of `install-action` we were using fetched wasm-pack from an old URL that no longer works.

## What changes are included in this PR?

* Update `install-action` pinned version

## Are these changes tested?

Not yet, we'll see if CI passes :)

## Are there any user-facing changes?

No.
