### PR TITLE
fix: reborrow metadata values when intersecting union metadata

### DIFF
--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -662,7 +662,7 @@ pub fn intersect_metadata_for_union<'a>(
             }
             Some(current) => {
                 // Only keep keys that exist in both with the same value
-                current.retain(|k, v| metadata.get(k) == Some(v));
+                current.retain(|k, v| metadata.get(k) == Some(&*v));
             }
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22488.

## Rationale for this change

`intersect_metadata_for_union` compares values retained by `HashMap::retain` with values from another metadata map. The retained value is passed as `&mut String`, which can make `Option` equality ambiguous for downstream crates when additional blanket `PartialEq` implementations are in scope.

Reborrowing the retained value as `&String` keeps the comparison type explicit without changing behavior.

## What changes are included in this PR?

The metadata retain predicate now compares `metadata.get(k)` with `Some(&*v)` instead of `Some(v)`.

## Are these changes tested?

Yes.

- `cargo test -p datafusion-expr intersect_metadata_tests`
- `cargo fmt --all -- --check`
- `git diff --check`

## Are there any user-facing changes?

No runtime behavior change. This avoids a downstream compilation failure in the reported dependency configuration.