### PR TITLE
fix: Handle EXECUTE without statement name

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -886,15 +886,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         "Execute statement with DEFAULT is not supported"
                     );
                 }
+                let name = name.ok_or_else(|| {
+                    plan_datafusion_err!("EXECUTE statement requires a name")
+                })?;
+
                 let empty_schema = DFSchema::empty();
                 let parameters = parameters
                     .into_iter()
                     .map(|expr| self.sql_to_expr(expr, &empty_schema, planner_context))
                     .collect::<Result<Vec<Expr>>>()?;
-
-                let name = name.ok_or_else(|| {
-                    plan_datafusion_err!("EXECUTE statement requires a name")
-                })?;
 
                 Ok(LogicalPlan::Statement(PlanStatement::Execute(Execute {
                     name: object_name_to_string(&name),

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -892,8 +892,12 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     .map(|expr| self.sql_to_expr(expr, &empty_schema, planner_context))
                     .collect::<Result<Vec<Expr>>>()?;
 
+                let name = name.ok_or_else(|| {
+                    plan_datafusion_err!("EXECUTE statement requires a name")
+                })?;
+
                 Ok(LogicalPlan::Statement(PlanStatement::Execute(Execute {
-                    name: object_name_to_string(&name.unwrap()),
+                    name: object_name_to_string(&name),
                     parameters,
                 })))
             }

--- a/datafusion/sqllogictest/test_files/prepare.slt
+++ b/datafusion/sqllogictest/test_files/prepare.slt
@@ -53,6 +53,22 @@ PREPARE my_plan(INT, INT) AS SELECT 1 + $1;
 statement error SQL error: ParserError
 PREPARE my_plan(INT) AS SELECT id, age  FROM person WHERE age is $1;
 
+# EXEC/EXECUTE with parentheses but no statement name must error instead of panic
+statement error EXECUTE statement requires a name
+EXEC();
+
+statement error EXECUTE statement requires a name
+EXEC('');
+
+statement error EXECUTE statement requires a name
+EXEC('any-string');
+
+statement error EXECUTE statement requires a name
+EXECUTE();
+
+statement error EXECUTE statement requires a name
+EXEC ('a');
+
 # #######################
 # Test prepare and execute statements
 

--- a/datafusion/sqllogictest/test_files/prepare.slt
+++ b/datafusion/sqllogictest/test_files/prepare.slt
@@ -64,6 +64,9 @@ statement error EXECUTE statement requires a name
 EXEC('any-string');
 
 statement error EXECUTE statement requires a name
+EXEC(unknown_column);
+
+statement error EXECUTE statement requires a name
 EXECUTE();
 
 statement error EXECUTE statement requires a name


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22197.

## Rationale for this change

`EXEC()` and `EXECUTE()` can parse as `Statement::Execute` without a statement name. The planner previously unwrapped that optional name and panicked on user-supplied SQL.

## What changes are included in this PR?

- Return a planning error when `EXECUTE` has no statement name.
- Add sqllogictest coverage for the malformed `EXEC` / `EXECUTE` forms from the issue.

## Are these changes tested?

- `cargo test -p datafusion-sqllogictest --test sqllogictests -- prepare`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

Malformed `EXEC` / `EXECUTE` statements without a name now return a planning error instead of panicking.
