### PR TITLE
fix: respect Parquet column order when pruning

### DIFF
--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -918,7 +918,7 @@ mod tests {
         let schema = test_schema(DataType::UInt32);
         let statistics = parquet_file_statistics(
             &schema,
-            ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), true),
+            ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), false),
             None,
         );
 

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -43,8 +43,8 @@ use parquet::DecodeResult;
 use parquet::arrow::arrow_reader::statistics::StatisticsConverter;
 use parquet::arrow::{parquet_column, parquet_to_arrow_schema};
 use parquet::file::metadata::{
-    PageIndexPolicy, ParquetMetaData, ParquetMetaDataPushDecoder, RowGroupMetaData,
-    SortingColumn,
+    FileMetaData, PageIndexPolicy, ParquetMetaData, ParquetMetaDataPushDecoder,
+    RowGroupMetaData, SortingColumn,
 };
 use parquet::schema::types::SchemaDescriptor;
 use std::any::Any;
@@ -346,7 +346,7 @@ impl<'a> DFParquetMetadata<'a> {
                                 distinct_counts_array: &mut distinct_counts_array,
                             };
                             summarize_column_statistics(
-                                file_metadata.schema_descr(),
+                                file_metadata,
                                 logical_file_schema,
                                 &physical_file_schema,
                                 &mut accumulators,
@@ -499,7 +499,7 @@ impl StatisticsAccumulators<'_> {
 }
 
 fn summarize_column_statistics(
-    parquet_schema: &SchemaDescriptor,
+    file_metadata: &FileMetaData,
     logical_file_schema: &Schema,
     physical_file_schema: &Schema,
     accumulators: &mut StatisticsAccumulators,
@@ -507,46 +507,62 @@ fn summarize_column_statistics(
     stats_converter: &StatisticsConverter,
     row_groups_metadata: &[RowGroupMetaData],
 ) -> Result<()> {
-    let max_values = stats_converter.row_group_maxes(row_groups_metadata)?;
-    let min_values = stats_converter.row_group_mins(row_groups_metadata)?;
     let null_counts = stats_converter.row_group_null_counts(row_groups_metadata)?;
-    let is_max_value_exact_stat =
-        stats_converter.row_group_is_max_value_exact(row_groups_metadata)?;
-    let is_min_value_exact_stat =
-        stats_converter.row_group_is_min_value_exact(row_groups_metadata)?;
 
-    if let Some(max_acc) = &mut accumulators.max_accs[logical_schema_index] {
-        max_acc.update_batch(&[Arc::clone(&max_values)])?;
+    if can_use_file_min_max_statistics(
+        file_metadata,
+        stats_converter,
+        row_groups_metadata,
+    ) {
+        let max_values = stats_converter.row_group_maxes(row_groups_metadata)?;
+        let min_values = stats_converter.row_group_mins(row_groups_metadata)?;
+        let is_max_value_exact_stat =
+            stats_converter.row_group_is_max_value_exact(row_groups_metadata)?;
+        let is_min_value_exact_stat =
+            stats_converter.row_group_is_min_value_exact(row_groups_metadata)?;
 
-        // handle the common special case when all row groups have exact statistics
-        let exactness = &is_max_value_exact_stat;
-        if !exactness.is_empty() && exactness.null_count() == 0 && !exactness.has_false()
-        {
-            accumulators.is_max_value_exact[logical_schema_index] = Some(true);
-        } else if !exactness.has_true() {
-            accumulators.is_max_value_exact[logical_schema_index] = Some(false);
-        } else {
-            let val = max_acc.evaluate()?;
-            accumulators.is_max_value_exact[logical_schema_index] =
-                has_any_exact_match(&val, &max_values, exactness);
+        if let Some(max_acc) = &mut accumulators.max_accs[logical_schema_index] {
+            max_acc.update_batch(&[Arc::clone(&max_values)])?;
+
+            // handle the common special case when all row groups have exact statistics
+            let exactness = &is_max_value_exact_stat;
+            if !exactness.is_empty()
+                && exactness.null_count() == 0
+                && !exactness.has_false()
+            {
+                accumulators.is_max_value_exact[logical_schema_index] = Some(true);
+            } else if !exactness.has_true() {
+                accumulators.is_max_value_exact[logical_schema_index] = Some(false);
+            } else {
+                let val = max_acc.evaluate()?;
+                accumulators.is_max_value_exact[logical_schema_index] =
+                    has_any_exact_match(&val, &max_values, exactness);
+            }
         }
-    }
 
-    if let Some(min_acc) = &mut accumulators.min_accs[logical_schema_index] {
-        min_acc.update_batch(&[Arc::clone(&min_values)])?;
+        if let Some(min_acc) = &mut accumulators.min_accs[logical_schema_index] {
+            min_acc.update_batch(&[Arc::clone(&min_values)])?;
 
-        // handle the common special case when all row groups have exact statistics
-        let exactness = &is_min_value_exact_stat;
-        if !exactness.is_empty() && exactness.null_count() == 0 && !exactness.has_false()
-        {
-            accumulators.is_min_value_exact[logical_schema_index] = Some(true);
-        } else if !exactness.has_true() {
-            accumulators.is_min_value_exact[logical_schema_index] = Some(false);
-        } else {
-            let val = min_acc.evaluate()?;
-            accumulators.is_min_value_exact[logical_schema_index] =
-                has_any_exact_match(&val, &min_values, exactness);
+            // handle the common special case when all row groups have exact statistics
+            let exactness = &is_min_value_exact_stat;
+            if !exactness.is_empty()
+                && exactness.null_count() == 0
+                && !exactness.has_false()
+            {
+                accumulators.is_min_value_exact[logical_schema_index] = Some(true);
+            } else if !exactness.has_true() {
+                accumulators.is_min_value_exact[logical_schema_index] = Some(false);
+            } else {
+                let val = min_acc.evaluate()?;
+                accumulators.is_min_value_exact[logical_schema_index] =
+                    has_any_exact_match(&val, &min_values, exactness);
+            }
         }
+    } else {
+        // Accumulators are per file, so disabling min/max for this column only
+        // affects this file's aggregated statistics.
+        accumulators.max_accs[logical_schema_index] = None;
+        accumulators.min_accs[logical_schema_index] = None;
     }
 
     accumulators.null_counts_array[logical_schema_index] = match sum(&null_counts) {
@@ -561,7 +577,7 @@ fn summarize_column_statistics(
     // This is the same logic as parquet_column but we start from arrow schema index
     // instead of looking up by name.
     let parquet_index = parquet_column(
-        parquet_schema,
+        file_metadata.schema_descr(),
         physical_file_schema,
         logical_file_schema.field(logical_schema_index).name(),
     )
@@ -612,6 +628,33 @@ fn summarize_column_statistics(
     );
 
     Ok(())
+}
+
+fn can_use_file_min_max_statistics(
+    file_metadata: &FileMetaData,
+    stats_converter: &StatisticsConverter,
+    row_groups_metadata: &[RowGroupMetaData],
+) -> bool {
+    let Some(parquet_column_index) = stats_converter.parquet_column_index() else {
+        return true;
+    };
+
+    // This is intentionally conservative: one deprecated chunk disables file
+    // min/max statistics for this column. TODO: switch to per-chunk masking if
+    // StatisticsConverter exposes that support.
+    let has_deprecated_min_max = row_groups_metadata.iter().any(|rg| {
+        rg.columns()
+            .get(parquet_column_index)
+            .and_then(|column| column.statistics())
+            .is_some_and(|statistics| statistics.is_min_max_deprecated())
+    });
+
+    crate::can_use_min_max_statistics(
+        file_metadata.schema_descr(),
+        parquet_column_index,
+        file_metadata.column_orders().map(Vec::as_slice),
+        has_deprecated_min_max,
+    )
 }
 
 /// Compute the Arrow in-memory size for a single column
@@ -811,6 +854,17 @@ fn sorting_columns_to_physical_exprs(
 mod tests {
     use super::*;
     use arrow::array::Int32Array;
+    use arrow::datatypes::Field;
+    use datafusion_datasource::PartitionedFile;
+    use datafusion_expr::{col, lit};
+    use datafusion_physical_expr::planner::logical2physical;
+    use datafusion_physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder};
+    use datafusion_pruning::FilePruner;
+    use parquet::arrow::ArrowSchemaConverter;
+    use parquet::basic::{ColumnOrder, SortOrder};
+    use parquet::data_type::ByteArray;
+    use parquet::file::metadata::{ColumnChunkMetaData, FileMetaData};
+    use parquet::file::statistics::Statistics as ParquetStatistics;
 
     #[test]
     fn test_has_any_exact_match() {
@@ -857,6 +911,161 @@ mod tests {
             let result = has_any_exact_match(&computed_max, &row_group_maxes, &exactness);
             assert_eq!(result, Some(false));
         }
+    }
+
+    #[test]
+    fn file_pruning_ignores_unsigned_min_max_without_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let metadata = unsigned_metadata_without_column_order(Arc::clone(&schema));
+
+        let statistics =
+            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
+                .unwrap();
+        assert_eq!(statistics.column_statistics[0].min_value, Precision::Absent);
+        assert_eq!(statistics.column_statistics[0].max_value, Precision::Absent);
+        assert_eq!(
+            statistics.column_statistics[0].null_count,
+            Precision::Exact(0)
+        );
+
+        let predicate = logical2physical(&col("c1").eq(lit(0u32)), &schema);
+        let metrics = ExecutionPlanMetricsSet::new();
+        let predicate_creation_errors =
+            MetricBuilder::new(&metrics).global_counter("predicate_creation_errors");
+        let file = PartitionedFile::new("file.parquet", 10)
+            .with_statistics(Arc::new(statistics));
+        let mut file_pruner =
+            FilePruner::try_new(predicate, &schema, &file, predicate_creation_errors)
+                .unwrap();
+
+        assert!(!file_pruner.should_prune().unwrap());
+    }
+
+    #[test]
+    fn file_pruning_ignores_string_min_max_without_column_order() {
+        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
+        let metadata = metadata_with_column_order(
+            Arc::clone(&schema),
+            ParquetStatistics::byte_array(
+                Some(ByteArray::from("a".as_bytes().to_vec())),
+                Some(ByteArray::from("m".as_bytes().to_vec())),
+                None,
+                Some(0),
+                false,
+            ),
+            None,
+        );
+
+        let statistics =
+            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
+                .unwrap();
+        assert_eq!(statistics.column_statistics[0].min_value, Precision::Absent);
+        assert_eq!(statistics.column_statistics[0].max_value, Precision::Absent);
+
+        let predicate = logical2physical(&col("c1").eq(lit("z")), &schema);
+        let metrics = ExecutionPlanMetricsSet::new();
+        let predicate_creation_errors =
+            MetricBuilder::new(&metrics).global_counter("predicate_creation_errors");
+        let file = PartitionedFile::new("file.parquet", 10)
+            .with_statistics(Arc::new(statistics));
+        let mut file_pruner =
+            FilePruner::try_new(predicate, &schema, &file, predicate_creation_errors)
+                .unwrap();
+
+        assert!(!file_pruner.should_prune().unwrap());
+    }
+
+    #[test]
+    fn file_pruning_uses_string_min_max_with_column_order() {
+        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
+        let metadata = metadata_with_column_order(
+            Arc::clone(&schema),
+            ParquetStatistics::byte_array(
+                Some(ByteArray::from("a".as_bytes().to_vec())),
+                Some(ByteArray::from("m".as_bytes().to_vec())),
+                None,
+                Some(0),
+                false,
+            ),
+            Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)]),
+        );
+
+        let statistics =
+            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
+                .unwrap();
+        assert_eq!(
+            statistics.column_statistics[0].min_value,
+            Precision::Exact(ScalarValue::Utf8(Some("a".to_string())))
+        );
+        assert_eq!(
+            statistics.column_statistics[0].max_value,
+            Precision::Exact(ScalarValue::Utf8(Some("m".to_string())))
+        );
+
+        let predicate = logical2physical(&col("c1").eq(lit("z")), &schema);
+        let metrics = ExecutionPlanMetricsSet::new();
+        let predicate_creation_errors =
+            MetricBuilder::new(&metrics).global_counter("predicate_creation_errors");
+        let file = PartitionedFile::new("file.parquet", 10)
+            .with_statistics(Arc::new(statistics));
+        let mut file_pruner =
+            FilePruner::try_new(predicate, &schema, &file, predicate_creation_errors)
+                .unwrap();
+
+        assert!(file_pruner.should_prune().unwrap());
+    }
+
+    #[test]
+    fn file_pruning_ignores_deprecated_unsigned_min_max_with_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let metadata = metadata_with_column_order(
+            Arc::clone(&schema),
+            ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), true),
+            Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)]),
+        );
+
+        let statistics =
+            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
+                .unwrap();
+        assert_eq!(statistics.column_statistics[0].min_value, Precision::Absent);
+        assert_eq!(statistics.column_statistics[0].max_value, Precision::Absent);
+        assert_eq!(
+            statistics.column_statistics[0].null_count,
+            Precision::Exact(0)
+        );
+    }
+
+    fn unsigned_metadata_without_column_order(schema: SchemaRef) -> ParquetMetaData {
+        metadata_with_column_order(
+            schema,
+            ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), true),
+            None,
+        )
+    }
+
+    fn metadata_with_column_order(
+        schema: SchemaRef,
+        statistics: ParquetStatistics,
+        column_orders: Option<Vec<ColumnOrder>>,
+    ) -> ParquetMetaData {
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+        let column = ColumnChunkMetaData::builder(schema_descr.column(0))
+            .set_num_values(2)
+            .set_statistics(statistics)
+            .build()
+            .unwrap();
+        let row_group = RowGroupMetaData::builder(Arc::clone(&schema_descr))
+            .set_num_rows(2)
+            .set_column_metadata(vec![column])
+            .build()
+            .unwrap();
+        let file_metadata =
+            FileMetaData::new(1, 2, None, None, Arc::clone(&schema_descr), column_orders);
+
+        ParquetMetaData::new(file_metadata, vec![row_group])
     }
 
     mod ndv_tests {

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -856,7 +856,7 @@ mod tests {
     use arrow::array::Int32Array;
     use arrow::datatypes::Field;
     use datafusion_datasource::PartitionedFile;
-    use datafusion_expr::{col, lit};
+    use datafusion_expr::{Expr, col, lit};
     use datafusion_physical_expr::planner::logical2physical;
     use datafusion_physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder};
     use datafusion_pruning::FilePruner;
@@ -915,72 +915,22 @@ mod tests {
 
     #[test]
     fn file_pruning_ignores_unsigned_min_max_without_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
-        let metadata = unsigned_metadata_without_column_order(Arc::clone(&schema));
-
-        let statistics =
-            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
-                .unwrap();
-        assert_eq!(statistics.column_statistics[0].min_value, Precision::Absent);
-        assert_eq!(statistics.column_statistics[0].max_value, Precision::Absent);
-        assert_eq!(
-            statistics.column_statistics[0].null_count,
-            Precision::Exact(0)
-        );
-
-        let predicate = logical2physical(&col("c1").eq(lit(0u32)), &schema);
-        let metrics = ExecutionPlanMetricsSet::new();
-        let predicate_creation_errors =
-            MetricBuilder::new(&metrics).global_counter("predicate_creation_errors");
-        let file = PartitionedFile::new("file.parquet", 10)
-            .with_statistics(Arc::new(statistics));
-        let mut file_pruner =
-            FilePruner::try_new(predicate, &schema, &file, predicate_creation_errors)
-                .unwrap();
-
-        assert!(!file_pruner.should_prune().unwrap());
-    }
-
-    #[test]
-    fn file_pruning_ignores_string_min_max_without_column_order() {
-        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
-        let metadata = metadata_with_column_order(
-            Arc::clone(&schema),
-            ParquetStatistics::byte_array(
-                Some(ByteArray::from("a".as_bytes().to_vec())),
-                Some(ByteArray::from("m".as_bytes().to_vec())),
-                None,
-                Some(0),
-                false,
-            ),
+        let schema = test_schema(DataType::UInt32);
+        let statistics = parquet_file_statistics(
+            &schema,
+            ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), true),
             None,
         );
 
-        let statistics =
-            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
-                .unwrap();
-        assert_eq!(statistics.column_statistics[0].min_value, Precision::Absent);
-        assert_eq!(statistics.column_statistics[0].max_value, Precision::Absent);
-
-        let predicate = logical2physical(&col("c1").eq(lit("z")), &schema);
-        let metrics = ExecutionPlanMetricsSet::new();
-        let predicate_creation_errors =
-            MetricBuilder::new(&metrics).global_counter("predicate_creation_errors");
-        let file = PartitionedFile::new("file.parquet", 10)
-            .with_statistics(Arc::new(statistics));
-        let mut file_pruner =
-            FilePruner::try_new(predicate, &schema, &file, predicate_creation_errors)
-                .unwrap();
-
-        assert!(!file_pruner.should_prune().unwrap());
+        assert_min_max_absent(&statistics);
+        assert_file_pruning(&schema, statistics, col("c1").eq(lit(0u32)), false);
     }
 
     #[test]
     fn file_pruning_uses_string_min_max_with_column_order() {
-        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
-        let metadata = metadata_with_column_order(
-            Arc::clone(&schema),
+        let schema = test_schema(DataType::Utf8);
+        let statistics = parquet_file_statistics(
+            &schema,
             ParquetStatistics::byte_array(
                 Some(ByteArray::from("a".as_bytes().to_vec())),
                 Some(ByteArray::from("m".as_bytes().to_vec())),
@@ -991,9 +941,6 @@ mod tests {
             Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)]),
         );
 
-        let statistics =
-            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
-                .unwrap();
         assert_eq!(
             statistics.column_statistics[0].min_value,
             Precision::Exact(ScalarValue::Utf8(Some("a".to_string())))
@@ -1002,33 +949,37 @@ mod tests {
             statistics.column_statistics[0].max_value,
             Precision::Exact(ScalarValue::Utf8(Some("m".to_string())))
         );
-
-        let predicate = logical2physical(&col("c1").eq(lit("z")), &schema);
-        let metrics = ExecutionPlanMetricsSet::new();
-        let predicate_creation_errors =
-            MetricBuilder::new(&metrics).global_counter("predicate_creation_errors");
-        let file = PartitionedFile::new("file.parquet", 10)
-            .with_statistics(Arc::new(statistics));
-        let mut file_pruner =
-            FilePruner::try_new(predicate, &schema, &file, predicate_creation_errors)
-                .unwrap();
-
-        assert!(file_pruner.should_prune().unwrap());
+        assert_file_pruning(&schema, statistics, col("c1").eq(lit("z")), true);
     }
 
     #[test]
     fn file_pruning_ignores_deprecated_unsigned_min_max_with_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
-        let metadata = metadata_with_column_order(
-            Arc::clone(&schema),
+        let schema = test_schema(DataType::UInt32);
+        let statistics = parquet_file_statistics(
+            &schema,
             ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), true),
             Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)]),
         );
 
