### PR TITLE
feat: Add `FFI_QueryPlanner` to support foreign query planners across shared-library boundaries

### DIFF
--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -17,6 +17,7 @@
 
 //! [`SessionContext`] API for registering data sources and executing queries
 
+use std::any::Any;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::{Arc, Weak};
@@ -2073,7 +2074,7 @@ impl From<SessionContext> for SessionStateBuilder {
 
 /// A planner used to add extensions to DataFusion logical and physical plans.
 #[async_trait]
-pub trait QueryPlanner: Debug {
+pub trait QueryPlanner: Any + Debug {
     /// Given a [`LogicalPlan`], create an [`ExecutionPlan`] suitable for execution
     async fn create_physical_plan(
         &self,

--- a/datafusion/ffi/src/session/mod.rs
+++ b/datafusion/ffi/src/session/mod.rs
@@ -37,7 +37,9 @@ use datafusion_expr::{
 };
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_plan::ExecutionPlan;
-use datafusion_proto::bytes::{logical_plan_from_bytes, logical_plan_to_bytes};
+use datafusion_proto::bytes::{
+    logical_plan_from_bytes, logical_plan_to_bytes_with_extension_codec,
+};
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
 use datafusion_proto::logical_plan::from_proto::parse_expr;
 use datafusion_proto::logical_plan::to_proto::serialize_expr;
@@ -63,6 +65,7 @@ use crate::util::FFI_Result;
 use crate::{df_result, sresult, sresult_return};
 
 pub mod config;
+pub mod planner;
 
 /// A stable struct for sharing [`Session`] across FFI boundaries.
 ///
@@ -550,8 +553,10 @@ impl Session for ForeignSession {
         &self,
         logical_plan: &LogicalPlan,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        let codec: Arc<dyn LogicalExtensionCodec> = (&self.session.logical_codec).into();
         unsafe {
-            let logical_plan = logical_plan_to_bytes(logical_plan)?;
+            let logical_plan =
+                logical_plan_to_bytes_with_extension_codec(logical_plan, codec.as_ref())?;
             let physical_plan = df_result!(
                 (self.session.create_physical_plan)(
                     &self.session,

--- a/datafusion/ffi/src/session/planner.rs
+++ b/datafusion/ffi/src/session/planner.rs
@@ -1,0 +1,313 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::ffi::c_void;
+use std::sync::Arc;
+
+use async_ffi::{FfiFuture, FutureExt};
+use async_trait::async_trait;
+use datafusion_common::DataFusionError;
+use datafusion_execution::TaskContext;
+use datafusion_expr::LogicalPlan;
+use datafusion_physical_plan::ExecutionPlan;
+use datafusion_proto::bytes::{
+    logical_plan_from_bytes_with_extension_codec,
+    logical_plan_to_bytes_with_extension_codec,
+};
+use datafusion_proto::logical_plan::{
+    DefaultLogicalExtensionCodec, LogicalExtensionCodec,
+};
+use datafusion_session::Session;
+use stabby::vec::Vec as SVec;
+use tokio::runtime::Handle;
+
+use crate::execution::FFI_TaskContextProvider;
+use crate::execution_plan::FFI_ExecutionPlan;
+use crate::proto::logical_extension_codec::FFI_LogicalExtensionCodec;
+use crate::session::{FFI_SessionRef, ForeignSession};
+use crate::util::FFI_Result;
+use crate::{df_result, sresult, sresult_return};
+
+/// FFI-compatible variant of `QueryPlanner` that accepts a `&dyn Session` instead of a
+/// concrete session type.
+///
+/// `QueryPlanner` requires a specific `SessionState` type, which cannot cross an FFI
+/// boundary. `QueryPlannerWeak` relaxes that requirement by accepting `&dyn Session`, making
+/// it possible for a planner implemented in a foreign library to participate in DataFusion's
+/// planning pipeline.
+///
+/// # Usage
+///
+/// This trait is not registered with DataFusion directly. Instead, wrap it in a
+/// `QueryPlanner` implementation (e.g. `DynamicForeignQueryPlaner` in the integration
+/// tests) and register that wrapper with the `SessionContext`.
+#[async_trait]
+pub trait QueryPlannerWeak: std::fmt::Debug + Send + Sync {
+    /// Converts a [LogicalPlan] into an [ExecutionPlan] suitable for execution.
+    ///
+    /// Mirrors `QueryPlanner::create_physical_plan` but receives session as
+    /// `&dyn Session` rather than `&SessionState`.
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        session: &dyn Session,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>>;
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct FFI_QueryPlanner {
+    // it would make sense, for ballista, to get access to this method.
+    // as the plan is going to be decode at the scheduler side.
+    //
+    // at the moment,FFI_SessionRef is not public, so we'd need to change it
+    /// Given a [`LogicalPlan`], create an [`ExecutionPlan`] suitable for execution
+    create_physical_plan:
+        unsafe extern "C" fn(
+            &Self,
+            logical_plan_serialized: SVec<u8>,
+            session: FFI_SessionRef,
+        ) -> FfiFuture<FFI_Result<FFI_ExecutionPlan>>,
+
+    /// Logical codec used to provide encoding and decoding of plans.
+    pub logical_codec: FFI_LogicalExtensionCodec,
+
+    /// Release the memory of the private data when it is no longer being used.
+    pub release: unsafe extern "C" fn(arg: &mut Self),
+
+    /// Internal data. This is only to be accessed by the planner of the plan.
+    /// The foreign library should never attempt to access this data.
+    pub private_data: *mut c_void,
+
+    /// Used to create a clone on the planner . This should
+    /// only need to be called by the receiver of the plan.
+    pub clone: unsafe extern "C" fn(plan: &Self) -> Self,
+
+    /// Utility to identify when FFI objects are accessed locally through
+    /// the foreign interface. See [`crate::get_library_marker_id`] and
+    /// the crate's `README.md` for more information.
+    pub library_marker_id: extern "C" fn() -> usize,
+}
+
+unsafe impl Send for FFI_QueryPlanner {}
+unsafe impl Sync for FFI_QueryPlanner {}
+
+struct QueryPlannerPrivateData {
+    planner: Arc<dyn QueryPlannerWeak>,
+}
+
+impl FFI_QueryPlanner {
+    fn inner(&self) -> &Arc<dyn QueryPlannerWeak> {
+        unsafe {
+            let private_data = self.private_data as *const QueryPlannerPrivateData;
+            &(*private_data).planner
+        }
+    }
+}
+
+unsafe extern "C" fn release_fn_wrapper(ctx: &mut FFI_QueryPlanner) {
+    unsafe {
+        let private_data =
+            Box::from_raw(ctx.private_data as *mut QueryPlannerPrivateData);
+        drop(private_data);
+    }
+}
+
+unsafe extern "C" fn create_physical_plan_fn_wrapper(
+    planner: &FFI_QueryPlanner,
+    logical_plan_serialized: SVec<u8>,
+    session: FFI_SessionRef,
+) -> FfiFuture<FFI_Result<FFI_ExecutionPlan>> {
+    unsafe {
+        let planner = Arc::clone(planner.inner());
+        let codec: Arc<dyn LogicalExtensionCodec> = (&session.logical_codec).into();
+        let runtime = session.runtime().clone();
+
+        async move {
+            let mut foreign_session = None;
+            let session = sresult_return!(
+                session
+                    .as_local()
+                    .map(Ok::<&(dyn Session + Send + Sync), DataFusionError>)
+                    .unwrap_or_else(|| {
+                        foreign_session = Some(ForeignSession::try_from(&session)?);
+                        Ok(foreign_session.as_ref().unwrap())
+                    })
+            );
+
+            let task_ctx: Arc<TaskContext> = session.task_ctx();
+
+            let logical_plan =
+                sresult_return!(logical_plan_from_bytes_with_extension_codec(
+                    logical_plan_serialized.as_slice(),
+                    task_ctx.as_ref(),
+                    codec.as_ref()
+                ));
+
+            let physical_plan =
+                planner.create_physical_plan(&logical_plan, session).await;
+
+            sresult!(physical_plan.map(|plan| FFI_ExecutionPlan::new(plan, runtime)))
+        }
+        .into_ffi()
+    }
+}
+
+unsafe extern "C" fn clone_fn_wrapper(planner: &FFI_QueryPlanner) -> FFI_QueryPlanner {
+    let codec = planner.logical_codec.clone();
+    let planner = Arc::clone(planner.inner());
+    FFI_QueryPlanner::new_with_ffi_codec(planner, codec)
+}
+
+impl Drop for FFI_QueryPlanner {
+    fn drop(&mut self) {
+        unsafe { (self.release)(self) }
+    }
+}
+
+impl FFI_QueryPlanner {
+    pub fn new(
+        planner: Arc<dyn QueryPlannerWeak>,
+        runtime: Option<&Handle>,
+        task_ctx_provider: impl Into<FFI_TaskContextProvider>,
+        logical_codec: Option<Arc<dyn LogicalExtensionCodec>>,
+    ) -> Self {
+        let logical_codec =
+            logical_codec.unwrap_or_else(|| Arc::new(DefaultLogicalExtensionCodec {}));
+        let logical_codec = FFI_LogicalExtensionCodec::new(
+            logical_codec,
+            runtime.cloned(),
+            task_ctx_provider.into(),
+        );
+
+        Self::new_with_ffi_codec(planner, logical_codec)
+    }
+
+    pub fn new_with_ffi_codec(
+        planner: Arc<dyn QueryPlannerWeak>,
+        codec: FFI_LogicalExtensionCodec,
+    ) -> Self {
+        let private_data = Box::new(QueryPlannerPrivateData { planner });
+
+        Self {
+            create_physical_plan: create_physical_plan_fn_wrapper,
+            logical_codec: codec,
+            clone: clone_fn_wrapper,
+            release: release_fn_wrapper,
+            private_data: Box::into_raw(private_data) as *mut c_void,
+            library_marker_id: crate::get_library_marker_id,
+        }
+    }
+}
+
+impl Clone for FFI_QueryPlanner {
+    fn clone(&self) -> Self {
+        unsafe { (self.clone)(self) }
+    }
+}
+
+#[derive(Debug)]
+pub struct ForeignQueryPlanner(pub FFI_QueryPlanner);
+
+impl From<&FFI_QueryPlanner> for Arc<dyn QueryPlannerWeak> {
+    fn from(planner: &FFI_QueryPlanner) -> Self {
+        if (planner.library_marker_id)() == crate::get_library_marker_id() {
+            Arc::clone(planner.inner())
+        } else {
+            Arc::new(ForeignQueryPlanner(planner.clone()))
+        }
+    }
+}
+
+#[async_trait]
+impl QueryPlannerWeak for ForeignQueryPlanner {
+    /// Given a [`LogicalPlan`], create an [`ExecutionPlan`] suitable for execution
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        session_state: &dyn Session,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        let codec: Arc<dyn LogicalExtensionCodec> = (&self.0.logical_codec).into();
+        let logical_plan_buf =
+            logical_plan_to_bytes_with_extension_codec(logical_plan, codec.as_ref())?;
+
+        let session_ref =
+            FFI_SessionRef::new(session_state, None, self.0.logical_codec.clone());
+
+        let plan = df_result!(unsafe {
+            (self.0.create_physical_plan)(
+                &self.0,
+                logical_plan_buf.as_ref().into(),
+                session_ref,
+            )
+            .await
+        })?;
+
+        Ok((&plan).try_into()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion_expr::LogicalPlan;
+    use datafusion_physical_plan::ExecutionPlan;
+    use datafusion_physical_plan::empty::EmptyExec;
+    use datafusion_session::Session;
+
+    use crate::session::planner::{FFI_QueryPlanner, QueryPlannerWeak};
+
+    #[derive(Debug, Default)]
+    struct DummyPlanner {}
+
+    #[async_trait::async_trait]
+    impl QueryPlannerWeak for DummyPlanner {
+        async fn create_physical_plan(
+            &self,
+            logical_plan: &LogicalPlan,
+            _session_state: &dyn Session,
+        ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+            let schema = logical_plan.schema().as_arrow().clone();
+            // will need better test
+            Ok(Arc::new(EmptyExec::new(Arc::new(schema))))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_end_to_end() -> datafusion::common::Result<()> {
+        let (ctx, task_ctx_provider) = crate::util::tests::test_session_and_ctx();
+
+        let df = ctx.sql("select 1 as i").await?;
+        let logical_plan = df.logical_plan();
+
+        let planner: Arc<dyn QueryPlannerWeak> = Arc::new(DummyPlanner::default());
+
+        let mut ffi_planner =
+            FFI_QueryPlanner::new(planner, None, task_ctx_provider, None);
+        ffi_planner.library_marker_id = crate::mock_foreign_marker_id;
+
+        let foreign_planner: Arc<dyn QueryPlannerWeak> = (&ffi_planner).into();
+
+        let empty_exec = foreign_planner
+            .create_physical_plan(logical_plan, &ctx.state())
+            .await?;
+
+        assert!(empty_exec.downcast_ref::<EmptyExec>().is_some());
+        Ok(())
+    }
+}

--- a/datafusion/ffi/src/tests/mod.rs
+++ b/datafusion/ffi/src/tests/mod.rs
@@ -35,6 +35,7 @@ use crate::execution_plan::FFI_ExecutionPlan;
 use crate::execution_plan::tests::EmptyExec;
 use crate::physical_optimizer::FFI_PhysicalOptimizerRule;
 use crate::proto::logical_extension_codec::FFI_LogicalExtensionCodec;
+use crate::session::planner::FFI_QueryPlanner;
 use crate::table_provider::FFI_TableProvider;
 use crate::table_provider_factory::FFI_TableProviderFactory;
 use crate::tests::catalog::create_catalog_provider_list;
@@ -47,6 +48,7 @@ mod async_provider;
 pub mod catalog;
 pub mod config;
 mod physical_optimizer;
+mod planner;
 mod sync_provider;
 mod table_provider_factory;
 mod udf_udaf_udwf;
@@ -99,6 +101,9 @@ pub struct ForeignLibraryModule {
     pub create_empty_exec: extern "C" fn() -> FFI_ExecutionPlan,
 
     pub create_physical_optimizer_rule: extern "C" fn() -> FFI_PhysicalOptimizerRule,
+
+    pub create_query_planner:
+        extern "C" fn(FFI_LogicalExtensionCodec) -> FFI_QueryPlanner,
 
     pub version: extern "C" fn() -> u64,
 }
@@ -164,6 +169,7 @@ pub extern "C" fn datafusion_ffi_get_module() -> ForeignLibraryModule {
         create_empty_exec,
         create_physical_optimizer_rule:
             physical_optimizer::create_physical_optimizer_rule,
+        create_query_planner: planner::create_query_planner,
         version: super::version,
     }
 }

--- a/datafusion/ffi/src/tests/planner.rs
+++ b/datafusion/ffi/src/tests/planner.rs
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use datafusion_expr::LogicalPlan;
+use datafusion_physical_plan::{ExecutionPlan, empty::EmptyExec};
+use datafusion_session::Session;
+
+use crate::{
+    proto::logical_extension_codec::FFI_LogicalExtensionCodec,
+    session::planner::{FFI_QueryPlanner, QueryPlannerWeak},
+};
+
+#[derive(Debug, Default)]
+struct MockPlanner {}
+
+#[async_trait::async_trait]
+impl QueryPlannerWeak for MockPlanner {
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        _session_state: &dyn Session,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        let schema = logical_plan.schema().as_arrow().clone();
+        Ok(Arc::new(EmptyExec::new(Arc::new(schema))))
+    }
+}
+
+pub(crate) extern "C" fn create_query_planner(
+    codec: FFI_LogicalExtensionCodec,
+) -> FFI_QueryPlanner {
+    let planner: Arc<dyn QueryPlannerWeak> = Arc::new(MockPlanner::default());
+    FFI_QueryPlanner::new_with_ffi_codec(planner, codec)
+}

--- a/datafusion/ffi/tests/ffi_planner.rs
+++ b/datafusion/ffi/tests/ffi_planner.rs
@@ -1,0 +1,151 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod utils;
+
+#[cfg(feature = "integration-tests")]
+mod tests {
+    use std::any::Any;
+    use std::sync::{Arc, RwLock};
+
+    use datafusion::execution::context::{QueryPlanner, SessionContext};
+    use datafusion::execution::{SessionState, SessionStateBuilder};
+    use datafusion_common::DataFusionError;
+    use datafusion_execution::TaskContextProvider;
+    use datafusion_expr::LogicalPlan;
+    use datafusion_ffi::execution::FFI_TaskContextProvider;
+    use datafusion_ffi::execution_plan::tests::EmptyExec;
+    use datafusion_ffi::proto::logical_extension_codec::FFI_LogicalExtensionCodec;
+    use datafusion_ffi::session::planner::{FFI_QueryPlanner, QueryPlannerWeak};
+    use datafusion_ffi::tests::utils::get_module;
+    use datafusion_physical_plan::ExecutionPlan;
+    use datafusion_proto::logical_plan::DefaultLogicalExtensionCodec;
+
+    #[tokio::test]
+    async fn test_ffi_query_planner() -> Result<(), DataFusionError> {
+        let module = get_module()?;
+        let (ctx, codec) = super::utils::ctx_and_codec();
+
+        let ffi_planner = (module.create_query_planner)(codec);
+        let foreign_planner: Arc<dyn QueryPlannerWeak> = (&ffi_planner).into();
+
+        let df = ctx.sql("select 1 as i").await?;
+        let logical_plan = df.logical_plan();
+
+        let empty_exec = foreign_planner
+            .create_physical_plan(logical_plan, &ctx.state())
+            .await?;
+
+        assert!(empty_exec.downcast_ref::<EmptyExec>().is_none());
+        assert!(empty_exec.schema().field_with_name("i").is_ok());
+        assert_eq!("EmptyExec", empty_exec.name());
+
+        Ok(())
+    }
+
+    // Verifies that an FFI planner can be injected into an already-constructed context.
+    //
+    // `SessionContext` requires a `QueryPlanner` at construction time, but the FFI planner
+    // is only available after the context exists (it needs a codec, which needs the context).
+    // `DynamicForeignQueryPlaner` breaks this cycle by acting as a placeholder that can be
+    // swapped for the real FFI planner once both sides are ready.
+    #[tokio::test]
+    async fn test_ffi_dynamic_query_planner() -> Result<(), DataFusionError> {
+        let module = get_module()?;
+        let (ctx, codec) = ctx_codec_planner();
+
+        let ffi_planner = (module.create_query_planner)(codec);
+
+        let state = ctx.state();
+        let planner = state.query_planner().as_ref();
+        let planer = (planner as &dyn Any)
+            .downcast_ref::<DynamicForeignQueryPlanner>()
+            .expect("proper query planner");
+
+        planer.set_planner(&ffi_planner);
+        let df = ctx.sql("select 1 as i").await?;
+        let plan = df.create_physical_plan().await?;
+
+        assert!(plan.downcast_ref::<EmptyExec>().is_none());
+        assert!(plan.schema().field_with_name("i").is_ok());
+        assert_eq!("EmptyExec", plan.name());
+
+        Ok(())
+    }
+
+    /// Builds a `SessionContext` pre-wired with a `DynamicForeignQueryPlaner` placeholder
+    /// and a matching `FFI_LogicalExtensionCodec`. The planner starts empty; call
+    /// `DynamicForeignQueryPlaner::set_planner` to install the real FFI planner before use.
+    pub fn ctx_codec_planner() -> (Arc<SessionContext>, FFI_LogicalExtensionCodec) {
+        let query_planner = Arc::new(DynamicForeignQueryPlanner::default());
+        let state = SessionStateBuilder::new_with_default_features()
+            .with_query_planner(query_planner)
+            .build();
+        let ctx = Arc::new(SessionContext::from(state));
+
+        let task_ctx_provider = Arc::clone(&ctx) as Arc<dyn TaskContextProvider>;
+        let task_ctx_provider = FFI_TaskContextProvider::from(&task_ctx_provider);
+        let codec = FFI_LogicalExtensionCodec::new(
+            Arc::new(DefaultLogicalExtensionCodec {}),
+            None,
+            task_ctx_provider,
+        );
+
+        (ctx, codec)
+    }
+
+    /// A `QueryPlanner` placeholder that can be hot-swapped with an FFI-backed planner.
+    ///
+    /// Exists solely to break the construction-time dependency cycle between
+    /// `SessionContext` and `FFI_QueryPlanner`. The inner planner starts as `None` and
+    /// must be set via `set_planner` before any query is executed.
+    #[derive(Debug, Default)]
+    struct DynamicForeignQueryPlanner {
+        inner: Arc<RwLock<Option<Arc<dyn QueryPlannerWeak>>>>,
+    }
+
+    impl DynamicForeignQueryPlanner {
+        /// Installs `ffi_planner` as the active planner. Converts the FFI type to the
+        /// `QueryPlannerWeak` trait object expected by `create_physical_plan`.
+        pub fn set_planner(&self, ffi_planner: &FFI_QueryPlanner) {
+            let foreign_planner: Arc<dyn QueryPlannerWeak> = (ffi_planner).into();
+            let mut inner = self.inner.write().unwrap();
+            *inner = Some(foreign_planner);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl QueryPlanner for DynamicForeignQueryPlanner {
+        async fn create_physical_plan(
+            &self,
+            logical_plan: &LogicalPlan,
+            session_state: &SessionState,
+        ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+            let planner = { self.inner.read().unwrap().clone() };
+
+            match planner {
+                Some(planner) => {
+                    planner
+                        .create_physical_plan(logical_plan, session_state)
+                        .await
+                }
+                // we could use default planner here instead of panicking
+                None => panic!("planner should be set before executing queries"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

This is follow up on #20249 which was co-authored with @timsaucer 

Closes #. (pending)

## Rationale for this change

DataFusion's FFI layer allows plugins and foreign libraries to extend query processing across shared-library boundaries. However, there was no way for a foreign library to participate in the physical planning pipeline — `QueryPlanner` required a concrete &`SessionState`, which cannot cross an FFI boundary.

PR rallies on `dyn Session` which limits use of this functionality, as `PhysicalPlanner`, which in most cases would be called,  expects `SessionState` and in FFI environments it would be unsafe to cast `dyn Session` to `SessionState`. Proposed change would unblock Ballista integration with DF python, but apart from that, I'm not sure how useful it would be until we align other important interfaces to use `dyn Session`.

## What changes are included in this PR?

- Adds `FFI_QueryPlanner` — an FFI-safe `repr-C` struct that wraps a foreign `QueryPlanner` implementation, serializing the `LogicalPlan` via datafusion-proto across the boundary and deserializing the resulting `ExecutionPlan`.
- Adds `QueryPlannerWeak` trait — a variant of `QueryPlanner` that accepts `&dyn Session` instead of `&SessionState`, making it implementable by foreign code. It make more sense to create new interface rather than changing `QueryPlanner`. The change would introduce big backward incompatibility, and limiting use cases this functionality could be used, Also, we can argue that having `SessionState` as parameter makes sense.
- Extends `QueryPlanner` with an `Any` bound to allow downcasting (needed by `DynamicForeignQueryPlanner`).
- Adds integration tests covering both direct use of `FFI_QueryPlanner` via `QueryPlannerWeak` and the deferred-injection pattern via `DynamicForeignQueryPlanner`.

The `DynamicForeignQueryPlanner` helper (in the integration tests) shows how to break the construction-time dependency cycle: `SessionContext` needs a `QueryPlanner` at build time, but the `FFI` planner needs the codec which needs the context. The placeholder is registered at build time and swapped for the real FFI planner once both sides exist.

## Are these changes tested?

Yes. Integration tests are added in `datafusion/ffi/tests/ffi_planner.rs`:

- `test_ffi_query_planner` — verifies that a foreign planner loaded from a shared library can produce a valid ExecutionPlan from a LogicalPlan.
- `test_ffi_dynamic_query_planner` — verifies the deferred-injection pattern where the FFI planner is installed into an already-constructed SessionContext via `DynamicForeignQueryPlanner`.

## Are there any user-facing changes?

Yes, one change to a public trait:

- `QueryPlanner` now requires Any as a supertrait (enables downcasting). This is not required for this implementation but it might be needed for implementors

## Open Questions

- I believe this is not generic enough;  mix of `SessionState` and `dyn Session` usage across internal interfaces & (physical) planners makes this proposal not really useful until we move all relevant traits to `dyn Session`; question is do we move this to datafusion-python to enable ballista use cases?
- there is chicken-egg problem at the moment, `SessionContext` is needed to create a `QueryPlanner` but `QueryPlanner` is required to create a `SessionContext` (I hope I did not get that horrible wrong)
- Name of `QueryPlannerWeak` is debatable, I cant come up with better name  
