### PR TITLE
Port LikeExpr to use try_to_proto / try_from_proto

### DIFF
--- a/datafusion/physical-expr/src/expressions/like.rs
+++ b/datafusion/physical-expr/src/expressions/like.rs
@@ -347,12 +347,7 @@ mod test {
     }
 }
 
-/// Tests for the `try_to_proto` / `try_from_proto` hooks (issue #22418).
-///
-/// These drive the encode/decode hooks directly with small stub
-/// encoder/decoders so every branch can be covered without depending on
-/// `datafusion-proto`: the happy path, the wrong-node and missing-child
-/// rejections, and child encode/decode error propagation.
+/// Tests for the `try_to_proto` / `try_from_proto` hooks.
 #[cfg(all(test, feature = "proto"))]
 mod proto_tests {
     use super::*;

--- a/datafusion/physical-expr/src/expressions/like.rs
+++ b/datafusion/physical-expr/src/expressions/like.rs
@@ -470,7 +470,7 @@ mod proto_tests {
         let err = LikeExpr::try_from_proto(&node, &ctx).unwrap_err();
         assert!(matches!(
             err,
-            DataFusionError::Internal(msg) if msg == "PhysicalExprNode is not a LikeExpr"
+            DataFusionError::Internal(msg) if msg.contains("PhysicalExprNode is not a LikeExpr")
         ));
     }
 
@@ -483,7 +483,7 @@ mod proto_tests {
         let err = LikeExpr::try_from_proto(&node, &ctx).unwrap_err();
         assert!(matches!(
             err,
-            DataFusionError::Internal(msg) if msg == "LikeExpr is missing required field 'expr'"
+            DataFusionError::Internal(msg) if msg.contains("LikeExpr is missing required field 'expr'")
         ));
     }
 
@@ -496,7 +496,7 @@ mod proto_tests {
         let err = LikeExpr::try_from_proto(&node, &ctx).unwrap_err();
         assert!(matches!(
             err,
-            DataFusionError::Internal(msg) if msg == "LikeExpr is missing required field 'pattern'"
+            DataFusionError::Internal(msg) if msg.contains("LikeExpr is missing required field 'pattern'")
         ));
     }
 

--- a/datafusion/physical-expr/src/expressions/like.rs
+++ b/datafusion/physical-expr/src/expressions/like.rs
@@ -346,3 +346,192 @@ mod test {
         Ok(())
     }
 }
