### PR TITLE
Propagate field metadata through NTH_VALUE, FIRST_VALUE, and LAST_VALUE window functions

### DIFF
--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -308,14 +308,19 @@ impl WindowUDFImpl for NthValue {
     }
 
     fn field(&self, field_args: WindowUDFFieldArgs) -> Result<FieldRef> {
-        let return_type = field_args
+        let input_field = field_args
             .input_fields()
             .first()
-            .map(|f| f.data_type())
             .cloned()
-            .unwrap_or(DataType::Null);
+            .unwrap_or_else(|| Arc::new(Field::new("", DataType::Null, true)));
 
-        Ok(Field::new(field_args.name(), return_type, true).into())
+        // Clone the input field to preserve metadata, update name and nullability
+        Ok(input_field
+            .as_ref()
+            .clone()
+            .with_name(field_args.name())
+            .with_nullable(true)
+            .into())
     }
 
     fn reverse_expr(&self) -> ReversedUDWF {

--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -308,11 +308,14 @@ impl WindowUDFImpl for NthValue {
     }
 
     fn field(&self, field_args: WindowUDFFieldArgs) -> Result<FieldRef> {
-        let input_field = field_args
-            .input_fields()
-            .first()
-            .cloned()
-            .unwrap_or_else(|| Arc::new(Field::new("", DataType::Null, true)));
+        let input_field =
+            field_args
+                .input_fields()
+                .first()
+                .cloned()
+                .unwrap_or_else(|| {
+                    Arc::new(Field::new(field_args.name(), DataType::Null, true))
+                });
 
         // Clone the input field to preserve metadata, update name and nullability
         Ok(input_field

--- a/datafusion/sqllogictest/test_files/metadata.slt
+++ b/datafusion/sqllogictest/test_files/metadata.slt
@@ -472,5 +472,51 @@ select arrow_metadata(with_metadata(id, 'unit', ''), 'unit') from table_with_met
 ----
 (empty)
 
+# Regression test: window functions should preserve field metadata
+# Test FIRST_VALUE window function preserves metadata
+query IT
+select
+  first_value(id) over (order by id asc nulls last) as fv,
+  arrow_metadata(first_value(id) over (order by id asc nulls last), 'metadata_key') as meta
+from table_with_metadata limit 1;
+----
+1 the id field
+
+# Test LAST_VALUE window function preserves metadata
+query IT
+select
+  last_value(id) over (order by id asc nulls last rows between unbounded preceding and unbounded following) as lv,
+  arrow_metadata(last_value(id) over (order by id asc nulls last rows between unbounded preceding and unbounded following), 'metadata_key') as meta
+from table_with_metadata limit 1;
+----
+NULL the id field
+
+# Test NTH_VALUE window function preserves metadata
+query IT
+select
+  nth_value(id, 2) over (order by id asc nulls last) as nv,
+  arrow_metadata(nth_value(id, 2) over (order by id asc nulls last), 'metadata_key') as meta
+from table_with_metadata limit 1;
+----
+NULL the id field
+
+# Test LEAD window function preserves metadata
+query IT
+select
+  lead(id) over (order by id asc nulls last) as ld,
+  arrow_metadata(lead(id) over (order by id asc nulls last), 'metadata_key') as meta
+from table_with_metadata limit 1;
+----
+3 the id field
+
+# Test LAG window function preserves metadata
+query IT
+select
+  lag(id) over (order by id asc nulls last) as lg,
+  arrow_metadata(lag(id) over (order by id asc nulls last), 'metadata_key') as meta
+from table_with_metadata limit 1;
+----
+NULL the id field
+
 statement ok
 drop table table_with_metadata;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22108

## Rationale for this change

lead and lag both preserve metadata from the input field but nth_value, first_value, and last_value do not.

## What changes are included in this PR?

The mechanism to calcluate the return field for nth_value was changed to match lead/lag (which had already been fixed).

## Are these changes tested?

Yes, I added tests to metadata.slt

## Are there any user-facing changes?

No
