### PR TITLE
Refactor Spark `format_string` integer conversion dispatch

### DIFF
--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -891,6 +891,9 @@ fn unsigned_to_char(value: u64) -> Result<char> {
     codepoint_to_char(codepoint)
 }
 
+/// Normalizes integer scalar payloads while preserving Spark formatting semantics:
+/// signed values format as decimal for `%d` / `%s` / `%c`, but use their original
+/// bit width for `%x` / `%o` via `unsigned_bits`.
 #[derive(Debug, Clone, Copy)]
 enum IntegerValue {
     Signed { decimal: i64, unsigned_bits: u64 },

--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -898,13 +898,6 @@ enum IntegerValue {
 }
 
 impl IntegerValue {
-    fn decimal(self) -> IntegerFormatValue {
-        match self {
-            Self::Signed { decimal, .. } => IntegerFormatValue::Signed(decimal),
-            Self::Unsigned(value) => IntegerFormatValue::Unsigned(value),
-        }
-    }
-
     fn unsigned_bits(self) -> u64 {
         match self {
             Self::Signed { unsigned_bits, .. } => unsigned_bits,
@@ -918,21 +911,58 @@ impl IntegerValue {
             Self::Unsigned(value) => unsigned_to_char(value),
         }
     }
-}
 
-enum IntegerFormatValue {
-    Signed(i64),
-    Unsigned(u64),
-}
-
-impl std::fmt::Display for IntegerFormatValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn format_decimal(
+        self,
+        spec: &ConversionSpecifier,
+        writer: &mut String,
+    ) -> Result<()> {
         match self {
-            Self::Signed(value) => write!(f, "{value}"),
-            Self::Unsigned(value) => write!(f, "{value}"),
+            Self::Signed { decimal, .. } => spec.format_signed(writer, decimal),
+            Self::Unsigned(value) => spec.format_unsigned(writer, value),
+        }
+    }
+
+    fn decimal_string(self) -> String {
+        match self {
+            Self::Signed { decimal, .. } => decimal.to_string(),
+            Self::Unsigned(value) => value.to_string(),
         }
     }
 }
+
+macro_rules! signed_integer_value {
+    ($source:ty, $unsigned:ty) => {
+        impl From<$source> for IntegerValue {
+            fn from(value: $source) -> Self {
+                Self::Signed {
+                    decimal: value as i64,
+                    unsigned_bits: (value as $unsigned) as u64,
+                }
+            }
+        }
+    };
+}
+
+signed_integer_value!(i8, u8);
+signed_integer_value!(i16, u16);
+signed_integer_value!(i32, u32);
+signed_integer_value!(i64, u64);
+
+macro_rules! unsigned_integer_value {
+    ($source:ty) => {
+        impl From<$source> for IntegerValue {
+            fn from(value: $source) -> Self {
+                Self::Unsigned(value as u64)
+            }
+        }
+    };
+}
+
+unsigned_integer_value!(u8);
+unsigned_integer_value!(u16);
+unsigned_integer_value!(u32);
+unsigned_integer_value!(u64);
 
 impl ConversionSpecifier {
     /// Validates that the grouping separator flag is not used with scientific
@@ -966,56 +996,14 @@ impl ConversionSpecifier {
 
                 _ => self.format_boolean(string, value),
             },
-            ScalarValue::Int8(value) => self.format_integer(
-                string,
-                value.map(|value| IntegerValue::Signed {
-                    decimal: value as i64,
-                    unsigned_bits: (value as u8) as u64,
-                }),
-                "Int8",
-            ),
-            ScalarValue::Int16(value) => self.format_integer(
-                string,
-                value.map(|value| IntegerValue::Signed {
-                    decimal: value as i64,
-                    unsigned_bits: (value as u16) as u64,
-                }),
-                "Int16",
-            ),
-            ScalarValue::Int32(value) => self.format_integer(
-                string,
-                value.map(|value| IntegerValue::Signed {
-                    decimal: value as i64,
-                    unsigned_bits: (value as u32) as u64,
-                }),
-                "Int32",
-            ),
-            ScalarValue::Int64(value) => self.format_integer(
-                string,
-                value.map(|value| IntegerValue::Signed {
-                    decimal: value,
-                    unsigned_bits: value as u64,
-                }),
-                "Int64",
-            ),
-            ScalarValue::UInt8(value) => self.format_integer(
-                string,
-                value.map(|value| IntegerValue::Unsigned(value as u64)),
-                "UInt8",
-            ),
-            ScalarValue::UInt16(value) => self.format_integer(
-                string,
-                value.map(|value| IntegerValue::Unsigned(value as u64)),
-                "UInt16",
-            ),
-            ScalarValue::UInt32(value) => self.format_integer(
-                string,
-                value.map(|value| IntegerValue::Unsigned(value as u64)),
-                "UInt32",
-            ),
-            ScalarValue::UInt64(value) => {
-                self.format_integer(string, value.map(IntegerValue::Unsigned), "UInt64")
-            }
+            ScalarValue::Int8(value) => self.format_integer(string, value, "Int8"),
+            ScalarValue::Int16(value) => self.format_integer(string, value, "Int16"),
+            ScalarValue::Int32(value) => self.format_integer(string, value, "Int32"),
+            ScalarValue::Int64(value) => self.format_integer(string, value, "Int64"),
+            ScalarValue::UInt8(value) => self.format_integer(string, value, "UInt8"),
+            ScalarValue::UInt16(value) => self.format_integer(string, value, "UInt16"),
+            ScalarValue::UInt32(value) => self.format_integer(string, value, "UInt32"),
+            ScalarValue::UInt64(value) => self.format_integer(string, value, "UInt64"),
             ScalarValue::Float16(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecFloatLower
@@ -1377,31 +1365,25 @@ impl ConversionSpecifier {
         }
     }
 
-    fn format_integer(
+    fn format_integer<T>(
         &self,
         writer: &mut String,
-        value: Option<IntegerValue>,
+        value: &Option<T>,
         type_name: &str,
-    ) -> Result<()> {
-        let Some(value) = value else {
+    ) -> Result<()>
+    where
+        T: Copy + Into<IntegerValue>,
+    {
+        let Some(value) = value.map(Into::into) else {
             return if self.conversion_type.supports_integer() {
                 self.format_string(writer, "null")
             } else {
-                exec_err!(
-                    "Invalid conversion type: {:?} for {}",
-                    self.conversion_type,
-                    type_name
-                )
+                self.invalid_integer_conversion(type_name)
             };
         };
 
         match self.conversion_type {
-            ConversionType::DecInt => match value.decimal() {
-                IntegerFormatValue::Signed(value) => self.format_signed(writer, value),
-                IntegerFormatValue::Unsigned(value) => {
-                    self.format_unsigned(writer, value)
-                }
-            },
+            ConversionType::DecInt => value.format_decimal(self, writer),
             ConversionType::HexIntLower
             | ConversionType::HexIntUpper
             | ConversionType::OctInt => {
@@ -1411,14 +1393,18 @@ impl ConversionSpecifier {
                 self.format_char(writer, value.to_char()?)
             }
             ConversionType::StringLower | ConversionType::StringUpper => {
-                self.format_string(writer, &value.decimal().to_string())
+                self.format_string(writer, &value.decimal_string())
             }
-            _ => exec_err!(
-                "Invalid conversion type: {:?} for {}",
-                self.conversion_type,
-                type_name
-            ),
+            _ => self.invalid_integer_conversion(type_name),
         }
+    }
+
+    fn invalid_integer_conversion<T>(&self, type_name: &str) -> Result<T> {
+        exec_err!(
+            "Invalid conversion type: {:?} for {}",
+            self.conversion_type,
+            type_name
+        )
     }
 
     fn format_hex_float(&self, writer: &mut String, value: f64) -> Result<()> {
@@ -2528,54 +2514,66 @@ mod tests {
     #[test]
     fn test_integer_formatting_across_widths() -> Result<()> {
         let cases = [
-            (ScalarValue::Int8(Some(-1)), "%d|%x|%o|%s", "-1|ff|377|-1"),
+            (
+                ScalarValue::Int8(Some(-1)),
+                "%d|%x|%o|%s",
+                4,
+                "-1|ff|377|-1",
+            ),
             (
                 ScalarValue::Int16(Some(-1)),
                 "%d|%x|%o|%s",
+                4,
                 "-1|ffff|177777|-1",
             ),
             (
                 ScalarValue::Int32(Some(-1)),
                 "%d|%x|%o|%s",
+                4,
                 "-1|ffffffff|37777777777|-1",
             ),
             (
                 ScalarValue::Int64(Some(-1)),
                 "%d|%x|%o|%s",
+                4,
                 "-1|ffffffffffffffff|1777777777777777777777|-1",
             ),
             (
                 ScalarValue::UInt8(Some(255)),
                 "%d|%x|%o|%s|%c",
+                5,
                 "255|ff|377|255|ÿ",
             ),
             (
                 ScalarValue::UInt16(Some(65535)),
                 "%d|%x|%o|%s",
+                4,
                 "65535|ffff|177777|65535",
             ),
             (
                 ScalarValue::UInt32(Some(u32::MAX)),
                 "%d|%x|%o|%s",
+                4,
                 "4294967295|ffffffff|37777777777|4294967295",
             ),
             (
                 ScalarValue::UInt64(Some(u64::MAX)),
                 "%d|%x|%o|%s",
+                4,
                 "18446744073709551615|ffffffffffffffff|1777777777777777777777|18446744073709551615",
             ),
             (
                 ScalarValue::Int32(None),
                 "%d|%x|%o|%s|%c",
+                5,
                 "null|null|null|null|null",
             ),
         ];
 
-        for (value, fmt, expected) in cases {
-            let data_types =
-                vec![value.data_type(); fmt.chars().filter(|c| *c == '%').count()];
+        for (value, fmt, arg_count, expected) in cases {
+            let data_types = vec![value.data_type(); arg_count];
             let formatter = Formatter::parse(fmt, &data_types)?;
-            let args = vec![value; data_types.len()];
+            let args = vec![value; arg_count];
             assert_eq!(formatter.format(&args)?, expected, "{fmt}");
         }
         Ok(())

--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -891,20 +891,46 @@ fn unsigned_to_char(value: u64) -> Result<char> {
     codepoint_to_char(codepoint)
 }
 
-/// Convert a non-null integer scalar to a [`char`] for the `%c` conversion.
-fn integer_scalar_to_char(scalar: &ScalarValue) -> Result<char> {
-    match scalar {
-        ScalarValue::Int8(Some(value)) => signed_to_char(*value as i64),
-        ScalarValue::Int16(Some(value)) => signed_to_char(*value as i64),
-        ScalarValue::Int32(Some(value)) => signed_to_char(*value as i64),
-        ScalarValue::Int64(Some(value)) => signed_to_char(*value),
-        ScalarValue::UInt8(Some(value)) => unsigned_to_char(*value as u64),
-        ScalarValue::UInt16(Some(value)) => unsigned_to_char(*value as u64),
-        ScalarValue::UInt32(Some(value)) => unsigned_to_char(*value as u64),
-        ScalarValue::UInt64(Some(value)) => unsigned_to_char(*value),
-        _ => datafusion_common::internal_err!(
-            "integer_scalar_to_char expects a non-null integer scalar, got {scalar:?}"
-        ),
+#[derive(Debug, Clone, Copy)]
+enum IntegerValue {
+    Signed { decimal: i64, unsigned_bits: u64 },
+    Unsigned(u64),
+}
+
+impl IntegerValue {
+    fn decimal(self) -> IntegerFormatValue {
+        match self {
+            Self::Signed { decimal, .. } => IntegerFormatValue::Signed(decimal),
+            Self::Unsigned(value) => IntegerFormatValue::Unsigned(value),
+        }
+    }
+
+    fn unsigned_bits(self) -> u64 {
+        match self {
+            Self::Signed { unsigned_bits, .. } => unsigned_bits,
+            Self::Unsigned(value) => value,
+        }
+    }
+
+    fn to_char(self) -> Result<char> {
+        match self {
+            Self::Signed { decimal, .. } => signed_to_char(decimal),
+            Self::Unsigned(value) => unsigned_to_char(value),
+        }
+    }
+}
+
+enum IntegerFormatValue {
+    Signed(i64),
+    Unsigned(u64),
+}
+
+impl std::fmt::Display for IntegerFormatValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Signed(value) => write!(f, "{value}"),
+            Self::Unsigned(value) => write!(f, "{value}"),
+        }
     }
 }
 
@@ -940,189 +966,56 @@ impl ConversionSpecifier {
 
                 _ => self.format_boolean(string, value),
             },
-            ScalarValue::Int8(Some(_))
-            | ScalarValue::Int16(Some(_))
-            | ScalarValue::Int32(Some(_))
-            | ScalarValue::Int64(Some(_))
-            | ScalarValue::UInt8(Some(_))
-            | ScalarValue::UInt16(Some(_))
-            | ScalarValue::UInt32(Some(_))
-            | ScalarValue::UInt64(Some(_))
-                if matches!(
-                    self.conversion_type,
-                    ConversionType::CharLower | ConversionType::CharUpper
-                ) =>
-            {
-                self.format_char(string, integer_scalar_to_char(value)?)
+            ScalarValue::Int8(value) => self.format_integer(
+                string,
+                value.map(|value| IntegerValue::Signed {
+                    decimal: value as i64,
+                    unsigned_bits: (value as u8) as u64,
+                }),
+                "Int8",
+            ),
+            ScalarValue::Int16(value) => self.format_integer(
+                string,
+                value.map(|value| IntegerValue::Signed {
+                    decimal: value as i64,
+                    unsigned_bits: (value as u16) as u64,
+                }),
+                "Int16",
+            ),
+            ScalarValue::Int32(value) => self.format_integer(
+                string,
+                value.map(|value| IntegerValue::Signed {
+                    decimal: value as i64,
+                    unsigned_bits: (value as u32) as u64,
+                }),
+                "Int32",
+            ),
+            ScalarValue::Int64(value) => self.format_integer(
+                string,
+                value.map(|value| IntegerValue::Signed {
+                    decimal: value,
+                    unsigned_bits: value as u64,
+                }),
+                "Int64",
+            ),
+            ScalarValue::UInt8(value) => self.format_integer(
+                string,
+                value.map(|value| IntegerValue::Unsigned(value as u64)),
+                "UInt8",
+            ),
+            ScalarValue::UInt16(value) => self.format_integer(
+                string,
+                value.map(|value| IntegerValue::Unsigned(value as u64)),
+                "UInt16",
+            ),
+            ScalarValue::UInt32(value) => self.format_integer(
+                string,
+                value.map(|value| IntegerValue::Unsigned(value as u64)),
+                "UInt32",
+            ),
+            ScalarValue::UInt64(value) => {
+                self.format_integer(string, value.map(IntegerValue::Unsigned), "UInt64")
             }
-            ScalarValue::Int8(value) => match (self.conversion_type, value) {
-                (ConversionType::DecInt, Some(value)) => {
-                    self.format_signed(string, *value as i64)
-                }
-                (
-                    ConversionType::HexIntLower
-                    | ConversionType::HexIntUpper
-                    | ConversionType::OctInt,
-                    Some(value),
-                ) => self.format_unsigned(string, (*value as u8) as u64),
-                (
-                    ConversionType::StringLower | ConversionType::StringUpper,
-                    Some(value),
-                ) => self.format_string(string, &value.to_string()),
-                (t, None) if t.supports_integer() => self.format_string(string, "null"),
-                _ => {
-                    exec_err!(
-                        "Invalid conversion type: {:?} for Int8",
-                        self.conversion_type
-                    )
-                }
-            },
-            ScalarValue::Int16(value) => match (self.conversion_type, value) {
-                (ConversionType::DecInt, Some(value)) => {
-                    self.format_signed(string, *value as i64)
-                }
-                (
-                    ConversionType::HexIntLower
-                    | ConversionType::HexIntUpper
-                    | ConversionType::OctInt,
-                    Some(value),
-                ) => self.format_unsigned(string, (*value as u16) as u64),
-                (
-                    ConversionType::StringLower | ConversionType::StringUpper,
-                    Some(value),
-                ) => self.format_string(string, &value.to_string()),
-                (t, None) if t.supports_integer() => self.format_string(string, "null"),
-                _ => {
-                    exec_err!(
-                        "Invalid conversion type: {:?} for Int16",
-                        self.conversion_type
-                    )
-                }
-            },
-            ScalarValue::Int32(value) => match (self.conversion_type, value) {
-                (ConversionType::DecInt, Some(value)) => {
-                    self.format_signed(string, *value as i64)
-                }
-                (
-                    ConversionType::HexIntLower
-                    | ConversionType::HexIntUpper
-                    | ConversionType::OctInt,
-                    Some(value),
-                ) => self.format_unsigned(string, (*value as u32) as u64),
-                (
-                    ConversionType::StringLower | ConversionType::StringUpper,
-                    Some(value),
-                ) => self.format_string(string, &value.to_string()),
-                (t, None) if t.supports_integer() => self.format_string(string, "null"),
-                _ => {
-                    exec_err!(
-                        "Invalid conversion type: {:?} for Int32",
-                        self.conversion_type
-                    )
-                }
-            },
-            ScalarValue::Int64(value) => match (self.conversion_type, value) {
-                (ConversionType::DecInt, Some(value)) => {
-                    self.format_signed(string, *value)
-                }
-                (
-                    ConversionType::HexIntLower
-                    | ConversionType::HexIntUpper
-                    | ConversionType::OctInt,
-                    Some(value),
-                ) => self.format_unsigned(string, *value as u64),
-                (
-                    ConversionType::StringLower | ConversionType::StringUpper,
-                    Some(value),
-                ) => self.format_string(string, &value.to_string()),
-                (t, None) if t.supports_integer() => self.format_string(string, "null"),
-                _ => {
-                    exec_err!(
-                        "Invalid conversion type: {:?} for Int64",
-                        self.conversion_type
-                    )
-                }
-            },
-            ScalarValue::UInt8(value) => match (self.conversion_type, value) {
-                (
-                    ConversionType::DecInt
-                    | ConversionType::HexIntLower
-                    | ConversionType::HexIntUpper
-                    | ConversionType::OctInt,
-                    Some(value),
-                ) => self.format_unsigned(string, *value as u64),
-                (
-                    ConversionType::StringLower | ConversionType::StringUpper,
-                    Some(value),
-                ) => self.format_string(string, &value.to_string()),
-                (t, None) if t.supports_integer() => self.format_string(string, "null"),
-                _ => {
-                    exec_err!(
-                        "Invalid conversion type: {:?} for UInt8",
-                        self.conversion_type
-                    )
-                }
-            },
-            ScalarValue::UInt16(value) => match (self.conversion_type, value) {
-                (
-                    ConversionType::DecInt
-                    | ConversionType::HexIntLower
-                    | ConversionType::HexIntUpper
-                    | ConversionType::OctInt,
-                    Some(value),
-                ) => self.format_unsigned(string, *value as u64),
-                (
-                    ConversionType::StringLower | ConversionType::StringUpper,
-                    Some(value),
-                ) => self.format_string(string, &value.to_string()),
-                (t, None) if t.supports_integer() => self.format_string(string, "null"),
-                _ => {
-                    exec_err!(
-                        "Invalid conversion type: {:?} for UInt16",
-                        self.conversion_type
-                    )
-                }
-            },
-            ScalarValue::UInt32(value) => match (self.conversion_type, value) {
-                (
-                    ConversionType::DecInt
-                    | ConversionType::HexIntLower
-                    | ConversionType::HexIntUpper
-                    | ConversionType::OctInt,
-                    Some(value),
-                ) => self.format_unsigned(string, *value as u64),
-                (
-                    ConversionType::StringLower | ConversionType::StringUpper,
-                    Some(value),
-                ) => self.format_string(string, &value.to_string()),
-                (t, None) if t.supports_integer() => self.format_string(string, "null"),
-                _ => {
-                    exec_err!(
-                        "Invalid conversion type: {:?} for UInt32",
-                        self.conversion_type
-                    )
-                }
-            },
-            ScalarValue::UInt64(value) => match (self.conversion_type, value) {
-                (
-                    ConversionType::DecInt
-                    | ConversionType::HexIntLower
-                    | ConversionType::HexIntUpper
-                    | ConversionType::OctInt,
-                    Some(value),
-                ) => self.format_unsigned(string, *value),
-                (
-                    ConversionType::StringLower | ConversionType::StringUpper,
-                    Some(value),
-                ) => self.format_string(string, &value.to_string()),
-                (t, None) if t.supports_integer() => self.format_string(string, "null"),
-                _ => {
-                    exec_err!(
-                        "Invalid conversion type: {:?} for UInt64",
-                        self.conversion_type
-                    )
-                }
-            },
             ScalarValue::Float16(value) => match (self.conversion_type, value) {
                 (
                     ConversionType::DecFloatLower
@@ -1481,6 +1374,50 @@ impl ConversionSpecifier {
                 self.format_string(string, &value)
             }
             _ => exec_err!("Invalid scalar value: {value}"),
+        }
+    }
+
+    fn format_integer(
+        &self,
+        writer: &mut String,
+        value: Option<IntegerValue>,
+        type_name: &str,
+    ) -> Result<()> {
+        let Some(value) = value else {
+            return if self.conversion_type.supports_integer() {
+                self.format_string(writer, "null")
+            } else {
+                exec_err!(
+                    "Invalid conversion type: {:?} for {}",
+                    self.conversion_type,
+                    type_name
+                )
+            };
+        };
+
+        match self.conversion_type {
+            ConversionType::DecInt => match value.decimal() {
+                IntegerFormatValue::Signed(value) => self.format_signed(writer, value),
+                IntegerFormatValue::Unsigned(value) => {
+                    self.format_unsigned(writer, value)
+                }
+            },
+            ConversionType::HexIntLower
+            | ConversionType::HexIntUpper
+            | ConversionType::OctInt => {
+                self.format_unsigned(writer, value.unsigned_bits())
+            }
+            ConversionType::CharLower | ConversionType::CharUpper => {
+                self.format_char(writer, value.to_char()?)
+            }
+            ConversionType::StringLower | ConversionType::StringUpper => {
+                self.format_string(writer, &value.decimal().to_string())
+            }
+            _ => exec_err!(
+                "Invalid conversion type: {:?} for {}",
+                self.conversion_type,
+                type_name
+            ),
         }
     }
 
@@ -2586,6 +2523,62 @@ mod tests {
             Utf8,
             StringArray
         );
+    }
+
+    #[test]
+    fn test_integer_formatting_across_widths() -> Result<()> {
+        let cases = [
+            (ScalarValue::Int8(Some(-1)), "%d|%x|%o|%s", "-1|ff|377|-1"),
+            (
+                ScalarValue::Int16(Some(-1)),
+                "%d|%x|%o|%s",
+                "-1|ffff|177777|-1",
+            ),
+            (
+                ScalarValue::Int32(Some(-1)),
+                "%d|%x|%o|%s",
+                "-1|ffffffff|37777777777|-1",
+            ),
+            (
+                ScalarValue::Int64(Some(-1)),
+                "%d|%x|%o|%s",
+                "-1|ffffffffffffffff|1777777777777777777777|-1",
+            ),
+            (
+                ScalarValue::UInt8(Some(255)),
+                "%d|%x|%o|%s|%c",
+                "255|ff|377|255|ÿ",
+            ),
+            (
+                ScalarValue::UInt16(Some(65535)),
+                "%d|%x|%o|%s",
+                "65535|ffff|177777|65535",
+            ),
+            (
+                ScalarValue::UInt32(Some(u32::MAX)),
+                "%d|%x|%o|%s",
+                "4294967295|ffffffff|37777777777|4294967295",
+            ),
+            (
+                ScalarValue::UInt64(Some(u64::MAX)),
+                "%d|%x|%o|%s",
+                "18446744073709551615|ffffffffffffffff|1777777777777777777777|18446744073709551615",
+            ),
+            (
+                ScalarValue::Int32(None),
+                "%d|%x|%o|%s|%c",
+                "null|null|null|null|null",
+            ),
+        ];
+
+        for (value, fmt, expected) in cases {
+            let data_types =
+                vec![value.data_type(); fmt.chars().filter(|c| *c == '%').count()];
+            let formatter = Formatter::parse(fmt, &data_types)?;
+            let args = vec![value; data_types.len()];
+            assert_eq!(formatter.format(&args)?, expected, "{fmt}");
+        }
+        Ok(())
     }
 
     #[test]

--- a/datafusion/spark/src/function/string/format_string.rs
+++ b/datafusion/spark/src/function/string/format_string.rs
@@ -891,57 +891,44 @@ fn unsigned_to_char(value: u64) -> Result<char> {
     codepoint_to_char(codepoint)
 }
 
-/// Normalizes integer scalar payloads while preserving Spark formatting semantics:
-/// signed values format as decimal for `%d` / `%s` / `%c`, but use their original
-/// bit width for `%x` / `%o` via `unsigned_bits`.
-#[derive(Debug, Clone, Copy)]
-enum IntegerValue {
-    Signed { decimal: i64, unsigned_bits: u64 },
-    Unsigned(u64),
-}
+/// Formatting operations that differ between signed and unsigned integer
+/// primitives. Signed values format as decimal for `%d` / `%s` / `%c`, but use
+/// their original bit width for `%x` / `%o` via `unsigned_bits`.
+trait IntegerFormatValue {
+    fn unsigned_bits(self) -> u64;
 
-impl IntegerValue {
-    fn unsigned_bits(self) -> u64 {
-        match self {
-            Self::Signed { unsigned_bits, .. } => unsigned_bits,
-            Self::Unsigned(value) => value,
-        }
-    }
-
-    fn to_char(self) -> Result<char> {
-        match self {
-            Self::Signed { decimal, .. } => signed_to_char(decimal),
-            Self::Unsigned(value) => unsigned_to_char(value),
-        }
-    }
+    fn to_char(self) -> Result<char>;
 
     fn format_decimal(
         self,
         spec: &ConversionSpecifier,
         writer: &mut String,
-    ) -> Result<()> {
-        match self {
-            Self::Signed { decimal, .. } => spec.format_signed(writer, decimal),
-            Self::Unsigned(value) => spec.format_unsigned(writer, value),
-        }
-    }
+    ) -> Result<()>;
 
-    fn decimal_string(self) -> String {
-        match self {
-            Self::Signed { decimal, .. } => decimal.to_string(),
-            Self::Unsigned(value) => value.to_string(),
-        }
-    }
+    fn decimal_string(self) -> String;
 }
 
 macro_rules! signed_integer_value {
     ($source:ty, $unsigned:ty) => {
-        impl From<$source> for IntegerValue {
-            fn from(value: $source) -> Self {
-                Self::Signed {
-                    decimal: value as i64,
-                    unsigned_bits: (value as $unsigned) as u64,
-                }
+        impl IntegerFormatValue for $source {
+            fn unsigned_bits(self) -> u64 {
+                (self as $unsigned) as u64
+            }
+
+            fn to_char(self) -> Result<char> {
+                signed_to_char(self as i64)
+            }
+
+            fn format_decimal(
+                self,
+                spec: &ConversionSpecifier,
+                writer: &mut String,
+            ) -> Result<()> {
+                spec.format_signed(writer, self as i64)
+            }
+
+            fn decimal_string(self) -> String {
+                self.to_string()
             }
         }
     };
@@ -954,9 +941,25 @@ signed_integer_value!(i64, u64);
 
 macro_rules! unsigned_integer_value {
     ($source:ty) => {
-        impl From<$source> for IntegerValue {
-            fn from(value: $source) -> Self {
-                Self::Unsigned(value as u64)
+        impl IntegerFormatValue for $source {
+            fn unsigned_bits(self) -> u64 {
+                self as u64
+            }
+
+            fn to_char(self) -> Result<char> {
+                unsigned_to_char(self as u64)
+            }
+
+            fn format_decimal(
+                self,
+                spec: &ConversionSpecifier,
+                writer: &mut String,
+            ) -> Result<()> {
+                spec.format_unsigned(writer, self as u64)
+            }
+
+            fn decimal_string(self) -> String {
+                self.to_string()
             }
         }
     };
@@ -1375,9 +1378,9 @@ impl ConversionSpecifier {
         type_name: &str,
     ) -> Result<()>
     where
-        T: Copy + Into<IntegerValue>,
+        T: Copy + IntegerFormatValue,
     {
-        let Some(value) = value.map(Into::into) else {
+        let Some(value) = *value else {
             return if self.conversion_type.supports_integer() {
                 self.format_string(writer, "null")
             } else {


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #22163

## Rationale for this change

`ConversionSpecifier::format` contained substantial duplication across integer `ScalarValue` variants for `%d`, `%x`, `%o`, `%s`, and `%c` handling. Each integer width repeated nearly identical conversion logic, making the code harder to maintain and increasing the risk of inconsistent behavior across integer types.

This change consolidates integer formatting behavior into shared internal helpers while preserving existing Spark-compatible semantics.

## What changes are included in this PR?

* Introduced a local `IntegerValue` enum to normalize signed and unsigned integer handling while preserving width-specific unsigned bit behavior for `%x` and `%o`.
* Replaced repeated per-variant integer dispatch branches in `ConversionSpecifier::format` with a shared `format_integer` helper.
* Added shared helper methods for:

  * decimal formatting
  * unsigned bit formatting
  * `%c` conversion
  * decimal string conversion
* Added small `macro_rules!` helpers to generate `From<T> for IntegerValue` implementations for signed and unsigned integer families, reducing repetitive conversion boilerplate while preserving width-specific unsigned formatting semantics.
* Added `invalid_integer_conversion` helper to centralize integer conversion error generation.
* Added table-driven regression coverage for integer formatting behavior across:

  * signed integer widths
  * unsigned integer widths
  * `%d`, `%x`, `%o`, `%s`, and `%c`
  * null handling behavior

## Are these changes tested?

Yes.

Added `test_integer_formatting_across_widths` covering:

* Signed integer formatting across `Int8`, `Int16`, `Int32`, and `Int64`
* Unsigned integer formatting across `UInt8`, `UInt16`, `UInt32`, and `UInt64`
* `%d`, `%x`, `%o`, `%s`, and `%c` formatting behavior
* Null integer formatting behavior

## Are there any user-facing changes?

No intended user-facing behavior changes. This PR is a structural refactor intended to preserve existing Spark-compatible integer formatting semantics.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.