+
+/// Tests for the `try_to_proto` / `try_from_proto` hooks (issue #22418).
+///
+/// These drive the encode/decode hooks directly with small stub
+/// encoder/decoders so every branch can be covered without depending on
+/// `datafusion-proto`: the happy path, the wrong-node and missing-child
+/// rejections, and child encode/decode error propagation.
+#[cfg(all(test, feature = "proto"))]
+mod proto_tests {
+    use super::*;
+    use crate::expressions::{Column, col};
+    use crate::proto_test_util::{
+        StubDecoder, StubEncoder, UnreachableDecoder, column_node,
+    };
+    use arrow::datatypes::Field;
+    use datafusion_common::DataFusionError;
+    use datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx;
+    use datafusion_physical_expr_common::physical_expr::proto_encode::PhysicalExprEncodeCtx;
+    use datafusion_proto_models::protobuf::{
+        PhysicalExprNode, PhysicalLikeExprNode, physical_expr_node,
+    };
+
+    /// Build a `LikeExpr` proto node with the given children.
+    fn like_node(
+        negated: bool,
+        case_insensitive: bool,
+        expr: Option<Box<PhysicalExprNode>>,
+        pattern: Option<Box<PhysicalExprNode>>,
+    ) -> PhysicalExprNode {
+        PhysicalExprNode {
+            expr_id: None,
+            expr_type: Some(physical_expr_node::ExprType::LikeExpr(Box::new(
+                PhysicalLikeExprNode {
+                    negated,
+                    case_insensitive,
+                    expr,
+                    pattern,
+                },
+            ))),
+        }
+    }
+
+    /// A `LikeExpr` over two `Utf8` columns with both flags set, so the
+    /// `negated` / `case_insensitive` wiring is actually exercised.
+    fn like_fixture() -> LikeExpr {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Utf8, false),
+            Field::new("b", DataType::Utf8, false),
+        ]);
+        LikeExpr::new(
+            true,
+            true,
+            col("a", &schema).unwrap(),
+            col("b", &schema).unwrap(),
+        )
+    }
+
+    #[test]
+    fn try_to_proto_encodes_like_expr() {
+        let like = like_fixture();
+        let encoder = StubEncoder::ok();
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+
+        let node = like
+            .try_to_proto(&ctx)
+            .unwrap()
+            .expect("LikeExpr should encode to Some(node)");
+
+        // Built-in exprs never set expr_id; only dynamic filters do.
+        assert!(node.expr_id.is_none());
+        let like_node = match node.expr_type {
+            Some(physical_expr_node::ExprType::LikeExpr(boxed)) => *boxed,
+            other => panic!("expected a LikeExpr node, got {other:?}"),
+        };
+        assert!(like_node.negated);
+        assert!(like_node.case_insensitive);
+        assert!(like_node.expr.is_some());
+        assert!(like_node.pattern.is_some());
+    }
+
+    #[test]
+    fn try_to_proto_propagates_expr_encode_error() {
+        let like = like_fixture();
+        let encoder = StubEncoder::failing_on(1);
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+        let err = like.try_to_proto(&ctx).unwrap_err();
+        assert!(matches!(err, DataFusionError::Internal(msg) if msg.contains("call 1")));
+    }
+
+    #[test]
+    fn try_to_proto_propagates_pattern_encode_error() {
+        let like = like_fixture();
+        let encoder = StubEncoder::failing_on(2);
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+        let err = like.try_to_proto(&ctx).unwrap_err();
+        assert!(matches!(err, DataFusionError::Internal(msg) if msg.contains("call 2")));
+    }
+
+    #[test]
+    fn try_from_proto_decodes_like_expr() {
+        let node = like_node(
+            true,
+            true,
+            Some(Box::new(column_node("a"))),
+            Some(Box::new(column_node("b"))),
+        );
+        let schema = Schema::empty();
+        let decoder = StubDecoder::ok();
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let decoded = LikeExpr::try_from_proto(&node, &ctx).unwrap();
+        let like = decoded
+            .downcast_ref::<LikeExpr>()
+            .expect("decoded expr should be a LikeExpr");
+        assert!(like.negated());
+        assert!(like.case_insensitive());
+        assert!(like.expr().downcast_ref::<Column>().is_some());
+        assert!(like.pattern().downcast_ref::<Column>().is_some());
+    }
+
+    #[test]
+    fn try_from_proto_rejects_non_like_node() {
+        let node = column_node("a");
+        let schema = Schema::empty();
+        let decoder = UnreachableDecoder;
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+        let err = LikeExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            DataFusionError::Internal(msg) if msg == "PhysicalExprNode is not a LikeExpr"
+        ));
+    }
+
+    #[test]
+    fn try_from_proto_rejects_missing_expr() {
+        let node = like_node(false, false, None, Some(Box::new(column_node("b"))));
+        let schema = Schema::empty();
+        let decoder = UnreachableDecoder;
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+        let err = LikeExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            DataFusionError::Internal(msg) if msg == "LikeExpr is missing required field 'expr'"
+        ));
+    }
+
+    #[test]
+    fn try_from_proto_rejects_missing_pattern() {
+        let node = like_node(false, false, Some(Box::new(column_node("a"))), None);
+        let schema = Schema::empty();
+        let decoder = UnreachableDecoder;
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+        let err = LikeExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            DataFusionError::Internal(msg) if msg == "LikeExpr is missing required field 'pattern'"
+        ));
+    }
+
+    #[test]
+    fn try_from_proto_propagates_expr_decode_error() {
+        let node = like_node(
+            false,
+            false,
+            Some(Box::new(column_node("a"))),
+            Some(Box::new(column_node("b"))),
+        );
+        let schema = Schema::empty();
+        let decoder = StubDecoder::failing_on(1);
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+        let err = LikeExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(matches!(err, DataFusionError::Internal(msg) if msg.contains("call 1")));
+    }
+
+    #[test]
+    fn try_from_proto_propagates_pattern_decode_error() {
+        let node = like_node(
+            false,
+            false,
+            Some(Box::new(column_node("a"))),
+            Some(Box::new(column_node("b"))),
+        );
+        let schema = Schema::empty();
+        let decoder = StubDecoder::failing_on(2);
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+        let err = LikeExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(matches!(err, DataFusionError::Internal(msg) if msg.contains("call 2")));
+    }
+}

