### PR TITLE
docs: updating arrays_zip output field naming

### DIFF
--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -566,8 +566,8 @@ Spark) instead of `c0`, `c1`, ..., `c{n-1}`.
 **Who is affected:**
 
 - Queries or downstream code that references the output struct fields by name
-  (e.g. `arrays_zip(a, b)['c0']`). Update field accessors to `1`, `2`,
-  etc.
+  (e.g. `arrays_zip(a, b)[1]['c0']`). Update field accessors to `'1'`, `'2'`,
+  etc. (e.g. `arrays_zip(a, b)[1]['1']`).
 
 See [PR #20886](https://github.com/apache/datafusion/pull/20886) for details.
 

--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -569,7 +569,7 @@ Spark) instead of `c0`, `c1`, ..., `c{n-1}`.
   (e.g. `arrays_zip(a, b)['c0']`). Update field accessors to `'1'`, `'2'`,
   etc.
 
-See [PR #21047](https://github.com/apache/datafusion/pull/21047) for details.
+See [PR #20886](https://github.com/apache/datafusion/pull/20886) for details.
 
 ### `Box<C>` and `Arc<C>` `TreeNodeContainer` impls now require `C: Default`
 

--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -566,7 +566,7 @@ Spark) instead of `c0`, `c1`, ..., `c{n-1}`.
 **Who is affected:**
 
 - Queries or downstream code that references the output struct fields by name
-  (e.g. `arrays_zip(a, b)['c0']`). Update field accessors to `'1'`, `'2'`,
+  (e.g. `arrays_zip(a, b)['c0']`). Update field accessors to `1`, `2`,
   etc.
 
 See [PR #20886](https://github.com/apache/datafusion/pull/20886) for details.

--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -557,6 +557,20 @@ are stored as `Arc<T>` so the map remains cheap to clone.
 - Custom `ParquetFileReaderFactory` implementations or other consumers that
   read `partitioned_file.extensions` and downcast manually.
 
+### `arrays_zip` struct field names changed
+
+The `arrays_zip` (and its alias `list_zip`) scalar function now names its
+output struct fields `"1"`, `"2"`, ..., `"n"` (1-indexed, matching DuckDB and
+Spark) instead of `c0`, `c1`, ..., `c{n-1}`.
+
+**Who is affected:**
+
+- Queries or downstream code that references the output struct fields by name
+  (e.g. `arrays_zip(a, b)['c0']`). Update field accessors to `'1'`, `'2'`,
+  etc.
+
+See [PR #21047](https://github.com/apache/datafusion/pull/21047) for details.
+
 ### `Box<C>` and `Arc<C>` `TreeNodeContainer` impls now require `C: Default`
 
 The generic `TreeNodeContainer` implementations for `Box<C>` and `Arc<C>` now


### PR DESCRIPTION
## Which issue does this PR close?

No issue opened, but discovered regression in unit tests in datafusion-python during upgrading to `main`

## Rationale for this change

Documentation only to let users know that they will need to update their field naming expectations. The change happened in https://github.com/apache/datafusion/pull/20886

## What changes are included in this PR?

Upgrade guide document.

## Are these changes tested?

N/A