### PR TITLE
fix: ln() error on non-positive input (PostgreSQL compat)

### DIFF
--- a/datafusion/functions/src/math/mod.rs
+++ b/datafusion/functions/src/math/mod.rs
@@ -51,6 +51,14 @@ fn validate_sqrt_input(value: f64) -> Result<()> {
     }
 }
 
+fn validate_ln_input(value: f64) -> Result<()> {
+    if value <= 0.0 {
+        exec_err!("cannot take logarithm of a negative number")
+    } else {
+        Ok(())
+    }
+}
+
 // Create UDFs
 make_udf_function!(abs::AbsFunc, abs);
 make_math_unary_udf!(
@@ -163,7 +171,8 @@ make_math_unary_udf!(
     ln,
     super::ln_order,
     super::bounds::unbounded_bounds,
-    super::get_ln_doc
+    super::get_ln_doc,
+    Some(super::validate_ln_input)
 );
 make_math_unary_udf!(
     Log2Func,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22271.

## Rationale for this change

`ln(-1.0::float8)` returns NaN in DataFusion but PostgreSQL raises an error: "cannot take logarithm of a negative number". This is one of the PostgreSQL compat issues tracked in #22247.

## What changes are included in this PR?

- Add `validate_ln_input` that errors when input ≤ 0
- Pass validator to `make_math_unary_udf!` for `LnFunc`, same pattern as `sqrt()`

## Are these changes tested?

Existing math tests pass. The validator follows the same pattern as `validate_sqrt_input` which is well-tested.

## Are there any user-facing changes?

Yes — `ln(x)` now returns an error for x ≤ 0 instead of NaN. This is a behavior change toward PostgreSQL compatibility.