### PR TITLE
fix nth_value window function negates i64::MIN

### DIFF
--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -685,9 +685,8 @@ mod tests {
             ))
             .unwrap_err();
 
-        assert!(
-            err.to_string()
-                .starts_with("Execution error: The second argument of nth_value must not be i64::MIN")
-        );
+        assert!(err.to_string().starts_with(
+            "Execution error: The second argument of nth_value must not be i64::MIN"
+        ));
     }
 }

--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -125,6 +125,14 @@ impl NthValue {
     }
 }
 
+fn validate_nth_value_n(n: i64) -> Result<i64> {
+    if n == i64::MIN {
+        return exec_err!("The second argument of nth_value must not be i64::MIN");
+    }
+
+    Ok(n)
+}
+
 static FIRST_VALUE_DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
     Documentation::builder(
         DOC_SECTION_ANALYTICAL,
@@ -287,6 +295,7 @@ impl WindowUDFImpl for NthValue {
         .map(|v| get_signed_integer(&v))
         {
             Some(Ok(n)) => {
+                let n = validate_nth_value_n(n)?;
                 if partition_evaluator_args.is_reversed() {
                     -n
                 } else {
@@ -659,5 +668,26 @@ mod tests {
             ]),
         )?;
         Ok(())
+    }
+
+    #[test]
+    fn nth_value_i64_min_returns_error() {
+        let expr = Arc::new(Column::new("c3", 0)) as Arc<dyn PhysicalExpr>;
+        let n_value = Arc::new(Literal::new(ScalarValue::Int64(Some(i64::MIN))))
+            as Arc<dyn PhysicalExpr>;
+
+        let err = NthValue::nth()
+            .partition_evaluator(PartitionEvaluatorArgs::new(
+                &[expr, n_value],
+                &[Field::new("f", DataType::Int32, true).into()],
+                false,
+                false,
+            ))
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Execution error: The second argument of nth_value must not be i64::MIN"
+        );
     }
 }

--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -685,9 +685,9 @@ mod tests {
             ))
             .unwrap_err();
 
-        assert_eq!(
-            err.to_string(),
-            "Execution error: The second argument of nth_value must not be i64::MIN"
+        assert!(
+            err.to_string()
+                .starts_with("Execution error: The second argument of nth_value must not be i64::MIN")
         );
     }
 }

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -1215,6 +1215,10 @@ NULL 3917
 -1114 -1114
 15673 15673
 
+statement error Execution error: The second argument of nth_value must not be i64::MIN
+SELECT nth_value(x, -9223372036854775808) OVER (ORDER BY x)
+FROM (VALUES (1)) AS t(x);
+
 
 
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22222.

## Rationale for this change

`nth_value` could panic at execution time when called with `i64::MIN` as the `n` argument. The implementation supports negative `n` for reverse indexing and negated the value internally, but negating `i64::MIN` overflows. This caused a runtime panic instead of returning a normal DataFusion error for invalid input.

## What changes are included in this PR?

This PR adds validation for the second argument of `nth_value` so that `i64::MIN` is rejected before any negation occurs. Instead of panicking during execution, the function now returns a regular execution error.

This PR also adds regression coverage at two levels:
- a unit test for the `nth_value` window function implementation
- a sqllogictest case covering the SQL query shape that previously triggered the panic

## Are these changes tested?

Yes.

The change is covered by:
1. a focused unit test in the window function implementation
2. a SQL logic test in `window.slt`

Validated with:
1. `cargo test -p datafusion-functions-window nth_value --lib`
2. `cargo test -p datafusion-sqllogictest --test sqllogictests window`

## Are there any user-facing changes?

Yes. Queries that previously panicked when calling `nth_value(..., -9223372036854775808)` now return a proper execution error instead.