### PR TITLE
Guard date_trunc lower-bound truncation

### DIFF
--- a/datafusion/functions/src/datetime/date_trunc.rs
+++ b/datafusion/functions/src/datetime/date_trunc.rs
@@ -133,6 +133,21 @@ impl DateTruncGranularity {
                 | Self::Microsecond
         )
     }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Microsecond => "microsecond",
+            Self::Millisecond => "millisecond",
+            Self::Second => "second",
+            Self::Minute => "minute",
+            Self::Hour => "hour",
+            Self::Day => "day",
+            Self::Week => "week",
+            Self::Month => "month",
+            Self::Quarter => "quarter",
+            Self::Year => "year",
+        }
+    }
 }
 
 #[user_doc(
@@ -629,6 +644,7 @@ fn date_trunc_coarse(
     value: i64,
     tz: Option<Tz>,
 ) -> Result<i64> {
+    let input = value;
     let value = match tz {
         Some(tz) => {
             // Use chrono DateTime<Tz> to clear the various fields because need to clear per timezone,
@@ -645,8 +661,12 @@ fn date_trunc_coarse(
         }
     }?;
 
-    // `with_x(0)` are infallible because `0` are always a valid
-    Ok(value.unwrap())
+    value.ok_or_else(|| {
+        exec_datafusion_err!(
+            "Timestamp {input} out of range after truncating to {}",
+            granularity.as_str()
+        )
+    })
 }
 
 /// Fast path for fine granularities (hour and smaller) that can be handled
@@ -877,6 +897,19 @@ mod tests {
             let result = date_trunc_coarse(granularity_enum, left, None).unwrap();
             assert_eq!(result, right, "{original} = {expected}");
         });
+    }
+
+    #[test]
+    fn date_trunc_out_of_range_lower_bound_returns_error() {
+        let timestamp = string_to_timestamp_nanos("1677-09-22T00:00:00Z").unwrap();
+        let err = date_trunc_coarse(DateTruncGranularity::Year, timestamp, None)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("out of range after truncating to year"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/datafusion/sqllogictest/test_files/date_trunc_boundaries.slt
+++ b/datafusion/sqllogictest/test_files/date_trunc_boundaries.slt
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Regression test for https://github.com/apache/datafusion/issues/22214
+query error .*out of range after truncating to year
+SELECT date_trunc(
+  'year',
+  arrow_cast(TIMESTAMP '1677-09-22 00:00:00', 'Timestamp(Nanosecond, None)')
+);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22214.

## Rationale for this change

Truncating a near-lower-bound nanosecond timestamp to a coarser calendar unit can produce a timestamp outside Arrow's nanosecond range. `date_trunc_coarse` already used fallible timestamp conversion, but it unwrapped the final conversion back to nanoseconds and could panic.

## What changes are included in this PR?

- Convert the final out-of-range truncation case into a DataFusion execution error.
- Add a small string helper for user-facing granularity names in the error.
- Add a unit regression and a sqllogictest regression for lower-bound nanosecond truncation.

## Are these changes tested?

Yes:

- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/home/sean/Projects/datafusion-runtime-set-nonascii/target CARGO_BUILD_JOBS=2 cargo test -p datafusion-functions --lib date_trunc_out_of_range_lower_bound_returns_error`
- `CARGO_TARGET_DIR=/home/sean/Projects/datafusion-runtime-set-nonascii/target CARGO_BUILD_JOBS=2 cargo test -p datafusion-sqllogictest --test sqllogictests -- date_trunc_boundaries.slt`
- `CARGO_TARGET_DIR=/home/sean/Projects/datafusion-runtime-set-nonascii/target CARGO_BUILD_JOBS=2 cargo clippy -p datafusion-functions --lib -- -D warnings`

## Are there any user-facing changes?

Instead of panicking, out-of-range `date_trunc` results now return an error.
