### PR TITLE
Add rand() alias for random()

### DIFF
--- a/datafusion/functions/src/math/random.rs
+++ b/datafusion/functions/src/math/random.rs
@@ -44,6 +44,7 @@ The random seed is unique to each row."#,
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct RandomFunc {
     signature: Signature,
+    aliases: Vec<String>,
 }
 
 impl Default for RandomFunc {
@@ -56,6 +57,7 @@ impl RandomFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::nullary(Volatility::Volatile),
+            aliases: vec![String::from("rand")],
         }
     }
 }
@@ -71,6 +73,10 @@ impl ScalarUDFImpl for RandomFunc {
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
         Ok(Float64)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -841,6 +841,12 @@ SELECT r FROM (SELECT r1 == r2 r, r1, r2 FROM (SELECT random()+1 r1, random()+1 
 ----
 false
 
+# Verify that rand() is accepted as an alias for random()
+query TB
+SELECT arrow_typeof(rand()), rand() >= 0 AND rand() < 1
+----
+Float64 true
+
 #######
 # verify that random() returns a different value for each row
 #######

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -59,6 +59,7 @@ dev/update_function_docs.sh file for updating surrounding text.
 - [pow](#pow)
 - [power](#power)
 - [radians](#radians)
+- [rand](#rand)
 - [random](#random)
 - [round](#round)
 - [signum](#signum)
@@ -739,6 +740,10 @@ radians(numeric_expression)
 +----------------+
 ```
 
+### `rand`
+
+_Alias of [random](#random)._
+
 ### `random`
 
 Returns a random float value in the range [0, 1).
@@ -758,6 +763,10 @@ random()
 | 0.7389238902938  |
 +------------------+
 ```
+
+#### Aliases
+
+- rand
 
 ### `round`
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

`rand()` is a common alias for `random()` in SQL engines. Supporting it improves compatibility and lets users write `rand()` as an equivalent zero-argument volatile random function.

## What changes are included in this PR?

- Adds `rand` as an alias for the existing `random()` scalar function.
- Adds a sqllogictest case verifying that `rand()` resolves successfully and returns a `Float64` value in the expected `[0, 1)` range.

## Are these changes tested?

Yes.

- `cargo fmt --all`
- `cargo test --package datafusion-functions random --lib`
- `cargo test --features backtrace,parquet_encryption --profile ci --package datafusion-sqllogictest --test sqllogictests -- functions.slt`

## Are there any user-facing changes?

Yes. Users can now call `rand()` as an alias for `random()`.