-        let statistics =
-            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
-                .unwrap();
+        assert_min_max_absent(&statistics);
+        assert_file_pruning(&schema, statistics, col("c1").eq(lit(0u32)), false);
+    }
+
+    fn test_schema(data_type: DataType) -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("c1", data_type, false)]))
+    }
+
+    fn parquet_file_statistics(
+        schema: &SchemaRef,
+        statistics: ParquetStatistics,
+        column_orders: Option<Vec<ColumnOrder>>,
+    ) -> Statistics {
+        let metadata =
+            metadata_with_column_order(Arc::clone(schema), statistics, column_orders);
+        DFParquetMetadata::statistics_from_parquet_metadata(&metadata, schema).unwrap()
+    }
+
+    fn assert_min_max_absent(statistics: &Statistics) {
         assert_eq!(statistics.column_statistics[0].min_value, Precision::Absent);
         assert_eq!(statistics.column_statistics[0].max_value, Precision::Absent);
         assert_eq!(
@@ -1037,12 +988,23 @@ mod tests {
         );
     }
 
-    fn unsigned_metadata_without_column_order(schema: SchemaRef) -> ParquetMetaData {
-        metadata_with_column_order(
-            schema,
-            ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), true),
-            None,
-        )
+    fn assert_file_pruning(
+        schema: &SchemaRef,
+        statistics: Statistics,
+        predicate: Expr,
+        expected_should_prune: bool,
+    ) {
+        let predicate = logical2physical(&predicate, schema);
+        let metrics = ExecutionPlanMetricsSet::new();
+        let predicate_creation_errors =
+            MetricBuilder::new(&metrics).global_counter("predicate_creation_errors");
+        let file = PartitionedFile::new("file.parquet", 10)
+            .with_statistics(Arc::new(statistics));
+        let mut file_pruner =
+            FilePruner::try_new(predicate, schema, &file, predicate_creation_errors)
+                .unwrap();
+
+        assert_eq!(file_pruner.should_prune().unwrap(), expected_should_prune);
     }
 
     fn metadata_with_column_order(

--- a/datafusion/datasource-parquet/src/mod.rs
+++ b/datafusion/datasource-parquet/src/mod.rs
@@ -89,3 +89,53 @@ pub(crate) fn can_use_min_max_statistics(
 
     actual_order.is_some_and(|actual_order| actual_order == expected_order)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use parquet::arrow::ArrowSchemaConverter;
+
+    #[test]
+    fn min_max_statistics_require_matching_column_order() {
+        let signed_schema = test_schema(DataType::Int32);
+        let unsigned_schema = test_schema(DataType::UInt32);
+        let string_schema = test_schema(DataType::Utf8);
+
+        assert!(can_use_min_max_statistics(&signed_schema, 0, None, false));
+        assert!(!can_use_min_max_statistics(
+            &unsigned_schema,
+            0,
+            None,
+            false
+        ));
+        assert!(can_use_min_max_statistics(
+            &unsigned_schema,
+            0,
+            Some(&column_orders(SortOrder::UNSIGNED)),
+            false
+        ));
+        assert!(!can_use_min_max_statistics(
+            &unsigned_schema,
+            0,
+            Some(&column_orders(SortOrder::SIGNED)),
+            false
+        ));
+        assert!(!can_use_min_max_statistics(
+            &unsigned_schema,
+            0,
+            Some(&column_orders(SortOrder::UNSIGNED)),
+            true
+        ));
+        assert!(!can_use_min_max_statistics(&string_schema, 0, None, false));
+    }
+
+    fn test_schema(data_type: DataType) -> SchemaDescriptor {
+        let schema = Schema::new(vec![Field::new("c1", data_type, false)]);
+        ArrowSchemaConverter::new().convert(&schema).unwrap()
+    }
+
+    fn column_orders(sort_order: SortOrder) -> Vec<ColumnOrder> {
+        vec![ColumnOrder::TYPE_DEFINED_ORDER(sort_order)]
+    }
+}

--- a/datafusion/datasource-parquet/src/mod.rs
+++ b/datafusion/datasource-parquet/src/mod.rs
@@ -38,6 +38,9 @@ pub mod source;
 mod supported_predicates;
 mod writer;
 
+use parquet::basic::{ColumnOrder, SortOrder};
+use parquet::schema::types::SchemaDescriptor;
+
 pub use access_plan::{ParquetAccessPlan, RowGroupAccess};
 pub use file_format::*;
 pub use metrics::ParquetFileMetrics;
@@ -47,3 +50,42 @@ pub use row_filter::build_row_filter;
 pub use row_filter::can_expr_be_pushed_down_with_schemas;
 pub use row_group_filter::RowGroupAccessPlanFilter;
 pub use writer::plan_to_parquet;
+
+/// Returns whether Parquet min/max statistics are safe to use for a column.
+///
+/// If `column_orders` is missing, DataFusion follows parquet-rs behavior and
+/// treats the stats as legacy signed-order stats. This means columns whose
+/// natural order is not signed, such as unsigned integers, strings, binary
+/// values, and booleans, do not use min/max pruning for legacy files without
+/// `column_orders`.
+///
+/// Deprecated row group statistics also use legacy signed ordering, so they are
+/// rejected for columns whose natural order is not signed.
+pub(crate) fn can_use_min_max_statistics(
+    parquet_schema: &SchemaDescriptor,
+    parquet_column_index: usize,
+    column_orders: Option<&[ColumnOrder]>,
+    has_deprecated_min_max: bool,
+) -> bool {
+    let column = parquet_schema.column(parquet_column_index);
+    let expected_order = column.sort_order();
+    if has_deprecated_min_max && !expected_order.is_signed() {
+        return false;
+    }
+
+    if expected_order == SortOrder::UNDEFINED {
+        return false;
+    }
+
+    let actual_order = match column_orders {
+        Some(column_orders) => column_orders
+            .get(parquet_column_index)
+            .map(ColumnOrder::sort_order),
+        // Missing column_orders means legacy undefined column order. Parquet-rs
+        // maps that to signed ordering. As a result, columns with non-signed
+        // natural order lose min/max pruning for legacy files.
+        None => Some(SortOrder::SIGNED),
+    };
+
+    actual_order.is_some_and(|actual_order| actual_order == expected_order)
+}

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -896,11 +896,15 @@ impl FiltersPreparedParquetOpen {
         // If there is a predicate that can be evaluated against the metadata
         if let Some(predicate) = self.pruning_predicate.as_ref().map(|p| p.as_ref()) {
             if prepared.enable_row_group_stats_pruning {
-                row_groups.prune_by_statistics(
+                row_groups.prune_by_statistics_with_column_orders(
                     &prepared.physical_file_schema,
                     loaded.reader_metadata.parquet_schema(),
                     rg_metadata,
                     predicate,
+                    file_metadata
+                        .file_metadata()
+                        .column_orders()
+                        .map(Vec::as_slice),
                     &prepared.file_metrics,
                 );
             } else {

--- a/datafusion/datasource-parquet/src/page_filter.rs
+++ b/datafusion/datasource-parquet/src/page_filter.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use super::metrics::ParquetFileMetrics;
 use crate::ParquetAccessPlan;
 
-use arrow::array::BooleanArray;
+use arrow::array::{BooleanArray, new_null_array};
 use arrow::{
     array::ArrayRef,
     datatypes::{Schema, SchemaRef},
@@ -405,6 +405,7 @@ struct PagesPruningStatistics<'a> {
     row_group_index: usize,
     row_group_metadatas: &'a [RowGroupMetaData],
     converter: StatisticsConverter<'a>,
+    can_use_min_max: bool,
     column_index: &'a ParquetColumnIndex,
     offset_index: &'a ParquetOffsetIndex,
     page_offsets: &'a Vec<PageLocation>,
@@ -428,10 +429,18 @@ impl<'a> PagesPruningStatistics<'a> {
             );
             return None;
         };
-
         let column_index = parquet_metadata.column_index()?;
         let offset_index = parquet_metadata.offset_index()?;
         let row_group_metadatas = parquet_metadata.row_groups();
+        let can_use_min_max = crate::can_use_min_max_statistics(
+            parquet_metadata.file_metadata().schema_descr(),
+            parquet_column_index,
+            parquet_metadata
+                .file_metadata()
+                .column_orders()
+                .map(Vec::as_slice),
+            false,
+        );
 
         let Some(row_group_page_offsets) = offset_index.get(row_group_index) else {
             trace!("No page offsets for row group {row_group_index}, skipping");
@@ -452,6 +461,7 @@ impl<'a> PagesPruningStatistics<'a> {
             row_group_index,
             row_group_metadatas,
             converter,
+            can_use_min_max,
             column_index,
             offset_index,
             page_offsets,
@@ -481,6 +491,13 @@ impl<'a> PagesPruningStatistics<'a> {
 }
 impl PruningStatistics for PagesPruningStatistics<'_> {
     fn min_values(&self, _column: &datafusion_common::Column) -> Option<ArrayRef> {
+        if !self.can_use_min_max {
+            return Some(new_null_array(
+                self.converter.arrow_field().data_type(),
+                self.num_containers(),
+            ));
+        }
+
         match self.converter.data_page_mins(
             self.column_index,
             self.offset_index,
@@ -495,6 +512,13 @@ impl PruningStatistics for PagesPruningStatistics<'_> {
     }
 
     fn max_values(&self, _column: &datafusion_common::Column) -> Option<ArrayRef> {
+        if !self.can_use_min_max {
+            return Some(new_null_array(
+                self.converter.arrow_field().data_type(),
+                self.num_containers(),
+            ));
+        }
+
         match self.converter.data_page_maxes(
             self.column_index,
             self.offset_index,
@@ -546,5 +570,214 @@ impl PruningStatistics for PagesPruningStatistics<'_> {
         _values: &HashSet<ScalarValue>,
     ) -> Option<BooleanArray> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use arrow::datatypes::{DataType, Field};
+    use datafusion_expr::{col, lit};
+    use datafusion_physical_expr::planner::logical2physical;
+    use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
+    use parquet::arrow::ArrowSchemaConverter;
+    use parquet::basic::{ColumnOrder, SortOrder, Type as PhysicalType};
+    use parquet::file::metadata::{
+        ColumnChunkMetaData, ColumnIndexBuilder, FileMetaData, OffsetIndexBuilder,
+        ParquetMetaDataBuilder, RowGroupMetaData,
+    };
+
+    #[test]
+    fn page_pruning_ignores_unsigned_stats_without_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let parquet_metadata = unsigned_page_index_metadata(Arc::clone(&schema));
+
+        let predicate = logical2physical(&col("c1").eq(lit(0u32)), &schema);
+        let page_filter =
+            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
+
+        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
+        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
+        let access_plan = page_filter.prune_plan_with_page_index(
+            ParquetAccessPlan::new_all(1),
+            &schema,
+            parquet_metadata.file_metadata().schema_descr(),
+            &parquet_metadata,
+            &file_metrics,
+        );
+
+        assert!(access_plan.should_scan(0));
+    }
+
+    #[test]
+    fn page_pruning_uses_unsigned_stats_with_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let parquet_metadata = page_index_metadata(
+            Arc::clone(&schema),
+            PhysicalType::INT32,
+            1i32.to_le_bytes().to_vec(),
+            10i32.to_le_bytes().to_vec(),
+            Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)]),
+        );
+
+        let predicate = logical2physical(&col("c1").gt(lit(15u32)), &schema);
+        let page_filter =
+            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
+
+        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
+        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
+        let access_plan = page_filter.prune_plan_with_page_index(
+            ParquetAccessPlan::new_all(1),
+            &schema,
+            parquet_metadata.file_metadata().schema_descr(),
+            &parquet_metadata,
+            &file_metrics,
+        );
+
+        assert!(!access_plan.should_scan(0));
+    }
+
+    #[test]
+    fn page_pruning_ignores_unsigned_stats_with_mismatched_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let parquet_metadata = page_index_metadata(
+            Arc::clone(&schema),
+            PhysicalType::INT32,
+            (-1i32).to_le_bytes().to_vec(),
+            0i32.to_le_bytes().to_vec(),
+            Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::SIGNED)]),
+        );
+
+        let predicate = logical2physical(&col("c1").eq(lit(0u32)), &schema);
+        let page_filter =
+            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
+
+        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
+        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
+        let access_plan = page_filter.prune_plan_with_page_index(
+            ParquetAccessPlan::new_all(1),
+            &schema,
+            parquet_metadata.file_metadata().schema_descr(),
+            &parquet_metadata,
+            &file_metrics,
+        );
+
+        assert!(access_plan.should_scan(0));
+    }
+
+    #[test]
+    fn page_pruning_ignores_string_stats_without_column_order() {
+        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
+        let parquet_metadata = page_index_metadata(
+            Arc::clone(&schema),
+            PhysicalType::BYTE_ARRAY,
+            b"a".to_vec(),
+            b"m".to_vec(),
+            None,
+        );
+
+        let predicate = logical2physical(&col("c1").eq(lit("z")), &schema);
+        let page_filter =
+            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
+
+        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
+        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
+        let access_plan = page_filter.prune_plan_with_page_index(
+            ParquetAccessPlan::new_all(1),
+            &schema,
+            parquet_metadata.file_metadata().schema_descr(),
+            &parquet_metadata,
+            &file_metrics,
+        );
+
+        assert!(access_plan.should_scan(0));
+    }
+
+    #[test]
+    fn page_pruning_uses_string_stats_with_column_order() {
+        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
+        let parquet_metadata = page_index_metadata(
+            Arc::clone(&schema),
+            PhysicalType::BYTE_ARRAY,
+            b"a".to_vec(),
+            b"m".to_vec(),
+            Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)]),
+        );
+
+        let predicate = logical2physical(&col("c1").eq(lit("z")), &schema);
+        let page_filter =
+            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
+
+        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
+        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
+        let access_plan = page_filter.prune_plan_with_page_index(
+            ParquetAccessPlan::new_all(1),
+            &schema,
+            parquet_metadata.file_metadata().schema_descr(),
+            &parquet_metadata,
+            &file_metrics,
+        );
+
+        assert!(!access_plan.should_scan(0));
+    }
+
+    fn unsigned_page_index_metadata(schema: SchemaRef) -> ParquetMetaData {
+        page_index_metadata(
+            schema,
+            PhysicalType::INT32,
+            (-1i32).to_le_bytes().to_vec(),
+            0i32.to_le_bytes().to_vec(),
+            None,
+        )
+    }
+
+    fn page_index_metadata(
+        schema: SchemaRef,
+        physical_type: PhysicalType,
+        min_value: Vec<u8>,
+        max_value: Vec<u8>,
+        column_orders: Option<Vec<ColumnOrder>>,
+    ) -> ParquetMetaData {
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+
+        let column = ColumnChunkMetaData::builder(schema_descr.column(0))
+            .set_num_values(10)
+            .build()
+            .unwrap();
+        let row_group = RowGroupMetaData::builder(Arc::clone(&schema_descr))
+            .set_num_rows(10)
+            .set_column_metadata(vec![column])
+            .build()
+            .unwrap();
+
+        let file_metadata = FileMetaData::new(
+            1,
+            10,
+            None,
+            None,
+            Arc::clone(&schema_descr),
+            column_orders,
+        );
+
+        let mut column_index = ColumnIndexBuilder::new(physical_type);
+        column_index.append(false, min_value, max_value, 0);
+        let column_index = column_index.build().unwrap();
+
+        let mut offset_index = OffsetIndexBuilder::new();
+        offset_index.append_row_count(10);
+        offset_index.append_offset_and_size(0, 1);
+        let offset_index = offset_index.build();
+
+        ParquetMetaDataBuilder::new(file_metadata)
+            .set_row_groups(vec![row_group])
+            .set_column_index(Some(vec![vec![column_index]]))
+            .set_offset_index(Some(vec![vec![offset_index]]))
+            .build()
     }
 }

