### PR TITLE
chore: update sqllogictest priority list with latest timing summary (8s --> 6s)

### DIFF
--- a/datafusion/sqllogictest/src/test_file.rs
+++ b/datafusion/sqllogictest/src/test_file.rs
@@ -107,26 +107,38 @@ impl Ord for TestFile {
 /// $ cargo test --profile=ci --test sqllogictests -- --timing-summary top
 /// ...
 /// Per-file elapsed summary (deterministic):
-/// 1.    3.568s  aggregate.slt
-/// 2.    3.464s  joins.slt
-/// 3.    3.336s  imdb.slt
-/// 4.    3.085s  push_down_filter_regression.slt
-/// 5.    2.926s  aggregate_skip_partial.slt
-/// 6.    2.399s  window.slt
-/// 7.    2.198s  group_by.slt
-/// 8.    1.281s  clickbench.slt
-/// 9.    1.058s  datetime/timestamps.slt
+/// 1.    5.437s  nested_loop_join_spill.slt
+/// 2.    3.471s  push_down_filter_regression.slt
+/// 3.    3.458s  aggregate.slt
+/// 4.    3.065s  joins.slt
+/// 5.    2.852s  aggregate_skip_partial.slt
+/// 6.    2.832s  imdb.slt
+/// 7.    2.453s  window.slt
+/// 8.    1.831s  group_by.slt
+/// 9.    1.282s  clickbench.slt
+/// 10.   1.055s  datetime/timestamps.slt
+/// 11.   0.994s  array/array_has.slt
+/// 12.   0.840s  cte.slt
+/// 13.   0.748s  sort_pushdown.slt
+/// 14.   0.714s  push_down_filter_parquet.slt
+/// 15.   0.668s  projection_pushdown.slt
 /// ```
 const TEST_PRIORITY_ENTRIES: &[&str] = &[
-    "aggregate.slt", //  longest-running files go first
-    "joins.slt",
-    "imdb.slt",
+    "nested_loop_join_spill.slt", //  longest-running files go first
     "push_down_filter_regression.slt",
+    "aggregate.slt",
+    "joins.slt",
     "aggregate_skip_partial.slt",
+    "imdb.slt",
     "window.slt",
     "group_by.slt",
     "clickbench.slt",
     "datetime/timestamps.slt",
+    "array/array_has.slt",
+    "cte.slt",
+    "sort_pushdown.slt",
+    "push_down_filter_parquet.slt",
+    "projection_pushdown.slt",
 ];
 
 /// Default priority for tests not in the priority map. Tests with lower


### PR DESCRIPTION
## Which issue does this PR close?

- Follow-up to #20656.

## Rationale for this change

Make running sqllogictests faster by improving scheduling / parallelism

The sqllogictest runner runs test files in parallel but each file
sequentially, so it prioritizes known long-running files to run first to
minimize total wall-clock time. This list was last set in #20656.

The relative timings have since shifted. Running with the
`--timing-summary` flag now reports a different ordering of the longest
files, with `nested_loop_join_spill.slt` having become the longest by a
fair margin:

```shell
$ cargo test --profile=ci --test sqllogictests -- --timing-summary
Per-file elapsed summary (deterministic):
  1.    5.437s  nested_loop_join_spill.slt
  2.    3.471s  push_down_filter_regression.slt
  3.    3.458s  aggregate.slt
  4.    3.065s  joins.slt
  5.    2.852s  aggregate_skip_partial.slt
  6.    2.832s  imdb.slt
  7.    2.453s  window.slt
  8.    1.831s  group_by.slt
  9.    1.282s  clickbench.slt
 10.    1.055s  datetime/timestamps.slt
 11.    0.994s  array/array_has.slt
 12.    0.840s  cte.slt
 13.    0.748s  sort_pushdown.slt
 14.    0.714s  push_down_filter_parquet.slt
 15.    0.668s  projection_pushdown.slt
```

## What changes are included in this PR?

- Update `TEST_PRIORITY_ENTRIES`  to match the latest `--timing-summary` ordering
- Update the example output in the accompanying doc comment.

## Are these changes tested?

There are some existing unit tests and I verified timings manually

```shell
cargo test --profile=ci --test sqllogictests
```

### Main
```shell
Running with 16 test threads (available parallelism: 16)
Completed 475 test files in 8 seconds
```

### This Branch

```shell
andrewlamb@Andrews-MacBook-Pro-3:~/Software/datafusion3$ cargo test --profile=ci --test sqllogictests
    Finished `ci` profile [unoptimized] target(s) in 0.53s
     Running bin/sqllogictests.rs (target/ci/deps/sqllogictests-0a94fbc565e8c132)
Running with 16 test threads (available parallelism: 16)
Completed 475 test files in 6 seconds
```

## Are there any user-facing changes?

No.


