### PR TITLE
fix(bench): avoid OOM in `array_replace` bench

### DIFF
--- a/datafusion/functions-nested/benches/array_expression.rs
+++ b/datafusion/functions-nested/benches/array_expression.rs
@@ -23,27 +23,22 @@ use std::hint::black_box;
 fn criterion_benchmark(c: &mut Criterion) {
     // Construct large arrays for benchmarking
 
-    let array_len = 100000000;
+    let array_len = 100_000;
 
     let array = (0..array_len).map(|_| lit(2_i64)).collect::<Vec<_>>();
     let list_array = make_array(vec![make_array(array); 3]);
     let from_array = make_array(vec![lit(2_i64); 3]);
     let to_array = make_array(vec![lit(-2_i64); 3]);
 
-    let expected_array = list_array.clone();
-
     // Benchmark array functions
 
     c.bench_function("array_replace", |b| {
         b.iter(|| {
-            assert_eq!(
-                array_replace_all(
-                    list_array.clone(),
-                    from_array.clone(),
-                    to_array.clone()
-                ),
-                *black_box(&expected_array)
-            )
+            black_box(array_replace_all(
+                list_array.clone(),
+                from_array.clone(),
+                to_array.clone(),
+            ))
         })
     });
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #18447.

## Rationale for this change

The `array_replace` benchmark allocated ~90GB of memory before running (3 × 100M `Expr` literals), causing OOM on normal machines.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

- Reduce `array_len` in `array_expression` bench from `100_000_000` to `100_000`.
- Remove a broken `assert_eq!` (and its unused `expected_array`) that compared the `ScalarFunction` `Expr` returned by `array_replace_all` against the unmodified input — the two `Expr` trees are never equal. The OOM previously hid the failing assertion.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes, `cargo bench -p datafusion-functions-nested --bench array_expression` passes locally

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