--- a/datafusion/datasource-parquet/src/page_filter.rs
+++ b/datafusion/datasource-parquet/src/page_filter.rs
@@ -579,7 +579,7 @@ mod tests {
 
     use super::*;
     use arrow::datatypes::{DataType, Field};
-    use datafusion_expr::{col, lit};
+    use datafusion_expr::{Expr, col, lit};
     use datafusion_physical_expr::planner::logical2physical;
     use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
     use parquet::arrow::ArrowSchemaConverter;
@@ -591,139 +591,55 @@ mod tests {
 
     #[test]
     fn page_pruning_ignores_unsigned_stats_without_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let schema = test_schema(DataType::UInt32);
         let parquet_metadata = unsigned_page_index_metadata(Arc::clone(&schema));
 
-        let predicate = logical2physical(&col("c1").eq(lit(0u32)), &schema);
-        let page_filter =
-            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
-
-        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
-        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
-        let access_plan = page_filter.prune_plan_with_page_index(
-            ParquetAccessPlan::new_all(1),
-            &schema,
-            parquet_metadata.file_metadata().schema_descr(),
-            &parquet_metadata,
-            &file_metrics,
-        );
-
-        assert!(access_plan.should_scan(0));
+        assert_page_pruning(&schema, &parquet_metadata, &col("c1").eq(lit(0u32)), true);
     }
 
     #[test]
     fn page_pruning_uses_unsigned_stats_with_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let schema = test_schema(DataType::UInt32);
         let parquet_metadata = page_index_metadata(
             Arc::clone(&schema),
             PhysicalType::INT32,
             1i32.to_le_bytes().to_vec(),
             10i32.to_le_bytes().to_vec(),
-            Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)]),
+            Some(column_orders(SortOrder::UNSIGNED)),
         );
 
