### PR TITLE
docs: add DataFusion Java to subproject listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ See [use cases] for examples. The following related subprojects target end users
 
 - [DataFusion Python](https://github.com/apache/datafusion-python/) offers a Python interface for SQL and DataFrame
   queries.
+- [DataFusion Java](https://github.com/apache/datafusion-java/) offers a Java interface for SQL and DataFrame
+  queries.
 - [DataFusion Comet](https://github.com/apache/datafusion-comet/) is an accelerator for Apache Spark based on
   DataFusion.
 

--- a/docs/source/contributor-guide/communication.md
+++ b/docs/source/contributor-guide/communication.md
@@ -44,7 +44,7 @@ all technical designs are recorded and formalized in GitHub issues.
 
 Historically, the most active discussion forum has been the [Arrow Rust Discord
 server][discord-link] which has specific channels for Arrow, DataFusion, and
-DataFusion subprojects such as Ballista, Comet, Python, etc.
+DataFusion subprojects such as Ballista, Comet, Java, Python, etc.
 DataFusion specific channels are prefixed with the `#datafusion-` tag.
 We recommend new users join this server for real-time discussions with the community.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,8 @@ The following related subprojects target end users and have separate documentati
 
 - `DataFusion Python <https://datafusion.apache.org/python/>`_ offers a Python interface for SQL and DataFrame
   queries.
+- `DataFusion Java <https://datafusion.apache.org/java/>`_ offers a Java interface for SQL and DataFrame
+  queries.
 - `DataFusion Comet <https://datafusion.apache.org/comet/>`_ is an accelerator for Apache Spark based on
   DataFusion.
 - `DataFusion Ballista <https://datafusion.apache.org/ballista/>`_ is distributed processing extension for DataFusion.
@@ -178,4 +180,5 @@ To get started, see
 
    DataFusion Ballista <https://datafusion.apache.org/ballista/>
    DataFusion Comet <https://datafusion.apache.org/comet/>
+   DataFusion Java <https://datafusion.apache.org/java/>
    DataFusion Python <https://datafusion.apache.org/python/>

--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -186,7 +186,7 @@ provide integrations with other systems, some of which are described below:
 - [datafusion-c](https://github.com/datafusion-contrib/datafusion-c)
 - [datafusion-python](https://github.com/apache/datafusion-python)
 - [datafusion-ruby](https://github.com/datafusion-contrib/datafusion-ruby)
-- [datafusion-java](https://github.com/datafusion-contrib/datafusion-java)
+- [datafusion-java](https://github.com/apache/datafusion-java)
 
 ### Integrations
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

The DataFusion Java subproject (https://datafusion.apache.org/java) is not yet listed alongside the other DataFusion subprojects (Python, Comet, Ballista) in the README and docs. This PR adds it so users discovering DataFusion can find the Java bindings.

## What changes are included in this PR?

- `README.md`: add DataFusion Java to the list of related subprojects next to DataFusion Python.
- `docs/source/index.rst`: add DataFusion Java to the related subprojects list and to the "DataFusion Subprojects" toctree.
- `docs/source/contributor-guide/communication.md`: mention Java in the list of subproject Discord channels.
- `docs/source/user-guide/introduction.md`: update the existing `datafusion-java` language-bindings entry to point at the official `apache/datafusion-java` repo (previously pointed at `datafusion-contrib/datafusion-java`).

## Are these changes tested?

Docs-only change; no tests added.

## Are there any user-facing changes?

Yes — documentation updates only.