### PR TITLE
fix ^ evaluates as bitwise XOR instead of exponentiation

### DIFF
--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -77,7 +77,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
 
     pub(crate) fn build_binary_expr(
         &self,
-        op: BinaryOperator,
+        op: &BinaryOperator,
         left: Expr,
         right: Expr,
     ) -> Result<Expr> {

--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -81,7 +81,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         left: Expr,
         right: Expr,
     ) -> Result<Expr> {
-        if op == BinaryOperator::PGExp {
+        if matches!(op, BinaryOperator::PGExp) {
             let fun_name = "power";
             let fun = self
                 .context_provider
@@ -100,7 +100,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
 
         Ok(Expr::BinaryExpr(BinaryExpr::new(
             Box::new(left),
-            self.parse_sql_binary_op(&op)?,
+            self.parse_sql_binary_op(op)?,
             Box::new(right),
         )))
     }

--- a/datafusion/sql/src/expr/binary_op.rs
+++ b/datafusion/sql/src/expr/binary_op.rs
@@ -16,8 +16,10 @@
 // under the License.
 
 use crate::planner::{ContextProvider, SqlToRel};
-use datafusion_common::{Result, not_impl_err};
+use datafusion_common::{Result, internal_datafusion_err, not_impl_err};
 use datafusion_expr::Operator;
+use datafusion_expr::expr::ScalarFunction;
+use datafusion_expr::{BinaryExpr, Expr};
 use sqlparser::ast::BinaryOperator;
 
 impl<S: ContextProvider> SqlToRel<'_, S> {
@@ -71,5 +73,35 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             BinaryOperator::Custom(s) if s == ":" => Ok(Operator::Colon),
             _ => not_impl_err!("Unsupported binary operator: {:?}", op),
         }
+    }
+
+    pub(crate) fn build_binary_expr(
+        &self,
+        op: BinaryOperator,
+        left: Expr,
+        right: Expr,
+    ) -> Result<Expr> {
+        if op == BinaryOperator::PGExp {
+            let fun_name = "power";
+            let fun = self
+                .context_provider
+                .get_function_meta(fun_name)
+                .ok_or_else(|| {
+                    internal_datafusion_err!(
+                        "Unable to find expected '{fun_name}' function"
+                    )
+                })?;
+
+            return Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
+                fun,
+                vec![left, right],
+            )));
+        }
+
+        Ok(Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(left),
+            self.parse_sql_binary_op(&op)?,
+            Box::new(right),
+        )))
     }
 }

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -142,28 +142,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         }
 
         let RawBinaryExpr { op, left, right } = binary_expr;
-        if op == BinaryOperator::PGExp {
-            let fun_name = "power";
-            let fun = self
-                .context_provider
-                .get_function_meta(fun_name)
-                .ok_or_else(|| {
-                    internal_datafusion_err!(
-                        "Unable to find expected '{fun_name}' function"
-                    )
-                })?;
-
-            return Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
-                fun,
-                vec![left, right],
-            )));
-        }
-
-        Ok(Expr::BinaryExpr(BinaryExpr::new(
-            Box::new(left),
-            self.parse_sql_binary_op(&op)?,
-            Box::new(right),
-        )))
+        self.build_binary_expr(op, left, right)
     }
 
     pub fn sql_to_expr_with_alias(

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -142,6 +142,23 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         }
 
         let RawBinaryExpr { op, left, right } = binary_expr;
+        if op == BinaryOperator::PGExp {
+            let fun_name = "power";
+            let fun = self
+                .context_provider
+                .get_function_meta(fun_name)
+                .ok_or_else(|| {
+                    internal_datafusion_err!(
+                        "Unable to find expected '{fun_name}' function"
+                    )
+                })?;
+
+            return Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
+                fun,
+                vec![left, right],
+            )));
+        }
+
         Ok(Expr::BinaryExpr(BinaryExpr::new(
             Box::new(left),
             self.parse_sql_binary_op(&op)?,

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -142,7 +142,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         }
 
         let RawBinaryExpr { op, left, right } = binary_expr;
-        self.build_binary_expr(op, left, right)
+        self.build_binary_expr(&op, left, right)
     }
 
     pub fn sql_to_expr_with_alias(

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1300,6 +1300,12 @@ NULL -32
 statement ok
 set datafusion.sql_parser.dialect = postgresql;
 
+# postgresql exponentiation uses caret
+query R
+select 2 ^ 3;
+----
+8
+
 # postgresql bitwise xor with column and scalar
 query I rowsort
 select c # 856 from signed_integers;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22252.

## Rationale for this change

In PostgreSQL, the `^` operator represents exponentiation, but DataFusion was interpreting it as bitwise XOR. This caused PostgreSQL-dialect queries such as `SELECT 2 ^ 3;` to return `1` instead of `8`.

This change aligns DataFusion's PostgreSQL SQL semantics with PostgreSQL for this operator while preserving existing non-PostgreSQL behavior.

## What changes are included in this PR?

- Added PostgreSQL-specific handling for `BinaryOperator::PGExp` during SQL expression lowering.
- Lowered PostgreSQL `^` expressions to the built-in `power(left, right)` scalar function instead of treating them as bitwise XOR.
- Kept existing generic-dialect `^` behavior unchanged.
- Kept PostgreSQL bitwise XOR behavior unchanged via `#`.
- Added a sqllogictest regression covering `SELECT 2 ^ 3;` under the PostgreSQL parser dialect.

## Are these changes tested?

Yes.

Added a regression test in scalar.slt to verify that PostgreSQL-dialect `^` is evaluated as exponentiation.

Validated with:

```bash
cargo test -p datafusion-sqllogictest --test sqllogictests scalar
```

## Are there any user-facing changes?

Yes.

For the PostgreSQL SQL parser dialect, `^` now behaves as exponentiation instead of bitwise XOR, matching PostgreSQL semantics. Generic-dialect behavior is unchanged, and PostgreSQL bitwise XOR remains available through `#`.