-        let predicate = logical2physical(&col("c1").gt(lit(15u32)), &schema);
-        let page_filter =
-            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
-
-        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
-        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
-        let access_plan = page_filter.prune_plan_with_page_index(
-            ParquetAccessPlan::new_all(1),
-            &schema,
-            parquet_metadata.file_metadata().schema_descr(),
-            &parquet_metadata,
-            &file_metrics,
-        );
-
-        assert!(!access_plan.should_scan(0));
+        assert_page_pruning(&schema, &parquet_metadata, &col("c1").gt(lit(15u32)), false);
     }
 
-    #[test]
-    fn page_pruning_ignores_unsigned_stats_with_mismatched_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
-        let parquet_metadata = page_index_metadata(
-            Arc::clone(&schema),
-            PhysicalType::INT32,
-            (-1i32).to_le_bytes().to_vec(),
-            0i32.to_le_bytes().to_vec(),
-            Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::SIGNED)]),
-        );
-
-        let predicate = logical2physical(&col("c1").eq(lit(0u32)), &schema);
-        let page_filter =
-            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
-
-        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
-        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
-        let access_plan = page_filter.prune_plan_with_page_index(
-            ParquetAccessPlan::new_all(1),
-            &schema,
-            parquet_metadata.file_metadata().schema_descr(),
-            &parquet_metadata,
-            &file_metrics,
-        );
-
-        assert!(access_plan.should_scan(0));
+    fn test_schema(data_type: DataType) -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("c1", data_type, false)]))
     }
 
