### PR TITLE
fix: translate SIMILAR TO pattern to PostgreSQL-compatible regex

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -995,6 +995,74 @@ pub fn similar_to(
     Ok(Arc::new(BinaryExpr::new(expr, binary_op, pattern)))
 }
 
+/// Translate a SQL `SIMILAR TO` pattern into an equivalent POSIX regex.
+///
+/// PostgreSQL `SIMILAR TO` mixes SQL LIKE wildcards with POSIX-style regex
+/// metacharacters and requires the pattern to match the entire string.
+/// In particular:
+///
+/// * `%` matches any sequence of zero or more characters (like LIKE).
+/// * `_` matches exactly one character (like LIKE).
+/// * `|`, `*`, `+`, `?`, `()`, `{m[,n]}`, `[...]` keep their POSIX regex meaning.
+/// * `.`, `^`, `$` are *literal* characters (not regex metacharacters).
+/// * `\` is the default escape character, so `\X` means a literal `X`.
+///
+/// The translated regex is wrapped with `^...$` so the regex engine enforces
+/// a full-string match.
+pub fn translate_similar_to_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len() + 2);
+    out.push('^');
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '%' => out.push_str(".*"),
+            '_' => out.push('.'),
+            '\\' => {
+                // Backslash escapes the next character in SIMILAR TO. Emit it
+                // as a literal in the regex by re-escaping it.
+                match chars.next() {
+                    Some(next) => {
+                        out.push('\\');
+                        out.push(next);
+                    }
+                    None => out.push_str("\\\\"),
+                }
+            }
+            '[' => {
+                // Pass through a POSIX bracket expression verbatim. Inside a
+                // bracket expression `%`/`_` are literal and most other
+                // metacharacters lose their special meaning, so we copy until
+                // the matching `]`.
+                out.push('[');
+                // The first character after `[` (or `[^`) is always literal
+                // even if it is `]`.
+                if matches!(chars.peek(), Some('^')) {
+                    out.push(chars.next().unwrap());
+                }
+                if matches!(chars.peek(), Some(']')) {
+                    out.push(chars.next().unwrap());
+                }
+                for b in chars.by_ref() {
+                    out.push(b);
+                    if b == ']' {
+                        break;
+                    }
+                }
+            }
+            // SIMILAR TO metacharacters that map 1:1 to regex.
+            '|' | '*' | '+' | '?' | '(' | ')' | '{' | '}' => out.push(c),
+            // Regex metacharacters that SIMILAR TO treats as literals.
+            '.' | '^' | '$' => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+    }
+    out.push('$');
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5409,5 +5477,39 @@ mod tests {
         let expected =
             BooleanArray::from_iter(vec![Some(true), Some(true), Some(true), Some(true)]);
         assert_eq!(eq_result.into_array(4).unwrap().as_boolean(), &expected);
+    }
+
+    #[test]
+    fn similar_to_pattern_translation() {
+        let cases = [
+            // Empty pattern matches only the empty string.
+            ("", "^$"),
+            // SQL wildcards expand to their POSIX regex equivalents.
+            ("a%", "^a.*$"),
+            ("a_b", "^a.b$"),
+            // POSIX metacharacters borrowed by SIMILAR TO pass through unchanged.
+            ("p[12]%", "^p[12].*$"),
+            ("(foo|bar)+", "^(foo|bar)+$"),
+            ("a{2,3}", "^a{2,3}$"),
+            // `.`, `^`, `$` are literal in SIMILAR TO and must be escaped for regex.
+            ("a.b", "^a\\.b$"),
+            ("^a$", "^\\^a\\$$"),
+            // Backslash escapes the SQL wildcards.
+            ("100\\%", "^100\\%$"),
+            ("a\\_b", "^a\\_b$"),
+            // Bracket expressions are passed through verbatim, including a
+            // leading literal `]` and `%`/`_` inside the class.
+            ("[%_]", "^[%_]$"),
+            ("[]abc]", "^[]abc]$"),
+            ("[^abc]", "^[^abc]$"),
+            ("[^]abc]", "^[^]abc]$"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                translate_similar_to_pattern(input),
+                expected,
+                "pattern: {input:?}"
+            );
+        }
     }
 }

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -40,7 +40,7 @@ pub use crate::PhysicalSortExpr;
 /// Module with some convenient methods used in expression building
 pub use crate::aggregate::stats::StatsType;
 
