### PR TITLE
fix: make replace no-op for empty search

### DIFF
--- a/datafusion/functions/src/string/replace.rs
+++ b/datafusion/functions/src/string/replace.rs
@@ -268,12 +268,9 @@ fn apply_replace<B: BulkNullStringArrayBuilder>(
     }
 
     if from.is_empty() {
-        // Empty `from`: insert `to` before each character and at both ends.
         builder.append_with(|w| {
-            w.write_str(to);
             for ch in string.chars() {
                 w.write_char(ch);
-                w.write_str(to);
             }
         });
         return;
@@ -319,6 +316,19 @@ mod tests {
         test_function!(
             ReplaceFunc::new(),
             vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("abc")))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::new()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("x")))),
+            ],
+            Ok(Some("abc")),
+            &str,
+            Utf8,
+            StringArray
+        );
+
+        test_function!(
+            ReplaceFunc::new(),
+            vec![
                 ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(String::from(
                     "aabbb"
                 )))),
@@ -334,6 +344,19 @@ mod tests {
         test_function!(
             ReplaceFunc::new(),
             vec![
+                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(String::from("abc")))),
+                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(String::new()))),
+                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(String::from("x")))),
+            ],
+            Ok(Some("abc")),
+            &str,
+            LargeUtf8,
+            LargeStringArray
+        );
+
+        test_function!(
+            ReplaceFunc::new(),
+            vec![
                 ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from(
                     "aabbbcw"
                 )))),
@@ -341,6 +364,19 @@ mod tests {
                 ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from("cc")))),
             ],
             Ok(Some("aaccbcw")),
+            &str,
+            Utf8,
+            StringArray
+        );
+
+        test_function!(
+            ReplaceFunc::new(),
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from("abc")))),
+                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::new()))),
+                ColumnarValue::Scalar(ScalarValue::Utf8View(Some(String::from("x")))),
+            ],
+            Ok(Some("abc")),
             &str,
             Utf8,
             StringArray

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -637,6 +637,11 @@ SELECT replace('abcdefabcdef', 'notmatch', 'XX')
 abcdefabcdef
 
 query T
+SELECT replace('abc', '', 'x')
+----
+abc
+
+query T
 SELECT replace('abcdefabcdef', NULL, 'XX')
 ----
 NULL


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22253.

## Rationale for this change

PostgreSQL treats `replace(str, '', replacement)` as a no-op. DataFusion currently inserts the replacement before every character and at both ends, so `replace('abc', '', 'x')` returns `xaxbxcx` instead of `abc`.

## What changes are included in this PR?

- Updates the string `replace` implementation so an empty search substring returns the original input string unchanged.
- Adds regression coverage for Utf8, LargeUtf8, Utf8View, and SQL execution.

## Are these changes tested?

Yes:

- `cargo fmt --all`
- `cargo test -p datafusion-functions string::replace::tests::test_functions`
- `cargo test -p datafusion-sqllogictest --test sqllogictests -- expr.slt:637`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Are there any user-facing changes?

Yes. `replace` now matches PostgreSQL-compatible behavior for an empty search substring.