-    #[test]
-    fn page_pruning_ignores_string_stats_without_column_order() {
-        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
-        let parquet_metadata = page_index_metadata(
-            Arc::clone(&schema),
-            PhysicalType::BYTE_ARRAY,
-            b"a".to_vec(),
-            b"m".to_vec(),
-            None,
-        );
-
-        let predicate = logical2physical(&col("c1").eq(lit("z")), &schema);
-        let page_filter =
-            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
-
-        let metrics = Arc::new(ExecutionPlanMetricsSet::new());
-        let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
-        let access_plan = page_filter.prune_plan_with_page_index(
-            ParquetAccessPlan::new_all(1),
-            &schema,
-            parquet_metadata.file_metadata().schema_descr(),
-            &parquet_metadata,
-            &file_metrics,
-        );
-
-        assert!(access_plan.should_scan(0));
+    fn column_orders(sort_order: SortOrder) -> Vec<ColumnOrder> {
+        vec![ColumnOrder::TYPE_DEFINED_ORDER(sort_order)]
     }
 
-    #[test]
-    fn page_pruning_uses_string_stats_with_column_order() {
-        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
-        let parquet_metadata = page_index_metadata(
-            Arc::clone(&schema),
-            PhysicalType::BYTE_ARRAY,
-            b"a".to_vec(),
-            b"m".to_vec(),
-            Some(vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)]),
-        );
-
-        let predicate = logical2physical(&col("c1").eq(lit("z")), &schema);
+    fn assert_page_pruning(
+        schema: &SchemaRef,
+        parquet_metadata: &ParquetMetaData,
+        predicate: &Expr,
+        expected_should_scan: bool,
+    ) {
+        let predicate = logical2physical(predicate, schema);
         let page_filter =
-            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(&schema));
+            PagePruningAccessPlanFilter::new(&predicate, Arc::clone(schema));
 
         let metrics = Arc::new(ExecutionPlanMetricsSet::new());
         let file_metrics = ParquetFileMetrics::new(0, "file.parquet", &metrics);
         let access_plan = page_filter.prune_plan_with_page_index(
             ParquetAccessPlan::new_all(1),
-            &schema,
+            schema,
             parquet_metadata.file_metadata().schema_descr(),
-            &parquet_metadata,
+            parquet_metadata,
             &file_metrics,
         );
 
