### PR TITLE
Fix panic on deep compound identifiers

### DIFF
--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -182,8 +182,8 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
                 None => {
                     // Return default where use all identifiers to not have a nested field
-                    // this len check is because at 5 identifiers will have to have a nested field
-                    if ids.len() == 5 {
+                    // this len check is because at 5 or more identifiers will have to have a nested field
+                    if ids.len() >= 5 {
                         not_impl_err!("compound identifier: {ids:?}")
                     } else {
                         // Check the outer_query_schema and try to find a match

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -2062,6 +2062,16 @@ fn select_where_compound_identifiers() {
 }
 
 #[test]
+fn select_unknown_deep_compound_identifier_returns_error() {
+    let err = logical_plan("SELECT a.b.c.d.e.f")
+        .expect_err("six-part compound identifier should be unsupported");
+    assert_contains!(
+        err.to_string(),
+        "This feature is not implemented: compound identifier: [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\"]"
+    );
+}
+
+#[test]
 fn select_order_by_index() {
     let sql = "SELECT id FROM person ORDER BY 1";
     let plan = logical_plan(sql).unwrap();


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22184.

## Rationale for this change

The SQL planner should return an error for unsupported user SQL rather than panic. Unknown compound identifiers with six or more parts could reach an unchecked `unwrap()` after failing schema lookup.

## What changes are included in this PR?

Updates compound identifier handling so unmatched identifiers with five or more parts return the existing `not_impl_err!` path instead of falling through to `form_identifier`.

Adds a regression test for `SELECT a.b.c.d.e.f` to verify planning returns an unsupported compound identifier error.

## Are these changes tested?

Yes:

- `cargo fmt --all`
- `cargo test -p datafusion-sql --test sql_integration select_unknown_deep_compound_identifier_returns_error`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

No API changes. Invalid deeply nested compound identifiers now return a planner error instead of panicking.
