### PR TITLE
fix(optimizer): avoid planning-time regex compilation in regexp_like

### DIFF
--- a/datafusion/core/tests/optimizer/mod.rs
+++ b/datafusion/core/tests/optimizer/mod.rs
@@ -136,6 +136,37 @@ fn concat_ws_literals() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for https://github.com/apache/datafusion/issues/22185.
+///
+/// `regexp_like('aaaaa', 'a{5}{5}{5}{5}{5}{5}{5}{5}')` used to stall planning
+/// while `regex::Regex::new` walked the crate's `size_limit`. The optimizer
+/// should leave the expression intact and avoid that work during planning.
+#[test]
+fn regexp_like_pathological_pattern_does_not_stall_planning() {
+    let pattern = format!("a{}", "{5}".repeat(8));
+    let sql = format!("SELECT regexp_like('aaaaa', '{pattern}') AS m");
+
+    let t0 = datafusion_common::instant::Instant::now();
+    let plan = test_sql(&sql).expect("optimize should succeed");
+    let elapsed = t0.elapsed();
+
+    // 100ms is comfortably above the post-fix wall time (a few ms even on
+    // CI) and well below the >1s DoS reported on the issue.
+    assert!(
+        elapsed < std::time::Duration::from_millis(100),
+        "planning took {elapsed:?} (expected < 100ms)"
+    );
+
+    // The pattern must survive optimization, i.e. it was not const-folded to
+    // a literal boolean. Guards against a future change that re-enables
+    // regex constant folding for `regexp_like`.
+    let rendered = format!("{plan}");
+    assert!(
+        rendered.contains("a{5}"),
+        "pattern absent from optimized plan: {rendered}"
+    );
+}
+
 fn test_sql(sql: &str) -> Result<LogicalPlan> {
     // parse the SQL
     let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...
@@ -148,7 +179,8 @@ fn test_sql(sql: &str) -> Result<LogicalPlan> {
         .with_udf(datetime::now(&config))
         .with_udf(datafusion_functions::core::arrow_cast())
         .with_udf(datafusion_functions::string::concat())
-        .with_udf(datafusion_functions::string::concat_ws());
+        .with_udf(datafusion_functions::string::concat_ws())
+        .with_udf(datafusion_functions::regex::regexp_like());
     let sql_to_rel = SqlToRel::new(&context_provider);
     let plan = sql_to_rel.sql_statement_to_plan(statement.clone()).unwrap();
 

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -309,6 +309,11 @@ impl ScalarUDF {
         self.inner.short_circuits()
     }
 
+    /// See [`ScalarUDFImpl::should_const_evaluate`].
+    pub fn should_const_evaluate(&self) -> bool {
+        self.inner.should_const_evaluate()
+    }
+
     /// Computes the output interval for a [`ScalarUDF`], given the input
     /// intervals.
     ///
@@ -856,6 +861,15 @@ pub trait ScalarUDFImpl: Debug + DynEq + DynHash + Send + Sync + Any {
     /// lazily.
     fn short_circuits(&self) -> bool {
         false
+    }
+
+    /// Returns `true` (the default) if the simplifier may evaluate this
+    /// function when all arguments are constants. Override to `false` for
+    /// functions whose literal arguments can make planning-time evaluation too
+    /// expensive, such as regex functions that compile user-provided patterns.
+    /// Returning `false` defers evaluation to execution time.
+    fn should_const_evaluate(&self) -> bool {
+        true
     }
 
     /// Determines which of the arguments passed to this function are evaluated eagerly

--- a/datafusion/functions/src/regex/regexplike.rs
+++ b/datafusion/functions/src/regex/regexplike.rs
@@ -121,6 +121,13 @@ impl ScalarUDFImpl for RegexpLikeFunc {
         })
     }
 
+    /// Some literal patterns can make regex compilation too expensive during
+    /// planning. Skip constant folding so the cost is paid at execution time.
+    /// See https://github.com/apache/datafusion/issues/22185.
+    fn should_const_evaluate(&self) -> bool {
+        false
+    }
+
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let args = &args.args;
         match args.as_slice() {

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -645,6 +645,11 @@ impl ConstEvaluator {
             | Expr::Placeholder(_) => false,
             Expr::ScalarFunction(ScalarFunction { func, .. }) => {
                 Self::volatility_ok(func.signature().volatility)
+                    // Some UDFs (for example, regexp_like) opt out of
+                    // constant folding because planning-time evaluation can be
+                    // too expensive. See
+                    // https://github.com/apache/datafusion/issues/22185.
+                    && func.should_const_evaluate()
             }
             Expr::HigherOrderFunction(HigherOrderFunction { func, .. }) => {
                 Self::volatility_ok(func.signature().volatility)
@@ -677,6 +682,18 @@ impl ConstEvaluator {
                 }
                 true
             }
+            // Regex operators compile the right-hand pattern during
+            // evaluation. Avoid constant folding for literal patterns so
+            // planning does not pay that cost. See
+            // https://github.com/apache/datafusion/issues/22185.
+            Expr::BinaryExpr(BinaryExpr {
+                op:
+                    Operator::RegexMatch
+                    | Operator::RegexIMatch
+                    | Operator::RegexNotMatch
+                    | Operator::RegexNotIMatch,
+                ..
+            }) => false,
             Expr::Literal(_, _)
             | Expr::Alias(..)
             | Expr::Unnest(_)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #22185.

## Rationale for this change

Pathological literal regexes in `regexp_like` can spend a long time in planning.

Today the simplifier can constant-fold `regexp_like` with literal arguments, or fold the lowered regex operator on a later pass. Both paths compile the user-provided regex during  planning. For patterns like `a{5}{5}{5}{5}{5}{5}{5}{5}`, that can walk the regex crate's `size_limit` and burn planner CPU before any data is touched.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

  - add `ScalarUDFImpl::should_const_evaluate()` so scalar UDFs can opt out of constant folding
  - make `regexp_like` opt out of constant folding
  - make `ConstEvaluator` skip regex match binary operators
  - add a regression test that plans a pathological `regexp_like` query and checks the expression is preserved

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No api change

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