-pub use binary::{BinaryExpr, binary, similar_to};
+pub use binary::{BinaryExpr, binary, similar_to, translate_similar_to_pattern};
 pub use case::{CaseExpr, case};
 pub use cast::{CastExpr, cast};
 pub use column::{Column, col, with_new_schema};

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -21,7 +21,9 @@ use crate::scalar_subquery::ScalarSubqueryExpr;
 use crate::{HigherOrderFunctionExpr, ScalarFunctionExpr};
 use crate::{
     PhysicalExpr,
-    expressions::{self, Column, Literal, binary, like, similar_to},
+    expressions::{
+        self, Column, Literal, binary, like, similar_to, translate_similar_to_pattern,
+    },
 };
 
 use arrow::datatypes::Schema;
@@ -253,8 +255,41 @@ pub fn create_physical_expr(
             }
             let physical_expr =
                 create_physical_expr(expr, input_dfschema, execution_props)?;
+            // SIMILAR TO uses SQL wildcards (`%`, `_`) layered on POSIX regex and
+            // requires a whole-string match. Translate literal patterns to an
+            // equivalent regex so the existing regex-match operator returns
+            // PostgreSQL-compatible results.
+            let translated_pattern = match pattern.as_ref() {
+                Expr::Literal(ScalarValue::Utf8(Some(s)), m) => Expr::Literal(
+                    ScalarValue::Utf8(Some(translate_similar_to_pattern(s))),
+                    m.clone(),
+                ),
+                Expr::Literal(ScalarValue::LargeUtf8(Some(s)), m) => Expr::Literal(
+                    ScalarValue::LargeUtf8(Some(translate_similar_to_pattern(s))),
+                    m.clone(),
+                ),
+                Expr::Literal(ScalarValue::Utf8View(Some(s)), m) => Expr::Literal(
+                    ScalarValue::Utf8View(Some(translate_similar_to_pattern(s))),
+                    m.clone(),
+                ),
+                // NULL pattern: regex match against NULL returns NULL. Use a
+                // typed Utf8 null so the regex kernel can handle it.
+                Expr::Literal(
+                    ScalarValue::Utf8(None)
+                    | ScalarValue::LargeUtf8(None)
+                    | ScalarValue::Utf8View(None)
+                    | ScalarValue::Null,
+                    m,
+                ) => Expr::Literal(ScalarValue::Utf8(None), m.clone()),
+                _ => {
+                    return not_impl_err!(
+                        "SIMILAR TO with a non-literal pattern is not yet supported"
+                    );
+                }
+            };
+            let pattern_expr = &translated_pattern;
             let physical_pattern =
