### PR TITLE
Guard insert placeholder zero

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -2435,17 +2435,23 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         span: _,
                     }) = val
                     {
-                        let name =
-                            name.replace('$', "").parse::<usize>().map_err(|_| {
-                                plan_datafusion_err!("Can't parse placeholder: {name}")
-                            })? - 1;
+                        let index = match name[1..].parse::<usize>().map_err(|_| {
+                            plan_datafusion_err!("Can't parse placeholder: {name}")
+                        })? {
+                            0 => {
+                                return plan_err!(
+                                    "Invalid placeholder, zero is not a valid index: {name}"
+                                );
+                            }
+                            index => index - 1,
+                        };
                         let field = fields.get(idx).ok_or_else(|| {
                             plan_datafusion_err!(
                                 "Placeholder ${} refers to a non existent column",
                                 idx + 1
                             )
                         })?;
-                        let _ = prepare_param_data_types.insert(name, Arc::clone(field));
+                        let _ = prepare_param_data_types.insert(index, Arc::clone(field));
                     }
                 }
             }

--- a/datafusion/sqllogictest/test_files/insert_values_placeholders.slt
+++ b/datafusion/sqllogictest/test_files/insert_values_placeholders.slt
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## INSERT VALUES placeholder tests
+##########
+
+statement ok
+CREATE TABLE placeholder_zero_insert(x BIGINT NULL);
+
+query error DataFusion error: Error during planning: Invalid placeholder, zero is not a valid index: \$0
+EXPLAIN INSERT INTO placeholder_zero_insert VALUES ($0);


### PR DESCRIPTION
## Which issue does this PR close?

- Fixes #22224.

## Rationale for this change

`EXPLAIN INSERT INTO t VALUES ($0)` currently panics while inferring parameter types for INSERT VALUES. Other SQL paths already reject `$0` as an invalid placeholder index, and the INSERT inference path should do the same instead of subtracting one from zero.

## What changes are included in this PR?

- Adds a zero-index guard before INSERT VALUES placeholder numbers are converted to parameter vector positions.
- Aligns the INSERT VALUES error with the existing invalid-placeholder planning error.
- Adds a standalone SQL logic regression for `EXPLAIN INSERT INTO ... VALUES ($0)`.

## Are these changes tested?

Yes.

- `cargo fmt --check --all`
- `cargo test -p datafusion-sqllogictest --test sqllogictests -- insert_values_placeholders`
- `cargo test -p datafusion-sql --test sql_integration test_insert_schema_errors` -> 6 passed
- `git diff --check origin/main...HEAD`
- `git diff --cached --check`

## Are there any user-facing changes?

Yes. `INSERT ... VALUES ($0)` now returns a planning error instead of panicking.

## Scope note

The change is limited to INSERT VALUES placeholder type inference and the new regression coverage. I did not find any broader placeholder semantics that needed to change.