### PR TITLE
chore: enable `unreachable_pub` lint at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     "cfg(tarpaulin_include)",
 ] }
 unused_qualifications = "deny"
+unreachable_pub = "deny"
 
 # --------------------
 # Compilation Profiles


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

Why looking at the code I thought I could use `InProgressSpillFile` since it marked as pub, or the function `create_in_progress_file` that is also `pub`, but `InProgressSpillFile` mod is behind `pub(crate)` so to avoid confusion when reading the source code I'm enabling this lint

## What changes are included in this PR?

- Adds `unreachable_pub = "deny"` under `[workspace.lints.rust]` in the root `Cargo.toml`.

## Are these changes tested?

CI

## Are there any user-facing changes?

No.