### PR TITLE
fix: wrong precision in a decimal256 log test

### DIFF
--- a/datafusion/functions/src/datetime/to_timestamp.rs
+++ b/datafusion/functions/src/datetime/to_timestamp.rs
@@ -26,8 +26,8 @@ use arrow::array::{
 use arrow::datatypes::DataType::*;
 use arrow::datatypes::TimeUnit::{Microsecond, Millisecond, Nanosecond, Second};
 use arrow::datatypes::{
-    ArrowTimestampType, DataType, TimestampMicrosecondType, TimestampMillisecondType,
-    TimestampNanosecondType, TimestampSecondType,
+    ArrowTimestampType, DECIMAL128_MAX_PRECISION, DataType, TimestampMicrosecondType,
+    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType,
 };
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{Result, ScalarType, ScalarValue, exec_err};
@@ -474,7 +474,8 @@ impl ScalarUDFImpl for ToTimestampFunc {
                 _ => exec_err!("Invalid Float64 value for to_timestamp"),
             },
             Decimal32(_, _) | Decimal64(_, _) | Decimal256(_, _) => {
-                let arg = args[0].cast_to(&Decimal128(38, 9), None)?;
+                let arg =
+                    args[0].cast_to(&Decimal128(DECIMAL128_MAX_PRECISION, 9), None)?;
                 decimal128_to_timestamp_nanos(&arg, tz)
             }
             Decimal128(_, _) => decimal128_to_timestamp_nanos(&args[0], tz),

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -1165,7 +1165,12 @@ mod tests {
     #[test]
     fn test_log_decimal256_large() {
         // Large Decimal256 values that don't fit in i128 now use f64 fallback
-        let arg_field = Field::new("a", DataType::Decimal256(38, 0), false).into();
+        let arg_field = Field::new(
+            "a",
+            DataType::Decimal256(DECIMAL256_MAX_PRECISION, 0),
+            false,
+        )
+        .into();
         let args = ScalarFunctionArgs {
             args: vec![
                 ColumnarValue::Array(Arc::new(Decimal256Array::from(vec![

--- a/datafusion/spark/src/function/aggregate/try_sum.rs
+++ b/datafusion/spark/src/function/aggregate/try_sum.rs
@@ -190,7 +190,7 @@ fn update_decimal128<T: ArrowNumericType>(
     acc: &mut TrySumAccumulator<T>,
     array: &PrimitiveArray<T>,
 ) -> Result<()> {
-    let precision = acc.dec_precision.unwrap_or(38);
+    let precision = acc.dec_precision.unwrap_or(DECIMAL128_MAX_PRECISION);
 
     for v in array.iter().flatten() {
         let v_i128 = unsafe { std::mem::transmute_copy::<T::Native, i128>(&v) };


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

Spotted wrong usage of decimal precision in `test_log_decimal256_large` - passed Decimal128 max precision instead of Decimal256. The test worked fine.

## What changes are included in this PR?

- Test fixup
- Unhardcode the usage decimal precision in non-test code

## Are these changes tested?

- Tests passed

## Are there any user-facing changes?

no