### PR TITLE
test: cover regexp_replace multiline flag

### DIFF
--- a/datafusion/functions/src/regex/regexpreplace.rs
+++ b/datafusion/functions/src/regex/regexpreplace.rs
@@ -878,6 +878,25 @@ mod tests {
     );
 
     #[test]
+    fn test_static_pattern_regexp_replace_multiline_flag() {
+        let values = StringArray::from(vec!["a\nb"]);
+        let patterns = StringArray::from(vec!["^b"]);
+        let replacements = StringArray::from(vec!["x"]);
+        let flags = StringArray::from(vec!["m"]);
+        let expected = StringArray::from(vec!["a\nx"]);
+
+        let re = regexp_replace_static_pattern_replace::<i32>(&[
+            Arc::new(values),
+            Arc::new(patterns),
+            Arc::new(replacements),
+            Arc::new(flags),
+        ])
+        .unwrap();
+
+        assert_eq!(re.as_ref(), &expected);
+    }
+
+    #[test]
     fn test_static_pattern_regexp_replace_early_abort() {
         let values = StringArray::from(vec!["abc"; 5]);
         let patterns = StringArray::from(vec![None::<&str>; 5]);

--- a/datafusion/sqllogictest/test_files/regexp/regexp_replace.slt
+++ b/datafusion/sqllogictest/test_files/regexp/regexp_replace.slt
@@ -113,6 +113,20 @@ SELECT regexp_replace('foobar', 'bar', 'xx', 'gi')
 ----
 fooxx
 
+query TT
+SELECT 'm', regexp_replace(concat('a', chr(10), 'b'), '^b', 'x', 'm')
+----
+m
+01)a
+02)x
+
+query TT
+SELECT 'gm', regexp_replace(concat('a', chr(10), 'b'), '^b', 'x', 'gm')
+----
+gm
+01)a
+02)x
+
 query T
 SELECT regexp_replace(arrow_cast('foobar', 'Dictionary(Int32, Utf8)'), 'bar', 'xx', 'gi')
 ----


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22258.

## Rationale for this change

PostgreSQL-compatible `regexp_replace` should honor the multiline flag `m` so anchors like `^` can match after newlines. The issue report covers `regexp_replace(E'a\nb', '^b', 'x', 'm')`, which should produce `a\nx`.

Current main already returns the PostgreSQL-compatible result, so this PR adds explicit regression coverage to keep that behavior from drifting.

## What changes are included in this PR?

- Adds Rust unit coverage for scalar/static `regexp_replace` with flag `m`.
- Adds sqllogictest coverage for `m` and `gm` multiline flag behavior.

## Are these changes tested?

- `cargo fmt --all`
- `TMPDIR=/home/sean/Projects/datafusion-regexp-replace/target/tmp cargo test -p datafusion-functions regex::regexpreplace::tests::test_static_pattern_regexp_replace_multiline_flag -- --nocapture`
- `TMPDIR=/home/sean/Projects/datafusion-regexp-replace/target/tmp cargo test --profile=ci --test sqllogictests -- regexp/regexp_replace.slt`
- `TMPDIR=/home/sean/Projects/datafusion-regexp-replace/target/tmp cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Are there any user-facing changes?

No behavior change intended. This adds regression coverage for PostgreSQL-compatible multiline `regexp_replace` behavior.
