### PR TITLE
Return None for cardinality overflow

### DIFF
--- a/datafusion/expr-common/src/interval_arithmetic.rs
+++ b/datafusion/expr-common/src/interval_arithmetic.rs
@@ -944,7 +944,7 @@ impl Interval {
             // Cardinality calculations are not implemented for this data type yet:
             None
         }
-        .map(|result| result + 1)
+        .and_then(|result| result.checked_add(1))
     }
 
     /// Reflects an [`Interval`] around the point zero.
@@ -4157,6 +4157,16 @@ mod tests {
             ScalarValue::TimestampNanosecond(Some(2_000_000_000), None),
         )?;
         assert_eq!(interval.cardinality().unwrap(), 1_000_000_001);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cardinality_full_i64_range_does_not_overflow() -> Result<()> {
+        let interval = Interval::try_new(
+            ScalarValue::Int64(Some(i64::MIN)),
+            ScalarValue::Int64(Some(i64::MAX)),
+        )?;
+        assert_eq!(interval.cardinality(), None);
 
         Ok(())
     }

--- a/datafusion/expr-common/src/interval_arithmetic.rs
+++ b/datafusion/expr-common/src/interval_arithmetic.rs
@@ -4161,13 +4161,18 @@ mod tests {
     }
 
     #[test]
-    fn test_cardinality_full_i64_range_does_not_overflow() -> Result<()> {
+    fn test_cardinality_full_integer_range_does_not_overflow() -> Result<()> {
         let interval = Interval::try_new(
             ScalarValue::Int64(Some(i64::MIN)),
             ScalarValue::Int64(Some(i64::MAX)),
         )?;
         assert_eq!(interval.cardinality(), None);
 
+        let interval = Interval::try_new(
+            ScalarValue::UInt64(Some(0)),
+            ScalarValue::UInt64(Some(u64::MAX)),
+        )?;
+        assert_eq!(interval.cardinality(), None);
         Ok(())
     }
 

--- a/datafusion/sqllogictest/test_files/select.slt
+++ b/datafusion/sqllogictest/test_files/select.slt
@@ -960,6 +960,12 @@ physical_plan
 01)ProjectionExec: expr=[c1@0 >= 2 AND c1@0 <= 3 as select_between_data.c1 BETWEEN Int64(2) AND Int64(3)]
 02)--DataSourceExec: partitions=1, partition_sizes=[1]
 
+# regression test: full i64 BETWEEN bounds should not overflow
+query I
+SELECT * FROM (VALUES (1)) AS t(x)
+WHERE x BETWEEN -9223372036854775808 AND 9223372036854775807
+----
+1
 
 # TODO: query_get_indexed_field
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22232
(cc @Dandandan )

## Rationale for this change

Prevent `Interval::cardinality()` from overflowing on the full `i64` range.

## What changes are included in this PR?

- use `checked_add(1)` instead of `+ 1`
- add a regression test for the full `i64` range

## Are these changes tested?

- `cargo fmt --all --check`
- `cargo test -p datafusion-expr-common test_cardinality_full_i64_range_does_not_overflow --lib`
- `cargo clippy --all-targets --all-features -- -D warnings` could not run locally because `cmake` is not installed

## Are there any user-facing changes?

- No