### PR TITLE
perf: combine_hashes for byte-view multi-column rehash

### DIFF
--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -345,9 +345,7 @@ fn hash_string_view_array_inner<
         // all views are inlined, no need to access external buffers
         if !HAS_BUFFERS || view_len <= 12 {
             if REHASH {
-                let mut hasher = seeded_state(*hash).build_hasher();
-                v.hash_write(&mut hasher);
-                *hash = hasher.finish();
+                *hash = combine_hashes(v.hash_one(random_state), *hash);
             } else {
                 *hash = v.hash_one(random_state);
             }
@@ -356,9 +354,7 @@ fn hash_string_view_array_inner<
         // view is not inlined, so we need to hash the bytes as well
         let value = view_bytes(view_len, v);
         if REHASH {
-            let mut hasher = seeded_state(*hash).build_hasher();
-            value.hash_write(&mut hasher);
-            *hash = hasher.finish();
+            *hash = combine_hashes(value.hash_one(random_state), *hash);
         } else {
             *hash = value.hash_one(random_state);
         }
@@ -390,9 +386,7 @@ fn hash_generic_byte_view_array<T: ByteViewType>(
         }
         (false, false, true) => {
             for (hash, &view) in hashes_buffer.iter_mut().zip(array.views().iter()) {
-                let mut hasher = seeded_state(*hash).build_hasher();
-                view.hash_write(&mut hasher);
-                *hash = hasher.finish();
+                *hash = combine_hashes(view.hash_one(random_state), *hash);
             }
         }
         (false, true, false) => hash_string_view_array_inner::<T, false, true, false>(


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No issue yet; happy to file one if preferred. -->

- Closes #.

## Rationale for this change

When multiple group keys participate in a grouped aggregate, `create_hashes` walks the columns left-to-right and rehashes each row by combining the current value's hash with the previously accumulated row hash. The generic variable-width path (`hash_array`) and the dictionary path (`hash_dictionary_array`) already do this with `combine_hashes(value.hash_one(random_state), *hash)`. The byte-view paths (`hash_string_view_array_inner` and the no-buffers rehash arm of `hash_generic_byte_view_array`) instead construct a fresh `foldhash::fast::SeedableRandomState` per row, seeded from the previous hash, and run the value through that. That approach is heavier on the hot loop and isn't necessary for correctness — the same hash distribution is achievable with `combine_hashes`.

The motivating workloads are ClickBench q16 and q17, which both group by `UserID, SearchPhrase`. `SearchPhrase` is a `Utf8View`, so the second column rehashes through `hash_string_view_array_inner` for every row. On current-main baselines of **1106.69 ms / 1127.64 ms** (`dfbench clickbench --query 16 --iterations 3` / `--query 17 --iterations 3`, partitioned dataset), 3-iteration runs with this change settled around:

| Query | Current main avg ms | Patched avg ms | Delta |
| --- | ---: | ---: | ---: |
| q16 | 1106.69 | 986.76 | **-10.8%** |
| q17 | 1127.64 | 1002.29 | **-11.1%** |

Guardrail single-query runs of other byte-view second-column rehash workloads (q14, q18, q39) did not regress.

This change is independent of, and stackable with, https://github.com/apache/datafusion/pull/22350 (the same idiom applied to `hash_array_primitive`). After both land, `seeded_state` becomes unused and can be removed in a small follow-up.

## What changes are included in this PR?

Replaces the three `seeded_state(...).build_hasher() / value.hash_write(...) / hasher.finish()` blocks in the byte-view rehash paths:

- `hash_string_view_array_inner`: inlined-view rehash branch and out-of-line bytes rehash branch
- `hash_generic_byte_view_array`: `(no nulls, no buffers, rehash)` specialization

Each is replaced with `combine_hashes(value.hash_one(random_state), *hash)`, matching the surrounding generic and dictionary paths. `seeded_state` itself and `hash_array_primitive` are unchanged.

## Are these changes tested?

Covered by existing tests in `datafusion-common::hash_utils`, including the multi-column / string-view tests:

- `cargo test -p datafusion-common hash_utils`
- `cargo clippy -p datafusion-common --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

No. This is an internal performance change with no API or behavioral impact — hash distribution properties are unchanged because `combine_hashes` is already the standard pattern in this file.