### PR TITLE
fix date_bin overflows subtracting extreme nanosecond timestamp origin

### DIFF
--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -321,7 +321,11 @@ impl Interval {
 
 // return time in nanoseconds that the source timestamp falls into based on the stride and origin
 fn date_bin_nanos_interval(stride_nanos: i64, source: i64, origin: i64) -> Result<i64> {
-    let time_diff = source - origin;
+    let time_diff = source.checked_sub(origin).ok_or_else(|| {
+        arrow::error::ArrowError::InvalidArgumentError(format!(
+            "date_bin source timestamp {source} - origin {origin} overflows i64"
+        ))
+    })?;
 
     // distance from origin to bin
     let time_delta = compute_distance(time_diff, stride_nanos);

--- a/datafusion/sqllogictest/test_files/date_bin_errors.slt
+++ b/datafusion/sqllogictest/test_files/date_bin_errors.slt
@@ -58,3 +58,13 @@ select date_bin(
 ) as b;
 ----
 NULL
+
+# Extreme timestamp overflow: source - origin overflows i64 (should return NULL, not panic)
+query P
+select date_bin(
+  interval '1 nanosecond',
+  arrow_cast(9223372036854775807, 'Timestamp(Nanosecond, None)'),
+  arrow_cast(-9223372036854775808, 'Timestamp(Nanosecond, None)')
+);
+----
+NULL


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22210 

## Rationale for this change

`date_bin` could overflow when subtracting extreme nanosecond timestamps, which could trigger a panic. This fix makes that path return an error instead, so the query safely returns `NULL` rather than crashing.

## What changes are included in this PR?

- In date_bin.rs, the nanosecond path now uses `checked_sub` instead of direct subtraction, and returns an `ArrowError::InvalidArgumentError` on overflow.
- In date_bin_errors.slt, a regression test was added for an extreme nanosecond timestamp case to verify that overflow returns `NULL` instead of panicking.

## Are these changes tested?

- Yes. The new sqllogictest covers the regression scenario and verifies that extreme nanosecond timestamp input returns `NULL`.

## Are there any user-facing changes?

- Yes. `date_bin` is now more robust for extreme nanosecond timestamp inputs and will return `NULL` instead of panicking.