-                create_physical_expr(pattern, input_dfschema, execution_props)?;
+                create_physical_expr(pattern_expr, input_dfschema, execution_props)?;
             similar_to(*negated, *case_insensitive, physical_expr, physical_pattern)
         }
         Expr::Case(case) => {

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -941,7 +941,10 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     ) -> Result<Expr> {
         let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
         let pattern_type = pattern.get_type(schema)?;
-        if pattern_type != DataType::Utf8 && pattern_type != DataType::Null {
+        if !matches!(
+            pattern_type,
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View | DataType::Null
+        ) {
             return plan_err!("Invalid pattern in SIMILAR TO expression");
         }
         let escape_char = match escape_char.map(|v| v.value) {

--- a/datafusion/sqllogictest/test_files/strings.slt
+++ b/datafusion/sqllogictest/test_files/strings.slt
@@ -72,8 +72,9 @@ p2e1
 p2m1e1
 
 # SIMILAR TO
+# Uses SQL wildcards (`%`) layered on POSIX regex with whole-string matching.
 query T rowsort
-SELECT s FROM test WHERE s SIMILAR TO 'p[12].*';
+SELECT s FROM test WHERE s SIMILAR TO 'p[12]%';
 ----
 p1
 p1e1
@@ -84,12 +85,63 @@ p2m1e1
 
 # NOT SIMILAR TO
 query T rowsort
-SELECT s FROM test WHERE s NOT SIMILAR TO 'p[12].*';
+SELECT s FROM test WHERE s NOT SIMILAR TO 'p[12]%';
 ----
 P1
 P1e1
 P1m1e1
 e1
+
+# Regression for https://github.com/apache/datafusion/issues/22263:
+# `%` must be treated as the SQL wildcard, not a literal.
+query B
+SELECT 'abc' SIMILAR TO 'a%';
+----
+true
+
+# `_` matches exactly one character.
+query BB
+SELECT 'abc' SIMILAR TO 'a_c', 'abc' SIMILAR TO 'a_';
+----
+true false
+
+# SIMILAR TO is anchored to the whole string, unlike regex `~`.
+query BB
+SELECT 'abc' SIMILAR TO 'b', 'abc' SIMILAR TO 'abc';
+----
+false true
+
+# `.`, `^`, `$` are literal in SIMILAR TO, not regex metacharacters.
+query BBB
+SELECT 'a.b' SIMILAR TO 'a.b',
+       'axb' SIMILAR TO 'a.b',
+       '^abc$' SIMILAR TO '^abc$';
+----
+true false true
+
+# POSIX regex metacharacters keep their meaning.
+query BBB
+SELECT 'foo' SIMILAR TO '(foo|bar)',
+       'aaaa' SIMILAR TO 'a{2,4}',
+       'abc' SIMILAR TO 'ab+c';
+----
+true true true
+
+# Backslash escapes the SQL wildcards.
+query BB
+SELECT '100%' SIMILAR TO '100\%', 'a_b' SIMILAR TO 'a\_b';
+----
+true true
+
+# NULL pattern yields NULL.
+query B
+SELECT 'abc' SIMILAR TO NULL;
+----
+NULL
+
+# Non-literal patterns are not yet supported (better an error than a wrong answer).
+statement error SIMILAR TO with a non-literal pattern is not yet supported
+SELECT s FROM test WHERE s SIMILAR TO s;
 
 # NOT LIKE
 query T rowsort


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22263.

## Rationale for this change

`SIMILAR TO` is supposed to mix SQL LIKE wildcards (`%`, `_`) with POSIX regex metacharacters and match the entire string. DataFusion was lowering `SIMILAR TO` directly to a `RegexMatch` over the pattern verbatim, so:

- `'abc' SIMILAR TO 'a%'` returned `false` (PG: `true`) because `%` was passed through as a literal regex character.
- `'abc' SIMILAR TO 'b'` returned `true` (PG: `false`) because the regex match isn't anchored.
- `.`, `^`, `$` were treated as regex metacharacters instead of literals.

## What changes are included in this PR?

- New `translate_similar_to_pattern()` helper in `datafusion/physical-expr/src/expressions/binary.rs` that converts a `SIMILAR TO` pattern into an equivalent POSIX regex:
  - Anchors the result with `^...$`.
  - `%` → `.*`, `_` → `.`.
  - Escapes `.`, `^`, `$` (literal in SIMILAR TO, meta in regex).
  - Passes POSIX metas (`|`, `*`, `+`, `?`, `()`, `{m,n}`, `[...]`) through unchanged.
  - Handles `\` as an escape for the next character.
  - Passes bracket expressions through verbatim, including a leading literal `]`/`^]`.
- Planner (`datafusion/physical-expr/src/planner.rs`) now translates literal `Utf8` / `LargeUtf8` / `Utf8View` patterns at planning time. NULL patterns flow through as a typed `Utf8` null. Non-literal patterns return a clear `not_impl_err` rather than the previous silently-wrong behavior.
- SQL layer (`datafusion/sql/src/expr/mod.rs`) pattern-type check widened to accept `LargeUtf8` and `Utf8View` literals (previously rejected even though the underlying regex match supports them).

## Are these changes tested?

Yes:

- Unit test `similar_to_pattern_translation` in `binary.rs` covers wildcards, anchoring, regex metas, literal `.`/`^`/`$`, backslash escapes, bracket expressions (including `[]abc]` and `[^]abc]`).
- `datafusion/sqllogictest/test_files/strings.slt` has a new regression block exercising the bug-report case, `_` wildcard, anchoring, literal `.`/`^`/`$`, regex metas (`|`, `{m,n}`, `+`), backslash-escaped wildcards, `NULL` pattern, and the non-literal-pattern error.
- The existing `SIMILAR TO 'p[12].*'` test in `strings.slt` was relying on the buggy regex-passthrough behavior (`p1e1` etc. matched only because `.` was treated as regex `.`); it's been changed to `'p[12]%'` which expresses the same intent under correct SIMILAR TO semantics.

## Are there any user-facing changes?

Yes — `SIMILAR TO` is now PostgreSQL-compatible:

- Behavior changes for patterns containing `%`, `_`, or unanchored matches. Existing patterns that relied on the previous regex-passthrough behavior may need to be updated (most obviously, change `.*` to `%`).
- Non-literal patterns now return `Not yet implemented: SIMILAR TO with a non-literal pattern is not yet supported` instead of silently returning a regex match. This was almost certainly broken in practice already, but it is a visible error message change.