### PR TITLE
Add regression coverage for DATE interval overflow

### DIFF
--- a/datafusion/sqllogictest/test_files/datetime/arith_date_interval.slt
+++ b/datafusion/sqllogictest/test_files/datetime/arith_date_interval.slt
@@ -47,3 +47,6 @@ SELECT arrow_cast('2020-01-01', 'Date64') + INTERVAL '999999' YEAR
 
 query error Arrow error: Compute error: Date arithmetic overflow
 SELECT arrow_cast('2020-01-01', 'Date64') - INTERVAL '999999' YEAR
+
+query error Arrow error: Compute error: Date arithmetic overflow
+SELECT DATE '2262-04-10' + INTERVAL '999999999' DAY


### PR DESCRIPTION
## Summary

- add sqllogictest coverage for DATE + INTERVAL day overflow near the Date32 boundary
- assert the issue repro returns the existing `Date arithmetic overflow` error instead of panicking

Closes #22233.

## Notes

Current upstream `main` already returns the expected overflow error for this repro, so this PR is regression coverage only.

## Tests

- `cargo test -p datafusion-expr-common test_overflow_handling -- --nocapture`
- `cargo test --profile=ci --test sqllogictests -- datetime/arith_date_interval.slt`