-        assert!(!access_plan.should_scan(0));
+        assert_eq!(access_plan.should_scan(0), expected_should_scan);
     }
 
     fn unsigned_page_index_metadata(schema: SchemaRef) -> ParquetMetaData {

--- a/datafusion/datasource-parquet/src/row_group_filter.rs
+++ b/datafusion/datasource-parquet/src/row_group_filter.rs
@@ -774,7 +774,7 @@ mod tests {
     use crate::reader::ParquetFileReader;
 
     use arrow::datatypes::DataType::Decimal128;
-    use arrow::datatypes::{DataType, Field};
+    use arrow::datatypes::{DataType, Field, SchemaRef};
     use datafusion_expr::{Expr, cast, col, lit};
     use datafusion_physical_expr::planner::logical2physical;
     use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
@@ -891,200 +891,35 @@ mod tests {
 
     #[test]
     fn row_group_pruning_uses_unsigned_stats_with_matching_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
-        let expr = logical2physical(&col("c1").gt(lit(15u32)), &schema);
-        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
-
-        let schema_descr =
-            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
-        let rgm = get_row_group_meta_data(
-            &schema_descr,
-            vec![ParquetStatistics::int32(
-                Some(1),
-                Some(10),
-                None,
-                Some(0),
-                false,
-            )],
+        assert_single_column_row_group_pruning(
+            DataType::UInt32,
+            &col("c1").gt(lit(15u32)),
+            vec![int32_statistics(1, 10, false)],
+            Some(SortOrder::UNSIGNED),
+            ExpectedPruning::All,
         );
-        let column_orders = vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)];
-
-        let metrics = parquet_file_metrics();
-        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
-        row_groups.prune_by_statistics_with_column_orders(
-            &schema,
-            &schema_descr,
-            &[rgm],
-            &pruning_predicate,
-            Some(&column_orders),
-            &metrics,
-        );
-        assert_pruned(row_groups, ExpectedPruning::All);
     }
 
     #[test]
     fn row_group_pruning_ignores_unsigned_stats_without_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
-        let expr = logical2physical(&col("c1").eq(lit(0u32)), &schema);
-        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
-
-        let schema_descr =
-            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
-        let rgm = get_row_group_meta_data(
-            &schema_descr,
-            vec![ParquetStatistics::int32(
-                Some(-1),
-                Some(0),
-                None,
-                Some(0),
-                true,
-            )],
+        assert_single_column_row_group_pruning(
+            DataType::UInt32,
+            &col("c1").eq(lit(0u32)),
+            vec![int32_statistics(-1, 0, false)],
+            None,
+            ExpectedPruning::None,
         );
-
-        let metrics = parquet_file_metrics();
-        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
-        row_groups.prune_by_statistics(
-            &schema,
-            &schema_descr,
-            &[rgm],
-            &pruning_predicate,
-            &metrics,
-        );
-        assert_pruned(row_groups, ExpectedPruning::None);
-    }
-
-    #[test]
-    fn row_group_pruning_ignores_string_stats_without_column_order() {
-        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
-        let expr = logical2physical(&col("c1").eq(lit("z")), &schema);
-        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
-
-        let schema_descr =
-            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
-        let rgm = get_row_group_meta_data(
-            &schema_descr,
-            vec![ParquetStatistics::byte_array(
-                Some(ByteArray::from("a".as_bytes().to_vec())),
-                Some(ByteArray::from("m".as_bytes().to_vec())),
-                None,
-                Some(0),
-                false,
-            )],
-        );
-
-        let metrics = parquet_file_metrics();
-        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
-        row_groups.prune_by_statistics(
-            &schema,
-            &schema_descr,
-            &[rgm],
-            &pruning_predicate,
-            &metrics,
-        );
-        assert_pruned(row_groups, ExpectedPruning::None);
-    }
-
-    #[test]
-    fn row_group_pruning_uses_string_stats_with_column_order() {
-        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
-        let expr = logical2physical(&col("c1").eq(lit("z")), &schema);
-        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
-
-        let schema_descr =
-            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
-        let rgm = get_row_group_meta_data(
-            &schema_descr,
-            vec![ParquetStatistics::byte_array(
-                Some(ByteArray::from("a".as_bytes().to_vec())),
-                Some(ByteArray::from("m".as_bytes().to_vec())),
-                None,
-                Some(0),
-                false,
-            )],
-        );
-        let column_orders = vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)];
-
-        let metrics = parquet_file_metrics();
-        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
-        row_groups.prune_by_statistics_with_column_orders(
-            &schema,
-            &schema_descr,
-            &[rgm],
-            &pruning_predicate,
-            Some(&column_orders),
-            &metrics,
-        );
-        assert_pruned(row_groups, ExpectedPruning::All);
-    }
-
-    #[test]
-    fn row_group_pruning_ignores_unsigned_stats_with_mismatched_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
-        let expr = logical2physical(&col("c1").eq(lit(0u32)), &schema);
-        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
-
-        let schema_descr =
-            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
-        let rgm = get_row_group_meta_data(
-            &schema_descr,
-            vec![ParquetStatistics::int32(
-                Some(-1),
-                Some(0),
-                None,
-                Some(0),
-                false,
-            )],
-        );
-        let column_orders = vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::SIGNED)];
-
-        let metrics = parquet_file_metrics();
-        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
-        row_groups.prune_by_statistics_with_column_orders(
-            &schema,
-            &schema_descr,
-            &[rgm],
-            &pruning_predicate,
-            Some(&column_orders),
-            &metrics,
-        );
-        assert_pruned(row_groups, ExpectedPruning::None);
     }
 
     #[test]
     fn row_group_pruning_ignores_deprecated_unsigned_stats_with_column_order() {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
-        let expr = logical2physical(&col("c1").eq(lit(0u32)), &schema);
-        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
-
-        let schema_descr =
-            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
-        let rgm = get_row_group_meta_data(
-            &schema_descr,
-            vec![ParquetStatistics::int32(
-                Some(-1),
-                Some(0),
-                None,
-                Some(0),
-                true,
-            )],
+        assert_single_column_row_group_pruning(
+            DataType::UInt32,
+            &col("c1").eq(lit(0u32)),
+            vec![int32_statistics(-1, 0, true)],
+            Some(SortOrder::UNSIGNED),
+            ExpectedPruning::None,
         );
-        let column_orders = vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)];
-
-        let metrics = parquet_file_metrics();
-        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
-        row_groups.prune_by_statistics_with_column_orders(
-            &schema,
-            &schema_descr,
-            &[rgm],
-            &pruning_predicate,
-            Some(&column_orders),
-            &metrics,
-        );
-        assert_pruned(row_groups, ExpectedPruning::None);
     }
 
     #[test]
@@ -1093,30 +928,16 @@ mod tests {
             Field::new("c1", DataType::UInt32, false),
             Field::new("c2", DataType::Int32, false),
         ]));
-        let expr = col("c1").eq(lit(0u32)).and(col("c2").gt(lit(15)));
-        let expr = logical2physical(&expr, &schema);
-        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
-
-        let schema_descr =
-            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
-        let rgm = get_row_group_meta_data(
-            &schema_descr,
-            vec![
-                ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), true),
-                ParquetStatistics::int32(Some(1), Some(10), None, Some(0), false),
-            ],
-        );
-
-        let metrics = parquet_file_metrics();
-        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
-        row_groups.prune_by_statistics(
+        assert_row_group_pruning(
             &schema,
-            &schema_descr,
-            &[rgm],
-            &pruning_predicate,
-            &metrics,
+            &col("c1").eq(lit(0u32)).and(col("c2").gt(lit(15))),
+            vec![
+                int32_statistics(-1, 0, true),
+                int32_statistics(1, 10, false),
+            ],
+            None,
+            ExpectedPruning::All,
         );
-        assert_pruned(row_groups, ExpectedPruning::All);
     }
 
     #[test]
@@ -1789,6 +1610,84 @@ mod tests {
             &metrics,
         );
         assert_pruned(row_groups, ExpectedPruning::Some(vec![1, 2]));
