### PR TITLE
[branch-54]: Backport 22404. Fix Spark slice function on negative OOB

### DIFF
--- a/datafusion/spark/src/function/array/slice.rs
+++ b/datafusion/spark/src/function/array/slice.rs
@@ -172,6 +172,15 @@ fn calculate_start_end(args: &[ArrayRef]) -> Result<(ArrayRef, ArrayRef)> {
             start
         };
 
+        // Spark returns an empty array when the adjusted start lands before
+        // position 1 (e.g. slice([1], -2, 2)). array_slice would otherwise
+        // treat 0 the same as 1 and return the first element.
+        if adjusted_start_value < 1 {
+            adjusted_start.append_value(1);
+            end.append_value(0);
+            continue;
+        }
+
         adjusted_start.append_value(adjusted_start_value);
         end.append_value(adjusted_start_value + (length - 1));
     }

--- a/datafusion/sqllogictest/test_files/spark/array/slice.slt
+++ b/datafusion/sqllogictest/test_files/spark/array/slice.slt
@@ -137,3 +137,18 @@ query ?
 SELECT slice(slice(make_array(NULL), 1, 2), 1, 2)
 ----
 [NULL]
+
+query ?
+SELECT slice(make_array(1), -2, 2)
+----
+[]
+
+query ?
+SELECT slice(make_array(1, 2, 3, 4), -5, 2)
+----
+[]
+
+query ?
+SELECT slice(make_array(1), 3, 4)
+----
+[]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Backport #22404 

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
