### PR TITLE
feat: fix windows decimal casting frame

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -592,38 +592,39 @@ impl PartialOrd for ScalarValue {
         // any newly added enum variant will require editing this list
         // or else face a compile error
         match (self, other) {
-            (Decimal32(v1, p1, s1), Decimal32(v2, p2, s2)) => {
-                if p1.eq(p2) && s1.eq(s2) {
+            (Decimal32(v1, _, s1), Decimal32(v2, _, s2)) => {
+                if s1.eq(s2) {
+                    // Same scale means the underlying integer values share
+                    // a common interpretation regardless of declared
+                    // precision (arithmetic such as `add_checked` widens
+                    // precision by 1 but does not change the numeric
+                    // meaning).
                     v1.partial_cmp(v2)
                 } else {
-                    // Two decimal values can be compared if they have the same precision and scale.
                     None
                 }
             }
             (Decimal32(_, _, _), _) => None,
-            (Decimal64(v1, p1, s1), Decimal64(v2, p2, s2)) => {
-                if p1.eq(p2) && s1.eq(s2) {
+            (Decimal64(v1, _, s1), Decimal64(v2, _, s2)) => {
+                if s1.eq(s2) {
                     v1.partial_cmp(v2)
                 } else {
-                    // Two decimal values can be compared if they have the same precision and scale.
                     None
                 }
             }
             (Decimal64(_, _, _), _) => None,
-            (Decimal128(v1, p1, s1), Decimal128(v2, p2, s2)) => {
-                if p1.eq(p2) && s1.eq(s2) {
+            (Decimal128(v1, _, s1), Decimal128(v2, _, s2)) => {
+                if s1.eq(s2) {
                     v1.partial_cmp(v2)
                 } else {
-                    // Two decimal values can be compared if they have the same precision and scale.
                     None
                 }
             }
             (Decimal128(_, _, _), _) => None,
-            (Decimal256(v1, p1, s1), Decimal256(v2, p2, s2)) => {
-                if p1.eq(p2) && s1.eq(s2) {
+            (Decimal256(v1, _, s1), Decimal256(v2, _, s2)) => {
+                if s1.eq(s2) {
                     v1.partial_cmp(v2)
                 } else {
-                    // Two decimal values can be compared if they have the same precision and scale.
                     None
                 }
             }

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -6432,6 +6432,119 @@ FROM (
 3 3
 
 ############################################################################
+# RANGE frame with DECIMAL ORDER BY: decimal arithmetic widens the result
+# precision (e.g. Decimal(10,0) ± Decimal(10,0) → Decimal(11,0)), which
+# previously left the boundary target incomparable with the ORDER BY
+# column and failed with "Internal error: Uncomparable values".
+############################################################################
+
+# Original reporter query.
+query I
+SELECT COUNT(*) OVER (
+  PARTITION BY 1
+  ORDER BY cast(1 as decimal(10, 0)) DESC
+  RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING
+) FROM (SELECT 1);
+----
+1
+
+# ASC + PRECEDING
+query RRR
+SELECT a,
+       first_value(a) OVER (ORDER BY a ASC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW),
+       last_value(a)  OVER (ORDER BY a ASC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM (
+  SELECT CAST(1 AS DECIMAL(10,0)) AS a
+  UNION ALL SELECT CAST(2 AS DECIMAL(10,0))
+  UNION ALL SELECT CAST(3 AS DECIMAL(10,0))
+)
+ORDER BY a;
+----
+1 1 1
+2 1 2
+3 2 3
+
+# ASC + FOLLOWING
+query RRR
+SELECT a,
+       first_value(a) OVER (ORDER BY a ASC RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING),
+       last_value(a)  OVER (ORDER BY a ASC RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM (
+  SELECT CAST(1 AS DECIMAL(10,0)) AS a
+  UNION ALL SELECT CAST(2 AS DECIMAL(10,0))
+  UNION ALL SELECT CAST(3 AS DECIMAL(10,0))
+)
+ORDER BY a;
+----
+1 1 2
+2 2 3
+3 3 3
+
+# DESC + PRECEDING
+query RRR
+SELECT a,
+       first_value(a) OVER (ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW),
+       last_value(a)  OVER (ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM (
+  SELECT CAST(1 AS DECIMAL(10,0)) AS a
+  UNION ALL SELECT CAST(2 AS DECIMAL(10,0))
+  UNION ALL SELECT CAST(3 AS DECIMAL(10,0))
+)
+ORDER BY a DESC;
+----
+3 3 3
+2 3 2
+1 2 1
+
+# DESC + FOLLOWING
+query RRR
+SELECT a,
+       first_value(a) OVER (ORDER BY a DESC RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING),
+       last_value(a)  OVER (ORDER BY a DESC RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM (
+  SELECT CAST(1 AS DECIMAL(10,0)) AS a
+  UNION ALL SELECT CAST(2 AS DECIMAL(10,0))
+  UNION ALL SELECT CAST(3 AS DECIMAL(10,0))
+)
+ORDER BY a DESC;
+----
+3 3 2
+2 2 1
+1 1 1
+
+# Symmetric N PRECEDING AND N FOLLOWING
+query RRR
+SELECT a,
+       first_value(a) OVER (ORDER BY a ASC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING),
+       last_value(a)  OVER (ORDER BY a ASC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM (
+  SELECT CAST(1 AS DECIMAL(10,0)) AS a
+  UNION ALL SELECT CAST(2 AS DECIMAL(10,0))
+  UNION ALL SELECT CAST(3 AS DECIMAL(10,0))
+)
+ORDER BY a;
+----
+1 1 2
+2 1 3
+3 2 3
+
+# Non-zero scale: Decimal(10,2)
+query RRR
+SELECT a,
+       first_value(a) OVER (ORDER BY a ASC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING),
+       last_value(a)  OVER (ORDER BY a ASC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM (
+  SELECT CAST(1.50 AS DECIMAL(10,2)) AS a
+  UNION ALL SELECT CAST(2.50 AS DECIMAL(10,2))
+  UNION ALL SELECT CAST(3.50 AS DECIMAL(10,2))
+)
+ORDER BY a;
+----
+1.5 1.5 2.5
+2.5 1.5 3.5
+3.5 2.5 3.5
+
+############################################################################
 # ROWS frame regression guard: huge offsets already saturate via
 # saturating_sub / min(length), verify we keep that behavior.
 ############################################################################

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -6437,8 +6437,6 @@ FROM (
 # previously left the boundary target incomparable with the ORDER BY
 # column and failed with "Internal error: Uncomparable values".
 ############################################################################
-
-# Original reporter query.
 query I
 SELECT COUNT(*) OVER (
   PARTITION BY 1


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #22113 .

## Rationale for this change
  
  `RANGE` window frames with a `DECIMAL` `ORDER BY` column crash at runtime:

  ```sql
  SELECT COUNT(*) OVER (
    PARTITION BY 1
    ORDER BY cast(1 as decimal(10, 0)) DESC
    RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING
  ) FROM (SELECT 1);
  -- Internal error: Uncomparable values: Decimal128(Some(0),11,0), Decimal128(Some(1),10,0).
  ```

  Frame-bound arithmetic (`value ± delta`) widens the decimal result precision by 1 (`Decimal(10,0) ± Decimal(10,0) → Decimal(11,0)`). `search_in_slice` then compares the widened target against the
  original `ORDER BY` column, and `ScalarValue::partial_cmp` rejects decimals whose precision differs — even when the scale matches and the underlying integer representation is directly comparable.

  That precision-equality gate is also inconsistent with SQL semantics: `DEC(10,0) 1` and `DEC(20,0) 1` represent the same number and should compare equal.

  ## What changes are included in this PR?
  
  **`datafusion/common/src/scalar/mod.rs`**
  - `ScalarValue::partial_cmp` for `Decimal32` / `Decimal64` / `Decimal128` / `Decimal256`: compare underlying values whenever scales match, regardless of declared precision. Different scales still
  return `None` (rescaling would be required).

  **`datafusion/sqllogictest/test_files/window.slt`**
  - Regression block covering the reporter query verbatim plus `ASC`/`DESC` × `PRECEDING`/`FOLLOWING`, symmetric `N PRECEDING AND N FOLLOWING`, and a non-zero-scale `DECIMAL(10,2)` case over multi-row 
  partitions.
