### PR TITLE
fixing array length for empty array

### DIFF
--- a/datafusion/functions-nested/src/length.rs
+++ b/datafusion/functions-nested/src/length.rs
@@ -188,7 +188,9 @@ fn compute_array_length(
 
     loop {
         if current_dimension == dimension {
-            return Ok(Some(value.len() as u64));
+            // PostgreSQL: array_length(anyarray, dimension) returns NULL when that
+            // dimension is empty (`array_length('{}'::int[], 1)`), not zero.
+            return Ok((!value.is_empty()).then(|| value.len() as u64));
         }
 
         match value.data_type() {

--- a/datafusion/sqllogictest/test_files/array/array_length.slt
+++ b/datafusion/sqllogictest/test_files/array/array_length.slt
@@ -65,11 +65,16 @@ select array_length(arrow_cast(array_repeat(array_repeat(array_repeat(3, 5), 2),
 ----
 3 2
 
-# array_length scalar function #5
+# array_length scalar function #5 empty array dimension (PostgreSQL-compatible)
 query III
 select array_length(make_array()), array_length(make_array(), 1), array_length(make_array(), 2)
 ----
-0 0 NULL
+NULL NULL NULL
+
+query I
+SELECT array_length(ARRAY[]::INT[], 1)
+----
+NULL
 
 # array_length scalar function #6 nested array
 query III

--- a/datafusion/sqllogictest/test_files/array/array_length.slt
+++ b/datafusion/sqllogictest/test_files/array/array_length.slt
@@ -76,6 +76,37 @@ SELECT array_length(ARRAY[]::INT[], 1)
 ----
 NULL
 
+# array_length scalar function #5b LargeList empty dimension
+query II
+select array_length(arrow_cast(make_array(), 'LargeList(Int64)')),
+       array_length(arrow_cast(make_array(), 'LargeList(Int64)'), 1)
+----
+NULL NULL
+
+# array_length scalar function #5c empty inner dimension (was 0, now NULL)
+query II
+select array_length(make_array(make_array()), 2),
+       array_length(make_array(make_array(make_array())), 3)
+----
+NULL NULL
+
+# list_length alias empty dimension
+query II
+select list_length(make_array()), list_length(make_array(), 1)
+----
+NULL NULL
+
+# array_length over a column with an empty-array row
+query ?II
+select arr, array_length(arr), array_length(arr, 1)
+from (values (make_array(1,2,3)),
+             (arrow_cast(make_array(), 'List(Int64)')),
+             (NULL::int[])) t(arr)
+----
+[1, 2, 3] 3 3
+[] NULL NULL
+NULL NULL NULL
+
 # array_length scalar function #6 nested array
 query III
 select array_length([[1, 2, 3, 4], [5, 6, 7, 8]]), array_length([[1, 2, 3, 4], [5, 6, 7, 8]], 1), array_length([[1, 2, 3, 4], [5, 6, 7, 8]], 2);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22264.

## Rationale for this change

PostgreSQL returns **NULL** for `array_length` on an empty dimension (e.g. `array_length(array[]::int[], 1)`). DataFusion returned **0**. This aligns semantics with PostgreSQL as requested in the issue.

## What changes are included in this PR?

- `array_length` / `list_length`: return SQL **NULL** when the evaluated dimension slice is empty, instead of `0`.
- Update `array/array_length.slt` expectations for empty arrays and add `array_length(ARRAY[]::INT[], 1)`.

## Are these changes tested?

Yes. `cargo test --profile=ci --test sqllogictests -- array/array_length`.

## Are there any user-facing changes?

Yes — observable SQL behavior: empty dimensions now yield **NULL** instead of **`0`** for `array_length` / `list_length`. Queries that depended on **`0`** may need **`IS NULL`** or **`COALESCE`**.