+    }
+
+    fn test_schema(data_type: DataType) -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("c1", data_type, false)]))
+    }
+
+    fn type_defined_column_orders(sort_order: SortOrder) -> Vec<ColumnOrder> {
+        vec![ColumnOrder::TYPE_DEFINED_ORDER(sort_order)]
+    }
+
+    fn int32_statistics(
+        min: i32,
+        max: i32,
+        is_min_max_deprecated: bool,
+    ) -> ParquetStatistics {
+        ParquetStatistics::int32(
+            Some(min),
+            Some(max),
+            None,
+            Some(0),
+            is_min_max_deprecated,
+        )
+    }
+
+    fn assert_single_column_row_group_pruning(
+        data_type: DataType,
+        predicate: &Expr,
+        column_statistics: Vec<ParquetStatistics>,
+        column_order: Option<SortOrder>,
+        expected: ExpectedPruning,
+    ) {
+        let schema = test_schema(data_type);
+        assert_row_group_pruning(
+            &schema,
+            predicate,
+            column_statistics,
+            column_order,
+            expected,
+        );
+    }
+
+    fn assert_row_group_pruning(
+        schema: &SchemaRef,
+        predicate: &Expr,
+        column_statistics: Vec<ParquetStatistics>,
+        column_order: Option<SortOrder>,
+        expected: ExpectedPruning,
+    ) {
+        let expr = logical2physical(predicate, schema);
+        let pruning_predicate =
+            PruningPredicate::try_new(expr, Arc::clone(schema)).unwrap();
+        let schema_descr = Arc::new(ArrowSchemaConverter::new().convert(schema).unwrap());
+        let row_group_metadata =
+            vec![get_row_group_meta_data(&schema_descr, column_statistics)];
+        let metrics = parquet_file_metrics();
+        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
+        let column_orders = column_order.map(type_defined_column_orders);
+
+        if let Some(column_orders) = column_orders.as_deref() {
+            row_groups.prune_by_statistics_with_column_orders(
+                schema,
+                &schema_descr,
+                &row_group_metadata,
+                &pruning_predicate,
+                Some(column_orders),
+                &metrics,
+            );
+        } else {
+            row_groups.prune_by_statistics(
+                schema,
+                &schema_descr,
+                &row_group_metadata,
+                &pruning_predicate,
+                &metrics,
+            );
+        }
+
+        assert_pruned(row_groups, expected);
     }
 
     fn get_row_group_meta_data(

--- a/datafusion/datasource-parquet/src/row_group_filter.rs
+++ b/datafusion/datasource-parquet/src/row_group_filter.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::{ParquetAccessPlan, ParquetFileMetrics};
-use arrow::array::{ArrayRef, BooleanArray, UInt64Array};
+use arrow::array::{ArrayRef, BooleanArray, UInt64Array, new_null_array};
 use arrow::datatypes::Schema;
 use datafusion_common::pruning::PruningStatistics;
 use datafusion_common::{Column, Result, ScalarValue};
@@ -30,7 +30,7 @@ use datafusion_physical_expr::utils::collect_columns;
 use datafusion_physical_expr::{PhysicalExpr, PhysicalExprSimplifier};
 use datafusion_pruning::PruningPredicate;
 use parquet::arrow::arrow_reader::statistics::StatisticsConverter;
-use parquet::basic::Type;
+use parquet::basic::{ColumnOrder, Type};
 use parquet::data_type::Decimal;
 use parquet::schema::types::SchemaDescriptor;
 use parquet::{bloom_filter::Sbbf, file::metadata::RowGroupMetaData};
@@ -48,6 +48,17 @@ pub struct RowGroupAccessPlanFilter {
     /// Row groups where ALL rows are known to match the pruning predicate
     /// (the predicate does not filter any rows)
     is_fully_matched: Vec<bool>,
+}
+
+#[derive(Clone, Copy)]
+struct FullyMatchedRowGroups<'a> {
+    candidate_row_group_indices: &'a [usize],
+    arrow_schema: &'a Schema,
+    parquet_schema: &'a SchemaDescriptor,
+    groups: &'a [RowGroupMetaData],
+    predicate: &'a PruningPredicate,
+    column_orders: Option<&'a [ColumnOrder]>,
+    metrics: &'a ParquetFileMetrics,
 }
 
 impl RowGroupAccessPlanFilter {
@@ -244,10 +255,16 @@ impl RowGroupAccessPlanFilter {
     /// Prune remaining row groups using min/max/null_count statistics and
     /// the [`PruningPredicate`] to determine if the predicate can not be true.
     ///
-    /// Updates this set to mark row groups that should not be scanned
+    /// This method does not receive Parquet column order metadata. Use
+    /// [`Self::prune_by_statistics_with_column_orders`] when file metadata is
+    /// available.
     ///
-    /// Note: This method currently ignores ColumnOrder
-    /// <https://github.com/apache/datafusion/issues/8335>
+    /// Missing column order metadata means legacy undefined ordering, so min/max
+    /// statistics are used only for columns with signed sort order. Unsigned
+    /// integers, strings, binary values, and booleans are not pruned by min/max
+    /// stats unless matching `column_orders` metadata is available.
+    ///
+    /// Updates this set to mark row groups that should not be scanned
     ///
     /// # Panics
     /// if `groups.len() != self.len()`
@@ -257,6 +274,33 @@ impl RowGroupAccessPlanFilter {
         parquet_schema: &SchemaDescriptor,
         groups: &[RowGroupMetaData],
         predicate: &PruningPredicate,
+        metrics: &ParquetFileMetrics,
+    ) {
+        self.prune_by_statistics_with_column_orders(
+            arrow_schema,
+            parquet_schema,
+            groups,
+            predicate,
+            None,
+            metrics,
+        )
+    }
+
+    /// Like [`Self::prune_by_statistics`], but uses Parquet column order
+    /// metadata to avoid unsafe min/max pruning.
+    ///
+    /// Pass `file_metadata.column_orders().map(Vec::as_slice)` when Parquet
+    /// file metadata is available. If `column_orders` is `None`, min/max
+    /// statistics are used only for columns with signed sort order. Unsigned
+    /// integers, strings, binary values, and booleans are not pruned by min/max
+    /// stats unless matching `column_orders` metadata is available.
+    pub fn prune_by_statistics_with_column_orders(
+        &mut self,
+        arrow_schema: &Schema,
+        parquet_schema: &SchemaDescriptor,
+        groups: &[RowGroupMetaData],
+        predicate: &PruningPredicate,
+        column_orders: Option<&[ColumnOrder]>,
         metrics: &ParquetFileMetrics,
     ) {
         // scoped timer updates on drop
@@ -274,6 +318,7 @@ impl RowGroupAccessPlanFilter {
             parquet_schema,
             row_group_metadatas,
             arrow_schema,
+            column_orders,
             // Preserve the existing row-group pruning behavior. This path only
             // proves whether matching rows may exist, so it uses the
             // StatisticsConverter default for older parquet-rs files where a
@@ -296,14 +341,15 @@ impl RowGroupAccessPlanFilter {
                 }
 
                 // Check if any of the matched row groups are fully contained by the predicate
-                self.identify_fully_matched_row_groups(
-                    &fully_contained_candidates_original_idx,
+                self.identify_fully_matched_row_groups(FullyMatchedRowGroups {
+                    candidate_row_group_indices: &fully_contained_candidates_original_idx,
                     arrow_schema,
                     parquet_schema,
                     groups,
                     predicate,
+                    column_orders,
                     metrics,
-                );
+                });
             }
             // stats filter array could not be built, so we can't prune
             Err(e) => {
@@ -321,15 +367,17 @@ impl RowGroupAccessPlanFilter {
     /// predicate, which implies all rows match the original predicate.
     ///
     /// Note: This optimization is relatively inexpensive for a limited number of row groups.
-    fn identify_fully_matched_row_groups(
-        &mut self,
-        candidate_row_group_indices: &[usize],
-        arrow_schema: &Schema,
-        parquet_schema: &SchemaDescriptor,
-        groups: &[RowGroupMetaData],
-        predicate: &PruningPredicate,
-        metrics: &ParquetFileMetrics,
-    ) {
+    fn identify_fully_matched_row_groups(&mut self, input: FullyMatchedRowGroups<'_>) {
+        let FullyMatchedRowGroups {
+            candidate_row_group_indices,
+            arrow_schema,
+            parquet_schema,
+            groups,
+            predicate,
+            column_orders,
+            metrics,
+        } = input;
+
         if candidate_row_group_indices.is_empty() {
             return;
         }
@@ -380,6 +428,7 @@ impl RowGroupAccessPlanFilter {
                 .map(|&i| &groups[i])
                 .collect::<Vec<_>>(),
             arrow_schema,
+            column_orders,
             // Fully matched row groups require a stronger proof: every row
             // must pass the predicate. Missing null counts are unknown here;
             // treating them as zero can incorrectly mark nullable row groups as
@@ -617,6 +666,7 @@ struct RowGroupPruningStatistics<'a> {
     parquet_schema: &'a SchemaDescriptor,
     row_group_metadatas: Vec<&'a RowGroupMetaData>,
     arrow_schema: &'a Schema,
+    column_orders: Option<&'a [ColumnOrder]>,
     missing_null_counts_as_zero: bool,
 }
 
@@ -637,19 +687,54 @@ impl<'a> RowGroupPruningStatistics<'a> {
         )?
         .with_missing_null_counts_as_zero(self.missing_null_counts_as_zero))
     }
+
+    fn can_use_min_max_statistics(&self, converter: &StatisticsConverter<'_>) -> bool {
+        let Some(parquet_column_index) = converter.parquet_column_index() else {
+            return true;
+        };
+
+        crate::can_use_min_max_statistics(
+            self.parquet_schema,
+            parquet_column_index,
+            self.column_orders,
+            self.has_deprecated_min_max_statistics(parquet_column_index),
+        )
+    }
+
+    fn has_deprecated_min_max_statistics(&self, parquet_column_index: usize) -> bool {
+        // This is intentionally conservative: one deprecated chunk disables
+        // min/max pruning for this column in this pruning round. TODO: switch
+        // to per-chunk masking if StatisticsConverter exposes that support.
+        self.row_group_metadatas.iter().any(|rg| {
+            rg.columns()
+                .get(parquet_column_index)
+                .and_then(|column| column.statistics())
+                .is_some_and(|statistics| statistics.is_min_max_deprecated())
+        })
+    }
+
+    fn min_max_null_array(&self, converter: &StatisticsConverter<'_>) -> ArrayRef {
+        new_null_array(converter.arrow_field().data_type(), self.num_containers())
+    }
 }
 
 impl PruningStatistics for RowGroupPruningStatistics<'_> {
     fn min_values(&self, column: &Column) -> Option<ArrayRef> {
-        self.statistics_converter(column)
-            .and_then(|c| Ok(c.row_group_mins(self.metadata_iter())?))
-            .ok()
+        let converter = self.statistics_converter(column).ok()?;
+        if !self.can_use_min_max_statistics(&converter) {
+            return Some(self.min_max_null_array(&converter));
+        }
+
+        converter.row_group_mins(self.metadata_iter()).ok()
     }
 
     fn max_values(&self, column: &Column) -> Option<ArrayRef> {
-        self.statistics_converter(column)
-            .and_then(|c| Ok(c.row_group_maxes(self.metadata_iter())?))
-            .ok()
+        let converter = self.statistics_converter(column).ok()?;
+        if !self.can_use_min_max_statistics(&converter) {
+            return Some(self.min_max_null_array(&converter));
+        }
+
+        converter.row_group_maxes(self.metadata_iter()).ok()
     }
 
     fn num_containers(&self) -> usize {
@@ -697,7 +782,7 @@ mod tests {
     use parquet::arrow::ArrowSchemaConverter;
     use parquet::arrow::ParquetRecordBatchStreamBuilder;
     use parquet::arrow::async_reader::ParquetObjectReader;
-    use parquet::basic::LogicalType;
+    use parquet::basic::{ColumnOrder, LogicalType, SortOrder};
     use parquet::data_type::{ByteArray, FixedLenByteArray};
     use parquet::file::metadata::ColumnChunkMetaData;
     use parquet::{
@@ -802,6 +887,236 @@ mod tests {
             &metrics,
         );
         assert_pruned(row_groups, ExpectedPruning::Some(vec![1]))
+    }
+
+    #[test]
+    fn row_group_pruning_uses_unsigned_stats_with_matching_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let expr = logical2physical(&col("c1").gt(lit(15u32)), &schema);
+        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
+
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+        let rgm = get_row_group_meta_data(
+            &schema_descr,
+            vec![ParquetStatistics::int32(
+                Some(1),
+                Some(10),
+                None,
+                Some(0),
+                false,
+            )],
+        );
+        let column_orders = vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)];
+
+        let metrics = parquet_file_metrics();
+        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
+        row_groups.prune_by_statistics_with_column_orders(
+            &schema,
+            &schema_descr,
+            &[rgm],
+            &pruning_predicate,
+            Some(&column_orders),
+            &metrics,
+        );
+        assert_pruned(row_groups, ExpectedPruning::All);
+    }
+
+    #[test]
+    fn row_group_pruning_ignores_unsigned_stats_without_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let expr = logical2physical(&col("c1").eq(lit(0u32)), &schema);
+        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
+
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+        let rgm = get_row_group_meta_data(
+            &schema_descr,
+            vec![ParquetStatistics::int32(
+                Some(-1),
+                Some(0),
+                None,
+                Some(0),
+                true,
+            )],
+        );
+
+        let metrics = parquet_file_metrics();
+        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
+        row_groups.prune_by_statistics(
+            &schema,
+            &schema_descr,
+            &[rgm],
+            &pruning_predicate,
+            &metrics,
+        );
+        assert_pruned(row_groups, ExpectedPruning::None);
+    }
+
+    #[test]
+    fn row_group_pruning_ignores_string_stats_without_column_order() {
+        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
+        let expr = logical2physical(&col("c1").eq(lit("z")), &schema);
+        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
+
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+        let rgm = get_row_group_meta_data(
+            &schema_descr,
+            vec![ParquetStatistics::byte_array(
+                Some(ByteArray::from("a".as_bytes().to_vec())),
+                Some(ByteArray::from("m".as_bytes().to_vec())),
+                None,
+                Some(0),
+                false,
+            )],
+        );
+
+        let metrics = parquet_file_metrics();
+        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
+        row_groups.prune_by_statistics(
+            &schema,
+            &schema_descr,
+            &[rgm],
+            &pruning_predicate,
+            &metrics,
+        );
+        assert_pruned(row_groups, ExpectedPruning::None);
+    }
+
+    #[test]
+    fn row_group_pruning_uses_string_stats_with_column_order() {
+        let schema = Arc::new(Schema::new(vec![Field::new("c1", DataType::Utf8, false)]));
+        let expr = logical2physical(&col("c1").eq(lit("z")), &schema);
+        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
+
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+        let rgm = get_row_group_meta_data(
+            &schema_descr,
+            vec![ParquetStatistics::byte_array(
+                Some(ByteArray::from("a".as_bytes().to_vec())),
+                Some(ByteArray::from("m".as_bytes().to_vec())),
+                None,
+                Some(0),
+                false,
+            )],
+        );
+        let column_orders = vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)];
+
+        let metrics = parquet_file_metrics();
+        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
+        row_groups.prune_by_statistics_with_column_orders(
+            &schema,
+            &schema_descr,
+            &[rgm],
+            &pruning_predicate,
+            Some(&column_orders),
+            &metrics,
+        );
+        assert_pruned(row_groups, ExpectedPruning::All);
+    }
+
+    #[test]
+    fn row_group_pruning_ignores_unsigned_stats_with_mismatched_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let expr = logical2physical(&col("c1").eq(lit(0u32)), &schema);
+        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
+
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+        let rgm = get_row_group_meta_data(
+            &schema_descr,
+            vec![ParquetStatistics::int32(
+                Some(-1),
+                Some(0),
+                None,
+                Some(0),
+                false,
+            )],
+        );
+        let column_orders = vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::SIGNED)];
+
+        let metrics = parquet_file_metrics();
+        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
+        row_groups.prune_by_statistics_with_column_orders(
+            &schema,
+            &schema_descr,
+            &[rgm],
+            &pruning_predicate,
+            Some(&column_orders),
+            &metrics,
+        );
+        assert_pruned(row_groups, ExpectedPruning::None);
+    }
+
+    #[test]
+    fn row_group_pruning_ignores_deprecated_unsigned_stats_with_column_order() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c1", DataType::UInt32, false)]));
+        let expr = logical2physical(&col("c1").eq(lit(0u32)), &schema);
+        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
+
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+        let rgm = get_row_group_meta_data(
+            &schema_descr,
+            vec![ParquetStatistics::int32(
+                Some(-1),
+                Some(0),
+                None,
+                Some(0),
+                true,
+            )],
+        );
+        let column_orders = vec![ColumnOrder::TYPE_DEFINED_ORDER(SortOrder::UNSIGNED)];
+
+        let metrics = parquet_file_metrics();
+        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
+        row_groups.prune_by_statistics_with_column_orders(
+            &schema,
+            &schema_descr,
+            &[rgm],
+            &pruning_predicate,
+            Some(&column_orders),
+            &metrics,
+        );
+        assert_pruned(row_groups, ExpectedPruning::None);
+    }
+
+    #[test]
+    fn row_group_pruning_keeps_safe_columns_when_another_column_is_unsafe() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("c1", DataType::UInt32, false),
+            Field::new("c2", DataType::Int32, false),
+        ]));
+        let expr = col("c1").eq(lit(0u32)).and(col("c2").gt(lit(15)));
+        let expr = logical2physical(&expr, &schema);
+        let pruning_predicate = PruningPredicate::try_new(expr, schema.clone()).unwrap();
+
+        let schema_descr =
+            Arc::new(ArrowSchemaConverter::new().convert(&schema).unwrap());
+        let rgm = get_row_group_meta_data(
+            &schema_descr,
+            vec![
+                ParquetStatistics::int32(Some(-1), Some(0), None, Some(0), true),
+                ParquetStatistics::int32(Some(1), Some(10), None, Some(0), false),
+            ],
+        );
+
+        let metrics = parquet_file_metrics();
+        let mut row_groups = RowGroupAccessPlanFilter::new(ParquetAccessPlan::new_all(1));
+        row_groups.prune_by_statistics(
+            &schema,
+            &schema_descr,
+            &[rgm],
+            &pruning_predicate,
+            &metrics,
+        );
+        assert_pruned(row_groups, ExpectedPruning::All);
     }
 
     #[test]

