### PR TITLE
fix: make replace empty search string a no-op

### DIFF
--- a/datafusion/functions/src/string/replace.rs
+++ b/datafusion/functions/src/string/replace.rs
@@ -268,14 +268,7 @@ fn apply_replace<B: BulkNullStringArrayBuilder>(
     }
 
     if from.is_empty() {
-        // Empty `from`: insert `to` before each character and at both ends.
-        builder.append_with(|w| {
-            w.write_str(to);
-            for ch in string.chars() {
-                w.write_char(ch);
-                w.write_str(to);
-            }
-        });
+        builder.append_value(string);
         return;
     }
 

--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -426,6 +426,20 @@ SELECT replace(arrow_cast('foobar', 'LargeUtf8'), arrow_cast('bar', 'LargeUtf8')
 ----
 foohello
 
+query T
+SELECT replace('abc', '', 'x')
+----
+abc
+
+query T
+SELECT replace(arrow_cast('abc', 'Utf8View'), arrow_cast('', 'Utf8View'), arrow_cast('x', 'Utf8View'))
+----
+abc
+
+query T
+SELECT replace(arrow_cast('abc', 'LargeUtf8'), arrow_cast('', 'LargeUtf8'), arrow_cast('x', 'LargeUtf8'))
+----
+abc
 
 query T
 SELECT reverse('abcde')


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22253.

## Rationale for this change

PostgreSQL treats `replace` with an empty search string as a no-op. DataFusion currently inserts the replacement string around each character, so `replace('abc', '', 'x')` returns `xaxbxcx` instead of `abc`.

## What changes are included in this PR?

- Return the input string unchanged when the `from` argument to `replace` is empty.
- Add SQLLogicTest coverage for Utf8, Utf8View, and LargeUtf8 inputs.

## Are these changes tested?

- `git diff --check`
- I could not run Rust tests locally because this environment does not have `cargo`/`rustc` installed; the added SQLLogicTest cases are intended for CI verification.
