### PR TITLE
fix: avoid panic in date_bin compute_distance near i64::MIN

### DIFF
--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -340,7 +340,11 @@ fn date_bin_nanos_interval(stride_nanos: i64, source: i64, origin: i64) -> Resul
 
 // distance from origin to bin
 fn compute_distance(time_diff: i64, stride: i64) -> Result<i64> {
-    let remainder = time_diff % stride;
+    let remainder = time_diff.checked_rem(stride).ok_or_else(|| {
+        arrow::error::ArrowError::InvalidArgumentError(format!(
+            "date_bin compute_distance time_diff {time_diff} % stride {stride} overflows i64"
+        ))
+    })?;
     let time_delta = time_diff.checked_sub(remainder).ok_or_else(|| {
         arrow::error::ArrowError::InvalidArgumentError(format!(
             "date_bin compute_distance time_diff {time_diff} - remainder {remainder} overflows i64"
@@ -1390,5 +1394,18 @@ mod tests {
         } else {
             panic!("Expected TimestampNanosecond scalar");
         }
+    }
+
+    #[test]
+    fn test_date_bin_compute_distance_rem_overflow() {
+        // Regression for #22215: `time_diff % stride` panics with "attempt to
+        // calculate the remainder with overflow" when `time_diff == i64::MIN`
+        // and `stride == -1`. Now it must return a normal Err that the scalar
+        // pipeline maps to NULL.
+        let result = date_bin_nanos_interval(-1, i64::MIN, 0);
+        assert!(
+            result.is_err(),
+            "expected Err for time_diff=i64::MIN, stride=-1, got {result:?}"
+        );
     }
 }

--- a/datafusion/functions/src/datetime/date_bin.rs
+++ b/datafusion/functions/src/datetime/date_bin.rs
@@ -328,20 +328,35 @@ fn date_bin_nanos_interval(stride_nanos: i64, source: i64, origin: i64) -> Resul
     })?;
 
     // distance from origin to bin
-    let time_delta = compute_distance(time_diff, stride_nanos);
+    let time_delta = compute_distance(time_diff, stride_nanos)?;
 
-    Ok(origin + time_delta)
+    origin.checked_add(time_delta).ok_or_else(|| {
+        arrow::error::ArrowError::InvalidArgumentError(format!(
+            "date_bin origin {origin} + delta {time_delta} overflows i64"
+        ))
+        .into()
+    })
 }
 
 // distance from origin to bin
-fn compute_distance(time_diff: i64, stride: i64) -> i64 {
-    let time_delta = time_diff - (time_diff % stride);
+fn compute_distance(time_diff: i64, stride: i64) -> Result<i64> {
+    let remainder = time_diff % stride;
+    let time_delta = time_diff.checked_sub(remainder).ok_or_else(|| {
+        arrow::error::ArrowError::InvalidArgumentError(format!(
+            "date_bin compute_distance time_diff {time_diff} - remainder {remainder} overflows i64"
+        ))
+    })?;
 
     if time_diff < 0 && stride > 1 && time_delta != time_diff {
         // The origin is later than the source timestamp, round down to the previous bin
-        time_delta - stride
+        time_delta.checked_sub(stride).ok_or_else(|| {
+            arrow::error::ArrowError::InvalidArgumentError(format!(
+                "date_bin compute_distance time_delta {time_delta} - stride {stride} overflows i64"
+            ))
+            .into()
+        })
     } else {
-        time_delta
+        Ok(time_delta)
     }
 }
 
@@ -357,7 +372,7 @@ fn date_bin_months_interval(stride_months: i64, source: i64, origin: i64) -> Res
         - origin_date.month() as i32;
 
     // distance from origin to bin
-    let month_delta = compute_distance(month_diff as i64, stride_months);
+    let month_delta = compute_distance(month_diff as i64, stride_months)?;
 
     let mut bin_time = if month_delta < 0 {
         match origin_date
@@ -1339,6 +1354,41 @@ mod tests {
             result.unwrap()
         {
             assert!(val.is_none(), "Expected None for out of range operation");
+        }
+    }
+
+    #[test]
+    fn test_date_bin_compute_distance_i64_min() {
+        // Regression for #22215: date_bin_nanos_interval on a source near i64::MIN
+        // previously panicked inside compute_distance with "attempt to subtract with overflow".
+        // Now it must return a normal Err that the scalar pipeline maps to NULL.
+        let result = date_bin_nanos_interval(3, i64::MIN, 0);
+        assert!(
+            result.is_err(),
+            "expected Err for source=i64::MIN, got {result:?}"
+        );
+
+        let return_field = &Arc::new(Field::new(
+            "f",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        ));
+        let args = vec![
+            ColumnarValue::Scalar(ScalarValue::new_interval_mdn(0, 0, 3)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(i64::MIN), None)),
+            ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(Some(0), None)),
+        ];
+        let result = invoke_date_bin_with_args(args, 1, return_field);
+        assert!(result.is_ok(), "expected Ok with NULL, got {result:?}");
+        if let ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(val, _)) =
+            result.unwrap()
+        {
+            assert!(
+                val.is_none(),
+                "Expected None for compute_distance overflow, got {val:?}"
+            );
+        } else {
+            panic!("Expected TimestampNanosecond scalar");
         }
     }
 }

--- a/datafusion/sqllogictest/test_files/date_bin_errors.slt
+++ b/datafusion/sqllogictest/test_files/date_bin_errors.slt
@@ -68,3 +68,13 @@ select date_bin(
 );
 ----
 NULL
+
+# compute_distance overflow: source at i64::MIN nanoseconds previously panicked
+# inside compute_distance; it must return NULL through the SQL execution path
+query P
+select date_bin(
+  interval '3 nanoseconds',
+  arrow_cast(-9223372036854775808, 'Timestamp(Nanosecond, None)')
+);
+----
+NULL


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22215.

## Rationale for this change

`date_bin` panics with `attempt to subtract with overflow` when the source timestamp sits near `i64::MIN` because `compute_distance` does `time_diff - (time_diff % stride)` and then `time_delta - stride` on raw `i64`. The scalar pipeline already maps `Err` from `bin_fn` into `NULL`, so the fix is to surface the overflow as a normal error.

## What changes are included in this PR?

- Convert `compute_distance` to return `Result<i64>` and use `checked_sub`.
- Propagate the result through `date_bin_nanos_interval` and `date_bin_months_interval`, plus replace the trailing `origin + time_delta` with `checked_add`.

## Are these changes tested?

Yes. Added `test_date_bin_compute_distance_i64_min` which previously panicked and now returns `NULL`. Ran `cargo test -p datafusion-functions --lib -- datetime::date_bin`, `cargo fmt --check`, and `cargo clippy -p datafusion-functions --lib --tests --no-deps`.

## Are there any user-facing changes?

Queries that previously panicked on extreme timestamps now return `NULL` (consistent with the existing out-of-range behavior covered by `test_date_bin_out_of_range`).