--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -25,6 +25,24 @@
 in this section pertains to features and changes that have already been merged
 to the main branch and are awaiting release in this version.
 
+### Parquet pruning now respects column order metadata
+
+DataFusion now checks Parquet `column_orders` metadata before using min/max
+statistics for file, row group, and page pruning. This avoids incorrect pruning
+when a file stores statistics using an order that does not match the column's
+natural order.
+
+For Parquet files without `column_orders`, DataFusion follows parquet-rs and
+treats the statistics as legacy signed-order statistics. This is conservative:
+min/max pruning is still used for signed-order columns, but is skipped for
+unsigned-order columns such as unsigned integers, strings, binary values, and
+booleans.
+
+This can make queries over older or externally written Parquet files scan more
+data than before, but avoids silently dropping rows. Files written by current
+parquet-rs/DataFusion include `column_orders` and keep min/max pruning for
+matching column orders.
+
 ### String/numeric comparison coercion now prefers numeric types
 
 Previously, comparing a numeric column with a string value (e.g.,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #8342.

## Rationale for this change

Parquet min/max statistics are only safe to use when DataFusion knows the order used to write them. If DataFusion uses stats with the wrong order, it can skip data that should be read and return wrong results.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

This PR checks Parquet column order before using min/max statistics for file, row group, and page pruning.

It also skips unsafe deprecated min/max statistics for columns whose natural order is not signed.

For files without column order metadata, DataFusion now uses a conservative fallback. It only uses min/max pruning for signed-order columns.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

 Yes.

Queries over older or external Parquet files without column order metadata may scan more data for unsigned integers, strings, binary values, and booleans. This is intentional to avoid wrong results.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