--- a/datafusion/physical-expr/src/expressions/like.rs
+++ b/datafusion/physical-expr/src/expressions/like.rs
@@ -145,6 +145,69 @@ impl PhysicalExpr for LikeExpr {
         write!(f, " {} ", self.op_name())?;
         self.pattern.fmt_sql(f)
     }
+
+    #[cfg(feature = "proto")]
+    fn try_to_proto(
+        &self,
+        ctx: &datafusion_physical_expr_common::physical_expr::proto_encode::PhysicalExprEncodeCtx<'_>,
+    ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalExprNode>> {
+        use datafusion_proto_models::protobuf;
+
+        Ok(Some(protobuf::PhysicalExprNode {
+            expr_id: None,
+            expr_type: Some(protobuf::physical_expr_node::ExprType::LikeExpr(Box::new(
+                protobuf::PhysicalLikeExprNode {
+                    negated: self.negated,
+                    case_insensitive: self.case_insensitive,
+                    expr: Some(Box::new(ctx.encode_child(&self.expr)?)),
+                    pattern: Some(Box::new(ctx.encode_child(&self.pattern)?)),
+                },
+            ))),
+        }))
+    }
+}
+
+#[cfg(feature = "proto")]
+impl LikeExpr {
+    /// Reconstruct a [`LikeExpr`] from its protobuf representation.
+    ///
+    /// Takes the whole [`PhysicalExprNode`] so the decode signature matches
+    /// other migrated expressions and can inspect outer-node metadata if
+    /// needed in the future.
+    ///
+    /// [`PhysicalExprNode`]: datafusion_proto_models::protobuf::PhysicalExprNode
+    pub fn try_from_proto(
+        node: &datafusion_proto_models::protobuf::PhysicalExprNode,
+        ctx: &datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx<'_>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        use datafusion_common::internal_err;
+        use datafusion_proto_models::protobuf;
+
+        let like_expr = match &node.expr_type {
+            Some(protobuf::physical_expr_node::ExprType::LikeExpr(like_expr)) => {
+                like_expr.as_ref()
+            }
+            _ => return internal_err!("PhysicalExprNode is not a LikeExpr"),
+        };
+
+        let expr = like_expr.expr.as_deref().ok_or_else(|| {
+            datafusion_common::DataFusionError::Internal(
+                "LikeExpr is missing required field 'expr'".to_string(),
+            )
+        })?;
+        let pattern = like_expr.pattern.as_deref().ok_or_else(|| {
+            datafusion_common::DataFusionError::Internal(
+                "LikeExpr is missing required field 'pattern'".to_string(),
+            )
+        })?;
+
+        Ok(Arc::new(LikeExpr::new(
+            like_expr.negated,
+            like_expr.case_insensitive,
+            ctx.decode(expr)?,
+            ctx.decode(pattern)?,
+        )))
+    }
 }
 
 /// used for optimize Dictionary like

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -40,6 +40,10 @@ mod partitioning;
 mod physical_expr;
 pub mod planner;
 pub mod projection;
+/// Shared test helpers for the `try_to_proto` / `try_from_proto` migration
+/// (issue #22418). Compiled only under `cfg(test)` with the `proto` feature.
+#[cfg(all(test, feature = "proto"))]
+pub(crate) mod proto_test_util;
 mod scalar_function;
 pub mod scalar_subquery;
 pub mod simplifier;

--- a/datafusion/physical-expr/src/lib.rs
+++ b/datafusion/physical-expr/src/lib.rs
@@ -40,8 +40,7 @@ mod partitioning;
 mod physical_expr;
 pub mod planner;
 pub mod projection;
-/// Shared test helpers for the `try_to_proto` / `try_from_proto` migration
-/// (issue #22418). Compiled only under `cfg(test)` with the `proto` feature.
+/// Shared test helpers for the `try_to_proto` / `try_from_proto` unit tests
 #[cfg(all(test, feature = "proto"))]
 pub(crate) mod proto_test_util;
 mod scalar_function;

