### PR TITLE
perf: apply min-alloc split to ByteViewGroupValueBuilder::take_n (follow-up to #22165)

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::aggregates::group_values::multi_group_by::{
-    GroupColumn, Nulls, nulls_equal_to,
+    GroupColumn, Nulls, nulls_equal_to, split_vec_min_alloc,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
 use arrow::array::{
@@ -363,7 +363,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
         //
         //   - Shift the `buffer index` of remaining non-inlined `views`
         //
-        let first_n_views = self.views.drain(0..n).collect::<Vec<_>>();
+        let first_n_views = split_vec_min_alloc(&mut self.views, n);
 
         let last_non_inlined_view = first_n_views
             .iter()


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #22165 / #22164.

## Rationale for this change

#22165 introduced the `split_vec_min_alloc` helper and applied it to the `take_n` paths in `bytes.rs` and `primitive.rs`, but did not cover the byte-view builder. `ByteViewGroupValueBuilder::take_n_inner` still used `self.views.drain(0..n).collect::<Vec<_>>()`, which always allocates `n` elements and leaves the retained vec at its pre-emit capacity.

Under an OOM-triggered `EmitTo::First(n)` emit, `n` is close to the length of `views`, so this copies the largest allocation — exactly the case #22164 was filed to fix. This PR routes the byte-view builder through the same `split_vec_min_alloc` helper, which allocates `min(n, len - n)` instead, so all three multi-group-by builders now share one strategy.

This PR previously also modified `bytes.rs` and `primitive.rs`; those changes are now fully covered by #22165 and have been dropped. The PR is rebased onto current `main` and reduced to the one builder #22165 missed.

## What changes are included in this PR?

`ByteViewGroupValueBuilder::take_n_inner`: replace `drain(0..n).collect()` with `split_vec_min_alloc(&mut self.views, n)`.

## Are these changes tested?

Behavior is unchanged. Existing `test_byte_view_take_n` and `test_byte_view_take_n_partial_completed_nonzero_index` exercise both the `drain` and `split_off` branches of the helper; all `take_n` tests pass locally.

## Are there any user-facing changes?

No.