### PR TITLE
perf: reuse mask in `truncate_list_nulls` and avoid counting all true bits

### DIFF
--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -31,7 +31,8 @@ use arrow::array::{
     cast::AsArray,
 };
 use arrow::array::{
-    ArrowPrimitiveType, BooleanArray, Datum, GenericListArray, Int32Array, Int64Array, MutableArrayData, PrimitiveArray, make_array
+    ArrowPrimitiveType, BooleanArray, Datum, GenericListArray, Int32Array, Int64Array,
+    MutableArrayData, PrimitiveArray, make_array,
 };
 use arrow::array::{LargeListViewArray, ListViewArray};
 use arrow::buffer::{OffsetBuffer, ScalarBuffer};
@@ -1143,7 +1144,7 @@ fn truncate_list_nulls<O: OffsetSizeTrait>(
         let empty = arrow::compute::kernels::cmp::eq(&lengths, zero)?;
         let valid_or_empty = empty.values() | nulls.inner();
         let valid_or_empty = BooleanArray::from(valid_or_empty);
-    
+
         if valid_or_empty.has_false() {
             let array_data = list.values().to_data();
             let offsets = list.offsets();

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -31,12 +31,10 @@ use arrow::array::{
     cast::AsArray,
 };
 use arrow::array::{
-    ArrowPrimitiveType, Datum, GenericListArray, Int32Array, Int64Array,
-    MutableArrayData, PrimitiveArray, make_array,
+    ArrowPrimitiveType, BooleanArray, Datum, GenericListArray, Int32Array, Int64Array, MutableArrayData, PrimitiveArray, make_array
 };
 use arrow::array::{LargeListViewArray, ListViewArray};
 use arrow::buffer::{OffsetBuffer, ScalarBuffer};
-use arrow::compute::kernels::cmp::neq;
 use arrow::compute::kernels::length::length;
 use arrow::compute::{SortColumn, SortOptions, partition};
 use arrow::datatypes::{
@@ -1142,17 +1140,18 @@ fn truncate_list_nulls<O: OffsetSizeTrait>(
             &Int64Array::new_scalar(0)
         };
 
-        let not_empty = neq(&lengths, zero)?;
-        let null_and_non_empty = &!nulls.inner() & not_empty.values();
-
-        if null_and_non_empty.count_set_bits() > 0 {
+        let empty = arrow::compute::kernels::cmp::eq(&lengths, zero)?;
+        let valid_or_empty = empty.values() | nulls.inner();
+        let valid_or_empty = BooleanArray::from(valid_or_empty);
+    
+        if valid_or_empty.has_false() {
             let array_data = list.values().to_data();
             let offsets = list.offsets();
             let capacity = offsets[offsets.len() - 1] - offsets[0];
             let mut mutable_array_data =
                 MutableArrayData::new(vec![&array_data], false, capacity.as_usize());
 
-            let valid_or_empty = nulls.inner() | &!not_empty.values();
+            let (valid_or_empty, _nulls) = valid_or_empty.into_parts();
 
             for (start, end) in valid_or_empty.set_slices() {
                 mutable_array_data.extend(

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -36,6 +36,7 @@ use arrow::array::{
 };
 use arrow::array::{LargeListViewArray, ListViewArray};
 use arrow::buffer::{OffsetBuffer, ScalarBuffer};
+use arrow::compute::kernels::cmp::eq;
 use arrow::compute::kernels::length::length;
 use arrow::compute::{SortColumn, SortOptions, partition};
 use arrow::datatypes::{
@@ -1128,6 +1129,7 @@ pub fn remove_list_null_values(array: &ArrayRef) -> Result<ArrayRef> {
     }
 }
 
+/// Create a new list array where all the nulls point to empty lists
 fn truncate_list_nulls<O: OffsetSizeTrait>(
     list: &GenericListArray<O>,
 ) -> Result<GenericListArray<O>> {
@@ -1141,8 +1143,8 @@ fn truncate_list_nulls<O: OffsetSizeTrait>(
             &Int64Array::new_scalar(0)
         };
 
-        let empty = arrow::compute::kernels::cmp::eq(&lengths, zero)?;
-        let valid_or_empty = empty.values() | nulls.inner();
+        let (mut valid_or_empty, _nulls) = eq(&lengths, zero)?.into_parts();
+        valid_or_empty |= nulls.inner();
         let valid_or_empty = BooleanArray::from(valid_or_empty);
 
         if valid_or_empty.has_false() {


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

1. instead of counting set bits to check if there is at least 1 set bits, we can use the existing helpers on `BooleanArray` that check if there is at least 1 set bit
2. Avoid unnecessary `BooleanBuffer` bitwise operations and reuse mask 

## What changes are included in this PR?

reused mask, and use helper to check if at least one false

## Are these changes tested?

Existing tests

## Are there any user-facing changes?

No

------

Cc @gstvg, @comphead 