--- a/datafusion/physical-expr/src/proto_test_util.rs
+++ b/datafusion/physical-expr/src/proto_test_util.rs
@@ -15,15 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Shared test helpers for exercising the `try_to_proto` / `try_from_proto`
-//! hooks (issue #22418) without depending on `datafusion-proto`.
-//!
-//! As built-in expressions are ported off the central proto downcast chain,
-//! each one's unit tests need to drive the new encode/decode hooks in
-//! isolation. The generic scaffolding — stub encoder/decoders and a
-//! placeholder child-node builder — lives here so it is written once and
-//! reused across expressions. Expression-specific node builders and fixtures
-//! stay in each expression's own test module.
+//! Shared test helpers for proto serialization / deserialization in expression unit tests
+//! without depending on `datafusion-proto` (which would create circular deps).
 
 use std::cell::Cell;
 use std::sync::Arc;

--- a/datafusion/physical-expr/src/proto_test_util.rs
+++ b/datafusion/physical-expr/src/proto_test_util.rs
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shared test helpers for exercising the `try_to_proto` / `try_from_proto`
+//! hooks (issue #22418) without depending on `datafusion-proto`.
+//!
+//! As built-in expressions are ported off the central proto downcast chain,
+//! each one's unit tests need to drive the new encode/decode hooks in
+//! isolation. The generic scaffolding — stub encoder/decoders and a
+//! placeholder child-node builder — lives here so it is written once and
+//! reused across expressions. Expression-specific node builders and fixtures
+//! stay in each expression's own test module.
+
+use std::cell::Cell;
+use std::sync::Arc;
+
+use arrow::datatypes::Schema;
+use datafusion_common::{DataFusionError, Result};
+use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
+use datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecode;
+use datafusion_physical_expr_common::physical_expr::proto_encode::PhysicalExprEncode;
+use datafusion_proto_models::protobuf::{self, PhysicalExprNode, physical_expr_node};
+
+use crate::expressions::Column;
+
+/// A proto node for a `Column`, useful as a stand-in child node when building
+/// an expression's proto representation in tests.
+pub(crate) fn column_node(name: &str) -> PhysicalExprNode {
+    PhysicalExprNode {
+        expr_id: None,
+        expr_type: Some(physical_expr_node::ExprType::Column(
+            protobuf::PhysicalColumn {
+                name: name.to_string(),
+                index: 0,
+            },
+        )),
+    }
+}
+
+/// Decoder stub for driving `try_from_proto`: returns a fixed `Column` for each
+/// child node, optionally failing on the Nth `decode` call so the
+/// `ctx.decode(..)?` error arms can be exercised.
+pub(crate) struct StubDecoder {
+    fail_on_call: Option<usize>,
+    calls: Cell<usize>,
+}
+
+impl StubDecoder {
+    /// Always succeeds, returning a placeholder `Column` per child.
+    pub(crate) fn ok() -> Self {
+        Self {
+            fail_on_call: None,
+            calls: Cell::new(0),
+        }
+    }
+
+    /// Fails on the `call`-th invocation (1-based), succeeding otherwise.
+    pub(crate) fn failing_on(call: usize) -> Self {
+        Self {
+            fail_on_call: Some(call),
+            calls: Cell::new(0),
+        }
+    }
+}
+
+impl PhysicalExprDecode for StubDecoder {
+    fn decode(
+        &self,
+        _node: &PhysicalExprNode,
+        _schema: &Schema,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        let call = self.calls.get() + 1;
+        self.calls.set(call);
+        if Some(call) == self.fail_on_call {
+            return Err(DataFusionError::Internal(format!(
+                "stub decode failure on call {call}"
+            )));
+        }
+        Ok(Arc::new(Column::new("decoded", 0)))
+    }
+}
+
+/// Decoder that must never run: used to assert that the reject paths of a
+/// `try_from_proto` (wrong node, missing child) bail out before decoding.
+pub(crate) struct UnreachableDecoder;
+
+impl PhysicalExprDecode for UnreachableDecoder {
+    fn decode(
+        &self,
+        _node: &PhysicalExprNode,
+        _schema: &Schema,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        unreachable!("decode must not be reached when the node is rejected")
+    }
+}
+
+/// Encoder stub for driving `try_to_proto`: emits a placeholder `Column` node
+/// for each child, optionally failing on the Nth `encode` call so the
+/// `ctx.encode_child(..)?` error arms can be exercised.
+pub(crate) struct StubEncoder {
+    fail_on_call: Option<usize>,
+    calls: Cell<usize>,
+}
+
+impl StubEncoder {
+    /// Always succeeds, emitting a placeholder `Column` node per child.
+    pub(crate) fn ok() -> Self {
+        Self {
+            fail_on_call: None,
+            calls: Cell::new(0),
+        }
+    }
+
+    /// Fails on the `call`-th invocation (1-based), succeeding otherwise.
+    pub(crate) fn failing_on(call: usize) -> Self {
+        Self {
+            fail_on_call: Some(call),
+            calls: Cell::new(0),
+        }
+    }
+}
+
+impl PhysicalExprEncode for StubEncoder {
+    fn encode(&self, _expr: &Arc<dyn PhysicalExpr>) -> Result<PhysicalExprNode> {
+        let call = self.calls.get() + 1;
+        self.calls.set(call);
+        if Some(call) == self.fail_on_call {
+            return Err(DataFusionError::Internal(format!(
+                "stub encode failure on call {call}"
+            )));
+        }
+        Ok(column_node("child"))
+    }
+}

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -426,24 +426,7 @@ pub fn parse_physical_expr_with_converter(
                 .with_nullable(e.nullable),
             )
         }
