### PR TITLE
fix: guard array_position start_from underflow

### DIFF
--- a/datafusion/functions-nested/src/position.rs
+++ b/datafusion/functions-nested/src/position.rs
@@ -207,14 +207,23 @@ fn resolve_start_from(
     match third_arg {
         None => Ok(vec![0i64; num_rows]),
         Some(ColumnarValue::Scalar(ScalarValue::Int64(Some(v)))) => {
-            Ok(vec![v - 1; num_rows])
+            Ok(vec![normalize_start_from(*v)?; num_rows])
         }
         Some(ColumnarValue::Scalar(s)) => {
             exec_err!("array_position expected Int64 for start_from, got {s}")
         }
-        Some(ColumnarValue::Array(a)) => {
-            Ok(as_int64_array(a)?.values().iter().map(|&x| x - 1).collect())
-        }
+        Some(ColumnarValue::Array(a)) => as_int64_array(a)?
+            .values()
+            .iter()
+            .map(|&x| normalize_start_from(x))
+            .collect(),
+    }
+}
+
+fn normalize_start_from(start_from: i64) -> Result<i64> {
+    match start_from.checked_sub(1) {
+        Some(start_from) => Ok(start_from),
+        None => exec_err!("start_from out of bounds: {start_from}"),
     }
 }
 
@@ -309,8 +318,8 @@ fn general_position_dispatch<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<Ar
         as_int64_array(&args[2])?
             .values()
             .iter()
-            .map(|&x| x - 1)
-            .collect::<Vec<_>>()
+            .map(|&x| normalize_start_from(x))
+            .collect::<Result<Vec<_>>>()?
     } else {
         vec![0; haystack.len()]
     };
@@ -592,8 +601,23 @@ fn array_positions_scalar<O: OffsetSizeTrait>(
 mod tests {
     use super::*;
     use arrow::array::AsArray;
+    use arrow::array::Int64Array;
     use arrow::datatypes::Int32Type;
     use datafusion_common::config::ConfigOptions;
+
+    #[test]
+    fn test_array_position_start_from_min_value() {
+        let scalar_arg = ColumnarValue::Scalar(ScalarValue::Int64(Some(i64::MIN)));
+        let array_arg = ColumnarValue::Array(Arc::new(Int64Array::from(vec![i64::MIN])));
+
+        for arg in [scalar_arg, array_arg] {
+            let err = resolve_start_from(Some(&arg), 1).unwrap_err().to_string();
+            assert!(
+                err.contains("start_from out of bounds: -9223372036854775808"),
+                "unexpected error: {err}"
+            );
+        }
+    }
 
     #[test]
     fn test_array_position_sliced_list() -> Result<()> {

--- a/datafusion/sqllogictest/test_files/array/array_position.slt
+++ b/datafusion/sqllogictest/test_files/array/array_position.slt
@@ -282,6 +282,9 @@ select array_position([1, 2, 3], 3, 4), array_position([1], 1, 2);
 ----
 NULL NULL
 
+query error DataFusion error: Execution error: start_from out of bounds: -9223372036854775808
+SELECT array_position([1], 1, -9223372036854775808);
+
 # array_position with empty array in various contexts
 query II
 select array_position(arrow_cast(make_array(), 'List(Int64)'), 1), array_position(arrow_cast(make_array(), 'LargeList(Int64)'), 1);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22220.

## Rationale for this change

`array_position` converts the optional 1-indexed `start_from` argument to a 0-indexed offset by subtracting one. When `start_from` is `i64::MIN`, that subtraction can underflow and panic before DataFusion can return a normal error.

## What changes are included in this PR?

- Adds a shared checked conversion for `array_position` `start_from` values.
- Uses it in both scalar and array `start_from` paths.
- Adds regression coverage for the `i64::MIN` boundary.

## Are these changes tested?

- `cargo fmt --all`
- `TMPDIR=/home/sean/Projects/datafusion-array-position-min/target/tmp cargo test -p datafusion-functions-nested position::tests::test_array_position_start_from_min_value -- --nocapture`
- `TMPDIR=/home/sean/Projects/datafusion-array-position-min/target/tmp cargo test --profile=ci --test sqllogictests -- array/array_position.slt`
- `TMPDIR=/home/sean/Projects/datafusion-array-position-min/target/tmp cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

I also manually checked the issue reproducer no longer panics: `EXPLAIN SELECT array_position([1], 1, -9223372036854775808);` now returns a plan, while plain execution returns `Execution error: start_from out of bounds: -9223372036854775808`.

## Are there any user-facing changes?

Invalid `array_position` `start_from` values at the `i64::MIN` boundary now return a normal DataFusion error instead of panicking.
