### PR TITLE
fix: round_even for floats for the single argument case

### DIFF
--- a/datafusion/functions/src/math/round.rs
+++ b/datafusion/functions/src/math/round.rs
@@ -630,15 +630,36 @@ fn round_columnar(
     }
 }
 
+trait RoundEven: num_traits::Float {
+    fn round_even(self) -> Self;
+}
+
+impl RoundEven for f32 {
+    fn round_even(self) -> Self {
+        self.round_ties_even()
+    }
+}
+
+impl RoundEven for f64 {
+    fn round_even(self) -> Self {
+        self.round_ties_even()
+    }
+}
+
 fn round_float<T>(value: T, decimal_places: i32) -> Result<T, ArrowError>
 where
-    T: num_traits::Float,
+    T: RoundEven,
 {
+    if decimal_places == 0 {
+        return Ok(value.round_even());
+    }
+
     let factor = T::from(10_f64.powi(decimal_places)).ok_or_else(|| {
         ArrowError::ComputeError(format!(
             "Invalid value for decimal places: {decimal_places}"
         ))
     })?;
+
     Ok((value * factor).round() / factor)
 }
 
@@ -810,6 +831,22 @@ mod test {
     }
 
     #[test]
+    fn test_round_even_f32_one_input() {
+        let args: Vec<ArrayRef> = vec![
+            Arc::new(Float32Array::from(vec![2.5, 3.5, -2.5, -3.5])), // input
+        ];
+
+        let result = round_arrays(Arc::clone(&args[0]), None)
+            .expect("failed to initialize function round");
+        let floats =
+            as_float32_array(&result).expect("failed to initialize function round");
+
+        let expected = Float32Array::from(vec![2.0, 4.0, -2.0, -4.0]);
+
+        assert_eq!(floats, &expected);
+    }
+
+    #[test]
     fn test_round_f64_one_input() {
         let args: Vec<ArrayRef> = vec![
             Arc::new(Float64Array::from(vec![125.2345, 12.345, 1.234, 0.1234])), // input
@@ -821,6 +858,22 @@ mod test {
             as_float64_array(&result).expect("failed to initialize function round");
 
         let expected = Float64Array::from(vec![125.0, 12.0, 1.0, 0.0]);
+
+        assert_eq!(floats, &expected);
+    }
+
+    #[test]
+    fn test_round_even_f64_one_input() {
+        let args: Vec<ArrayRef> = vec![
+            Arc::new(Float64Array::from(vec![2.5, 3.5, -2.5, -3.5])), // input
+        ];
+
+        let result = round_arrays(Arc::clone(&args[0]), None)
+            .expect("failed to initialize function round");
+        let floats =
+            as_float64_array(&result).expect("failed to initialize function round");
+
+        let expected = Float64Array::from(vec![2.0, 4.0, -2.0, -4.0]);
 
         assert_eq!(floats, &expected);
     }

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -918,8 +918,8 @@ select round(a), round(b), round(c) from small_floats;
 ----
 -1 0 -1
 -1 NULL NULL
+0 0 0
 0 0 1
-1 0 0
 
 # round with too large
 #  max Int32 is 2147483647


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22269.

## Rationale for this change

round(float8) should match PostgreSQL half-tie behavior (banker's rounding / round-half-to-even).


## What changes are included in this PR?

- Changed round_float() to use round-half-to-even (ties-to-even) for the
  zero-decimal / single-argument case only
- The two-argument form is intentionally unchanged, as PostgreSQL does not
  support round(double precision, int) — that form operates on numeric types
- Added regression tests for f32 and f64 with canonical half-tie values
  (2.5, 3.5, -2.5, -3.5)
- Updated scalar.slt expected output to reflect the corrected behavior

## Are these changes tested?

Ran:
`cargo test --package datafusion-functions round`
and
```
cargo test -p datafusion --test parquet_integration
cargo test --profile=ci --test sqllogictests
``` 

## Are there any user-facing changes?
Yes — round(x) where x is a float and x is a half-tie value (e.g. 0.5, 1.5, 2.5)
will now return a different result. This is a correctness fix to match PostgreSQL behavior.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
To run the CI : @kumarUjjawal 