-        ExprType::LikeExpr(like_expr) => Arc::new(LikeExpr::new(
-            like_expr.negated,
-            like_expr.case_insensitive,
-            parse_required_physical_expr(
-                like_expr.expr.as_deref(),
-                ctx,
-                "expr",
-                input_schema,
-                proto_converter,
-            )?,
-            parse_required_physical_expr(
-                like_expr.pattern.as_deref(),
-                ctx,
-                "pattern",
-                input_schema,
-                proto_converter,
-            )?,
-        )),
+        ExprType::LikeExpr(_) => LikeExpr::try_from_proto(proto, &decode_ctx)?,
         ExprType::HashExpr(hash_expr) => {
             let on_columns = parse_physical_exprs(
                 &hash_expr.on_columns,

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -37,7 +37,7 @@ use datafusion_physical_expr::window::{SlidingAggregateWindowExpr, StandardWindo
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
 use datafusion_physical_plan::expressions::{
     CaseExpr, CastExpr, DynamicFilterPhysicalExpr, InListExpr, IsNotNullExpr, IsNullExpr,
-    LikeExpr, Literal, NegativeExpr, NotExpr, TryCastExpr, UnKnownColumn,
+    Literal, NegativeExpr, NotExpr, TryCastExpr, UnKnownColumn,
 };
 use datafusion_physical_plan::joins::{HashExpr, HashTableLookupExpr};
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
@@ -485,22 +485,6 @@ pub fn serialize_physical_expr_with_converter(
                         .to_string(),
                 },
             )),
-        })
-    } else if let Some(expr) = expr.downcast_ref::<LikeExpr>() {
-        Ok(protobuf::PhysicalExprNode {
-            expr_id,
-            expr_type: Some(protobuf::physical_expr_node::ExprType::LikeExpr(Box::new(
-                protobuf::PhysicalLikeExprNode {
-                    negated: expr.negated(),
-                    case_insensitive: expr.case_insensitive(),
-                    expr: Some(Box::new(
-                        proto_converter.physical_expr_to_proto(expr.expr(), codec)?,
-                    )),
-                    pattern: Some(Box::new(
-                        proto_converter.physical_expr_to_proto(expr.pattern(), codec)?,
-                    )),
-                },
-            ))),
         })
     } else if let Some(expr) = expr.downcast_ref::<HashExpr>() {
         Ok(protobuf::PhysicalExprNode {


### PR DESCRIPTION
## Which issue does this PR close?

  - Closes #22431.

  ## Rationale for this change

  `LikeExpr` still serialized through the central physical proto conversion chain. This change moves serialization and deserialization responsibility into the expression
  type itself, following the established migration pattern used for `Column` and `BinaryExpr`.

  ## What changes are included in this PR?

  - Add `LikeExpr::try_to_proto`
  - Add `LikeExpr::try_from_proto`
  - Route physical proto decode through `LikeExpr::try_from_proto`
  - Remove the central `LikeExpr` encode and decode branches
  - Keep behavior and wire shape unchanged
  - Rely on existing physical proto roundtrip coverage instead of an extra expression-local roundtrip test

  ## Are these changes tested?

  Yes.

  Existing physical proto roundtrip coverage already covers `LikeExpr`.

  Verification run:
  - `cargo fmt --all`
  - `cargo test -p datafusion-physical-expr --features proto`
  - `cargo check -p datafusion-proto --all-features`
  - `cargo clippy -p datafusion-physical-expr -p datafusion-proto --all-targets --all-features -- -D warnings`

  ## Are there any user-facing changes?

  No.