### PR TITLE
fix negative array subscripts should not index from the end

### DIFF
--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -233,15 +233,15 @@ where
     where
         i64: TryInto<O>,
     {
+        if index <= 0 {
+            return Ok(None);
+        }
+
         let index: O = index.try_into().map_err(|_| {
             exec_datafusion_err!("array_element got invalid index: {index}")
         })?;
-        // 0 ~ len - 1
-        let adjusted_zero_index = if index < O::usize_as(0) {
-            index + len
-        } else {
-            index - O::usize_as(1)
-        };
+        // Convert from 1-based indexing to 0-based indexing.
+        let adjusted_zero_index = index - O::usize_as(1);
 
         if O::usize_as(0) <= adjusted_zero_index && adjusted_zero_index < len {
             Ok(Some(adjusted_zero_index))

--- a/datafusion/sqllogictest/test_files/array/array_element.slt
+++ b/datafusion/sqllogictest/test_files/array/array_element.slt
@@ -106,17 +106,17 @@ NULL NULL
 query IT
 select array_element(make_array(1, 2, 3, 4, 5), -2), array_element(make_array('h', 'e', 'l', 'l', 'o'), -3);
 ----
-4 l
+NULL NULL
 
 query IT
 select array_element(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), -2), array_element(arrow_cast(make_array('h', 'e', 'l', 'l', 'o'), 'LargeList(Utf8)'), -3);
 ----
-4 l
+NULL NULL
 
 query IT
 select array_element(arrow_cast(make_array(1, 2, 3, 4, 5), 'FixedSizeList(5, Int64)'), -2), array_element(arrow_cast(make_array('h', 'e', 'l', 'l', 'o'), 'FixedSizeList(5, Utf8)'), -3);
 ----
-4 l
+NULL NULL
 
 # array_element scalar function #6 (with negative index; out of bounds)
 query IT
@@ -205,7 +205,7 @@ select array_element(column1, column2) from slices;
 NULL
 12
 NULL
-37
+NULL
 NULL
 NULL
 55
@@ -216,7 +216,7 @@ select array_element(arrow_cast(column1, 'LargeList(Int64)'), column2) from slic
 NULL
 12
 NULL
-37
+NULL
 NULL
 NULL
 55
@@ -227,7 +227,7 @@ select array_element(column1, column2) from fixed_slices;
 NULL
 12
 NULL
-37
+NULL
 NULL
 55
 
@@ -238,7 +238,7 @@ select array_element(make_array(1, 2, 3, 4, 5), column2), array_element(column1,
 1 3
 2 13
 NULL 23
-2 33
+NULL 33
 4 NULL
 NULL 43
 5 NULL
@@ -249,7 +249,7 @@ select array_element(arrow_cast(make_array(1, 2, 3, 4, 5), 'LargeList(Int64)'), 
 1 3
 2 13
 NULL 23
-2 33
+NULL 33
 4 NULL
 NULL 43
 5 NULL
@@ -260,7 +260,7 @@ select array_element(make_array(1, 2, 3, 4, 5), column2), array_element(column1,
 1 3
 2 13
 NULL 23
-2 33
+NULL 33
 NULL 43
 5 NULL
 

--- a/datafusion/sqllogictest/test_files/array/array_index.slt
+++ b/datafusion/sqllogictest/test_files/array/array_index.slt
@@ -38,13 +38,13 @@ NULL
 query IRT
 select make_array(1, 2, 3)[-1], make_array(1.0, 2.0, 3.0)[-2], make_array('h', 'e', 'l', 'l', 'o')[-3];
 ----
-3 2 l
+NULL NULL NULL
 
 # single index with scalars #4 (complex index)
 query IRT
 select make_array(1, 2, 3)[1 + 2 - 1], make_array(1.0, 2.0, 3.0)[2 * 1 * 0 - 2], make_array('h', 'e', 'l', 'l', 'o')[2 - 3];
 ----
-2 2 o
+2 NULL NULL
 
 # single index with columns #1 (positive index)
 query ?RT
@@ -74,23 +74,23 @@ NULL NULL NULL
 query ?RT
 select column1[-2], column2[-3], column3[-1] from arrays;
 ----
-[NULL, 2] 1.1 m
-[3, 4] NULL m
-[5, 6] 7.7 r
-[7, NULL] 10.1 t
-NULL 13.3 t
-[11, 12] NULL ,
-[15, 16] 16.6 NULL
+NULL NULL NULL
+NULL NULL NULL
+NULL NULL NULL
+NULL NULL NULL
+NULL NULL NULL
+NULL NULL NULL
+NULL NULL NULL
 
 # single index with columns #4 (complex index)
 query ?RT
 select column1[9 - 7], column2[2 * 0], column3[1 - 3] from arrays;
 ----
-[3, NULL] NULL e
-[5, 6] NULL u
-[7, 8] NULL o
-[9, 10] NULL i
-NULL NULL e
+[3, NULL] NULL NULL
+[5, 6] NULL NULL
+[7, 8] NULL NULL
+[9, 10] NULL NULL
+NULL NULL NULL
 [13, 14] NULL NULL
 [NULL, 18] NULL NULL
 

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -67,7 +67,7 @@ statement error Parser error: Invalid timezone "Foo": failed to parse timezone
 SELECT arrow_cast('2021-01-02T03:04:00', 'Timestamp(Nanosecond, Some("Foo"))')
 
 # test_array_index
-query III??IIIIII
+query III??IIIIIII
 SELECT
     ([5,4,3,2,1])[1],
     ([5,4,3,2,1])[2],
@@ -80,11 +80,11 @@ SELECT
     -- out of bounds
     ([5,4,3,2,1])[0],
     ([5,4,3,2,1])[6],
-    -- ([5,4,3,2,1])[-1], -- TODO: wrong answer
+    ([5,4,3,2,1])[-1],
     -- ([5,4,3,2,1])[null], -- TODO: not supported
     ([5,4,3,2,1])[100]
 ----
-5 4 1 [1, 2] [3, 4] 1 3 4 NULL NULL NULL
+5 4 1 [1, 2] [3, 4] 1 3 4 NULL NULL NULL NULL
 
 # test_array_literals
 query ?????


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22254 

## Rationale for this change

PostgreSQL treats negative array subscripts as out of bounds and returns `NULL`. DataFusion was incorrectly interpreting negative subscripts as indexing from the end of the array, which caused behavioral mismatch.

## What changes are included in this PR?

- Updated `array_element` / array subscript evaluation to treat non-positive indexes as out of bounds and return `NULL`.
- Updated sqllogictest coverage for array subscript and `array_element` behavior, including the `[-1]` case.

## Are these changes tested?

Yes.

Validated with:
- `cargo test -p datafusion-functions-nested test_array_element_non_positive_indexes_return_null`
- `cargo test -p datafusion-sqllogictest --test sqllogictests array_index`
- `cargo test -p datafusion-sqllogictest --test sqllogictests expr`

## Are there any user-facing changes?

Yes. Array subscripts with negative indexes now return `NULL` instead of indexing from the end, aligning DataFusion behavior with PostgreSQL.
