### PR TITLE
Improve 54.0.0 upgrade guide for ExecutionPlan::apply_expressions

### DIFF
--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -15,7 +15,7 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
--->
+-->requied 
 
 # Upgrade Guides
 
@@ -171,7 +171,13 @@ where string types are preferred (`UNION`, `CASE THEN/ELSE`, `NVL2`).
 
 ### `ExecutionPlan::apply_expressions` is now a required method
 
-`apply_expressions` has been added as a **required** method on the `ExecutionPlan` trait (no default implementation). The same applies to the `FileSource` and `DataSource` traits. Any custom implementation of these traits must now implement `apply_expressions`.
+A new function, `apply_expressions` is now **required** for `ExecutionPlan`, 
+`FileSource` and `DataSource` traits, so any custom implementation of these
+traits must now implement `apply_expressions`.
+
+`apply_expressions` is used to visit all `PhysicalExpr` instances owned by the
+node, allowing the caller to apply a function to them (e.g. for expression
+rewriting or analysis).
 
 **Who is affected:**
 

--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -15,7 +15,7 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
--->requied 
+-->
 
 # Upgrade Guides
 
@@ -171,8 +171,8 @@ where string types are preferred (`UNION`, `CASE THEN/ELSE`, `NVL2`).
 
 ### `ExecutionPlan::apply_expressions` is now a required method
 
-A new function, `apply_expressions` is now **required** for `ExecutionPlan`, 
-`FileSource` and `DataSource` traits, so any custom implementation of these
+A new function, `apply_expressions`, is now **required** for the `ExecutionPlan`,
+`FileSource`, and `DataSource` traits, so any custom implementation of these
 traits must now implement `apply_expressions`.
 
 `apply_expressions` is used to visit all `PhysicalExpr` instances owned by the

--- a/docs/source/library-user-guide/upgrading/54.0.0.md
+++ b/docs/source/library-user-guide/upgrading/54.0.0.md
@@ -171,13 +171,9 @@ where string types are preferred (`UNION`, `CASE THEN/ELSE`, `NVL2`).
 
 ### `ExecutionPlan::apply_expressions` is now a required method
 
-A new function, `apply_expressions`, is now **required** for the `ExecutionPlan`,
-`FileSource`, and `DataSource` traits, so any custom implementation of these
-traits must now implement `apply_expressions`.
-
-`apply_expressions` is used to visit all `PhysicalExpr` instances owned by the
-node, allowing the caller to apply a function to them (e.g. for expression
-rewriting or analysis).
+`apply_expressions` is now **required** on the `ExecutionPlan`, `FileSource`,
+and `DataSource` traits. It visits every `PhysicalExpr` owned by the node so
+callers can analyze or rewrite them (e.g. to discover dynamic filters).
 
 **Who is affected:**
 
@@ -186,7 +182,7 @@ rewriting or analysis).
 
 **Migration guide:**
 
-Add `apply_expressions` to your implementation. Call `f` on each top-level `PhysicalExpr` your node owns, using `visit_sibling` to correctly propagate `TreeNodeRecursion`:
+Call `f` on each top-level `PhysicalExpr` your node owns, using `visit_sibling` to propagate `TreeNodeRecursion` when iterating:
 
 **Node with no expressions:**
 
@@ -225,7 +221,7 @@ fn apply_expressions(
 }
 ```
 
-**Node whose only expressions are in `output_ordering()` (e.g. a synthetic test node with no owned expression fields):**
+**Node whose expressions live in `output_ordering()`:**
 
 ```rust,ignore
 fn apply_expressions(


### PR DESCRIPTION
## Which issue does this PR close?

- Addresses feedback from https://github.com/apache/datafusion/issues/21080#issuecomment-4507775224

## Rationale for this change

As @milenkovicm noted after upgrading Ballista, the upgrade guide for the new required `ExecutionPlan::apply_expressions` method explains *what* the method does but not *why* downstream implementors need to implement it. Without that motivation, it's not obvious whether a no-op `Ok(TreeNodeRecursion::Continue)` is safe, or what the consequences of skipping expressions are.

## What changes are included in this PR?


This PR tightens the section and adds a brief explanation of the purpose of the method (visiting every `PhysicalExpr` owned by the node so optimizer passes/analyzers — e.g. dynamic filter discovery — can see them).

## Are these changes tested?

By CI

## Are there any user-facing changes?

Yes — clarifies the upgrade guide for users implementing custom `ExecutionPlan`, `FileSource`, or `DataSource` traits. No API change.