### PR TITLE
feat: DuckDB-compatible glob expressions in listing-table paths (filesystem + s3/gs/http URLs)

### DIFF
--- a/datafusion/core/src/datasource/listing_table_factory.rs
+++ b/datafusion/core/src/datasource/listing_table_factory.rs
@@ -71,7 +71,7 @@ impl TableProviderFactory for ListingTableFactory {
             ))?
             .create(session_state, &cmd.options)?;
 
-        let mut table_path =
+        let table_path =
             ListingTableUrl::parse(&cmd.location)?.with_table_ref(cmd.name.clone());
         let file_extension = match table_path.is_collection() {
             // Setting the extension to be empty instead of allowing the default extension seems
@@ -152,24 +152,42 @@ impl TableProviderFactory for ListingTableFactory {
             // specifically for parquet file format.
             // See: https://github.com/apache/datafusion/issues/7317
             None => {
-                // if the folder then rewrite a file path as 'path/*.parquet'
-                // to only read the files the reader can understand
+                // If the location is a folder, filter the listing down
+                // to files the reader can understand by setting the file
+                // extension on the listing options.
+                //
+                // The historical approach was to inject a glob like
+                // `*.parquet` onto `table_path`, which doubled as both
+                // an extension filter *and* a way to gate the listing
+                // to top-level files when
+                // `listing_table_ignore_subdirectory` was true. Under
+                // DuckDB-compatible glob semantics a single-segment
+                // glob does not cross `/`, so injecting `*.parquet`
+                // would silently break recursion when the user turned
+                // `ignore_subdirectory` off. Using the explicit
+                // file-extension filter does the same filtering while
+                // leaving directory-recursion behaviour to
+                // `ListingTableUrl::contains`.
                 if table_path.is_folder() && table_path.get_glob().is_none() {
-                    // Since there are no files yet to infer an actual extension,
-                    // derive the pattern based on compression type.
-                    // So for gzipped CSV the pattern is `*.csv.gz`
-                    let glob = match options.format.compression_type() {
+                    // Derive the extension from the configured format /
+                    // compression so newly written files (none on disk
+                    // at table-creation time) are also matched; for
+                    // gzipped CSV this gives `.csv.gz`.
+                    let ext = match options.format.compression_type() {
                         Some(compression) => {
                             match options.format.get_ext_with_compression(&compression) {
-                                // Use glob based on `FileFormat` extension
-                                Ok(ext) => format!("*.{ext}"),
-                                // Fallback to `file_type`, if not supported by `FileFormat`
-                                Err(_) => format!("*.{}", cmd.file_type.to_lowercase()),
+                                Ok(ext) => ext,
+                                Err(_) => cmd.file_type.to_lowercase(),
                             }
                         }
-                        None => format!("*.{}", cmd.file_type.to_lowercase()),
+                        None => cmd.file_type.to_lowercase(),
                     };
-                    table_path = table_path.with_glob(glob.as_ref())?;
+                    let ext_with_dot = if ext.starts_with('.') {
+                        ext
+                    } else {
+                        format!(".{ext}")
+                    };
+                    options = options.with_file_extension(ext_with_dot);
                 }
                 let schema = options.infer_schema(session_state, &table_path).await?;
                 let df_schema = Arc::clone(&schema).to_dfschema()?;
@@ -234,7 +252,6 @@ mod tests {
     use datafusion_execution::cache::file_statistics_cache::DefaultFileStatisticsCache;
     use datafusion_execution::config::SessionConfig;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
-    use glob::Pattern;
     use std::collections::HashMap;
     use std::fs;
     use std::fs::File;
@@ -342,12 +359,15 @@ mod tests {
         assert_eq!(csv_options.compression, CompressionTypeVariant::GZIP);
 
         let listing_options = listing_table.options();
-        assert_eq!("", listing_options.file_extension);
-        // Glob pattern is set to search for gzipped files
+        // The folder LOCATION configures extension-based filtering on
+        // the listing options (`.csv.gz` here) instead of injecting a
+        // glob into the URL; that keeps DuckDB-compatible glob
+        // semantics from interfering with `ignore_subdirectory`.
+        assert_eq!(".csv.gz", listing_options.file_extension);
         let table_path = listing_table.table_paths().first().unwrap();
-        assert_eq!(
-            table_path.get_glob().clone().unwrap(),
-            Pattern::new("*.csv.gz").unwrap()
+        assert!(
+            table_path.get_glob().is_none(),
+            "folder LOCATION should not auto-add a glob to the URL",
         );
     }
 
@@ -380,12 +400,14 @@ mod tests {
         let listing_table = table_provider.downcast_ref::<ListingTable>().unwrap();
 
         let listing_options = listing_table.options();
-        assert_eq!("", listing_options.file_extension);
-        // Glob pattern is set to search for gzipped files
+        // See `test_create_using_folder_with_compression` — folder
+        // LOCATION values filter by extension on the listing options
+        // rather than by a glob on the URL.
+        assert_eq!(".csv", listing_options.file_extension);
         let table_path = listing_table.table_paths().first().unwrap();
-        assert_eq!(
-            table_path.get_glob().clone().unwrap(),
-            Pattern::new("*.csv").unwrap()
+        assert!(
+            table_path.get_glob().is_none(),
+            "folder LOCATION should not auto-add a glob to the URL",
         );
     }
 
@@ -414,7 +436,9 @@ mod tests {
         let listing_table = table_provider.downcast_ref::<ListingTable>().unwrap();
 
         let listing_options = listing_table.options();
-        assert_eq!("", listing_options.file_extension);
+        // Folder LOCATION → the factory now sets the extension on the
+        // listing options instead of injecting a glob into the URL.
+        assert_eq!(".parquet", listing_options.file_extension);
     }
 
     #[tokio::test]

--- a/datafusion/datasource/src/listing_glob.rs
+++ b/datafusion/datasource/src/listing_glob.rs
@@ -15,13 +15,39 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Helpers for detecting and splitting glob expressions inside listing-table
-//! paths and URLs.
+//! Helpers for detecting, splitting, and matching glob expressions inside
+//! listing-table paths and URLs.
 //!
 //! This module owns the small surface that decides what counts as a glob
-//! expression in a path (`?`, `*`, `[`), and how to split a path into a
-//! literal listing prefix and the trailing glob pattern. Behaviour matching
-//! and `glob::Pattern` construction live in [`crate::url`].
+//! expression in a path (`?`, `*`, `[`), how to split a path into a
+//! literal listing prefix and the trailing glob pattern, and the
+//! [`glob::MatchOptions`] used to match listed object-store paths against
+//! the pattern. `glob::Pattern` construction itself lives in [`crate::url`].
+
+use std::borrow::Cow;
+
+use glob::MatchOptions;
+
+/// Glob matching options used when checking listed object-store paths
+/// against an explicit glob in a [`crate::url::ListingTableUrl`].
+///
+/// These mirror DuckDB's filesystem glob semantics:
+///
+/// * `*` matches any characters within a single path segment and does
+///   **not** cross `/`.
+/// * `**` is required to match across directory levels (matches zero or
+///   more directory components).
+/// * `?` matches exactly one non-separator character.
+/// * `[abc]` / `[a-z]` matches one character from a class.
+///
+/// Hidden files (segments starting with `.`) are not auto-excluded;
+/// DataFusion's object-store listing does not special-case them either,
+/// so this options struct mirrors that for consistency.
+pub(crate) const LISTING_GLOB_MATCH_OPTIONS: MatchOptions = MatchOptions {
+    case_sensitive: true,
+    require_literal_separator: true,
+    require_literal_leading_dot: false,
+};
 
 /// Characters whose presence in a path segment marks the start of a glob
 /// expression: `?` (single character), `*` (any characters), `[` (character
@@ -55,9 +81,85 @@ pub(crate) fn split_glob_expression(path: &str) -> Option<(&str, &str)> {
     None
 }
 
+/// Normalize OS-specific path separators in a glob pattern to `/` so that
+/// the pattern can be matched against object-store paths (which always
+/// use `/` as the delimiter).
+///
+/// On Unix this is a no-op. On Windows the raw glob substring returned
+/// by [`split_glob_expression`] may contain `\`, because
+/// [`std::path::is_separator`] treats `\` as a separator on that
+/// platform.
+pub(crate) fn normalize_glob_separators(glob: &str) -> Cow<'_, str> {
+    if cfg!(windows) && glob.contains('\\') {
+        Cow::Owned(glob.replace('\\', "/"))
+    } else {
+        Cow::Borrowed(glob)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use glob::Pattern;
+
+    /// Verifies the `LISTING_GLOB_MATCH_OPTIONS` reproduces DuckDB's
+    /// glob semantics for paths and patterns produced by
+    /// [`split_glob_expression`]. The expected results were
+    /// cross-checked against `duckdb` v1.5.2 on the same inputs.
+    #[test]
+    fn test_listing_glob_match_options_duckdb_parity() {
+        fn m(pat: &str, s: &str) -> bool {
+            Pattern::new(pat)
+                .unwrap()
+                .matches_with(s, LISTING_GLOB_MATCH_OPTIONS)
+        }
+
+        // `*` does not cross `/`
+        assert!(m("abc*123.parquet", "abc_X_123.parquet"));
+        assert!(m("abc*123.parquet", "abc123.parquet")); // `*` matches empty
+        assert!(!m("abc*123.parquet", "sub/abc_S_123.parquet"));
+        assert!(!m("*123.parquet", "sub/abc_S_123.parquet"));
+
+        // `**` matches zero or more directory components
+        assert!(m("**/abc*123.parquet", "abc_X_123.parquet"));
+        assert!(m("**/abc*123.parquet", "sub/abc_S_123.parquet"));
+        assert!(m("**/abc*123.parquet", "a/b/abc_X_123.parquet"));
+
+        // partition-style (`key=value`) directories match literally
+        assert!(m("**/abc*123.parquet", "year=2021/abc_X_123.parquet"));
+        assert!(m("year=*/abc*123.parquet", "year=2021/abc_X_123.parquet"));
+
+        // `*` occupies exactly one directory segment
+        assert!(m("*/abc*123.parquet", "year=2021/abc_X_123.parquet"));
+        assert!(!m("*/abc*123.parquet", "a/b/abc_X_123.parquet"));
+
+        // `?` matches exactly one non-separator character
+        assert!(m("abc?123.parquet", "abcX123.parquet"));
+        assert!(!m("abc?123.parquet", "abc123.parquet"));
+        assert!(!m("abc?123.parquet", "abcXY123.parquet"));
+
+        // character classes
+        assert!(m("abc[X9]*.parquet", "abc999.parquet"));
+        assert!(m("abc[X9]*.parquet", "abcX123.parquet"));
+        assert!(!m("abc[X9]*.parquet", "abcZ123.parquet"));
+    }
+
+    #[test]
+    fn test_normalize_glob_separators() {
+        assert!(matches!(
+            normalize_glob_separators("**/x.parquet"),
+            Cow::Borrowed("**/x.parquet")
+        ));
+        // Unix paths never contain `\`, so it is preserved as a literal.
+        if !cfg!(windows) {
+            assert!(matches!(
+                normalize_glob_separators("a\\b*.parquet"),
+                Cow::Borrowed("a\\b*.parquet")
+            ));
+        } else {
+            assert_eq!(normalize_glob_separators("**\\x.parquet"), "**/x.parquet");
+        }
+    }
 
     #[test]
     fn test_split_glob() {

--- a/datafusion/datasource/src/listing_glob.rs
+++ b/datafusion/datasource/src/listing_glob.rs
@@ -97,6 +97,36 @@ pub(crate) fn normalize_glob_separators(glob: &str) -> Cow<'_, str> {
     }
 }
 
+/// Locate the byte index at which the path component of a URL string
+/// begins, so callers can apply [`split_glob_expression`] to the raw
+/// path *before* `Url::parse` runs (URL parsing eats `?` as the
+/// query-string delimiter and would otherwise prevent globs that use
+/// `?` from being detected in remote-store URLs).
+///
+/// Returns `None` if the string contains no `://` scheme separator at
+/// all. For a URL with a scheme but no path (e.g. `s3://bucket`),
+/// returns `s.len()` — the path is the empty suffix.
+///
+/// The authority (the segment between `://` and the first path `/`)
+/// may include an IPv6 host enclosed in `[...]`; `/` characters inside
+/// the brackets are ignored when locating the path start.
+pub(crate) fn find_url_path_start(s: &str) -> Option<usize> {
+    let after_scheme = s.find("://")? + 3;
+    let bytes = s.as_bytes();
+    let mut i = after_scheme;
+    let mut in_brackets = false;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'[' => in_brackets = true,
+            b']' => in_brackets = false,
+            b'/' if !in_brackets => return Some(i),
+            _ => {}
+        }
+        i += 1;
+    }
+    Some(bytes.len())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,6 +189,36 @@ mod tests {
         } else {
             assert_eq!(normalize_glob_separators("**\\x.parquet"), "**/x.parquet");
         }
+    }
+
+    #[test]
+    fn test_find_url_path_start() {
+        fn split(s: &str) -> Option<(&str, &str)> {
+            find_url_path_start(s).map(|i| (&s[..i], &s[i..]))
+        }
+        assert_eq!(
+            split("s3://bucket/p/*.parquet"),
+            Some(("s3://bucket", "/p/*.parquet"))
+        );
+        // `s3://bucket` — no path component
+        assert_eq!(split("s3://bucket"), Some(("s3://bucket", "")));
+        // `file:///foo` — empty authority, path starts at the third `/`
+        assert_eq!(
+            split("file:///foo/**/x.parquet"),
+            Some(("file://", "/foo/**/x.parquet"))
+        );
+        // IPv6 host — `/` inside `[...]` is part of the authority,
+        // not the start of the path
+        assert_eq!(
+            split("http://[::1]:8080/p/*.parquet"),
+            Some(("http://[::1]:8080", "/p/*.parquet"))
+        );
+        assert_eq!(
+            split("http://[::1]/p/*.parquet"),
+            Some(("http://[::1]", "/p/*.parquet"))
+        );
+        // No scheme separator
+        assert_eq!(find_url_path_start("/local/path/*.parquet"), None);
     }
 
     #[test]

--- a/datafusion/datasource/src/listing_glob.rs
+++ b/datafusion/datasource/src/listing_glob.rs
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Helpers for detecting and splitting glob expressions inside listing-table
+//! paths and URLs.
+//!
+//! This module owns the small surface that decides what counts as a glob
+//! expression in a path (`?`, `*`, `[`), and how to split a path into a
+//! literal listing prefix and the trailing glob pattern. Behaviour matching
+//! and `glob::Pattern` construction live in [`crate::url`].
+
+/// Characters whose presence in a path segment marks the start of a glob
+/// expression: `?` (single character), `*` (any characters), `[` (character
+/// class).
+pub(crate) const GLOB_START_CHARS: [char; 3] = ['?', '*', '['];
+
+/// Splits `path` at the first path segment containing a glob expression,
+/// returning `None` if no glob expression is found.
+///
+/// The returned tuple is `(literal_prefix, glob_pattern)` where
+/// `literal_prefix` is suitable for passing to an object-store `list` call
+/// and `glob_pattern` is the trailing portion to match against listed paths.
+///
+/// Path delimiters are determined using [`std::path::is_separator`], which
+/// permits `/` as a path delimiter even on Windows platforms.
+pub(crate) fn split_glob_expression(path: &str) -> Option<(&str, &str)> {
+    let mut last_separator = 0;
+
+    for (byte_idx, char) in path.char_indices() {
+        if GLOB_START_CHARS.contains(&char) {
+            if last_separator == 0 {
+                return Some((".", path));
+            }
+            return Some(path.split_at(last_separator));
+        }
+
+        if std::path::is_separator(char) {
+            last_separator = byte_idx + char.len_utf8();
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_glob() {
+        fn test(input: &str, expected: Option<(&str, &str)>) {
+            assert_eq!(
+                split_glob_expression(input),
+                expected,
+                "testing split_glob_expression with {input}"
+            );
+        }
+
+        // no glob patterns
+        test("/", None);
+        test("/a.txt", None);
+        test("/a", None);
+        test("/a/", None);
+        test("/a/b", None);
+        test("/a/b/", None);
+        test("/a/b.txt", None);
+        test("/a/b/c.txt", None);
+        // glob patterns, thus we build the longest path (os-specific)
+        test("*.txt", Some((".", "*.txt")));
+        test("/*.txt", Some(("/", "*.txt")));
+        test("/a/*b.txt", Some(("/a/", "*b.txt")));
+        test("/a/*/b.txt", Some(("/a/", "*/b.txt")));
+        test("/a/b/[123]/file*.txt", Some(("/a/b/", "[123]/file*.txt")));
+        test("/a/b*.txt", Some(("/a/", "b*.txt")));
+        test("/a/b/**/c*.txt", Some(("/a/b/", "**/c*.txt")));
+
+        // https://github.com/apache/datafusion/issues/2465
+        test(
+            "/a/b/c//alltypes_plain*.parquet",
+            Some(("/a/b/c//", "alltypes_plain*.parquet")),
+        );
+    }
+}

--- a/datafusion/datasource/src/mod.rs
+++ b/datafusion/datasource/src/mod.rs
@@ -37,6 +37,8 @@ pub mod file_groups;
 pub mod file_scan_config;
 pub mod file_sink_config;
 pub mod file_stream;
+#[cfg(not(target_arch = "wasm32"))]
+mod listing_glob;
 pub mod memory;
 pub mod morsel;
 pub mod projection;

--- a/datafusion/datasource/src/mod.rs
+++ b/datafusion/datasource/src/mod.rs
@@ -822,6 +822,70 @@ mod tests {
         assert!(url.contains(&Path::parse("/var/data/mytable/").unwrap(), false));
     }
 
+    /// Covers the glob arm of [`ListingTableUrl::contains`] end-to-end:
+    /// the path-with-glob string is parsed, then synthetic file paths are
+    /// matched against it. Asserts DuckDB-compatible semantics and that
+    /// `ignore_subdirectory` is ignored once an explicit glob is present.
+    #[test]
+    fn test_url_contains_glob() {
+        let cases: &[(&str, &[(&str, bool)])] = &[
+            // `*` does not cross `/`
+            (
+                "/var/data/mytable/*.parquet",
+                &[
+                    ("/var/data/mytable/file.parquet", true),
+                    ("/var/data/mytable/sub/file.parquet", false),
+                    ("/var/data/mytable/file.csv", false),
+                ],
+            ),
+            // `**` recurses, matching zero or more directory levels
+            (
+                "/var/data/mytable/**/*.parquet",
+                &[
+                    ("/var/data/mytable/file.parquet", true),
+                    ("/var/data/mytable/sub/file.parquet", true),
+                    ("/var/data/mytable/a/b/c/file.parquet", true),
+                    ("/var/data/mytable/file.csv", false),
+                ],
+            ),
+            // partition-style `key=value` dirs are matched literally,
+            // unlike the no-glob arm which skips them
+            (
+                "/var/data/mytable/year=*/file.parquet",
+                &[
+                    ("/var/data/mytable/year=2024/file.parquet", true),
+                    ("/var/data/mytable/year=2025/file.parquet", true),
+                    ("/var/data/mytable/month=01/file.parquet", false),
+                    ("/var/data/mytable/file.parquet", false),
+                ],
+            ),
+            // `*` spans exactly one directory segment
+            (
+                "/var/data/mytable/*/file.parquet",
+                &[
+                    ("/var/data/mytable/sub/file.parquet", true),
+                    ("/var/data/mytable/a/b/file.parquet", false),
+                ],
+            ),
+        ];
+
+        for (pattern, checks) in cases {
+            let url = ListingTableUrl::parse(pattern).unwrap();
+            for (path, expected) in *checks {
+                let p = Path::parse(path).unwrap();
+                // With an explicit glob, `ignore_subdirectory` is not
+                // consulted, so both values must agree with `expected`.
+                for ignore in [true, false] {
+                    assert_eq!(
+                        url.contains(&p, ignore),
+                        *expected,
+                        "pattern={pattern} path={path} ignore_subdirectory={ignore}"
+                    );
+                }
+            }
+        }
+    }
+
     /// Regression test for <https://github.com/apache/datafusion/issues/19605>
     #[tokio::test]
     async fn test_calculate_range_single_line_file() {

--- a/datafusion/datasource/src/mod.rs
+++ b/datafusion/datasource/src/mod.rs
@@ -886,6 +886,82 @@ mod tests {
         }
     }
 
+    /// Round-trips scheme URLs (s3://, gs://, file://, http(s)://)
+    /// through [`ListingTableUrl::parse`] and asserts the detected
+    /// glob and listing prefix match the user's intent. URL paths
+    /// previously had no glob detection at all.
+    #[test]
+    fn test_url_parse_glob_in_scheme_urls() {
+        // (input, expected scheme, expected prefix (as_ref), expected glob string or None)
+        let cases: &[(&str, &str, &str, Option<&str>)] = &[
+            // s3 + recursive. object_store `Path` strips the trailing
+            // `/`, so the listing prefix is `data` not `data/`.
+            (
+                "s3://bucket/data/**/x.parquet",
+                "s3",
+                "data",
+                Some("**/x.parquet"),
+            ),
+            // s3 + filename glob — prefix is the bucket root (empty
+            // path).
+            ("s3://bucket/*.parquet", "s3", "", Some("*.parquet")),
+            // gs:// with directory-segment wildcard
+            (
+                "gs://bucket/year=*/part-*.parquet",
+                "gs",
+                "",
+                Some("year=*/part-*.parquet"),
+            ),
+            // file:// URL with glob — works the same as a path
+            (
+                "file:///foo/**/x.parquet",
+                "file",
+                "foo",
+                Some("**/x.parquet"),
+            ),
+            // http(s) with IPv6 host
+            (
+                "https://[::1]:8080/data/*.parquet",
+                "https",
+                "data",
+                Some("*.parquet"),
+            ),
+            // No glob in path — preserved verbatim
+            (
+                "s3://bucket/data/file.parquet",
+                "s3",
+                "data/file.parquet",
+                None,
+            ),
+            // `?` is reserved for the URL query delimiter even though
+            // it would be a glob char in a filesystem path. Path
+            // glob is `None`, query is preserved in the URL.
+            ("https://host.example/p?a=b", "https", "p", None),
+            // Percent-encoded `*` is literal, not a glob
+            ("s3://bucket/data/%2A.parquet", "s3", "data/*.parquet", None),
+        ];
+
+        for (input, scheme, prefix, expected_glob) in cases {
+            let url = ListingTableUrl::parse(input)
+                .unwrap_or_else(|e| panic!("failed to parse {input}: {e}"));
+            assert_eq!(url.scheme(), *scheme, "scheme mismatch for {input}");
+            assert_eq!(
+                url.prefix().as_ref(),
+                *prefix,
+                "prefix mismatch for {input}"
+            );
+            match (url.get_glob(), expected_glob) {
+                (Some(g), Some(want)) => {
+                    assert_eq!(g.as_str(), *want, "glob mismatch for {input}",)
+                }
+                (None, None) => {}
+                (got, want) => {
+                    panic!("glob mismatch for {input}: got={got:?} want={want:?}",)
+                }
+            }
+        }
+    }
+
     /// Regression test for <https://github.com/apache/datafusion/issues/19605>
     #[tokio::test]
     async fn test_calculate_range_single_line_file() {

--- a/datafusion/datasource/src/url.rs
+++ b/datafusion/datasource/src/url.rs
@@ -19,7 +19,9 @@ use std::sync::Arc;
 
 use crate::listing_glob::LISTING_GLOB_MATCH_OPTIONS;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::listing_glob::{normalize_glob_separators, split_glob_expression};
+use crate::listing_glob::{
+    find_url_path_start, normalize_glob_separators, split_glob_expression,
+};
 use datafusion_common::{DataFusionError, Result, TableReference};
 use datafusion_execution::cache::TableScopedPath;
 use datafusion_execution::cache::cache_manager::CachedFileList;
@@ -93,16 +95,36 @@ impl ListingTableUrl {
     /// of ambiguity it is recommended users always include trailing `/` when intending to
     /// refer to a directory.
     ///
-    /// ## Glob File Paths
+    /// ## Glob Expressions
     ///
-    /// If no scheme is provided, and the path contains a glob expression, it will
-    /// be resolved as follows.
+    /// Glob expressions (`*`, `**`, `?`, `[abc]`) are supported in both
+    /// scheme-less filesystem paths and scheme URLs (e.g.
+    /// `s3://bucket/data/**/x.parquet`, `file:///foo/*.parquet`).
     ///
-    /// The string up to the first path segment containing a glob expression will be extracted,
-    /// and resolved in the same manner as a normal scheme-less path above.
+    /// The string up to the first path segment containing a glob
+    /// character will be extracted as the literal listing prefix
+    /// (passed to `ObjectStore::list`). The remaining string will be
+    /// interpreted as a [`glob::Pattern`] and used to filter the
+    /// listed paths.
     ///
-    /// The remaining string will be interpreted as a [`glob::Pattern`] and used as a
-    /// filter when listing files from object storage
+    /// Match semantics mirror DuckDB's filesystem glob:
+    ///
+    /// * `*` matches any characters within a single path segment; it
+    ///   does **not** cross `/`.
+    /// * `**` matches zero or more directory levels (required for
+    ///   recursion across subdirectories).
+    /// * `?` matches exactly one non-separator character. **Only in
+    ///   scheme-less paths** — in scheme URLs, `?` is reserved for the
+    ///   URL query delimiter; use `[abc]` or `*` to match arbitrary
+    ///   single characters in remote-store globs.
+    /// * `[abc]` / `[a-z]` matches one character from the class.
+    /// * Partition-style `key=value` directory segments are matched
+    ///   literally (e.g. `year=*/x.parquet`).
+    ///
+    /// When an explicit glob is present, the
+    /// `datafusion.execution.listing_table_ignore_subdirectory`
+    /// session option is **not** consulted — the pattern is
+    /// authoritative.
     ///
     /// [file URI]: https://en.wikipedia.org/wiki/File_URI_scheme
     /// [URL]: https://url.spec.whatwg.org/
@@ -116,11 +138,61 @@ impl ListingTableUrl {
         }
 
         match Url::parse(s) {
+            #[cfg(not(target_arch = "wasm32"))]
+            Ok(_) => Self::parse_url(s),
+            #[cfg(target_arch = "wasm32")]
             Ok(url) => Self::try_new(url, None),
             #[cfg(not(target_arch = "wasm32"))]
             Err(url::ParseError::RelativeUrlWithoutBase) => Self::parse_path(s),
             Err(e) => Err(DataFusionError::External(Box::new(e))),
         }
+    }
+
+    /// Creates a new [`ListingTableUrl`] from a string that
+    /// [`Url::parse`] accepts, detecting any trailing glob expression
+    /// in the *path* component (the segment between the authority and
+    /// the optional `?query`/`#fragment`).
+    ///
+    /// We split on the raw input string rather than on the parsed URL
+    /// because `Url::parse` strips path information into structured
+    /// components, but we want the literal text to feed into
+    /// [`split_glob_expression`].
+    ///
+    /// `?` is **not** treated as a glob wildcard inside scheme URLs —
+    /// it is reserved for the URL query delimiter to avoid ambiguity
+    /// with HTTP-style queries (e.g. `https://host/p?a=b`). The other
+    /// wildcards (`*`, `**`, `[abc]`) are unaffected and remain the
+    /// recommended way to glob remote-store paths.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn parse_url(s: &str) -> Result<Self> {
+        let Some(path_start) = find_url_path_start(s) else {
+            // Should be unreachable: `Url::parse` accepted `s`, so a
+            // `://` separator must be present.
+            let url =
+                Url::parse(s).map_err(|e| DataFusionError::External(Box::new(e)))?;
+            return Self::try_new(url, None);
+        };
+        let after_authority = &s[path_start..];
+        // Slice the URL path off at the first `?` (query) or `#`
+        // (fragment) so glob detection only sees the structural path.
+        let path_end = after_authority
+            .find(['?', '#'])
+            .unwrap_or(after_authority.len());
+        let path = &after_authority[..path_end];
+        let suffix = &after_authority[path_end..];
+
+        let (prefix, glob) = match split_glob_expression(path) {
+            Some((prefix, glob)) => {
+                let glob = Pattern::new(&normalize_glob_separators(glob))
+                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                (prefix, Some(glob))
+            }
+            None => (path, None),
+        };
+        let reconstructed = format!("{}{}{}", &s[..path_start], prefix, suffix);
+        let url = Url::parse(&reconstructed)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Self::try_new(url, glob)
     }
 
     /// Creates a new [`ListingTableUrl`] interpreting `s` as a filesystem path
@@ -180,7 +252,7 @@ impl ListingTableUrl {
     ///
     /// When an explicit glob is present, it is matched against the full
     /// relative path below this URL's prefix using DuckDB-compatible
-    /// semantics (see [`LISTING_GLOB_MATCH_OPTIONS`]): `*` does not cross
+    /// semantics: `*` does not cross
     /// `/`, `**` is required for recursion, partition-style `key=value`
     /// directory segments are matched literally, and the
     /// `ignore_subdirectory` option is **not** consulted — the explicit

--- a/datafusion/datasource/src/url.rs
+++ b/datafusion/datasource/src/url.rs
@@ -17,6 +17,8 @@
 
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
+use crate::listing_glob::split_glob_expression;
 use datafusion_common::{DataFusionError, Result, TableReference};
 use datafusion_execution::cache::TableScopedPath;
 use datafusion_execution::cache::cache_manager::CachedFileList;
@@ -479,33 +481,6 @@ impl std::fmt::Display for ListingTableUrl {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-const GLOB_START_CHARS: [char; 3] = ['?', '*', '['];
-
-/// Splits `path` at the first path segment containing a glob expression, returning
-/// `None` if no glob expression found.
-///
-/// Path delimiters are determined using [`std::path::is_separator`] which
-/// permits `/` as a path delimiter even on Windows platforms.
-#[cfg(not(target_arch = "wasm32"))]
-fn split_glob_expression(path: &str) -> Option<(&str, &str)> {
-    let mut last_separator = 0;
-
-    for (byte_idx, char) in path.char_indices() {
-        if GLOB_START_CHARS.contains(&char) {
-            if last_separator == 0 {
-                return Some((".", path));
-            }
-            return Some(path.split_at(last_separator));
-        }
-
-        if std::path::is_separator(char) {
-            last_separator = byte_idx + char.len_utf8();
-        }
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -627,41 +602,6 @@ mod tests {
 
         let path = Path::from("other/bar/partition/foo.parquet");
         assert!(url.strip_prefix(&path).is_none());
-    }
-
-    #[test]
-    fn test_split_glob() {
-        fn test(input: &str, expected: Option<(&str, &str)>) {
-            assert_eq!(
-                split_glob_expression(input),
-                expected,
-                "testing split_glob_expression with {input}"
-            );
-        }
-
-        // no glob patterns
-        test("/", None);
-        test("/a.txt", None);
-        test("/a", None);
-        test("/a/", None);
-        test("/a/b", None);
-        test("/a/b/", None);
-        test("/a/b.txt", None);
-        test("/a/b/c.txt", None);
-        // glob patterns, thus we build the longest path (os-specific)
-        test("*.txt", Some((".", "*.txt")));
-        test("/*.txt", Some(("/", "*.txt")));
-        test("/a/*b.txt", Some(("/a/", "*b.txt")));
-        test("/a/*/b.txt", Some(("/a/", "*/b.txt")));
-        test("/a/b/[123]/file*.txt", Some(("/a/b/", "[123]/file*.txt")));
-        test("/a/b*.txt", Some(("/a/", "b*.txt")));
-        test("/a/b/**/c*.txt", Some(("/a/b/", "**/c*.txt")));
-
-        // https://github.com/apache/datafusion/issues/2465
-        test(
-            "/a/b/c//alltypes_plain*.parquet",
-            Some(("/a/b/c//", "alltypes_plain*.parquet")),
-        );
     }
 
     #[test]

--- a/datafusion/datasource/src/url.rs
+++ b/datafusion/datasource/src/url.rs
@@ -17,8 +17,9 @@
 
 use std::sync::Arc;
 
+use crate::listing_glob::LISTING_GLOB_MATCH_OPTIONS;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::listing_glob::split_glob_expression;
+use crate::listing_glob::{normalize_glob_separators, split_glob_expression};
 use datafusion_common::{DataFusionError, Result, TableReference};
 use datafusion_execution::cache::TableScopedPath;
 use datafusion_execution::cache::cache_manager::CachedFileList;
@@ -127,7 +128,10 @@ impl ListingTableUrl {
     fn parse_path(s: &str) -> Result<Self> {
         let (path, glob) = match split_glob_expression(s) {
             Some((prefix, glob)) => {
-                let glob = Pattern::new(glob)
+                // On Windows the glob substring can contain `\` because
+                // [`std::path::is_separator`] treats it as a separator;
+                // object-store paths always use `/`, so normalize here.
+                let glob = Pattern::new(&normalize_glob_separators(glob))
                     .map_err(|e| DataFusionError::External(Box::new(e)))?;
                 (prefix, Some(glob))
             }
@@ -173,31 +177,40 @@ impl ListingTableUrl {
     }
 
     /// Returns `true` if `path` matches this [`ListingTableUrl`]
+    ///
+    /// When an explicit glob is present, it is matched against the full
+    /// relative path below this URL's prefix using DuckDB-compatible
+    /// semantics (see [`LISTING_GLOB_MATCH_OPTIONS`]): `*` does not cross
+    /// `/`, `**` is required for recursion, partition-style `key=value`
+    /// directory segments are matched literally, and the
+    /// `ignore_subdirectory` option is **not** consulted — the explicit
+    /// pattern is authoritative.
+    ///
+    /// When no glob is present, `ignore_subdirectory` controls whether
+    /// the listing recurses; `key=value` segments (Hive partition dirs)
+    /// are still followed in either case so that partitioned tables work.
     pub fn contains(&self, path: &Path, ignore_subdirectory: bool) -> bool {
-        let Some(all_segments) = self.strip_prefix(path) else {
+        let Some(mut all_segments) = self.strip_prefix(path) else {
             return false;
         };
 
-        // remove any segments that contain `=` as they are allowed even
-        // when ignore subdirectories is `true`.
-        let mut segments = all_segments.filter(|s| !s.contains('='));
-
         match &self.glob {
             Some(glob) => {
-                if ignore_subdirectory {
-                    segments
-                        .next()
-                        .is_some_and(|file_name| glob.matches(file_name))
-                } else {
-                    let stripped = segments.join(DELIMITER);
-                    glob.matches(&stripped)
-                }
+                // Explicit glob: match the full relative path (including
+                // any `key=value` segments). `ignore_subdirectory` is
+                // intentionally ignored — `*`/`**` in the pattern fully
+                // describe the user's intent re: directory traversal.
+                let stripped = all_segments.join(DELIMITER);
+                glob.matches_with(&stripped, LISTING_GLOB_MATCH_OPTIONS)
             }
-            // where we are ignoring subdirectories, we require
-            // the path to be either empty, or contain just the
-            // final file name segment.
-            None if ignore_subdirectory => segments.count() <= 1,
-            // in this case, any valid path at or below the url is allowed
+            // No glob: when ignoring subdirectories, only the final file
+            // segment is accepted, but `key=value` (Hive partition)
+            // segments are skipped so partitioned tables still work.
+            None if ignore_subdirectory => {
+                all_segments.filter(|s| !s.contains('=')).count() <= 1
+            }
+            // No glob and recursion permitted: any valid path at or
+            // below the URL is allowed.
             None => true,
         }
     }

--- a/datafusion/sqllogictest/test_files/dynamic_file.slt
+++ b/datafusion/sqllogictest/test_files/dynamic_file.slt
@@ -265,3 +265,52 @@ SELECT id, CAST(string_col AS varchar) FROM '../../parquet-testing/data/alltypes
 3 1
 0 0
 1 1
+
+# Glob expressions in dynamic-file paths (DuckDB-compatible
+# semantics). The `CREATE EXTERNAL TABLE` equivalents live in
+# `glob.slt`.
+
+statement ok
+CREATE TABLE glob_seed2(id INT) AS VALUES (1), (2);
+
+statement ok
+CREATE TABLE glob_seed3(id INT) AS VALUES (1), (2), (3);
+
+query I
+COPY (SELECT * FROM glob_seed2) TO 'test_files/scratch/dynamic_file/glob/top1.parquet' STORED AS PARQUET;
+----
+2
+
+query I
+COPY (SELECT * FROM glob_seed2) TO 'test_files/scratch/dynamic_file/glob/top2.parquet' STORED AS PARQUET;
+----
+2
+
+query I
+COPY (SELECT * FROM glob_seed3) TO 'test_files/scratch/dynamic_file/glob/nested/a/b/deep.parquet' STORED AS PARQUET;
+----
+3
+
+# `*` does not cross `/`: only the two top-level files match.
+query I
+SELECT count(*) FROM 'test_files/scratch/dynamic_file/glob/*.parquet';
+----
+4
+
+# `**` recurses across directory levels.
+query I
+SELECT count(*) FROM 'test_files/scratch/dynamic_file/glob/**/deep.parquet';
+----
+3
+
+# Character classes work.
+query I
+SELECT count(*) FROM 'test_files/scratch/dynamic_file/glob/top[12].parquet';
+----
+4
+
+statement ok
+DROP TABLE glob_seed2;
+
+statement ok
+DROP TABLE glob_seed3;

--- a/datafusion/sqllogictest/test_files/glob.slt
+++ b/datafusion/sqllogictest/test_files/glob.slt
@@ -1,0 +1,200 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+# End-to-end glob semantics for `CREATE EXTERNAL TABLE ... LOCATION
+# '<path-with-glob>'`. Match semantics mirror DuckDB's filesystem
+# glob — cross-checked against duckdb v1.5.2 on the same inputs.
+# See `ListingTableUrl::parse` for the spec.
+#
+# Fixture layout (rows per file in parentheses):
+#
+#   test_files/scratch/glob/top1.parquet                    (2)
+#   test_files/scratch/glob/top2.parquet                    (2)
+#   test_files/scratch/glob/nested/a/b/deep.parquet         (3)
+#   test_files/scratch/glob/nested/x/y/deep.parquet         (5)
+#   test_files/scratch/glob/parts/year=2021/d.parquet       (5)
+#   test_files/scratch/glob/parts/year=2022/d.parquet       (7)
+#
+# `SELECT * FROM '<path-with-glob>'` (dynamic-file table) requires
+# `enable_url_table` on the SessionContext (see `dynamic_file.slt`),
+# which the default sqllogictest runner does not enable. URL-parse
+# coverage for `s3://`/`gs://`/`file://` lives in the Rust unit
+# test `mod::tests::test_url_parse_glob_in_scheme_urls`.
+##########
+
+# Fixture setup -------------------------------------------------------
+
+statement ok
+CREATE TABLE seed2(id INT) AS VALUES (1), (2);
+
+statement ok
+CREATE TABLE seed3(id INT) AS VALUES (1), (2), (3);
+
+statement ok
+CREATE TABLE seed5(id INT) AS VALUES (1), (2), (3), (4), (5);
+
+statement ok
+CREATE TABLE seed7(id INT) AS VALUES (1), (2), (3), (4), (5), (6), (7);
+
+query I
+COPY (SELECT * FROM seed2) TO 'test_files/scratch/glob/top1.parquet' STORED AS PARQUET;
+----
+2
+
+query I
+COPY (SELECT * FROM seed2) TO 'test_files/scratch/glob/top2.parquet' STORED AS PARQUET;
+----
+2
+
+query I
+COPY (SELECT * FROM seed3) TO 'test_files/scratch/glob/nested/a/b/deep.parquet' STORED AS PARQUET;
+----
+3
+
+query I
+COPY (SELECT * FROM seed5) TO 'test_files/scratch/glob/nested/x/y/deep.parquet' STORED AS PARQUET;
+----
+5
+
+query I
+COPY (SELECT * FROM seed5) TO 'test_files/scratch/glob/parts/year=2021/d.parquet' STORED AS PARQUET;
+----
+5
+
+query I
+COPY (SELECT * FROM seed7) TO 'test_files/scratch/glob/parts/year=2022/d.parquet' STORED AS PARQUET;
+----
+7
+
+# `*` does NOT cross `/` -----------------------------------------------
+
+statement ok
+CREATE EXTERNAL TABLE g_star
+STORED AS PARQUET
+LOCATION 'test_files/scratch/glob/*.parquet';
+
+# Only the two top-level files; subdir files are excluded.
+query I
+SELECT count(*) FROM g_star;
+----
+4
+
+# `ignore_subdirectory` is NOT consulted when an explicit glob is
+# present (the pattern is authoritative). Both values must agree.
+statement ok
+set datafusion.execution.listing_table_ignore_subdirectory = false;
+
+query I
+SELECT count(*) FROM g_star;
+----
+4
+
+statement ok
+set datafusion.execution.listing_table_ignore_subdirectory = true;
+
+# `**` recurses across zero or more directory levels ------------------
+
+statement ok
+CREATE EXTERNAL TABLE g_recursive
+STORED AS PARQUET
+LOCATION 'test_files/scratch/glob/nested/**/deep.parquet';
+
+query I
+SELECT count(*) FROM g_recursive;
+----
+8
+
+# `*` spans exactly one directory segment -----------------------------
+
+statement ok
+CREATE EXTERNAL TABLE g_single_dir
+STORED AS PARQUET
+LOCATION 'test_files/scratch/glob/parts/*/d.parquet';
+
+query I
+SELECT count(*) FROM g_single_dir;
+----
+12
+
+# Partition-style `key=value` dirs are matched LITERALLY --------------
+
+statement ok
+CREATE EXTERNAL TABLE g_partition_glob
+STORED AS PARQUET
+LOCATION 'test_files/scratch/glob/parts/year=*/d.parquet';
+
+query I
+SELECT count(*) FROM g_partition_glob;
+----
+12
+
+# Character classes ---------------------------------------------------
+
+statement ok
+CREATE EXTERNAL TABLE g_class
+STORED AS PARQUET
+LOCATION 'test_files/scratch/glob/top[12].parquet';
+
+query I
+SELECT count(*) FROM g_class;
+----
+4
+
+# `?` single-character wildcard (filesystem paths only) ---------------
+
+statement ok
+CREATE EXTERNAL TABLE g_question
+STORED AS PARQUET
+LOCATION 'test_files/scratch/glob/top?.parquet';
+
+query I
+SELECT count(*) FROM g_question;
+----
+4
+
+# Cleanup -------------------------------------------------------------
+
+statement ok
+DROP TABLE g_star;
+
+statement ok
+DROP TABLE g_recursive;
+
+statement ok
+DROP TABLE g_single_dir;
+
+statement ok
+DROP TABLE g_partition_glob;
+
+statement ok
+DROP TABLE g_class;
+
+statement ok
+DROP TABLE g_question;
+
+statement ok
+DROP TABLE seed2;
+
+statement ok
+DROP TABLE seed3;
+
+statement ok
+DROP TABLE seed5;
+
+statement ok
+DROP TABLE seed7;

--- a/datafusion/sqllogictest/test_files/parquet.slt
+++ b/datafusion/sqllogictest/test_files/parquet.slt
@@ -300,9 +300,27 @@ select count(*) from listing_table;
 statement ok
 set datafusion.execution.listing_table_ignore_subdirectory = false;
 
-# scan file: 0.parquet 1.parquet 2.parquet 3.parquet
+# An explicit glob is authoritative under DuckDB-compatible semantics:
+# `*` does not cross `/`, so `*.parquet` matches the three top-level
+# files but NOT `subdir/3.parquet`, regardless of
+# `listing_table_ignore_subdirectory`. To include subdir/3.parquet, use
+# `**/*.parquet` (see `listing_table_recursive` below) or point at the
+# directory without a glob.
+# scan file: 0.parquet 1.parquet 2.parquet
 query I
 select count(*) from listing_table;
+----
+9
+
+# Recursive variant — `**` is required to cross directory levels.
+statement ok
+CREATE EXTERNAL TABLE listing_table_recursive
+STORED AS PARQUET
+LOCATION 'test_files/scratch/parquet/test_table/**/*.parquet';
+
+# scan file: 0.parquet 1.parquet 2.parquet subdir/3.parquet
+query I
+select count(*) from listing_table_recursive;
 ----
 12
 

--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -25,6 +25,48 @@
 in this section pertains to features and changes that have already been merged
 to the main branch and are awaiting release in this version.
 
+### Glob expressions in listing-table paths use DuckDB-compatible semantics
+
+Glob expressions in `LOCATION` (for `CREATE EXTERNAL TABLE`) and in the
+dynamic `SELECT * FROM '<path>'` form now match DuckDB:
+
+- `*` matches characters within a **single path segment** and no longer
+  crosses `/`. Use `**` for recursion across subdirectory levels.
+- Glob expressions are also detected inside scheme URLs
+  (`s3://bucket/data/**/x.parquet`, `file:///foo/*.parquet`), where
+  they were previously treated as literal object names.
+- Partition-style `key=value` directory segments are matched literally
+  (`year=*/file.parquet` works as expected).
+- When an explicit glob is present, the
+  `datafusion.execution.listing_table_ignore_subdirectory` session
+  option is **not** consulted — the pattern is authoritative.
+
+**Migration:** if you were relying on `*` crossing `/` (only possible
+under the non-default `listing_table_ignore_subdirectory = false`),
+switch to `**`. For example, change
+
+```sql
+LOCATION '/data/*.parquet'
+-- with listing_table_ignore_subdirectory = false (previously also
+-- read subdir/x.parquet)
+```
+
+to
+
+```sql
+LOCATION '/data/**/*.parquet'
+```
+
+Folder-style `LOCATION` values without a glob are unchanged and
+continue to recurse based on `listing_table_ignore_subdirectory`. The
+full supported syntax and
+limitations are documented in [datasources.md](../../user-guide/cli/datasources.md#glob-expressions-in-paths).
+
+Library callers: `ListingTableUrl::contains` now matches the full
+relative path against the glob (rather than just the first segment)
+and uses `glob::MatchOptions { require_literal_separator: true, .. }`.
+The public signature is unchanged.
+
 ### `AggregateFunctionExpr::human_display()` now returns `Option<&str>`
 
 `datafusion_physical_expr::aggregate::AggregateFunctionExpr::human_display()`

--- a/docs/source/user-guide/cli/datasources.md
+++ b/docs/source/user-guide/cli/datasources.md
@@ -100,9 +100,7 @@ additional configuration options.
 # `CREATE EXTERNAL TABLE`
 
 It is also possible to create a table backed by files or remote locations via
-`CREATE EXTERNAL TABLE` as shown below. Note that DataFusion does not support
-wildcards (e.g. `*`) in file paths; instead, specify the directory path directly
-to read all compatible files in that directory.
+`CREATE EXTERNAL TABLE` as shown below.
 
 For example, to create a table `hits` backed by a local parquet file named `hits.parquet`:
 
@@ -132,35 +130,48 @@ select count(*) from hits;
 1 row in set. Query took 0.344 seconds.
 ```
 
-**Why Wildcards Are Not Supported**
+## Glob expressions in paths
 
-Although wildcards (e.g., _.parquet or \*\*/_.parquet) may work for local
-filesystems in some cases, they are not supported by DataFusion CLI. This
-is because wildcards are not universally applicable across all storage backends
-(e.g., S3, GCS). Instead, DataFusion expects the user to specify the directory
-path, and it will automatically read all compatible files within that directory.
+`LOCATION` (and the dynamic `SELECT * FROM '<path>'` form) supports glob
+expressions in both local filesystem paths and scheme URLs (`s3://`,
+`gs://`, `file://`, `https://`, ...). Match semantics follow DuckDB's
+filesystem glob:
 
-For example, the following usage is not supported:
+| Wildcard         | Meaning                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `*`              | matches any characters within a single path segment; does **not** cross `/`                                                                      |
+| `**`             | matches zero or more directory levels (use this for recursion)                                                                                   |
+| `?`              | matches exactly one non-separator character. Filesystem paths only — in scheme URLs `?` is reserved for the query delimiter; use `[abc]` or `*`. |
+| `[abc]`, `[a-z]` | matches one character from the class                                                                                                             |
+| `key=value` dirs | matched literally, so partition-style globs like `year=*/file.parquet` work                                                                      |
 
-```sql
-CREATE EXTERNAL TABLE test (
-    message TEXT,
-    day DATE
-)
-STORED AS PARQUET
-LOCATION 'gs://bucket/*.parquet';
-```
-
-Instead, you should use:
+Examples:
 
 ```sql
-CREATE EXTERNAL TABLE test (
-    message TEXT,
-    day DATE
-)
-STORED AS PARQUET
-LOCATION 'gs://bucket/my_table/';
+-- Top-level files only (`*` does not cross `/`).
+CREATE EXTERNAL TABLE t1 STORED AS PARQUET
+LOCATION '/data/events/*.parquet';
+
+-- Recursive over any subdirectory depth.
+CREATE EXTERNAL TABLE t2 STORED AS PARQUET
+LOCATION '/data/events/**/*.parquet';
+
+-- Glob over Hive partition directories.
+CREATE EXTERNAL TABLE t3 STORED AS PARQUET
+LOCATION 's3://bucket/events/year=*/month=*/*.parquet';
+
+-- Same forms work for ad-hoc queries:
+SELECT count(*) FROM '/data/events/**/*.parquet';
 ```
+
+When an explicit glob is present, the
+`datafusion.execution.listing_table_ignore_subdirectory` session option
+is **not** consulted — the pattern is authoritative. The option still
+governs bare-directory listings (`LOCATION '/data/events/'`), where
+`true` (the default) restricts to top-level files and `false` recurses.
+
+Brace expansion (`{a,b}`) is not supported, matching DuckDB. To union
+multiple distinct locations, create separate tables or use `UNION ALL`.
 
 When specifying a directory path that has a Hive compliant partition structure, by default, DataFusion CLI will
 automatically parse and incorporate the Hive columns and their values into the table's schema and data. Given the


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #. <!-- TODO: link tracking issue -->

## Rationale for this change

DuckDB supports rich glob expressions in file paths (`SELECT * FROM '/data/**/x.parquet'`, `CREATE EXTERNAL TABLE … LOCATION '/data/**/x.parquet'`), and DataFusion users routinely expect the same. Today DataFusion has *most* of the glob infrastructure (`glob::Pattern`, `ListingTableUrl` prefix splitting), but the matching semantics diverge from DuckDB in two important ways:

1. **`*` crosses `/`.** DataFusion uses the `glob` crate's default `MatchOptions` (`require_literal_separator: false`), so `*.parquet` will silently match `subdir/3.parquet` under `listing_table_ignore_subdirectory = false`. DuckDB only crosses `/` for `**`.
2. **Recursive globs silently return wrong results under the default config.** With `listing_table_ignore_subdirectory = true` (default) and an explicit glob, `ListingTableUrl::contains` only matched the glob against the *first* path segment. That meant `/data/**/x.parquet` returned only top-level matches and silently dropped everything under any subdirectory — no error, just wrong counts.
3. Globs are not detected at all inside scheme URLs, so `s3://bucket/**/x.parquet` was treated as a literal object name.

This PR brings DataFusion's listing-table glob semantics into line with DuckDB (verified empirically against duckdb v1.5.2 on the same patterns and paths) for both filesystem paths and scheme URLs.

## What changes are included in this PR?

Five small, reviewable, stacked commits, each builds green on its own:

1. **`refactor(datasource)`** — Extract `split_glob_expression` (and its unit tests) from `url.rs` into a new `datafusion/datasource/src/listing_glob.rs` module. No behaviour change; sets up the subsequent commits.
2. **`feat(datasource): DuckDB-compatible glob semantics`** — Add `LISTING_GLOB_MATCH_OPTIONS` (`require_literal_separator: true`) and `normalize_glob_separators` (Windows `\` → `/`). Rewrite `ListingTableUrl::contains` to match the **full relative path** with these options when an explicit glob is present, and to ignore `listing_table_ignore_subdirectory` (the pattern is authoritative). Stop injecting an auto-glob in `ListingTableFactory` for folder LOCATIONs — that injection broke `ignore_subdirectory=false` recursion under the new `*`-doesn't-cross-`/` semantics; the extension filter on the listing options does the same job without breaking recursion.
3. **`feat(datasource): detect globs in scheme URLs`** — Add `find_url_path_start` (handles IPv6 hosts via `[...]` bracket tracking) and a new `parse_url` path that glob-splits the raw URL path *before* `Url::parse` runs (so glob characters like `?` don't get consumed as the URL query delimiter). The URL path is sliced at the first `?` or `#` so HTTP-style queries are preserved.
4. **`test(sqllogictest)`** — New `datafusion/sqllogictest/test_files/glob.slt` end-to-end exercising `*` not-crossing-`/`, `**` recursive, single-segment `*/dir`, partition-style `year=*/x.parquet`, character classes, and `?` — through `CREATE EXTERNAL TABLE`. Equivalent dynamic-file (`SELECT * FROM '<glob>'`) coverage added to `dynamic_file.slt` (which carries the `enable_url_table` SessionContext flag).
5. **`docs`** — Rewrite the (previously incorrect) wildcard section in `docs/source/user-guide/cli/datasources.md` with the supported syntax, examples, and the `?`-vs-URL-query caveat. Upgrade-guide entry in `54.0.0.md`.

### Semantics summary

| Wildcard         | Meaning                                                                                            |
| ---------------- | -------------------------------------------------------------------------------------------------- |
| `*`              | any chars within a single segment; does **not** cross `/`                                          |
| `**`             | zero or more directory levels                                                                      |
| `?`              | exactly one non-separator char. Filesystem paths only — reserved for URL query delimiter in scheme URLs |
| `[abc]`, `[a-z]` | one char from class                                                                                |
| `key=value` dirs | matched literally, so `year=*/x.parquet` works                                                     |

### Justifiable differences from DuckDB

- **`?` not supported in scheme URLs** — it is the URL query delimiter and the ambiguity with HTTP-style queries (`https://host/p?a=b`) is worse than the limitation. Use `[abc]` or `*` for single-char matching in remote globs. `?` continues to work as a glob in scheme-less filesystem paths.
- **Braces `{a,b}` not supported** — DuckDB doesn't support them either; use separate tables or `UNION ALL`.

### Breaking change

`*` no longer crosses `/`. Blast radius is small (only manifests under non-default `listing_table_ignore_subdirectory = false`, and the previous behaviour was already non-standard and DuckDB-incompatible). Existing `parquet.slt` glob test updated and a sibling `**/*.parquet` test added that returns the full set. The upgrade guide has migration guidance.

## Are these changes tested?

Yes:

- **Rust unit tests** in `listing_glob.rs` cover `LISTING_GLOB_MATCH_OPTIONS` (cross-checked against duckdb v1.5.2 directly), `find_url_path_start` (s3, file, http, IPv6), `split_glob_expression`, and separator normalisation.
- **`test_url_contains_glob`** and **`test_url_parse_glob_in_scheme_urls`** in `datafusion/datasource/src/mod.rs` cover the public-API `contains()` and `parse()` end-to-end including partition-dir globs, percent-encoded literals, URL-query preservation, and IPv6 hosts.
- **`glob.slt`** is a new end-to-end sqllogictest covering all DuckDB-target cases through `CREATE EXTERNAL TABLE`.
- **`dynamic_file.slt`** extended with the `SELECT * FROM '<glob>'` equivalents.
- **Factory unit tests** (`test_create_using_folder_{with,without}_compression`, `test_odd_directory_names`) updated to assert the new contract — folder LOCATIONs set `file_extension` on the listing options and leave `url.glob` as `None`.
- **Empirical end-to-end** against the built `datafusion-cli` on a nested local filesystem fixture, every count matched DuckDB's reference output.

## Are there any user-facing changes?

Yes — see the **Breaking change** section above and the new upgrade-guide entry at `docs/source/library-user-guide/upgrading/54.0.0.md`. Tagging this PR with the `api change` label.

Library callers: `ListingTableUrl::contains` now matches the full relative path against the glob (rather than just the first segment) and uses `glob::MatchOptions { require_literal_separator: true, .. }`. Public signatures are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
