### PR TITLE
fix date_bin overflows scaling extreme Timestamp(Second) source

### DIFF
--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -746,9 +746,10 @@ fn date_bin_impl(
 
                 let result: PrimitiveArray<T> = array
                     .try_unary(|val| {
-                        let scaled = scale_timestamp_to_nanos(val, scale).map_err(|e| {
-                            arrow::error::ArrowError::ComputeError(e.to_string())
-                        })?;
+                        let scaled =
+                            scale_timestamp_to_nanos(val, scale).map_err(|e| {
+                                arrow::error::ArrowError::ComputeError(e.to_string())
+                            })?;
 
                         stride_fn(stride, scaled, origin)
                             .map(|binned| binned / scale)
@@ -756,7 +757,9 @@ fn date_bin_impl(
                                 arrow::error::ArrowError::ComputeError(e.to_string())
                             })
                     })
-                    .map_err(|e| datafusion_common::DataFusionError::Execution(e.to_string()))?;
+                    .map_err(|e| {
+                        datafusion_common::DataFusionError::Execution(e.to_string())
+                    })?;
 
                 let array = result.with_timezone_opt(tz_opt.clone());
                 Ok(ColumnarValue::Array(Arc::new(array)))

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -334,7 +334,7 @@ fn date_bin_nanos_interval(stride_nanos: i64, source: i64, origin: i64) -> Resul
     let time_delta = compute_distance(time_diff, stride_nanos)?;
 
     origin.checked_add(time_delta).ok_or_else(|| {
-        arrow::error::ArrowError::InvalidArgumentError(format!(
+        ArrowError::InvalidArgumentError(format!(
             "date_bin origin {origin} + delta {time_delta} overflows i64"
         ))
         .into()
@@ -344,12 +344,12 @@ fn date_bin_nanos_interval(stride_nanos: i64, source: i64, origin: i64) -> Resul
 // distance from origin to bin
 fn compute_distance(time_diff: i64, stride: i64) -> Result<i64> {
     let remainder = time_diff.checked_rem(stride).ok_or_else(|| {
-        arrow::error::ArrowError::InvalidArgumentError(format!(
+        ArrowError::InvalidArgumentError(format!(
             "date_bin compute_distance time_diff {time_diff} % stride {stride} overflows i64"
         ))
     })?;
     let time_delta = time_diff.checked_sub(remainder).ok_or_else(|| {
-        arrow::error::ArrowError::InvalidArgumentError(format!(
+        ArrowError::InvalidArgumentError(format!(
             "date_bin compute_distance time_diff {time_diff} - remainder {remainder} overflows i64"
         ))
     })?;
@@ -357,7 +357,7 @@ fn compute_distance(time_diff: i64, stride: i64) -> Result<i64> {
     if time_diff < 0 && stride > 1 && time_delta != time_diff {
         // The origin is later than the source timestamp, round down to the previous bin
         time_delta.checked_sub(stride).ok_or_else(|| {
-            arrow::error::ArrowError::InvalidArgumentError(format!(
+            ArrowError::InvalidArgumentError(format!(
                 "date_bin compute_distance time_delta {time_delta} - stride {stride} overflows i64"
             ))
             .into()

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -606,8 +606,10 @@ fn date_bin_impl(
         }
     }
 
-    fn timestamp_scale_overflow_message(x: i64) -> String {
-        format!("DATE_BIN source timestamp {x} cannot be represented in nanoseconds")
+    fn timestamp_scale_overflow_error(x: i64) -> DataFusionError {
+        DataFusionError::Execution(format!(
+            "DATE_BIN source timestamp {x} cannot be represented in nanoseconds"
+        ))
     }
 
     Ok(match array {
@@ -616,11 +618,9 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
                 match *v {
                     Some(val) => {
-                        let scaled = val.checked_mul(scale).ok_or_else(|| {
-                            DataFusionError::Execution(timestamp_scale_overflow_message(
-                                val,
-                            ))
-                        })?;
+                        let scaled = val
+                            .checked_mul(scale)
+                            .ok_or_else(|| timestamp_scale_overflow_error(val))?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
                             Err(_) => None,
@@ -636,11 +636,9 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
                 match *v {
                     Some(val) => {
-                        let scaled = val.checked_mul(scale).ok_or_else(|| {
-                            DataFusionError::Execution(timestamp_scale_overflow_message(
-                                val,
-                            ))
-                        })?;
+                        let scaled = val
+                            .checked_mul(scale)
+                            .ok_or_else(|| timestamp_scale_overflow_error(val))?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
                             Err(_) => None,
@@ -656,11 +654,9 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
                 match *v {
                     Some(val) => {
-                        let scaled = val.checked_mul(scale).ok_or_else(|| {
-                            DataFusionError::Execution(timestamp_scale_overflow_message(
-                                val,
-                            ))
-                        })?;
+                        let scaled = val
+                            .checked_mul(scale)
+                            .ok_or_else(|| timestamp_scale_overflow_error(val))?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
                             Err(_) => None,
@@ -676,11 +672,9 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::TimestampSecond(
                 match *v {
                     Some(val) => {
-                        let scaled = val.checked_mul(scale).ok_or_else(|| {
-                            DataFusionError::Execution(timestamp_scale_overflow_message(
-                                val,
-                            ))
-                        })?;
+                        let scaled = val
+                            .checked_mul(scale)
+                            .ok_or_else(|| timestamp_scale_overflow_error(val))?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
                             Err(_) => None,
@@ -746,14 +740,6 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::Time64Microsecond(result))
         }
         ColumnarValue::Array(array) => {
-            fn df_to_arrow(e: DataFusionError) -> ArrowError {
-                match e {
-                    DataFusionError::Execution(msg) => ArrowError::ComputeError(msg),
-                    DataFusionError::ArrowError(ae, _) => *ae,
-                    other => ArrowError::ComputeError(other.to_string()),
-                }
-            }
-
             fn transform_array_with_stride<T>(
                 origin: i64,
                 stride: i64,
@@ -771,11 +757,9 @@ fn date_bin_impl(
                     .iter()
                     .map(|val| match val {
                         Some(val) => {
-                            let scaled = val.checked_mul(scale).ok_or_else(|| {
-                                DataFusionError::Execution(
-                                    timestamp_scale_overflow_message(val),
-                                )
-                            })?;
+                            let scaled = val
+                                .checked_mul(scale)
+                                .ok_or_else(|| timestamp_scale_overflow_error(val))?;
                             Ok(stride_fn(stride, scaled, origin)
                                 .ok()
                                 .map(|binned| binned / scale))
@@ -825,7 +809,7 @@ fn date_bin_impl(
                                     let nanos = binned_nanos % (NANOSECONDS_IN_DAY);
                                     (nanos / NANOS_PER_MILLI) as i32
                                 })
-                                .map_err(df_to_arrow)
+                                .map_err(|e| ArrowError::ComputeError(e.to_string()))
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }
@@ -843,7 +827,7 @@ fn date_bin_impl(
                                     let nanos = binned_nanos % (NANOSECONDS_IN_DAY);
                                     (nanos / NANOS_PER_SEC) as i32
                                 })
-                                .map_err(df_to_arrow)
+                                .map_err(|e| ArrowError::ComputeError(e.to_string()))
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }
@@ -861,7 +845,7 @@ fn date_bin_impl(
                                     let nanos = binned_nanos % (NANOSECONDS_IN_DAY);
                                     nanos / NANOS_PER_MICRO
                                 })
-                                .map_err(df_to_arrow)
+                                .map_err(|e| ArrowError::ComputeError(e.to_string()))
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }
@@ -876,7 +860,7 @@ fn date_bin_impl(
                         array.try_unary(|x| {
                             stride_fn(stride, x, origin)
                                 .map(|binned_nanos| binned_nanos % (NANOSECONDS_IN_DAY))
-                                .map_err(df_to_arrow)
+                                    .map_err(|e| ArrowError::ComputeError(e.to_string()))
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -860,7 +860,7 @@ fn date_bin_impl(
                         array.try_unary(|x| {
                             stride_fn(stride, x, origin)
                                 .map(|binned_nanos| binned_nanos % (NANOSECONDS_IN_DAY))
-                                    .map_err(|e| ArrowError::ComputeError(e.to_string()))
+                                .map_err(|e| ArrowError::ComputeError(e.to_string()))
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -34,7 +34,9 @@ use arrow::datatypes::{
 use arrow::error::ArrowError;
 use arrow::temporal_conversions::NANOSECONDS_IN_DAY;
 use datafusion_common::cast::as_primitive_array;
-use datafusion_common::{DataFusionError, Result, ScalarValue, exec_err, not_impl_err, plan_err};
+use datafusion_common::{
+    DataFusionError, Result, ScalarValue, exec_err, not_impl_err, plan_err,
+};
 use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
 use datafusion_expr::{
@@ -880,7 +882,9 @@ mod tests {
 
     use crate::datetime::date_bin::{DateBinFunc, date_bin_nanos_interval};
     use arrow::array::types::TimestampNanosecondType;
-    use arrow::array::{Array, IntervalDayTimeArray, TimestampNanosecondArray, TimestampSecondArray};
+    use arrow::array::{
+        Array, IntervalDayTimeArray, TimestampNanosecondArray, TimestampSecondArray,
+    };
     use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
     use arrow::datatypes::{DataType, Field, FieldRef, TimeUnit};
 
@@ -1136,7 +1140,11 @@ mod tests {
         );
 
         // source: overflow while scaling to nanoseconds (array path)
-        let input = Arc::new(vec![Some(i64::MAX)].into_iter().collect::<TimestampSecondArray>());
+        let input = Arc::new(
+            vec![Some(i64::MAX)]
+                .into_iter()
+                .collect::<TimestampSecondArray>(),
+        );
         let return_field_second = &Arc::new(Field::new(
             "f",
             DataType::Timestamp(TimeUnit::Second, None),

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -594,53 +594,85 @@ fn date_bin_impl(
         return exec_err!("DATE_BIN stride must be non-zero");
     }
 
-    fn stride_map_fn<T: ArrowTimestampType>(
-        origin: i64,
-        stride: i64,
-        stride_fn: BinFunction,
-    ) -> impl Fn(i64) -> Result<i64> {
-        let scale = match T::UNIT {
+    fn timestamp_scale<T: ArrowTimestampType>() -> i64 {
+        match T::UNIT {
             Nanosecond => 1,
             Microsecond => NANOS_PER_MICRO,
             Millisecond => NANOS_PER_MILLI,
             Second => NANOSECONDS,
-        };
-        move |x: i64| match stride_fn(stride, x * scale, origin) {
-            Ok(result) => Ok(result / scale),
-            Err(e) => Err(e),
         }
+    }
+
+    fn scale_timestamp_to_nanos(x: i64, scale: i64) -> Result<i64> {
+        x.checked_mul(scale).ok_or_else(|| {
+            datafusion_common::DataFusionError::Execution(format!(
+                "DATE_BIN source timestamp {x} cannot be represented in nanoseconds"
+            ))
+        })
     }
 
     Ok(match array {
         ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(v, tz_opt)) => {
-            let apply_stride_fn =
-                stride_map_fn::<TimestampNanosecondType>(origin, stride, stride_fn);
+            let scale = timestamp_scale::<TimestampNanosecondType>();
             ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
-                v.and_then(|val| apply_stride_fn(val).ok()),
+                match *v {
+                    Some(val) => {
+                        let scaled = scale_timestamp_to_nanos(val, scale)?;
+                        match stride_fn(stride, scaled, origin) {
+                            Ok(result) => Some(result / scale),
+                            Err(_) => None,
+                        }
+                    }
+                    None => None,
+                },
                 tz_opt.clone(),
             ))
         }
         ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(v, tz_opt)) => {
-            let apply_stride_fn =
-                stride_map_fn::<TimestampMicrosecondType>(origin, stride, stride_fn);
+            let scale = timestamp_scale::<TimestampMicrosecondType>();
             ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-                v.and_then(|val| apply_stride_fn(val).ok()),
+                match *v {
+                    Some(val) => {
+                        let scaled = scale_timestamp_to_nanos(val, scale)?;
+                        match stride_fn(stride, scaled, origin) {
+                            Ok(result) => Some(result / scale),
+                            Err(_) => None,
+                        }
+                    }
+                    None => None,
+                },
                 tz_opt.clone(),
             ))
         }
         ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(v, tz_opt)) => {
-            let apply_stride_fn =
-                stride_map_fn::<TimestampMillisecondType>(origin, stride, stride_fn);
+            let scale = timestamp_scale::<TimestampMillisecondType>();
             ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                v.and_then(|val| apply_stride_fn(val).ok()),
+                match *v {
+                    Some(val) => {
+                        let scaled = scale_timestamp_to_nanos(val, scale)?;
+                        match stride_fn(stride, scaled, origin) {
+                            Ok(result) => Some(result / scale),
+                            Err(_) => None,
+                        }
+                    }
+                    None => None,
+                },
                 tz_opt.clone(),
             ))
         }
         ColumnarValue::Scalar(ScalarValue::TimestampSecond(v, tz_opt)) => {
-            let apply_stride_fn =
-                stride_map_fn::<TimestampSecondType>(origin, stride, stride_fn);
+            let scale = timestamp_scale::<TimestampSecondType>();
             ColumnarValue::Scalar(ScalarValue::TimestampSecond(
-                v.and_then(|val| apply_stride_fn(val).ok()),
+                match *v {
+                    Some(val) => {
+                        let scaled = scale_timestamp_to_nanos(val, scale)?;
+                        match stride_fn(stride, scaled, origin) {
+                            Ok(result) => Some(result / scale),
+                            Err(_) => None,
+                        }
+                    }
+                    None => None,
+                },
                 tz_opt.clone(),
             ))
         }
@@ -710,20 +742,21 @@ fn date_bin_impl(
                 T: ArrowTimestampType,
             {
                 let array = as_primitive_array::<T>(array)?;
-                let scale = match T::UNIT {
-                    Nanosecond => 1,
-                    Microsecond => NANOS_PER_MICRO,
-                    Millisecond => NANOS_PER_MILLI,
-                    Second => NANOSECONDS,
-                };
+                let scale = timestamp_scale::<T>();
 
-                let result: PrimitiveArray<T> = array.try_unary(|val| {
-                    stride_fn(stride, val * scale, origin)
-                        .map(|binned| binned / scale)
-                        .map_err(|e| {
+                let result: PrimitiveArray<T> = array
+                    .try_unary(|val| {
+                        let scaled = scale_timestamp_to_nanos(val, scale).map_err(|e| {
                             arrow::error::ArrowError::ComputeError(e.to_string())
-                        })
-                })?;
+                        })?;
+
+                        stride_fn(stride, scaled, origin)
+                            .map(|binned| binned / scale)
+                            .map_err(|e| {
+                                arrow::error::ArrowError::ComputeError(e.to_string())
+                            })
+                    })
+                    .map_err(|e| datafusion_common::DataFusionError::Execution(e.to_string()))?;
 
                 let array = result.with_timezone_opt(tz_opt.clone());
                 Ok(ColumnarValue::Array(Arc::new(array)))
@@ -1084,6 +1117,24 @@ mod tests {
         assert_eq!(
             res.err().unwrap().strip_backtrace(),
             "This feature is not implemented: DATE_BIN only supports literal values for the origin argument, not arrays"
+        );
+
+        // source: overflow while scaling to nanoseconds
+        args = vec![
+            ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(
+                IntervalMonthDayNano {
+                    months: 0,
+                    days: 0,
+                    nanoseconds: 1,
+                },
+            ))),
+            ColumnarValue::Scalar(ScalarValue::TimestampSecond(Some(i64::MAX), None)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(0), None)),
+        ];
+        let res = invoke_date_bin_with_args(args, 1, return_field);
+        assert_eq!(
+            res.err().unwrap().strip_backtrace(),
+            "Execution error: DATE_BIN source timestamp 9223372036854775807 cannot be represented in nanoseconds"
         );
     }
 

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -607,9 +607,7 @@ fn date_bin_impl(
     }
 
     fn timestamp_scale_overflow_message(x: i64) -> String {
-        format!(
-            "DATE_BIN source timestamp {x} cannot be represented in nanoseconds"
-        )
+        format!("DATE_BIN source timestamp {x} cannot be represented in nanoseconds")
     }
 
     Ok(match array {
@@ -619,9 +617,9 @@ fn date_bin_impl(
                 match *v {
                     Some(val) => {
                         let scaled = val.checked_mul(scale).ok_or_else(|| {
-                            DataFusionError::Execution(
-                                timestamp_scale_overflow_message(val),
-                            )
+                            DataFusionError::Execution(timestamp_scale_overflow_message(
+                                val,
+                            ))
                         })?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
@@ -639,9 +637,9 @@ fn date_bin_impl(
                 match *v {
                     Some(val) => {
                         let scaled = val.checked_mul(scale).ok_or_else(|| {
-                            DataFusionError::Execution(
-                                timestamp_scale_overflow_message(val),
-                            )
+                            DataFusionError::Execution(timestamp_scale_overflow_message(
+                                val,
+                            ))
                         })?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
@@ -659,9 +657,9 @@ fn date_bin_impl(
                 match *v {
                     Some(val) => {
                         let scaled = val.checked_mul(scale).ok_or_else(|| {
-                            DataFusionError::Execution(
-                                timestamp_scale_overflow_message(val),
-                            )
+                            DataFusionError::Execution(timestamp_scale_overflow_message(
+                                val,
+                            ))
                         })?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
@@ -679,9 +677,9 @@ fn date_bin_impl(
                 match *v {
                     Some(val) => {
                         let scaled = val.checked_mul(scale).ok_or_else(|| {
-                            DataFusionError::Execution(
-                                timestamp_scale_overflow_message(val),
-                            )
+                            DataFusionError::Execution(timestamp_scale_overflow_message(
+                                val,
+                            ))
                         })?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
@@ -905,8 +903,7 @@ mod tests {
     use crate::datetime::date_bin::{DateBinFunc, date_bin_nanos_interval};
     use arrow::array::types::TimestampNanosecondType;
     use arrow::array::{
-        Array, IntervalDayTimeArray, TimestampMillisecondArray,
-        TimestampNanosecondArray,
+        Array, IntervalDayTimeArray, TimestampMillisecondArray, TimestampNanosecondArray,
     };
     use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
     use arrow::datatypes::{DataType, Field, FieldRef, TimeUnit};
@@ -1143,7 +1140,6 @@ mod tests {
             res.err().unwrap().strip_backtrace(),
             "This feature is not implemented: DATE_BIN only supports literal values for the origin argument, not arrays"
         );
-
     }
 
     #[test]

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -902,9 +902,7 @@ mod tests {
 
     use crate::datetime::date_bin::{DateBinFunc, date_bin_nanos_interval};
     use arrow::array::types::TimestampNanosecondType;
-    use arrow::array::{
-        Array, IntervalDayTimeArray, TimestampNanosecondArray,
-    };
+    use arrow::array::{Array, IntervalDayTimeArray, TimestampNanosecondArray};
     use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
     use arrow::datatypes::{DataType, Field, FieldRef, TimeUnit};
 

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -903,7 +903,7 @@ mod tests {
     use crate::datetime::date_bin::{DateBinFunc, date_bin_nanos_interval};
     use arrow::array::types::TimestampNanosecondType;
     use arrow::array::{
-        Array, IntervalDayTimeArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        Array, IntervalDayTimeArray, TimestampNanosecondArray,
     };
     use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
     use arrow::datatypes::{DataType, Field, FieldRef, TimeUnit};

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -31,9 +31,10 @@ use arrow::datatypes::{
     DataType, Time32MillisecondType, Time32SecondType, Time64MicrosecondType,
     Time64NanosecondType, TimeUnit,
 };
+use arrow::error::ArrowError;
 use arrow::temporal_conversions::NANOSECONDS_IN_DAY;
 use datafusion_common::cast::as_primitive_array;
-use datafusion_common::{Result, ScalarValue, exec_err, not_impl_err, plan_err};
+use datafusion_common::{DataFusionError, Result, ScalarValue, exec_err, not_impl_err, plan_err};
 use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
 use datafusion_expr::{
@@ -322,7 +323,7 @@ impl Interval {
 // return time in nanoseconds that the source timestamp falls into based on the stride and origin
 fn date_bin_nanos_interval(stride_nanos: i64, source: i64, origin: i64) -> Result<i64> {
     let time_diff = source.checked_sub(origin).ok_or_else(|| {
-        arrow::error::ArrowError::InvalidArgumentError(format!(
+        ArrowError::InvalidArgumentError(format!(
             "date_bin source timestamp {source} - origin {origin} overflows i64"
         ))
     })?;
@@ -605,7 +606,7 @@ fn date_bin_impl(
 
     fn scale_timestamp_to_nanos(x: i64, scale: i64) -> Result<i64> {
         x.checked_mul(scale).ok_or_else(|| {
-            datafusion_common::DataFusionError::Execution(format!(
+            DataFusionError::Execution(format!(
                 "DATE_BIN source timestamp {x} cannot be represented in nanoseconds"
             ))
         })
@@ -731,6 +732,14 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::Time64Microsecond(result))
         }
         ColumnarValue::Array(array) => {
+            fn df_to_arrow(e: DataFusionError) -> ArrowError {
+                match e {
+                    DataFusionError::Execution(msg) => ArrowError::ComputeError(msg),
+                    DataFusionError::ArrowError(ae, _) => *ae,
+                    other => ArrowError::ComputeError(other.to_string()),
+                }
+            }
+
             fn transform_array_with_stride<T>(
                 origin: i64,
                 stride: i64,
@@ -747,19 +756,13 @@ fn date_bin_impl(
                 let result: PrimitiveArray<T> = array
                     .try_unary(|val| {
                         let scaled =
-                            scale_timestamp_to_nanos(val, scale).map_err(|e| {
-                                arrow::error::ArrowError::ComputeError(e.to_string())
-                            })?;
+                            scale_timestamp_to_nanos(val, scale).map_err(df_to_arrow)?;
 
                         stride_fn(stride, scaled, origin)
                             .map(|binned| binned / scale)
-                            .map_err(|e| {
-                                arrow::error::ArrowError::ComputeError(e.to_string())
-                            })
+                            .map_err(df_to_arrow)
                     })
-                    .map_err(|e| {
-                        datafusion_common::DataFusionError::Execution(e.to_string())
-                    })?;
+                    .map_err(DataFusionError::from)?;
 
                 let array = result.with_timezone_opt(tz_opt.clone());
                 Ok(ColumnarValue::Array(Arc::new(array)))
@@ -800,9 +803,7 @@ fn date_bin_impl(
                                     let nanos = binned_nanos % (NANOSECONDS_IN_DAY);
                                     (nanos / NANOS_PER_MILLI) as i32
                                 })
-                                .map_err(|e| {
-                                    arrow::error::ArrowError::ComputeError(e.to_string())
-                                })
+                                .map_err(df_to_arrow)
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }
@@ -820,9 +821,7 @@ fn date_bin_impl(
                                     let nanos = binned_nanos % (NANOSECONDS_IN_DAY);
                                     (nanos / NANOS_PER_SEC) as i32
                                 })
-                                .map_err(|e| {
-                                    arrow::error::ArrowError::ComputeError(e.to_string())
-                                })
+                                .map_err(df_to_arrow)
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }
@@ -840,9 +839,7 @@ fn date_bin_impl(
                                     let nanos = binned_nanos % (NANOSECONDS_IN_DAY);
                                     nanos / NANOS_PER_MICRO
                                 })
-                                .map_err(|e| {
-                                    arrow::error::ArrowError::ComputeError(e.to_string())
-                                })
+                                .map_err(df_to_arrow)
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }
@@ -857,9 +854,7 @@ fn date_bin_impl(
                         array.try_unary(|x| {
                             stride_fn(stride, x, origin)
                                 .map(|binned_nanos| binned_nanos % (NANOSECONDS_IN_DAY))
-                                .map_err(|e| {
-                                    arrow::error::ArrowError::ComputeError(e.to_string())
-                                })
+                                .map_err(df_to_arrow)
                         })?;
                     ColumnarValue::Array(Arc::new(result))
                 }
@@ -885,7 +880,7 @@ mod tests {
 
     use crate::datetime::date_bin::{DateBinFunc, date_bin_nanos_interval};
     use arrow::array::types::TimestampNanosecondType;
-    use arrow::array::{Array, IntervalDayTimeArray, TimestampNanosecondArray};
+    use arrow::array::{Array, IntervalDayTimeArray, TimestampNanosecondArray, TimestampSecondArray};
     use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
     use arrow::datatypes::{DataType, Field, FieldRef, TimeUnit};
 
@@ -1138,6 +1133,32 @@ mod tests {
         assert_eq!(
             res.err().unwrap().strip_backtrace(),
             "Execution error: DATE_BIN source timestamp 9223372036854775807 cannot be represented in nanoseconds"
+        );
+
+        // source: overflow while scaling to nanoseconds (array path)
+        let input = Arc::new(vec![Some(i64::MAX)].into_iter().collect::<TimestampSecondArray>());
+        let return_field_second = &Arc::new(Field::new(
+            "f",
+            DataType::Timestamp(TimeUnit::Second, None),
+            true,
+        ));
+        args = vec![
+            ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(
+                IntervalMonthDayNano {
+                    months: 0,
+                    days: 0,
+                    nanoseconds: 1,
+                },
+            ))),
+            ColumnarValue::Array(input),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(0), None)),
+        ];
+        let res = invoke_date_bin_with_args(args, 1, return_field_second);
+        assert!(
+            res.err()
+                .unwrap()
+                .strip_backtrace()
+                .contains("DATE_BIN source timestamp 9223372036854775807 cannot be represented in nanoseconds")
         );
     }
 

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -606,12 +606,10 @@ fn date_bin_impl(
         }
     }
 
-    fn scale_timestamp_to_nanos(x: i64, scale: i64) -> Result<i64> {
-        x.checked_mul(scale).ok_or_else(|| {
-            DataFusionError::Execution(format!(
-                "DATE_BIN source timestamp {x} cannot be represented in nanoseconds"
-            ))
-        })
+    fn timestamp_scale_overflow_message(x: i64) -> String {
+        format!(
+            "DATE_BIN source timestamp {x} cannot be represented in nanoseconds"
+        )
     }
 
     Ok(match array {
@@ -620,7 +618,11 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
                 match *v {
                     Some(val) => {
-                        let scaled = scale_timestamp_to_nanos(val, scale)?;
+                        let scaled = val.checked_mul(scale).ok_or_else(|| {
+                            DataFusionError::Execution(
+                                timestamp_scale_overflow_message(val),
+                            )
+                        })?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
                             Err(_) => None,
@@ -636,7 +638,11 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
                 match *v {
                     Some(val) => {
-                        let scaled = scale_timestamp_to_nanos(val, scale)?;
+                        let scaled = val.checked_mul(scale).ok_or_else(|| {
+                            DataFusionError::Execution(
+                                timestamp_scale_overflow_message(val),
+                            )
+                        })?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
                             Err(_) => None,
@@ -652,7 +658,11 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
                 match *v {
                     Some(val) => {
-                        let scaled = scale_timestamp_to_nanos(val, scale)?;
+                        let scaled = val.checked_mul(scale).ok_or_else(|| {
+                            DataFusionError::Execution(
+                                timestamp_scale_overflow_message(val),
+                            )
+                        })?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
                             Err(_) => None,
@@ -668,7 +678,11 @@ fn date_bin_impl(
             ColumnarValue::Scalar(ScalarValue::TimestampSecond(
                 match *v {
                     Some(val) => {
-                        let scaled = scale_timestamp_to_nanos(val, scale)?;
+                        let scaled = val.checked_mul(scale).ok_or_else(|| {
+                            DataFusionError::Execution(
+                                timestamp_scale_overflow_message(val),
+                            )
+                        })?;
                         match stride_fn(stride, scaled, origin) {
                             Ok(result) => Some(result / scale),
                             Err(_) => None,
@@ -755,16 +769,24 @@ fn date_bin_impl(
                 let array = as_primitive_array::<T>(array)?;
                 let scale = timestamp_scale::<T>();
 
-                let result: PrimitiveArray<T> = array
-                    .try_unary(|val| {
-                        let scaled =
-                            scale_timestamp_to_nanos(val, scale).map_err(df_to_arrow)?;
-
-                        stride_fn(stride, scaled, origin)
-                            .map(|binned| binned / scale)
-                            .map_err(df_to_arrow)
+                let values = array
+                    .iter()
+                    .map(|val| match val {
+                        Some(val) => {
+                            let scaled = val.checked_mul(scale).ok_or_else(|| {
+                                DataFusionError::Execution(
+                                    timestamp_scale_overflow_message(val),
+                                )
+                            })?;
+                            Ok(stride_fn(stride, scaled, origin)
+                                .ok()
+                                .map(|binned| binned / scale))
+                        }
+                        None => Ok(None),
                     })
-                    .map_err(DataFusionError::from)?;
+                    .collect::<Result<Vec<_>>>()?;
+
+                let result = PrimitiveArray::<T>::from_iter(values);
 
                 let array = result.with_timezone_opt(tz_opt.clone());
                 Ok(ColumnarValue::Array(Arc::new(array)))
@@ -883,7 +905,8 @@ mod tests {
     use crate::datetime::date_bin::{DateBinFunc, date_bin_nanos_interval};
     use arrow::array::types::TimestampNanosecondType;
     use arrow::array::{
-        Array, IntervalDayTimeArray, TimestampNanosecondArray, TimestampSecondArray,
+        Array, IntervalDayTimeArray, TimestampMillisecondArray,
+        TimestampNanosecondArray,
     };
     use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
     use arrow::datatypes::{DataType, Field, FieldRef, TimeUnit};
@@ -1121,53 +1144,6 @@ mod tests {
             "This feature is not implemented: DATE_BIN only supports literal values for the origin argument, not arrays"
         );
 
-        // source: overflow while scaling to nanoseconds
-        args = vec![
-            ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(
-                IntervalMonthDayNano {
-                    months: 0,
-                    days: 0,
-                    nanoseconds: 1,
-                },
-            ))),
-            ColumnarValue::Scalar(ScalarValue::TimestampSecond(Some(i64::MAX), None)),
-            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(0), None)),
-        ];
-        let res = invoke_date_bin_with_args(args, 1, return_field);
-        assert_eq!(
-            res.err().unwrap().strip_backtrace(),
-            "Execution error: DATE_BIN source timestamp 9223372036854775807 cannot be represented in nanoseconds"
-        );
-
-        // source: overflow while scaling to nanoseconds (array path)
-        let input = Arc::new(
-            vec![Some(i64::MAX)]
-                .into_iter()
-                .collect::<TimestampSecondArray>(),
-        );
-        let return_field_second = &Arc::new(Field::new(
-            "f",
-            DataType::Timestamp(TimeUnit::Second, None),
-            true,
-        ));
-        args = vec![
-            ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(
-                IntervalMonthDayNano {
-                    months: 0,
-                    days: 0,
-                    nanoseconds: 1,
-                },
-            ))),
-            ColumnarValue::Array(input),
-            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(0), None)),
-        ];
-        let res = invoke_date_bin_with_args(args, 1, return_field_second);
-        assert!(
-            res.err()
-                .unwrap()
-                .strip_backtrace()
-                .contains("DATE_BIN source timestamp 9223372036854775807 cannot be represented in nanoseconds")
-        );
     }
 
     #[test]

--- a/datafusion/sqllogictest/test_files/date_bin_errors.slt
+++ b/datafusion/sqllogictest/test_files/date_bin_errors.slt
@@ -86,3 +86,14 @@ select date_bin(
   arrow_cast(9223372036854775807, 'Timestamp(Second, None)'),
   timestamp '1970-01-01 00:00:00'
 );
+
+# Source timestamp scaling to nanoseconds overflows in array path: should return an error, not panic
+query error DataFusion error: Execution error: DATE_BIN source timestamp 9223372036854775807 cannot be represented in nanoseconds
+select date_bin(
+  interval '1 nanosecond',
+  ts,
+  timestamp '1970-01-01 00:00:00'
+)
+from (
+  values (arrow_cast(9223372036854775807, 'Timestamp(Second, None)'))
+) as t(ts);

--- a/datafusion/sqllogictest/test_files/date_bin_errors.slt
+++ b/datafusion/sqllogictest/test_files/date_bin_errors.slt
@@ -78,3 +78,11 @@ select date_bin(
 );
 ----
 NULL
+
+# Source timestamp scaling to nanoseconds overflows: should return an error, not panic
+query error DataFusion error: Execution error: DATE_BIN source timestamp 9223372036854775807 cannot be represented in nanoseconds
+select date_bin(
+  interval '1 nanosecond',
+  arrow_cast(9223372036854775807, 'Timestamp(Second, None)'),
+  timestamp '1970-01-01 00:00:00'
+);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22211.

## Rationale for this change

`date_bin` could panic during planning or constant evaluation when scaling a non-nanosecond source timestamp to nanoseconds overflowed. This change makes that path return a regular error instead of panicking.

## What changes are included in this PR?

- Added checked overflow handling for source timestamp scaling in `date_bin`.
- Return an error for out-of-range source timestamp conversion instead of panicking.
- Preserved existing `NULL` behavior for unrelated out-of-range `date_bin` cases.
- Added Rust unit test and sqllogictest coverage for the overflow case.

## Are these changes tested?

Yes.

Verified with:

- `cargo test -p datafusion-functions test_date_bin --lib`
- `cargo test -p datafusion-sqllogictest --test sqllogictests date_bin_errors`

## Are there any user-facing changes?

Yes. Queries that previously could panic now return a normal error:

`Execution error: DATE_BIN source timestamp ... cannot be represented in nanoseconds`