### PR TITLE
Optimize Parquet metadata row-group level statistics collection

### DIFF
--- a/datafusion/datasource-parquet/Cargo.toml
+++ b/datafusion/datasource-parquet/Cargo.toml
@@ -86,3 +86,7 @@ harness = false
 [[bench]]
 name = "parquet_struct_filter_pushdown"
 harness = false
+
+[[bench]]
+name = "parquet_metadata_statistics"
+harness = false

--- a/datafusion/datasource-parquet/benches/parquet_metadata_statistics.rs
+++ b/datafusion/datasource-parquet/benches/parquet_metadata_statistics.rs
@@ -195,7 +195,7 @@ fn make_array(
 }
 
 fn nullable_value<T>(row: usize, value: T) -> Option<T> {
-    (row % 7 != 0).then_some(value)
+    (!row.is_multiple_of(7)).then_some(value)
 }
 
 fn value(column_idx: usize, row_group: usize, row: usize) -> i64 {

--- a/datafusion/datasource-parquet/benches/parquet_metadata_statistics.rs
+++ b/datafusion/datasource-parquet/benches/parquet_metadata_statistics.rs
@@ -1,0 +1,206 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmarks for deriving DataFusion table statistics from Parquet metadata.
+//!
+//! This mirrors the structure of Arrow's `arrow_statistics` benchmark: build
+//! Parquet metadata once, then repeatedly measure statistics extraction. The
+//! benchmark targets the cold planning/statistics path used by listing tables.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion_common::stats::Precision;
+use datafusion_datasource_parquet::metadata::DFParquetMetadata;
+use parquet::arrow::ArrowWriter;
+use parquet::file::metadata::ParquetMetaData;
+use parquet::file::properties::{EnabledStatistics, WriterProperties};
+
+#[derive(Debug, Copy, Clone)]
+struct BenchmarkSpec {
+    name: &'static str,
+    columns: usize,
+    row_groups: usize,
+    rows_per_group: usize,
+}
+
+struct BenchmarkCase {
+    spec: BenchmarkSpec,
+    schema: SchemaRef,
+    metadata: ParquetMetaData,
+}
+
+fn parquet_metadata_statistics(c: &mut Criterion) {
+    let specs = [
+        BenchmarkSpec {
+            name: "wide_one_row_group",
+            columns: 1024,
+            row_groups: 1,
+            rows_per_group: 16,
+        },
+        BenchmarkSpec {
+            name: "moderate_width_many_row_groups",
+            columns: 64,
+            row_groups: 128,
+            rows_per_group: 8,
+        },
+        BenchmarkSpec {
+            name: "wide_many_row_groups",
+            columns: 256,
+            row_groups: 32,
+            rows_per_group: 8,
+        },
+    ];
+
+    let cases: Vec<_> = specs.into_iter().map(BenchmarkCase::new).collect();
+    let mut group = c.benchmark_group("parquet_metadata_statistics");
+    group.sample_size(10);
+
+    for case in &cases {
+        group.bench_function(BenchmarkId::from_parameter(case.spec.name), |b| {
+            b.iter(|| {
+                let statistics = DFParquetMetadata::statistics_from_parquet_metadata(
+                    black_box(&case.metadata),
+                    black_box(&case.schema),
+                )
+                .expect("statistics extraction failed");
+                black_box(statistics);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+impl BenchmarkCase {
+    fn new(spec: BenchmarkSpec) -> Self {
+        let schema = make_schema(spec.columns);
+        let props = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(spec.rows_per_group))
+            .set_statistics_enabled(EnabledStatistics::Chunk)
+            .build();
+        let file = tempfile::Builder::new()
+            .prefix("parquet_metadata_statistics")
+            .suffix(".parquet")
+            .tempfile()
+            .expect("failed to create temporary parquet file");
+        let mut writer = ArrowWriter::try_new(
+            file.reopen().expect("failed to reopen temporary file"),
+            Arc::clone(&schema),
+            Some(props),
+        )
+        .expect("failed to create parquet writer");
+
+        for row_group in 0..spec.row_groups {
+            writer
+                .write(&make_batch(&schema, row_group, spec.rows_per_group))
+                .expect("failed to write benchmark row group");
+        }
+
+        let metadata = writer.close().expect("failed to close parquet writer");
+        assert_eq!(metadata.row_groups().len(), spec.row_groups);
+
+        let statistics =
+            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
+                .expect("failed to validate benchmark metadata");
+        assert_eq!(statistics.column_statistics.len(), spec.columns);
+        assert_eq!(
+            statistics.num_rows,
+            Precision::Exact(spec.row_groups * spec.rows_per_group)
+        );
+
+        Self {
+            spec,
+            schema,
+            metadata,
+        }
+    }
+}
+
+fn make_schema(columns: usize) -> SchemaRef {
+    let fields = (0..columns)
+        .map(|idx| {
+            let data_type = match idx % 4 {
+                0 => DataType::Int64,
+                1 => DataType::Float64,
+                2 => DataType::Utf8,
+                _ => DataType::Int64,
+            };
+            Field::new(format!("c{idx:04}"), data_type, true)
+        })
+        .collect::<Vec<_>>();
+
+    Arc::new(Schema::new(fields))
+}
+
+fn make_batch(
+    schema: &SchemaRef,
+    row_group: usize,
+    rows_per_group: usize,
+) -> RecordBatch {
+    let columns = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(column_idx, field)| {
+            make_array(field.data_type(), column_idx, row_group, rows_per_group)
+        })
+        .collect::<Vec<_>>();
+
+    RecordBatch::try_new(Arc::clone(schema), columns)
+        .expect("failed to create benchmark record batch")
+}
+
+fn make_array(
+    data_type: &DataType,
+    column_idx: usize,
+    row_group: usize,
+    rows_per_group: usize,
+) -> ArrayRef {
+    match data_type {
+        DataType::Int64 => {
+            Arc::new(Int64Array::from_iter((0..rows_per_group).map(|row| {
+                nullable_value(row, value(column_idx, row_group, row))
+            })))
+        }
+        DataType::Float64 => {
+            Arc::new(Float64Array::from_iter((0..rows_per_group).map(|row| {
+                nullable_value(row, value(column_idx, row_group, row) as f64 * 1.5)
+            })))
+        }
+        DataType::Utf8 => {
+            Arc::new(StringArray::from_iter((0..rows_per_group).map(|row| {
+                nullable_value(row, format!("s{column_idx}_{row_group}_{row}"))
+            })))
+        }
+        other => unreachable!("unsupported benchmark data type: {other:?}"),
+    }
+}
+
+fn nullable_value<T>(row: usize, value: T) -> Option<T> {
+    (row % 7 != 0).then_some(value)
+}
+
+fn value(column_idx: usize, row_group: usize, row: usize) -> i64 {
+    (column_idx as i64 * 10_000) + (row_group as i64 * 100) + row as i64
+}
+
+criterion_group!(benches, parquet_metadata_statistics);
+criterion_main!(benches);

--- a/datafusion/datasource-parquet/benches/parquet_metadata_statistics.rs
+++ b/datafusion/datasource-parquet/benches/parquet_metadata_statistics.rs
@@ -24,66 +24,89 @@
 use std::hint::black_box;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use datafusion_common::stats::Precision;
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use datafusion_datasource_parquet::metadata::DFParquetMetadata;
-use parquet::arrow::ArrowWriter;
-use parquet::file::metadata::ParquetMetaData;
-use parquet::file::properties::{EnabledStatistics, WriterProperties};
+use parquet::arrow::ArrowSchemaConverter;
+use parquet::data_type::ByteArray;
+use parquet::file::metadata::{
+    ColumnChunkMetaData, FileMetaData, ParquetMetaData, RowGroupMetaData,
+};
+use parquet::file::statistics::{Statistics as ParquetStatistics, ValueStatistics};
+
+const ROWS_PER_GROUP: usize = 8;
 
 #[derive(Debug, Copy, Clone)]
 struct BenchmarkSpec {
-    name: &'static str,
     columns: usize,
     row_groups: usize,
-    rows_per_group: usize,
+    metadata: MetadataState,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum MetadataState {
+    Full,
+    Mixed,
+    None,
+}
+
+impl std::fmt::Display for MetadataState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Full => write!(f, "full"),
+            Self::Mixed => write!(f, "mixed"),
+            Self::None => write!(f, "none"),
+        }
+    }
 }
 
 struct BenchmarkCase {
-    spec: BenchmarkSpec,
     schema: SchemaRef,
     metadata: ParquetMetaData,
 }
 
 fn parquet_metadata_statistics(c: &mut Criterion) {
-    let specs = [
-        BenchmarkSpec {
-            name: "wide_one_row_group",
-            columns: 1024,
-            row_groups: 1,
-            rows_per_group: 16,
-        },
-        BenchmarkSpec {
-            name: "moderate_width_many_row_groups",
-            columns: 64,
-            row_groups: 128,
-            rows_per_group: 8,
-        },
-        BenchmarkSpec {
-            name: "wide_many_row_groups",
-            columns: 256,
-            row_groups: 32,
-            rows_per_group: 8,
-        },
+    let metadata_states = [
+        MetadataState::Full,
+        MetadataState::Mixed,
+        MetadataState::None,
     ];
+    let column_counts = [8, 64, 256];
+    let row_group_counts = [1, 32, 128];
 
-    let cases: Vec<_> = specs.into_iter().map(BenchmarkCase::new).collect();
     let mut group = c.benchmark_group("parquet_metadata_statistics");
-    group.sample_size(10);
 
-    for case in &cases {
-        group.bench_function(BenchmarkId::from_parameter(case.spec.name), |b| {
-            b.iter(|| {
-                let statistics = DFParquetMetadata::statistics_from_parquet_metadata(
-                    black_box(&case.metadata),
-                    black_box(&case.schema),
-                )
-                .expect("statistics extraction failed");
-                black_box(statistics);
-            });
-        });
+    for metadata in metadata_states {
+        for columns in column_counts {
+            for row_groups in row_group_counts {
+                let spec = BenchmarkSpec {
+                    columns,
+                    row_groups,
+                    metadata,
+                };
+                group.bench_function(
+                    BenchmarkId::from_parameter(format!(
+                        "metadata_{}_col_{}_rg_{}",
+                        spec.metadata, spec.columns, spec.row_groups,
+                    )),
+                    |b| {
+                        b.iter_batched(
+                            || BenchmarkCase::new(spec),
+                            |case| {
+                                let statistics =
+                                    DFParquetMetadata::statistics_from_parquet_metadata(
+                                        black_box(&case.metadata),
+                                        black_box(&case.schema),
+                                    )
+                                    .expect("statistics extraction failed");
+                                black_box(statistics);
+                            },
+                            BatchSize::PerIteration,
+                        );
+                    },
+                );
+            }
+        }
     }
 
     group.finish();
@@ -92,45 +115,149 @@ fn parquet_metadata_statistics(c: &mut Criterion) {
 impl BenchmarkCase {
     fn new(spec: BenchmarkSpec) -> Self {
         let schema = make_schema(spec.columns);
-        let props = WriterProperties::builder()
-            .set_max_row_group_row_count(Some(spec.rows_per_group))
-            .set_statistics_enabled(EnabledStatistics::Chunk)
-            .build();
-        let file = tempfile::Builder::new()
-            .prefix("parquet_metadata_statistics")
-            .suffix(".parquet")
-            .tempfile()
-            .expect("failed to create temporary parquet file");
-        let mut writer = ArrowWriter::try_new(
-            file.reopen().expect("failed to reopen temporary file"),
-            Arc::clone(&schema),
-            Some(props),
-        )
-        .expect("failed to create parquet writer");
+        let metadata = match spec.metadata {
+            MetadataState::Full => {
+                make_synthetic_metadata(&schema, spec, full_statistics)
+            }
+            MetadataState::Mixed => {
+                make_synthetic_metadata(&schema, spec, mixed_statistics)
+            }
+            MetadataState::None => make_synthetic_metadata(&schema, spec, |_, _, _| None),
+        };
 
-        for row_group in 0..spec.row_groups {
-            writer
-                .write(&make_batch(&schema, row_group, spec.rows_per_group))
-                .expect("failed to write benchmark row group");
+        Self { schema, metadata }
+    }
+}
+
+fn make_synthetic_metadata(
+    schema: &SchemaRef,
+    spec: BenchmarkSpec,
+    statistics: fn(&DataType, usize, usize) -> Option<ParquetStatistics>,
+) -> ParquetMetaData {
+    let schema_descr = Arc::new(
+        ArrowSchemaConverter::new()
+            .convert(schema.as_ref())
+            .expect("failed to convert arrow schema"),
+    );
+    let row_groups = (0..spec.row_groups)
+        .map(|row_group| {
+            let columns = schema
+                .fields()
+                .iter()
+                .enumerate()
+                .map(|(column_idx, field)| {
+                    let mut builder =
+                        ColumnChunkMetaData::builder(schema_descr.column(column_idx));
+                    if let Some(statistics) =
+                        statistics(field.data_type(), column_idx, row_group)
+                    {
+                        builder = builder.set_statistics(statistics);
+                    }
+                    builder
+                        .set_num_values(ROWS_PER_GROUP as i64)
+                        .build()
+                        .expect("failed to build column metadata")
+                })
+                .collect::<Vec<_>>();
+
+            RowGroupMetaData::builder(Arc::clone(&schema_descr))
+                .set_num_rows(ROWS_PER_GROUP as i64)
+                .set_total_byte_size((spec.columns * ROWS_PER_GROUP * 8) as i64)
+                .set_column_metadata(columns)
+                .build()
+                .expect("failed to build row group metadata")
+        })
+        .collect::<Vec<_>>();
+
+    let file_metadata = FileMetaData::new(
+        1,
+        (spec.row_groups * ROWS_PER_GROUP) as i64,
+        Some("datafusion parquet metadata benchmark".to_string()),
+        None,
+        schema_descr,
+        None,
+    );
+
+    ParquetMetaData::new(file_metadata, row_groups)
+}
+
+fn full_statistics(
+    data_type: &DataType,
+    column_idx: usize,
+    row_group: usize,
+) -> Option<ParquetStatistics> {
+    Some(statistics(
+        data_type,
+        column_idx,
+        row_group,
+        true,
+        true,
+        Some(null_count_for_rows()),
+    ))
+}
+
+fn mixed_statistics(
+    data_type: &DataType,
+    column_idx: usize,
+    row_group: usize,
+) -> Option<ParquetStatistics> {
+    if column_idx.is_multiple_of(16) || row_group.is_multiple_of(5) {
+        return None;
+    }
+
+    let min_exact = !row_group.is_multiple_of(3);
+    let max_exact = !row_group.is_multiple_of(4);
+    let null_count = (!row_group.is_multiple_of(7)).then(null_count_for_rows);
+
+    Some(statistics(
+        data_type, column_idx, row_group, min_exact, max_exact, null_count,
+    ))
+}
+
+fn statistics(
+    data_type: &DataType,
+    column_idx: usize,
+    row_group: usize,
+    min_exact: bool,
+    max_exact: bool,
+    null_count: Option<u64>,
+) -> ParquetStatistics {
+    let min_row = first_non_null_row();
+    let max_row = last_non_null_row();
+
+    match data_type {
+        DataType::Int64 => {
+            let min = min_row.map(|row| value(column_idx, row_group, row));
+            let max = max_row.map(|row| value(column_idx, row_group, row));
+            ParquetStatistics::Int64(
+                ValueStatistics::new(min, max, None, null_count, false)
+                    .with_min_is_exact(min_exact)
+                    .with_max_is_exact(max_exact),
+            )
         }
-
-        let metadata = writer.close().expect("failed to close parquet writer");
-        assert_eq!(metadata.row_groups().len(), spec.row_groups);
-
-        let statistics =
-            DFParquetMetadata::statistics_from_parquet_metadata(&metadata, &schema)
-                .expect("failed to validate benchmark metadata");
-        assert_eq!(statistics.column_statistics.len(), spec.columns);
-        assert_eq!(
-            statistics.num_rows,
-            Precision::Exact(spec.row_groups * spec.rows_per_group)
-        );
-
-        Self {
-            spec,
-            schema,
-            metadata,
+        DataType::Float64 => {
+            let min = min_row.map(|row| value(column_idx, row_group, row) as f64 * 1.5);
+            let max = max_row.map(|row| value(column_idx, row_group, row) as f64 * 1.5);
+            ParquetStatistics::Double(
+                ValueStatistics::new(min, max, None, null_count, false)
+                    .with_min_is_exact(min_exact)
+                    .with_max_is_exact(max_exact),
+            )
         }
+        DataType::Utf8 => {
+            let min = min_row.map(|row| {
+                ByteArray::from(string_value(column_idx, row_group, row).into_bytes())
+            });
+            let max = max_row.map(|row| {
+                ByteArray::from(string_value(column_idx, row_group, row).into_bytes())
+            });
+            ParquetStatistics::ByteArray(
+                ValueStatistics::new(min, max, None, null_count, false)
+                    .with_min_is_exact(min_exact)
+                    .with_max_is_exact(max_exact),
+            )
+        }
+        other => unreachable!("unsupported benchmark data type: {other:?}"),
     }
 }
 
@@ -150,56 +277,26 @@ fn make_schema(columns: usize) -> SchemaRef {
     Arc::new(Schema::new(fields))
 }
 
-fn make_batch(
-    schema: &SchemaRef,
-    row_group: usize,
-    rows_per_group: usize,
-) -> RecordBatch {
-    let columns = schema
-        .fields()
-        .iter()
-        .enumerate()
-        .map(|(column_idx, field)| {
-            make_array(field.data_type(), column_idx, row_group, rows_per_group)
-        })
-        .collect::<Vec<_>>();
-
-    RecordBatch::try_new(Arc::clone(schema), columns)
-        .expect("failed to create benchmark record batch")
+fn first_non_null_row() -> Option<usize> {
+    (0..ROWS_PER_GROUP).find(|row| !row.is_multiple_of(7))
 }
 
-fn make_array(
-    data_type: &DataType,
-    column_idx: usize,
-    row_group: usize,
-    rows_per_group: usize,
-) -> ArrayRef {
-    match data_type {
-        DataType::Int64 => {
-            Arc::new(Int64Array::from_iter((0..rows_per_group).map(|row| {
-                nullable_value(row, value(column_idx, row_group, row))
-            })))
-        }
-        DataType::Float64 => {
-            Arc::new(Float64Array::from_iter((0..rows_per_group).map(|row| {
-                nullable_value(row, value(column_idx, row_group, row) as f64 * 1.5)
-            })))
-        }
-        DataType::Utf8 => {
-            Arc::new(StringArray::from_iter((0..rows_per_group).map(|row| {
-                nullable_value(row, format!("s{column_idx}_{row_group}_{row}"))
-            })))
-        }
-        other => unreachable!("unsupported benchmark data type: {other:?}"),
-    }
+fn last_non_null_row() -> Option<usize> {
+    (0..ROWS_PER_GROUP).rev().find(|row| !row.is_multiple_of(7))
 }
 
-fn nullable_value<T>(row: usize, value: T) -> Option<T> {
-    (!row.is_multiple_of(7)).then_some(value)
+fn null_count_for_rows() -> u64 {
+    (0..ROWS_PER_GROUP)
+        .filter(|row| row.is_multiple_of(7))
+        .count() as u64
 }
 
 fn value(column_idx: usize, row_group: usize, row: usize) -> i64 {
     (column_idx as i64 * 10_000) + (row_group as i64 * 100) + row as i64
+}
+
+fn string_value(column_idx: usize, row_group: usize, row: usize) -> String {
+    format!("s{column_idx:04}_{row_group:04}_{row:04}")
 }
 
 criterion_group!(benches, parquet_metadata_statistics);

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -680,7 +680,7 @@ fn summarize_distinct_counts(
         return Precision::Absent;
     }
 
-    let required_count = required_ndv_count(num_row_groups);
+    let required_count = (num_row_groups as f64 * PARTIAL_NDV_THRESHOLD).ceil() as usize;
     let mut ndv_count = 0;
     let mut max_distinct_count: Option<u64> = None;
 
@@ -698,6 +698,7 @@ fn summarize_distinct_counts(
             });
         }
 
+        // Return early if there's no chance to reach the required coverage.
         let remaining = num_row_groups - row_group_idx - 1;
         if ndv_count + remaining < required_count {
             return Precision::Absent;
@@ -711,10 +712,6 @@ fn summarize_distinct_counts(
         Some(distinct_count) => Precision::Inexact(distinct_count as usize),
         None => Precision::Absent,
     }
-}
-
-fn required_ndv_count(num_row_groups: usize) -> usize {
-    (num_row_groups as f64 * PARTIAL_NDV_THRESHOLD).ceil() as usize
 }
 
 /// Compute the Arrow in-memory size for a single column

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -20,8 +20,8 @@
 
 use crate::{Int96Coercer, apply_file_schema_type_coercions};
 use arrow::array::{Array, ArrayRef, BooleanArray};
-use arrow::compute::and;
 use arrow::compute::kernels::cmp::eq;
+use arrow::compute::{and, sum};
 use arrow::datatypes::{DataType, Schema, SchemaRef, TimeUnit};
 use datafusion_common::encryption::FileDecryptionProperties;
 use datafusion_common::stats::Precision;
@@ -537,7 +537,7 @@ fn summarize_column_statistics(
     }
 
     accumulators.null_counts_array[logical_schema_index] =
-        summarize_null_counts(parquet_index, row_groups_metadata);
+        summarize_null_counts(stats_converter, row_groups_metadata)?;
 
     accumulators.distinct_counts_array[logical_schema_index] =
         summarize_distinct_counts(parquet_index, row_groups_metadata);
@@ -583,36 +583,21 @@ fn summarize_bound<A: Accumulator>(
 }
 
 fn summarize_null_counts(
-    parquet_idx: Option<usize>,
+    stats_converter: &StatisticsConverter,
     row_groups_metadata: &[RowGroupMetaData],
-) -> Precision<usize> {
-    let Some(parquet_idx) = parquet_idx else {
-        return match row_groups_metadata.len() {
-            0 => Precision::Exact(0),
-            _ => Precision::Absent,
-        };
-    };
-
-    let mut null_count_sum = 0_u64;
-    let mut has_known_count = false;
-    for row_group in row_groups_metadata {
-        let Some(null_count) = row_group
-            .columns()
-            .get(parquet_idx)
-            .and_then(|column| column.statistics())
-            .map(|statistics| statistics.null_count_opt().unwrap_or(0))
-        else {
-            continue;
-        };
-
-        has_known_count = true;
-        null_count_sum += null_count;
+) -> Result<Precision<usize>> {
+    if row_groups_metadata.is_empty() {
+        return Ok(Precision::Exact(0));
     }
 
-    if has_known_count || row_groups_metadata.is_empty() {
-        Precision::Exact(null_count_sum as usize)
-    } else {
-        Precision::Absent
+    let null_counts = stats_converter.row_group_null_counts(row_groups_metadata)?;
+    match sum(&null_counts) {
+        Some(null_count) => Ok(Precision::Exact(null_count as usize)),
+        None => match null_counts.len() {
+            // If sum() returned None we either have no rows or all values are null
+            0 => Ok(Precision::Exact(0)),
+            _ => Ok(Precision::Absent),
+        },
     }
 }
 
@@ -1071,6 +1056,7 @@ mod tests {
         #[test]
         fn test_summarize_null_counts() {
             let schema_descr = create_schema_descr(1);
+            let arrow_schema = create_arrow_schema(2);
             let stats_with_count =
                 ParquetStatistics::int32(Some(1), Some(10), None, Some(2), false);
             let stats_without_count =
@@ -1084,19 +1070,73 @@ mod tests {
                 ),
                 create_row_group_with_stats(
                     &schema_descr,
-                    vec![Some(stats_without_count)],
+                    vec![Some(stats_without_count.clone())],
                     10,
                 ),
                 create_row_group_with_stats(&schema_descr, vec![None], 10),
             ];
+            let stats_converter =
+                StatisticsConverter::try_new("col_0", &arrow_schema, &schema_descr)
+                    .unwrap();
+            let missing_column_converter =
+                StatisticsConverter::try_new("col_1", &arrow_schema, &schema_descr)
+                    .unwrap();
 
             assert_eq!(
-                summarize_null_counts(Some(0), &row_groups),
-                Precision::Exact(2)
+                summarize_null_counts(&stats_converter, &row_groups).unwrap(),
+                Precision::Inexact(2)
             );
-            assert_eq!(summarize_null_counts(None, &row_groups), Precision::Absent);
-            assert_eq!(summarize_null_counts(Some(0), &[]), Precision::Exact(0));
-            assert_eq!(summarize_null_counts(None, &[]), Precision::Exact(0));
+            assert_eq!(
+                summarize_null_counts(&missing_column_converter, &row_groups).unwrap(),
+                Precision::Absent
+            );
+            assert_eq!(
+                summarize_null_counts(&stats_converter, &[]).unwrap(),
+                Precision::Exact(0)
+            );
+            assert_eq!(
+                summarize_null_counts(&missing_column_converter, &[]).unwrap(),
+                Precision::Exact(0)
+            );
+
+            let missing_counts_unknown_converter =
+                StatisticsConverter::try_new("col_0", &arrow_schema, &schema_descr)
+                    .unwrap()
+                    .with_missing_null_counts_as_zero(false);
+            assert_eq!(
+                summarize_null_counts(&missing_counts_unknown_converter, &row_groups)
+                    .unwrap(),
+                Precision::Inexact(2)
+            );
+
+            let row_groups_without_count = vec![
+                create_row_group_with_stats(
+                    &schema_descr,
+                    vec![Some(stats_without_count.clone())],
+                    10,
+                ),
+                create_row_group_with_stats(
+                    &schema_descr,
+                    vec![Some(stats_without_count)],
+                    10,
+                ),
+            ];
+            assert_eq!(
+                summarize_null_counts(&stats_converter, &row_groups_without_count)
+                    .unwrap(),
+                Precision::Exact(0)
+            );
+
+            let missing_counts_unknown_converter =
+                stats_converter.with_missing_null_counts_as_zero(false);
+            assert_eq!(
+                summarize_null_counts(
+                    &missing_counts_unknown_converter,
+                    &row_groups_without_count,
+                )
+                .unwrap(),
+                Precision::Absent
+            );
         }
 
         #[test]

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -594,9 +594,9 @@ fn summarize_null_counts(
 
     match sum(&null_counts) {
         Some(count) => {
-           // If any row group has an unknown null_count, either because column
-           // statistics are absent or because the null_count field is omitted,
-           // report the aggregate as inexact.
+            // If any row group has an unknown null_count, either because column
+            // statistics are absent or because the null_count field is omitted,
+            // report the aggregate as inexact.
             if null_counts.null_count() > 0 {
                 Ok(Precision::Inexact(count as usize))
             } else {

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -591,8 +591,17 @@ fn summarize_null_counts(
     }
 
     let null_counts = stats_converter.row_group_null_counts(row_groups_metadata)?;
+
     match sum(&null_counts) {
-        Some(null_count) => Ok(Precision::Exact(null_count as usize)),
+        Some(count) => {
+            // If any row group has a null `null_count` (either because the column chunk doesn't have statistics
+            // or the value itself is null), we report the total as inexact.
+            if null_counts.null_count() > 0 {
+                Ok(Precision::Inexact(count as usize))
+            } else {
+                Ok(Precision::Exact(count as usize))
+            }
+        }
         None => match null_counts.len() {
             // If sum() returned None we either have no rows or all values are null
             0 => Ok(Precision::Exact(0)),

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -22,7 +22,6 @@ use crate::{Int96Coercer, apply_file_schema_type_coercions};
 use arrow::array::{Array, ArrayRef, BooleanArray};
 use arrow::compute::and;
 use arrow::compute::kernels::cmp::eq;
-use arrow::compute::sum;
 use arrow::datatypes::{DataType, Schema, SchemaRef, TimeUnit};
 use datafusion_common::encryption::FileDecryptionProperties;
 use datafusion_common::stats::Precision;
@@ -46,6 +45,7 @@ use parquet::file::metadata::{
     PageIndexPolicy, ParquetMetaData, ParquetMetaDataPushDecoder, RowGroupMetaData,
     SortingColumn,
 };
+use parquet::file::statistics::Statistics as ParquetStatistics;
 use parquet::schema::types::SchemaDescriptor;
 use std::any::Any;
 use std::collections::HashMap;
@@ -353,13 +353,12 @@ impl<'a> DFParquetMetadata<'a> {
                                 distinct_counts_array: &mut distinct_counts_array,
                             };
                             summarize_column_statistics(
-                                file_metadata.schema_descr(),
                                 logical_file_schema,
-                                &physical_file_schema,
                                 &mut accumulators,
                                 idx,
                                 &stats_converter,
                                 row_groups_metadata,
+                                num_rows,
                             )
                             .ok();
                         }
@@ -506,119 +505,216 @@ impl StatisticsAccumulators<'_> {
 }
 
 fn summarize_column_statistics(
-    parquet_schema: &SchemaDescriptor,
     logical_file_schema: &Schema,
-    physical_file_schema: &Schema,
     accumulators: &mut StatisticsAccumulators,
     logical_schema_index: usize,
     stats_converter: &StatisticsConverter,
     row_groups_metadata: &[RowGroupMetaData],
+    num_rows: usize,
 ) -> Result<()> {
-    let max_values = stats_converter.row_group_maxes(row_groups_metadata)?;
-    let min_values = stats_converter.row_group_mins(row_groups_metadata)?;
-    let null_counts = stats_converter.row_group_null_counts(row_groups_metadata)?;
-    let is_max_value_exact_stat =
-        stats_converter.row_group_is_max_value_exact(row_groups_metadata)?;
-    let is_min_value_exact_stat =
-        stats_converter.row_group_is_min_value_exact(row_groups_metadata)?;
+    let parquet_index = stats_converter.parquet_column_index();
 
     if let Some(max_acc) = &mut accumulators.max_accs[logical_schema_index] {
-        max_acc.update_batch(&[Arc::clone(&max_values)])?;
-
-        // handle the common special case when all row groups have exact statistics
-        let exactness = &is_max_value_exact_stat;
-        if !exactness.is_empty() && exactness.null_count() == 0 && !exactness.has_false()
-        {
-            accumulators.is_max_value_exact[logical_schema_index] = Some(true);
-        } else if !exactness.has_true() {
-            accumulators.is_max_value_exact[logical_schema_index] = Some(false);
-        } else {
-            let val = max_acc.evaluate()?;
-            accumulators.is_max_value_exact[logical_schema_index] =
-                has_any_exact_match(&val, &max_values, exactness);
-        }
+        accumulators.is_max_value_exact[logical_schema_index] = summarize_bound(
+            max_acc,
+            &stats_converter.row_group_maxes(row_groups_metadata)?,
+            parquet_index,
+            row_groups_metadata,
+            ParquetStatistics::max_is_exact,
+            || Ok(stats_converter.row_group_is_max_value_exact(row_groups_metadata)?),
+        )?;
     }
 
     if let Some(min_acc) = &mut accumulators.min_accs[logical_schema_index] {
-        min_acc.update_batch(&[Arc::clone(&min_values)])?;
-
-        // handle the common special case when all row groups have exact statistics
-        let exactness = &is_min_value_exact_stat;
-        if !exactness.is_empty() && exactness.null_count() == 0 && !exactness.has_false()
-        {
-            accumulators.is_min_value_exact[logical_schema_index] = Some(true);
-        } else if !exactness.has_true() {
-            accumulators.is_min_value_exact[logical_schema_index] = Some(false);
-        } else {
-            let val = min_acc.evaluate()?;
-            accumulators.is_min_value_exact[logical_schema_index] =
-                has_any_exact_match(&val, &min_values, exactness);
-        }
+        accumulators.is_min_value_exact[logical_schema_index] = summarize_bound(
+            min_acc,
+            &stats_converter.row_group_mins(row_groups_metadata)?,
+            parquet_index,
+            row_groups_metadata,
+            ParquetStatistics::min_is_exact,
+            || Ok(stats_converter.row_group_is_min_value_exact(row_groups_metadata)?),
+        )?;
     }
 
-    accumulators.null_counts_array[logical_schema_index] = match sum(&null_counts) {
-        Some(null_count) => Precision::Exact(null_count as usize),
-        None => match null_counts.len() {
-            // If sum() returned None we either have no rows or all values are null
-            0 => Precision::Exact(0),
-            _ => Precision::Absent,
-        },
-    };
+    accumulators.null_counts_array[logical_schema_index] =
+        summarize_null_counts(parquet_index, row_groups_metadata);
 
-    // This is the same logic as parquet_column but we start from arrow schema index
-    // instead of looking up by name.
-    let parquet_index = parquet_column(
-        parquet_schema,
-        physical_file_schema,
-        logical_file_schema.field(logical_schema_index).name(),
-    )
-    .map(|(idx, _)| idx);
-
-    // Extract distinct counts from row group column statistics
     accumulators.distinct_counts_array[logical_schema_index] =
-        if let Some(parquet_idx) = parquet_index {
-            let num_row_groups = row_groups_metadata.len();
-            let distinct_counts: Vec<u64> = row_groups_metadata
-                .iter()
-                .filter_map(|rg| {
-                    rg.columns()
-                        .get(parquet_idx)
-                        .and_then(|col| col.statistics())
-                        .and_then(|stats| stats.distinct_count_opt())
-                })
-                .collect();
-
-            let coverage = distinct_counts.len() as f64 / num_row_groups.max(1) as f64;
-
-            if coverage < PARTIAL_NDV_THRESHOLD {
-                Precision::Absent
-            } else if distinct_counts.len() == 1 && num_row_groups == 1 {
-                // Single row group with distinct count - use exact value
-                Precision::Exact(distinct_counts[0] as usize)
-            } else {
-                // Multiple row groups - use max as a lower bound estimate
-                // (can't accurately merge NDV since duplicates may exist across row groups)
-                match distinct_counts.iter().max() {
-                    Some(&max_ndv) => Precision::Inexact(max_ndv as usize),
-                    None => Precision::Absent,
-                }
-            }
-        } else {
-            Precision::Absent
-        };
+        summarize_distinct_counts(parquet_index, row_groups_metadata);
 
     let arrow_field = logical_file_schema.field(logical_schema_index);
     accumulators.column_byte_sizes[logical_schema_index] = compute_arrow_column_size(
         arrow_field.data_type(),
         row_groups_metadata,
         parquet_index,
-        row_groups_metadata
-            .iter()
-            .map(|rg| rg.num_rows() as usize)
-            .sum(),
+        num_rows,
     );
 
     Ok(())
+}
+
+/// Feed a column's per-row-group min or max `values` into `acc` and decide
+/// whether the resulting bound is exact across all row groups.
+///
+/// `is_exact` reads the per-row-group exactness flag straight from the raw
+/// parquet statistics. `row_group_exactness` rebuilds the exactness as a Boolean
+/// array and is only called for the rare case where row groups disagree.
+fn summarize_bound<A: Accumulator>(
+    acc: &mut A,
+    values: &ArrayRef,
+    parquet_index: Option<usize>,
+    row_groups_metadata: &[RowGroupMetaData],
+    is_exact: impl Fn(&ParquetStatistics) -> bool,
+    row_group_exactness: impl FnOnce() -> Result<BooleanArray>,
+) -> Result<Option<bool>> {
+    acc.update_batch(&[Arc::clone(values)])?;
+
+    Ok(
+        match summarize_row_group_exactness(parquet_index, row_groups_metadata, is_exact)
+        {
+            ExactnessSummary::AllExact => Some(true),
+            ExactnessSummary::NoneExact => Some(false),
+            ExactnessSummary::Mixed => {
+                let exactness = row_group_exactness()?;
+                has_any_exact_match(&acc.evaluate()?, values, &exactness)
+            }
+        },
+    )
+}
+
+fn summarize_null_counts(
+    parquet_idx: Option<usize>,
+    row_groups_metadata: &[RowGroupMetaData],
+) -> Precision<usize> {
+    let Some(parquet_idx) = parquet_idx else {
+        return match row_groups_metadata.len() {
+            0 => Precision::Exact(0),
+            _ => Precision::Absent,
+        };
+    };
+
+    let mut null_count_sum = 0_u64;
+    let mut has_known_count = false;
+    for row_group in row_groups_metadata {
+        let Some(null_count) = row_group
+            .columns()
+            .get(parquet_idx)
+            .and_then(|column| column.statistics())
+            .map(|statistics| statistics.null_count_opt().unwrap_or(0))
+        else {
+            continue;
+        };
+
+        has_known_count = true;
+        null_count_sum += null_count;
+    }
+
+    if has_known_count || row_groups_metadata.is_empty() {
+        Precision::Exact(null_count_sum as usize)
+    } else {
+        Precision::Absent
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ExactnessSummary {
+    AllExact,
+    NoneExact,
+    Mixed,
+}
+
+fn summarize_row_group_exactness(
+    parquet_idx: Option<usize>,
+    row_groups_metadata: &[RowGroupMetaData],
+    exactness: impl Fn(&ParquetStatistics) -> bool,
+) -> ExactnessSummary {
+    let Some(parquet_idx) = parquet_idx else {
+        return ExactnessSummary::NoneExact;
+    };
+
+    summarize_exactness(row_groups_metadata.iter().map(|row_group| {
+        row_group
+            .columns()
+            .get(parquet_idx)
+            .and_then(|column| column.statistics())
+            .map(&exactness)
+    }))
+}
+
+fn summarize_exactness<I>(exactness: I) -> ExactnessSummary
+where
+    I: IntoIterator<Item = Option<bool>>,
+{
+    let mut has_true = false;
+    let mut has_false_or_null = false;
+
+    for exactness in exactness {
+        match exactness {
+            Some(true) => has_true = true,
+            Some(false) | None => has_false_or_null = true,
+        }
+
+        if has_true && has_false_or_null {
+            return ExactnessSummary::Mixed;
+        }
+    }
+
+    if has_true {
+        ExactnessSummary::AllExact
+    } else {
+        ExactnessSummary::NoneExact
+    }
+}
+
+/// Extract distinct counts from row group column statistics.
+fn summarize_distinct_counts(
+    parquet_idx: Option<usize>,
+    row_groups_metadata: &[RowGroupMetaData],
+) -> Precision<usize> {
+    let Some(parquet_idx) = parquet_idx else {
+        return Precision::Absent;
+    };
+
+    let num_row_groups = row_groups_metadata.len();
+    if num_row_groups == 0 {
+        return Precision::Absent;
+    }
+
+    let required_count = required_ndv_count(num_row_groups);
+    let mut ndv_count = 0;
+    let mut max_distinct_count: Option<u64> = None;
+
+    for (row_group_idx, row_group) in row_groups_metadata.iter().enumerate() {
+        if let Some(distinct_count) = row_group
+            .columns()
+            .get(parquet_idx)
+            .and_then(|col| col.statistics())
+            .and_then(|stats| stats.distinct_count_opt())
+        {
+            ndv_count += 1;
+            max_distinct_count = Some(match max_distinct_count {
+                Some(max) => max.max(distinct_count),
+                None => distinct_count,
+            });
+        }
+
+        let remaining = num_row_groups - row_group_idx - 1;
+        if ndv_count + remaining < required_count {
+            return Precision::Absent;
+        }
+    }
+
+    match max_distinct_count {
+        Some(distinct_count) if num_row_groups == 1 => {
+            Precision::Exact(distinct_count as usize)
+        }
+        Some(distinct_count) => Precision::Inexact(distinct_count as usize),
+        None => Precision::Absent,
+    }
+}
+
+fn required_ndv_count(num_row_groups: usize) -> usize {
+    (num_row_groups as f64 * PARTIAL_NDV_THRESHOLD).ceil() as usize
 }
 
 /// Compute the Arrow in-memory size for a single column
@@ -866,6 +962,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_summarize_exactness() {
+        assert_eq!(
+            summarize_exactness([Some(true), Some(true)]),
+            ExactnessSummary::AllExact
+        );
+        assert_eq!(
+            summarize_exactness([Some(false), None]),
+            ExactnessSummary::NoneExact
+        );
+        assert_eq!(
+            summarize_exactness([Some(true), Some(false)]),
+            ExactnessSummary::Mixed
+        );
+        assert_eq!(
+            summarize_exactness([Some(true), None]),
+            ExactnessSummary::Mixed
+        );
+        assert_eq!(
+            summarize_exactness(std::iter::empty()),
+            ExactnessSummary::NoneExact
+        );
+    }
+
     mod ndv_tests {
         use super::*;
         use arrow::datatypes::Field;
@@ -949,6 +1069,37 @@ mod tests {
             );
 
             ParquetMetaData::new(file_meta, row_groups)
+        }
+
+        #[test]
+        fn test_summarize_null_counts() {
+            let schema_descr = create_schema_descr(1);
+            let stats_with_count =
+                ParquetStatistics::int32(Some(1), Some(10), None, Some(2), false);
+            let stats_without_count =
+                ParquetStatistics::int32(Some(1), Some(10), None, None, false);
+
+            let row_groups = vec![
+                create_row_group_with_stats(
+                    &schema_descr,
+                    vec![Some(stats_with_count)],
+                    10,
+                ),
+                create_row_group_with_stats(
+                    &schema_descr,
+                    vec![Some(stats_without_count)],
+                    10,
+                ),
+                create_row_group_with_stats(&schema_descr, vec![None], 10),
+            ];
+
+            assert_eq!(
+                summarize_null_counts(Some(0), &row_groups),
+                Precision::Exact(2)
+            );
+            assert_eq!(summarize_null_counts(None, &row_groups), Precision::Absent);
+            assert_eq!(summarize_null_counts(Some(0), &[]), Precision::Exact(0));
+            assert_eq!(summarize_null_counts(None, &[]), Precision::Exact(0));
         }
 
         #[test]

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -594,8 +594,9 @@ fn summarize_null_counts(
 
     match sum(&null_counts) {
         Some(count) => {
-            // If any row group has a null `null_count` (either because the column chunk doesn't have statistics
-            // or the value itself is null), we report the total as inexact.
+           // If any row group has an unknown null_count, either because column
+           // statistics are absent or because the null_count field is omitted,
+           // report the aggregate as inexact.
             if null_counts.null_count() > 0 {
                 Ok(Precision::Inexact(count as usize))
             } else {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

The current stats aggregation does a bunch of unnecessary work, this PR tries to do the minimal amount of work at every step.

## What changes are included in this PR?

In addition to splitting up the summarization logic into some clearer functions and a reusable function for min/max, I've tried to do the minimal amount of work at each step:
1. Only allocate boolean masks if there's a mix of exact/inexact stats between row groups.
2. No need to allocate an Arrow array for null count.
3. No need to re-calculate the parquet column index - its already in `stats_converter`, as far as I can tell its exactly the same code path.
4. No need to recalculate the number of rows - we already know it.

I've also included a benchmark, the effect on my laptop is:
```
parquet_metadata_statistics/wide_one_row_group
                        time:   [2.9945 ms 3.0313 ms 3.0487 ms]
                        change: [−44.473% −43.790% −43.044%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parquet_metadata_statistics/moderate_width_many_row_groups: Collecting 10 samples in estimated 5
parquet_metadata_statistics/moderate_width_many_row_groups
                        time:   [236.75 µs 237.37 µs 238.48 µs]
                        change: [−22.330% −21.550% −20.794%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking parquet_metadata_statistics/wide_many_row_groups: Collecting 10 samples in estimated 5.0127 s (7
parquet_metadata_statistics/wide_many_row_groups
                        time:   [628.67 µs 636.88 µs 645.79 µs]
                        change: [−29.409% −28.225% −26.999%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

## Are these changes tested?

Existing tests and few additional small unit tests. 

## Are there any user-facing changes?

None
