### PR TITLE
perf: combine_hashes for primitive multi-column rehash

### DIFF
--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -211,8 +211,8 @@ fn seeded_state(seed: u64) -> foldhash::fast::SeedableRandomState {
 }
 
 /// Builds hash values of PrimitiveArray and writes them into `hashes_buffer`
-/// If `rehash==true` this folds the existing hash into the hasher state
-/// and hashes only the new value (avoiding a separate combine step).
+/// If `rehash==true` this combines the previous hash value in the buffer
+/// with the new hash using `combine_hashes`.
 #[cfg(not(feature = "force_hash_collisions"))]
 fn hash_array_primitive<T>(
     array: &PrimitiveArray<T>,
@@ -231,9 +231,7 @@ fn hash_array_primitive<T>(
     if array.null_count() == 0 {
         if rehash {
             for (hash, &value) in hashes_buffer.iter_mut().zip(array.values().iter()) {
-                let mut hasher = seeded_state(*hash).build_hasher();
-                value.hash_write(&mut hasher);
-                *hash = hasher.finish();
+                *hash = combine_hashes(value.hash_one(random_state), *hash);
             }
         } else {
             for (hash, &value) in hashes_buffer.iter_mut().zip(array.values().iter()) {
@@ -243,9 +241,8 @@ fn hash_array_primitive<T>(
     } else if rehash {
         for i in array.nulls().unwrap().valid_indices() {
             let value = unsafe { array.value_unchecked(i) };
-            let mut hasher = seeded_state(hashes_buffer[i]).build_hasher();
-            value.hash_write(&mut hasher);
-            hashes_buffer[i] = hasher.finish();
+            hashes_buffer[i] =
+                combine_hashes(value.hash_one(random_state), hashes_buffer[i]);
         }
     } else {
         for i in array.nulls().unwrap().valid_indices() {


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No issue yet; happy to file one if preferred. -->

- Closes #.

## Rationale for this change

When multiple group keys participate in a grouped aggregate, `create_hashes` walks the columns left-to-right and rehashes each row by combining the current value's hash with the previously accumulated row hash. The generic variable-width path (`hash_array`) and the dictionary path (`hash_dictionary_array`) already do this with `combine_hashes(value.hash_one(random_state), *hash)`. The primitive path (`hash_array_primitive`) instead constructs a fresh `foldhash::fast::SeedableRandomState` per row, seeded from the previous hash, and runs the value through that. That approach is heavier on the hot loop and isn't necessary for correctness — the same hash distribution is achievable with `combine_hashes`.

The motivating workload is ClickBench q32 on the partitioned dataset:

```sql
SELECT "WatchID", "ClientIP", COUNT(*) AS c, SUM("IsRefresh"), AVG("ResolutionWidth")
FROM hits
GROUP BY "WatchID", "ClientIP"
ORDER BY c DESC
LIMIT 10
```

The two group keys are both primitive (`Int64`/`Int32`), and the partial aggregate spends most of its time in group-id calculation. On a current-main baseline of **3988.27 ms** (`dfbench clickbench --query 32 --iterations 3`), a 10-iteration same-machine run with this change settled around **1.7 s**, with a warm tail of **1.4-1.5 s** per iteration.

Guardrail single-query runs of other primitive multi-key aggregates (q30, q31, q35) and the q18 path that benefits from primitive rehashing as a second column did not regress.

## What changes are included in this PR?

Replaces the two `seeded_state(...).build_hasher() / value.hash_write(...) / hasher.finish()` blocks in `hash_array_primitive`'s rehash branch (no-null and nullable variants) with the same `combine_hashes(value.hash_one(random_state), *hash)` pattern already used by the surrounding generic and dictionary paths. `seeded_state` itself is unchanged and still used by the byte-view hash paths.

Doc comment on `hash_array_primitive` updated to match the new behavior.

## Are these changes tested?

Covered by existing tests in `datafusion-common::hash_utils`, including the multi-column hash tests:

- `cargo test -p datafusion-common hash_utils`
- `cargo clippy -p datafusion-common --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

No. This is an internal performance change with no API or behavioral impact — hash distribution properties are unchanged because `combine_hashes` is already the standard pattern in this file.