### PR TITLE
Refactor Spark `format_string` numeric `%c` conversion dispatch

### DIFF
--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -891,6 +891,23 @@ fn unsigned_to_char(value: u64) -> Result<char> {
     codepoint_to_char(codepoint)
 }
 
+/// Convert a non-null integer scalar to a [`char`] for the `%c` conversion.
+fn integer_scalar_to_char(value: &ScalarValue) -> Result<char> {
+    match value {
+        ScalarValue::Int8(Some(value)) => signed_to_char(*value as i64),
+        ScalarValue::Int16(Some(value)) => signed_to_char(*value as i64),
+        ScalarValue::Int32(Some(value)) => signed_to_char(*value as i64),
+        ScalarValue::Int64(Some(value)) => signed_to_char(*value),
+        ScalarValue::UInt8(Some(value)) => unsigned_to_char(*value as u64),
+        ScalarValue::UInt16(Some(value)) => unsigned_to_char(*value as u64),
+        ScalarValue::UInt32(Some(value)) => unsigned_to_char(*value as u64),
+        ScalarValue::UInt64(Some(value)) => unsigned_to_char(*value),
+        _ => datafusion_common::internal_err!(
+            "integer_scalar_to_char expects a non-null integer scalar, got {value:?}"
+        ),
+    }
+}
+
 impl ConversionSpecifier {
     /// Validates that the grouping separator flag is not used with scientific
     /// notation conversions, matching Java/Spark behavior which throws
@@ -923,7 +940,7 @@ impl ConversionSpecifier {
 
                 _ => self.format_boolean(string, value),
             },
-            ScalarValue::Int8(value) => match (self.conversion_type, value) {
+            scalar @ ScalarValue::Int8(value) => match (self.conversion_type, value) {
                 (ConversionType::DecInt, Some(value)) => {
                     self.format_signed(string, *value as i64)
                 }
@@ -933,8 +950,8 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, (*value as u8) as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(value)) => {
-                    self.format_char(string, signed_to_char(*value as i64)?)
+                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
+                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
@@ -948,12 +965,12 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            ScalarValue::Int16(value) => match (self.conversion_type, value) {
+            scalar @ ScalarValue::Int16(value) => match (self.conversion_type, value) {
                 (ConversionType::DecInt, Some(value)) => {
                     self.format_signed(string, *value as i64)
                 }
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(value)) => {
-                    self.format_char(string, signed_to_char(*value as i64)?)
+                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
+                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::HexIntLower
@@ -973,7 +990,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            ScalarValue::Int32(value) => match (self.conversion_type, value) {
+            scalar @ ScalarValue::Int32(value) => match (self.conversion_type, value) {
                 (ConversionType::DecInt, Some(value)) => {
                     self.format_signed(string, *value as i64)
                 }
@@ -983,8 +1000,8 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, (*value as u32) as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(value)) => {
-                    self.format_char(string, signed_to_char(*value as i64)?)
+                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
+                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
@@ -998,7 +1015,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            ScalarValue::Int64(value) => match (self.conversion_type, value) {
+            scalar @ ScalarValue::Int64(value) => match (self.conversion_type, value) {
                 (ConversionType::DecInt, Some(value)) => {
                     self.format_signed(string, *value)
                 }
@@ -1008,8 +1025,8 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(value)) => {
-                    self.format_char(string, signed_to_char(*value)?)
+                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
+                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
@@ -1023,7 +1040,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            ScalarValue::UInt8(value) => match (self.conversion_type, value) {
+            scalar @ ScalarValue::UInt8(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecInt
                     | ConversionType::HexIntLower
@@ -1031,8 +1048,8 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(value)) => {
-                    self.format_char(string, unsigned_to_char(*value as u64)?)
+                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
+                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
@@ -1046,7 +1063,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            ScalarValue::UInt16(value) => match (self.conversion_type, value) {
+            scalar @ ScalarValue::UInt16(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecInt
                     | ConversionType::HexIntLower
@@ -1054,8 +1071,8 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(value)) => {
-                    self.format_char(string, unsigned_to_char(*value as u64)?)
+                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
+                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
@@ -1069,7 +1086,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            ScalarValue::UInt32(value) => match (self.conversion_type, value) {
+            scalar @ ScalarValue::UInt32(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecInt
                     | ConversionType::HexIntLower
@@ -1077,8 +1094,8 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(value)) => {
-                    self.format_char(string, unsigned_to_char(*value as u64)?)
+                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
+                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
@@ -1092,7 +1109,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            ScalarValue::UInt64(value) => match (self.conversion_type, value) {
+            scalar @ ScalarValue::UInt64(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecInt
                     | ConversionType::HexIntLower
@@ -1100,8 +1117,8 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(value)) => {
-                    self.format_char(string, unsigned_to_char(*value)?)
+                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
+                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,

--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -892,8 +892,8 @@ fn unsigned_to_char(value: u64) -> Result<char> {
 }
 
 /// Convert a non-null integer scalar to a [`char`] for the `%c` conversion.
-fn integer_scalar_to_char(value: &ScalarValue) -> Result<char> {
-    match value {
+fn integer_scalar_to_char(scalar: &ScalarValue) -> Result<char> {
+    match scalar {
         ScalarValue::Int8(Some(value)) => signed_to_char(*value as i64),
         ScalarValue::Int16(Some(value)) => signed_to_char(*value as i64),
         ScalarValue::Int32(Some(value)) => signed_to_char(*value as i64),
@@ -903,7 +903,7 @@ fn integer_scalar_to_char(value: &ScalarValue) -> Result<char> {
         ScalarValue::UInt32(Some(value)) => unsigned_to_char(*value as u64),
         ScalarValue::UInt64(Some(value)) => unsigned_to_char(*value),
         _ => datafusion_common::internal_err!(
-            "integer_scalar_to_char expects a non-null integer scalar, got {value:?}"
+            "integer_scalar_to_char expects a non-null integer scalar, got {scalar:?}"
         ),
     }
 }
@@ -940,7 +940,22 @@ impl ConversionSpecifier {
 
                 _ => self.format_boolean(string, value),
             },
-            scalar @ ScalarValue::Int8(value) => match (self.conversion_type, value) {
+            ScalarValue::Int8(Some(_))
+            | ScalarValue::Int16(Some(_))
+            | ScalarValue::Int32(Some(_))
+            | ScalarValue::Int64(Some(_))
+            | ScalarValue::UInt8(Some(_))
+            | ScalarValue::UInt16(Some(_))
+            | ScalarValue::UInt32(Some(_))
+            | ScalarValue::UInt64(Some(_))
+                if matches!(
+                    self.conversion_type,
+                    ConversionType::CharLower | ConversionType::CharUpper
+                ) =>
+            {
+                self.format_char(string, integer_scalar_to_char(value)?)
+            }
+            ScalarValue::Int8(value) => match (self.conversion_type, value) {
                 (ConversionType::DecInt, Some(value)) => {
                     self.format_signed(string, *value as i64)
                 }
@@ -950,9 +965,6 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, (*value as u8) as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
-                    self.format_char(string, integer_scalar_to_char(scalar)?)
-                }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
                     Some(value),
@@ -965,12 +977,9 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            scalar @ ScalarValue::Int16(value) => match (self.conversion_type, value) {
+            ScalarValue::Int16(value) => match (self.conversion_type, value) {
                 (ConversionType::DecInt, Some(value)) => {
                     self.format_signed(string, *value as i64)
-                }
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
-                    self.format_char(string, integer_scalar_to_char(scalar)?)
                 }
                 (
                     ConversionType::HexIntLower
@@ -990,7 +999,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            scalar @ ScalarValue::Int32(value) => match (self.conversion_type, value) {
+            ScalarValue::Int32(value) => match (self.conversion_type, value) {
                 (ConversionType::DecInt, Some(value)) => {
                     self.format_signed(string, *value as i64)
                 }
@@ -1000,9 +1009,6 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, (*value as u32) as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
-                    self.format_char(string, integer_scalar_to_char(scalar)?)
-                }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
                     Some(value),
@@ -1015,7 +1021,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            scalar @ ScalarValue::Int64(value) => match (self.conversion_type, value) {
+            ScalarValue::Int64(value) => match (self.conversion_type, value) {
                 (ConversionType::DecInt, Some(value)) => {
                     self.format_signed(string, *value)
                 }
@@ -1025,9 +1031,6 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
-                    self.format_char(string, integer_scalar_to_char(scalar)?)
-                }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
                     Some(value),
@@ -1040,7 +1043,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            scalar @ ScalarValue::UInt8(value) => match (self.conversion_type, value) {
+            ScalarValue::UInt8(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecInt
                     | ConversionType::HexIntLower
@@ -1048,9 +1051,6 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
-                    self.format_char(string, integer_scalar_to_char(scalar)?)
-                }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
                     Some(value),
@@ -1063,7 +1063,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            scalar @ ScalarValue::UInt16(value) => match (self.conversion_type, value) {
+            ScalarValue::UInt16(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecInt
                     | ConversionType::HexIntLower
@@ -1071,9 +1071,6 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
-                    self.format_char(string, integer_scalar_to_char(scalar)?)
-                }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
                     Some(value),
@@ -1086,7 +1083,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            scalar @ ScalarValue::UInt32(value) => match (self.conversion_type, value) {
+            ScalarValue::UInt32(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecInt
                     | ConversionType::HexIntLower
@@ -1094,9 +1091,6 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value as u64),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
-                    self.format_char(string, integer_scalar_to_char(scalar)?)
-                }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
                     Some(value),
@@ -1109,7 +1103,7 @@ impl ConversionSpecifier {
                     )
                 }
             },
-            scalar @ ScalarValue::UInt64(value) => match (self.conversion_type, value) {
+            ScalarValue::UInt64(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecInt
                     | ConversionType::HexIntLower
@@ -1117,9 +1111,6 @@ impl ConversionSpecifier {
                     | ConversionType::OctInt,
                     Some(value),
                 ) => self.format_unsigned(string, *value),
-                (ConversionType::CharLower | ConversionType::CharUpper, Some(_)) => {
-                    self.format_char(string, integer_scalar_to_char(scalar)?)
-                }
                 (
                     ConversionType::StringLower | ConversionType::StringUpper,
                     Some(value),


### PR DESCRIPTION


## Which issue does this PR close?

* Part of #22163

## Rationale for this change

The `%c` conversion path in Spark `format_string` duplicated nearly identical logic across all signed and unsigned integer scalar variants. This duplication increased maintenance overhead and the risk of future `%c` fixes being applied inconsistently.

This change centralizes numeric scalar-to-character conversion in a single helper while preserving existing behavior and error propagation semantics.

## What changes are included in this PR?

* Added a local `integer_scalar_to_char` helper to centralize integer scalar `%c` conversion handling.
* Routed all non-null integer `%c` conversion paths through the new helper.
* Removed duplicated `%c` conversion branches from individual integer scalar match arms.
* Preserved existing signed/unsigned conversion semantics by continuing to use the existing `signed_to_char` and `unsigned_to_char` helpers.
* Left all non-`%c` formatting behavior unchanged.

## Are these changes tested?

No new tests were added in this PR.

This refactor is intended to preserve existing behavior, and existing `%c` formatting tests continue to validate valid and invalid code point handling.

Suggested validation command:

```bash
cargo test -p datafusion-spark format_char
```

## Are there any user-facing changes?

No. This is a maintainability refactor only and is not intended to change observable behavior or error messages.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
