### PR TITLE
Fix: deadlink in "Concepts, Reading, Events" page to DataFusion blog

### DIFF
--- a/docs/source/user-guide/concepts-readings-events.md
+++ b/docs/source/user-guide/concepts-readings-events.md
@@ -41,7 +41,7 @@ This is a list of DataFusion related blog posts, articles, and other resources. 
 
 - **2026-04-04** [Video: Generalized Consensus & Native Top-K Joins in ParadeDB](https://www.youtube.com/watch?v=TeFsBVIYBis)
 
-- **2026-03-31** [Blog: Writing Custom Table Providers in Apache DataFusion](https://datafusion.apache.org/blog/2026/03/31/custom-table-providers/)
+- **2026-03-31** [Blog: Writing Custom Table Providers in Apache DataFusion](https://datafusion.apache.org/blog/2026/03/31/writing-table-providers/)
 
 - **2026-03-24** [Podcast: The Data Fusion Secret & Why Custom Query Engines Fail with Nikita Lapkov](https://www.youtube.com/watch?v=HkYF2So6nHQ)
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22324.

## Rationale for this change

Fixes deadlink in documentation.

## What changes are included in this PR?

Using correct URL.

## Are these changes tested?

Manual.

## Are there any user-facing changes?
Documentation.

