### PR TITLE
Migrate UnKnownColumn proto hooks

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -4873,22 +4873,10 @@ mod tests {
         );
 
         // The probability of being distinct is 1 - 1 / 16 = 15 / 16.
-        let got = neq.evaluate_statistics(&[left_stat, right_stat])?;
-        let expected = Distribution::new_bernoulli(ScalarValue::from(15.0 / 16.0))?;
-        match (got, expected) {
-            (Bernoulli(g), Bernoulli(e)) => {
-                let gp = match g.p_value() {
-                    ScalarValue::Float64(Some(v)) => v,
-                    _ => panic!("got unexpected p type"),
-                };
-                let ep = match e.p_value() {
-                    ScalarValue::Float64(Some(v)) => v,
-                    _ => panic!("expected unexpected p type"),
-                };
-                assert!((gp - ep).abs() < 1e-12);
-            }
-            _ => panic!("unexpected distribution variants"),
-        }
+        assert_eq!(
+            neq.evaluate_statistics(&[left_stat, right_stat])?,
+            Distribution::new_bernoulli(ScalarValue::from(15.0 / 16.0))?
+        );
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -4873,10 +4873,22 @@ mod tests {
         );
 
         // The probability of being distinct is 1 - 1 / 16 = 15 / 16.
-        assert_eq!(
-            neq.evaluate_statistics(&[left_stat, right_stat])?,
-            Distribution::new_bernoulli(ScalarValue::from(15.0 / 16.0))?
-        );
+        let got = neq.evaluate_statistics(&[left_stat, right_stat])?;
+        let expected = Distribution::new_bernoulli(ScalarValue::from(15.0 / 16.0))?;
+        match (got, expected) {
+                    (Bernoulli(g), Bernoulli(e)) => {
+                let gp = match g.p_value() {
+                    ScalarValue::Float64(Some(v)) => v,
+                    _ => panic!("got unexpected p type"),
+                };
+                let ep = match e.p_value() {
+                    ScalarValue::Float64(Some(v)) => v,
+                    _ => panic!("expected unexpected p type"),
+                };
+                assert!((gp - ep).abs() < 1e-12);
+            }
+            _ => panic!("unexpected distribution variants"),
+        }
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -4876,7 +4876,7 @@ mod tests {
         let got = neq.evaluate_statistics(&[left_stat, right_stat])?;
         let expected = Distribution::new_bernoulli(ScalarValue::from(15.0 / 16.0))?;
         match (got, expected) {
-                    (Bernoulli(g), Bernoulli(e)) => {
+            (Bernoulli(g), Bernoulli(e)) => {
                 let gp = match g.p_value() {
                     ScalarValue::Float64(Some(v)) => v,
                     _ => panic!("got unexpected p type"),

--- a/datafusion/physical-expr/src/expressions/unknown_column.rs
+++ b/datafusion/physical-expr/src/expressions/unknown_column.rs
@@ -140,82 +140,104 @@ impl PartialEq for UnKnownColumn {
     }
 }
 
-#[cfg(test)]
-mod tests {
+/// Tests for the `try_to_proto` / `try_from_proto` hooks.
+#[cfg(all(test, feature = "proto"))]
+mod proto_tests {
     use super::*;
-
-    #[cfg(feature = "proto")]
-    use std::sync::Arc;
-
-    #[cfg(feature = "proto")]
+    use crate::proto_test_util::{StubEncoder, UnreachableDecoder, column_node};
     use arrow::datatypes::Schema;
-
-    #[cfg(feature = "proto")]
-    use datafusion_common::{Result, internal_err};
-
-    #[cfg(feature = "proto")]
+    use datafusion_common::DataFusionError;
     use datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx;
+    use datafusion_physical_expr_common::physical_expr::proto_encode::PhysicalExprEncodeCtx;
+    use datafusion_proto_models::protobuf::{self, physical_expr_node};
 
-    #[cfg(feature = "proto")]
-    struct DummyDecode;
+    // ── try_to_proto ─────────────────────────────────────────────────────────
 
-    #[cfg(feature = "proto")]
-    impl datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecode
-        for DummyDecode
-    {
-        fn decode(
-            &self,
-            _node: &datafusion_proto_models::protobuf::PhysicalExprNode,
-            _schema: &Schema,
-        ) -> Result<Arc<dyn PhysicalExpr>> {
-            internal_err!("decode should not be called")
-        }
+    #[test]
+    fn try_to_proto_encodes_unknown_column() {
+        let expr = UnKnownColumn::new("my_col");
+        let encoder = StubEncoder::ok();
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+
+        let node = expr
+            .try_to_proto(&ctx)
+            .unwrap()
+            .expect("UnKnownColumn should encode to Some(node)");
+
+        // Built-in exprs never set expr_id; only dynamic filters do.
+        assert!(node.expr_id.is_none());
+
+        // Verify the encoded name matches the original.
+        let protobuf::UnknownColumn { name } = match node.expr_type {
+            Some(physical_expr_node::ExprType::UnknownColumn(c)) => c,
+            other => panic!("expected UnknownColumn proto node, got {other:?}"),
+        };
+        assert_eq!(name, "my_col");
     }
 
-    #[cfg(feature = "proto")]
-    #[test]
-    fn try_from_proto_reports_found_variant() {
-        use datafusion_proto_models::protobuf;
+    // ── try_from_proto ───────────────────────────────────────────────────────
 
+    #[test]
+    fn try_from_proto_decodes_name() {
         let node = protobuf::PhysicalExprNode {
-            expr_id: Some(7),
-            expr_type: Some(protobuf::physical_expr_node::ExprType::Column(
-                protobuf::PhysicalColumn {
-                    name: "col_a".to_string(),
-                    index: 0,
+            expr_id: None,
+            expr_type: Some(physical_expr_node::ExprType::UnknownColumn(
+                protobuf::UnknownColumn {
+                    name: "my_col".to_string(),
                 },
             )),
         };
         let schema = Schema::empty();
-        let decoder = DummyDecode;
-        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
-
-        let err = UnKnownColumn::try_from_proto(&node, &ctx).unwrap_err();
-        let err = err.to_string();
-
-        assert!(err.contains("expr_id=Some(7)"));
-        assert!(err.contains("PhysicalColumn"));
-    }
-
-    #[cfg(feature = "proto")]
-    #[test]
-    fn unknown_column_proto_roundtrip() {
-        use datafusion_proto_models::protobuf;
-
-        let name = "col_b".to_string();
-        let node = protobuf::PhysicalExprNode {
-            expr_id: Some(42),
-            expr_type: Some(protobuf::physical_expr_node::ExprType::UnknownColumn(
-                protobuf::UnknownColumn { name: name.clone() },
-            )),
-        };
-
-        let schema = Schema::empty();
-        let decoder = DummyDecode;
+        // UnKnownColumn has no child exprs so the decoder is never called.
+        let decoder = UnreachableDecoder;
         let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
 
         let decoded = UnKnownColumn::try_from_proto(&node, &ctx).unwrap();
-        let col = decoded.as_ref().downcast_ref::<UnKnownColumn>().unwrap();
-        assert_eq!(col.name(), name.as_str());
+        let col = decoded
+            .downcast_ref::<UnKnownColumn>()
+            .expect("decoded expr should be an UnKnownColumn");
+        assert_eq!(col.name(), "my_col");
+    }
+
+    #[test]
+    fn try_from_proto_rejects_non_unknown_column_node() {
+        // column_node produces an ExprType::Column node, not UnknownColumn.
+        let node = column_node("a");
+        let schema = Schema::empty();
+        let decoder = UnreachableDecoder;
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+        let err = UnKnownColumn::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            DataFusionError::Internal(ref msg)
+                if msg.contains("PhysicalExprNode is not an UnKnownColumn")
+                // The error includes the actual expr_type for easier diagnosis.
+                && msg.contains("PhysicalColumn")
+        ));
+    }
+
+    // ── roundtrip ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn unknown_column_proto_roundtrip() {
+        let expr = UnKnownColumn::new("col_b");
+        let encoder = StubEncoder::ok();
+        let enc_ctx = PhysicalExprEncodeCtx::new(&encoder);
+
+        let node = expr
+            .try_to_proto(&enc_ctx)
+            .unwrap()
+            .expect("UnKnownColumn should encode to Some(node)");
+
+        let schema = Schema::empty();
+        // UnKnownColumn has no child exprs so the decoder is never called.
+        let decoder = UnreachableDecoder;
+        let dec_ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let decoded = UnKnownColumn::try_from_proto(&node, &dec_ctx).unwrap();
+        let col = decoded
+            .downcast_ref::<UnKnownColumn>()
+            .expect("decoded expr should be an UnKnownColumn");
+        assert_eq!(col.name(), "col_b");
     }
 }

--- a/datafusion/physical-expr/src/expressions/unknown_column.rs
+++ b/datafusion/physical-expr/src/expressions/unknown_column.rs
@@ -28,8 +28,6 @@ use arrow::{
 };
 use datafusion_common::{Result, internal_err};
 
-#[cfg(feature = "proto")]
-use datafusion_proto_models::protobuf;
 use datafusion_expr::ColumnarValue;
 
 #[derive(Debug, Clone, Eq)]
@@ -92,7 +90,9 @@ impl PhysicalExpr for UnKnownColumn {
     fn try_to_proto(
         &self,
         _ctx: &datafusion_physical_expr_common::physical_expr::proto_encode::PhysicalExprEncodeCtx<'_>,
-    ) -> Result<Option<protobuf::PhysicalExprNode>> {
+    ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalExprNode>> {
+        use datafusion_proto_models::protobuf;
+
         Ok(Some(protobuf::PhysicalExprNode {
             expr_id: None,
             expr_type: Some(protobuf::physical_expr_node::ExprType::UnknownColumn(
@@ -108,14 +108,79 @@ impl PhysicalExpr for UnKnownColumn {
 impl UnKnownColumn {
     /// Reconstruct an [`UnKnownColumn`] from its protobuf representation.
     pub fn try_from_proto(
-        node: &protobuf::PhysicalExprNode,
+        node: &datafusion_proto_models::protobuf::PhysicalExprNode,
         _ctx: &datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx<'_>,
     ) -> Result<Arc<dyn PhysicalExpr>> {
+        use datafusion_proto_models::protobuf;
+
         let protobuf::UnknownColumn { name } = match &node.expr_type {
             Some(protobuf::physical_expr_node::ExprType::UnknownColumn(c)) => c,
-            _ => return internal_err!("PhysicalExprNode is not an UnKnownColumn"),
+            other => {
+                return internal_err!(
+                    "PhysicalExprNode is not an UnKnownColumn (expr_id={:?}, expr_type={other:?})",
+                    node.expr_id
+                );
+            }
         };
         Ok(Arc::new(UnKnownColumn::new(name)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "proto")]
+    use std::sync::Arc;
+
+    #[cfg(feature = "proto")]
+    use arrow::datatypes::Schema;
+
+    #[cfg(feature = "proto")]
+    use datafusion_common::{Result, internal_err};
+
+    #[cfg(feature = "proto")]
+    use datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx;
+
+    #[cfg(feature = "proto")]
+    struct DummyDecode;
+
+    #[cfg(feature = "proto")]
+    impl datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecode
+        for DummyDecode
+    {
+        fn decode(
+            &self,
+            _node: &datafusion_proto_models::protobuf::PhysicalExprNode,
+            _schema: &Schema,
+        ) -> Result<Arc<dyn PhysicalExpr>> {
+            internal_err!("decode should not be called")
+        }
+    }
+
+    #[cfg(feature = "proto")]
+    #[test]
+    fn try_from_proto_reports_found_variant() {
+        use datafusion_proto_models::protobuf;
+
+        let node = protobuf::PhysicalExprNode {
+            expr_id: Some(7),
+            expr_type: Some(protobuf::physical_expr_node::ExprType::Column(
+                protobuf::PhysicalColumn {
+                    name: "col_a".to_string(),
+                    index: 0,
+                },
+            )),
+        };
+        let schema = Schema::empty();
+        let decoder = DummyDecode;
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let err = UnKnownColumn::try_from_proto(&node, &ctx).unwrap_err();
+        let err = err.to_string();
+
+        assert!(err.contains("expr_id=Some(7)"));
+        assert!(err.contains("PhysicalColumn"));
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/unknown_column.rs
+++ b/datafusion/physical-expr/src/expressions/unknown_column.rs
@@ -126,6 +126,20 @@ impl UnKnownColumn {
     }
 }
 
+impl Hash for UnKnownColumn {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl PartialEq for UnKnownColumn {
+    fn eq(&self, _other: &Self) -> bool {
+        // UnknownColumn is not a valid expression, so it should not be equal to any other expression.
+        // See https://github.com/apache/datafusion/pull/11536
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,19 +195,5 @@ mod tests {
 
         assert!(err.contains("expr_id=Some(7)"));
         assert!(err.contains("PhysicalColumn"));
-    }
-}
-
-impl Hash for UnKnownColumn {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.name.hash(state);
-    }
-}
-
-impl PartialEq for UnKnownColumn {
-    fn eq(&self, _other: &Self) -> bool {
-        // UnknownColumn is not a valid expression, so it should not be equal to any other expression.
-        // See https://github.com/apache/datafusion/pull/11536
-        false
     }
 }

--- a/datafusion/physical-expr/src/expressions/unknown_column.rs
+++ b/datafusion/physical-expr/src/expressions/unknown_column.rs
@@ -27,6 +27,9 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use datafusion_common::{Result, internal_err};
+
+#[cfg(feature = "proto")]
+use datafusion_proto_models::protobuf;
 use datafusion_expr::ColumnarValue;
 
 #[derive(Debug, Clone, Eq)]
@@ -83,6 +86,36 @@ impl PhysicalExpr for UnKnownColumn {
 
     fn fmt_sql(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)
+    }
+
+    #[cfg(feature = "proto")]
+    fn try_to_proto(
+        &self,
+        _ctx: &datafusion_physical_expr_common::physical_expr::proto_encode::PhysicalExprEncodeCtx<'_>,
+    ) -> Result<Option<protobuf::PhysicalExprNode>> {
+        Ok(Some(protobuf::PhysicalExprNode {
+            expr_id: None,
+            expr_type: Some(protobuf::physical_expr_node::ExprType::UnknownColumn(
+                protobuf::UnknownColumn {
+                    name: self.name.clone(),
+                },
+            )),
+        }))
+    }
+}
+
+#[cfg(feature = "proto")]
+impl UnKnownColumn {
+    /// Reconstruct an [`UnKnownColumn`] from its protobuf representation.
+    pub fn try_from_proto(
+        node: &protobuf::PhysicalExprNode,
+        _ctx: &datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx<'_>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        let protobuf::UnknownColumn { name } = match &node.expr_type {
+            Some(protobuf::physical_expr_node::ExprType::UnknownColumn(c)) => c,
+            _ => return internal_err!("PhysicalExprNode is not an UnKnownColumn"),
+        };
+        Ok(Arc::new(UnKnownColumn::new(name)))
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/unknown_column.rs
+++ b/datafusion/physical-expr/src/expressions/unknown_column.rs
@@ -111,18 +111,15 @@ impl UnKnownColumn {
         node: &datafusion_proto_models::protobuf::PhysicalExprNode,
         _ctx: &datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx<'_>,
     ) -> Result<Arc<dyn PhysicalExpr>> {
+        use datafusion_physical_expr_common::expect_expr_variant;
         use datafusion_proto_models::protobuf;
 
-        let protobuf::UnknownColumn { name } = match &node.expr_type {
-            Some(protobuf::physical_expr_node::ExprType::UnknownColumn(c)) => c,
-            other => {
-                return internal_err!(
-                    "PhysicalExprNode is not an UnKnownColumn (expr_id={:?}, expr_type={other:?})",
-                    node.expr_id
-                );
-            }
-        };
-        Ok(Arc::new(UnKnownColumn::new(name)))
+        let unknown_col = expect_expr_variant!(
+            node,
+            protobuf::physical_expr_node::ExprType::UnknownColumn,
+            "UnKnownColumn",
+        );
+        Ok(Arc::new(UnKnownColumn::new(&unknown_col.name)))
     }
 }
 
@@ -210,9 +207,7 @@ mod proto_tests {
         assert!(matches!(
             err,
             DataFusionError::Internal(ref msg)
-                if msg.contains("PhysicalExprNode is not an UnKnownColumn")
-                // The error includes the actual expr_type for easier diagnosis.
-                && msg.contains("PhysicalColumn")
+                if msg.contains("PhysicalExprNode is not a UnKnownColumn")
         ));
     }
 

--- a/datafusion/physical-expr/src/expressions/unknown_column.rs
+++ b/datafusion/physical-expr/src/expressions/unknown_column.rs
@@ -196,4 +196,26 @@ mod tests {
         assert!(err.contains("expr_id=Some(7)"));
         assert!(err.contains("PhysicalColumn"));
     }
+
+    #[cfg(feature = "proto")]
+    #[test]
+    fn unknown_column_proto_roundtrip() {
+        use datafusion_proto_models::protobuf;
+
+        let name = "col_b".to_string();
+        let node = protobuf::PhysicalExprNode {
+            expr_id: Some(42),
+            expr_type: Some(protobuf::physical_expr_node::ExprType::UnknownColumn(
+                protobuf::UnknownColumn { name: name.clone() },
+            )),
+        };
+
+        let schema = Schema::empty();
+        let decoder = DummyDecode;
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let decoded = UnKnownColumn::try_from_proto(&node, &ctx).unwrap();
+        let col = decoded.as_ref().downcast_ref::<UnKnownColumn>().unwrap();
+        assert_eq!(col.name(), name.as_str());
+    }
 }

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -282,7 +282,7 @@ pub fn parse_physical_expr_with_converter(
         // their own `ExprType` variant — see #21835. This match only routes
         // to the right constructor.
         ExprType::Column(_) => Column::try_from_proto(proto, &decode_ctx)?,
-        ExprType::UnknownColumn(c) => Arc::new(UnKnownColumn::new(&c.name)),
+        ExprType::UnknownColumn(_) => UnKnownColumn::try_from_proto(proto, &decode_ctx)?,
         ExprType::Literal(scalar) => Arc::new(Literal::new(scalar.try_into()?)),
         ExprType::BinaryExpr(_) => BinaryExpr::try_from_proto(proto, &decode_ctx)?,
         ExprType::AggregateExpr(_) => {

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -37,7 +37,6 @@ use datafusion_physical_expr::window::{SlidingAggregateWindowExpr, StandardWindo
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
 use datafusion_physical_plan::expressions::{
     CaseExpr, DynamicFilterPhysicalExpr, IsNotNullExpr, IsNullExpr, Literal, TryCastExpr,
-    UnKnownColumn,
 };
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
 use datafusion_physical_plan::windows::{PlainAggregateWindowExpr, WindowUDFExpr};
@@ -303,16 +302,7 @@ pub fn serialize_physical_expr_with_converter(
         return Ok(node);
     }
 
-    if let Some(expr) = expr.downcast_ref::<UnKnownColumn>() {
-        Ok(protobuf::PhysicalExprNode {
-            expr_id,
-            expr_type: Some(protobuf::physical_expr_node::ExprType::UnknownColumn(
-                protobuf::UnknownColumn {
-                    name: expr.name().to_string(),
-                },
-            )),
-        })
-    } else if let Some(expr) = expr.downcast_ref::<CaseExpr>() {
+    if let Some(expr) = expr.downcast_ref::<CaseExpr>() {
         Ok(protobuf::PhysicalExprNode {
             expr_id,
             expr_type: Some(


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22420.

## Rationale for this change

This issue is part of the migration to the new proto hooks (	ry_to_proto / 	ry_from_proto). UnKnownColumn was still handled in the legacy match arms, so this ports it to the hook-based path for consistency with other migrated expressions (e.g. Column, BinaryExpr).

## What changes are included in this PR?

- Add 	ry_to_proto / 	ry_from_proto implementations for UnKnownColumn in physical-expr.
- Remove the legacy UnKnownColumn match arms in datafusion/proto physical plan conversion.

## Are these changes tested?

- cargo test -p datafusion-proto --lib

## Are there any user-facing changes?

No user-facing changes.