### PR TITLE
feat(functions-nested): add `filter` and `transform` aliases for array_filter/array_transform

### DIFF
--- a/datafusion/functions-nested/src/array_filter.rs
+++ b/datafusion/functions-nested/src/array_filter.rs
@@ -91,7 +91,7 @@ impl ArrayFilter {
                 vec![ValueOrLambda::Value(()), ValueOrLambda::Lambda(())],
                 Volatility::Immutable,
             ),
-            aliases: vec![String::from("list_filter")],
+            aliases: vec![String::from("list_filter"), String::from("filter")],
         }
     }
 }

--- a/datafusion/functions-nested/src/array_transform.rs
+++ b/datafusion/functions-nested/src/array_transform.rs
@@ -84,7 +84,7 @@ impl ArrayTransform {
                 vec![ValueOrLambda::Value(()), ValueOrLambda::Lambda(())],
                 Volatility::Immutable,
             ),
-            aliases: vec![String::from("list_transform")],
+            aliases: vec![String::from("list_transform"), String::from("transform")],
         }
     }
 }

--- a/datafusion/sqllogictest/test_files/array/array_filter.slt
+++ b/datafusion/sqllogictest/test_files/array/array_filter.slt
@@ -52,6 +52,12 @@ SELECT list_filter([1, 2, 3, 4, 5], v -> v > 2);
 ----
 [3, 4, 5]
 
+# alias filter works
+query ?
+SELECT filter([1, 2, 3, 4, 5], v -> v > 2);
+----
+[3, 4, 5]
+
 # multiple sublists — t.list rows are [1,50], [4,50], [7,50]
 query ?
 SELECT array_filter(list, v -> v > 40) from t;

--- a/datafusion/sqllogictest/test_files/array/array_transform.slt
+++ b/datafusion/sqllogictest/test_files/array/array_transform.slt
@@ -46,6 +46,18 @@ SELECT array_transform([1,2,3,4,5], v -> v*2);
 ----
 [2, 4, 6, 8, 10]
 
+# alias list_transform works
+query ?
+SELECT list_transform([1,2,3,4,5], v -> v*2);
+----
+[2, 4, 6, 8, 10]
+
+# alias transform works
+query ?
+SELECT transform([1,2,3,4,5], v -> v*2);
+----
+[2, 4, 6, 8, 10]
+
 query ?
 SELECT array_transform([1,2,3,4,5], v -> repeat("a", v));
 ----

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -3299,6 +3299,7 @@ _Alias of [current_date](#current_date)._
 - [cosine_distance](#cosine_distance)
 - [dot_product](#dot_product)
 - [empty](#empty)
+- [filter](#filter)
 - [flatten](#flatten)
 - [generate_series](#generate_series)
 - [inner_product](#inner_product)
@@ -3356,6 +3357,7 @@ _Alias of [current_date](#current_date)._
 - [range](#range)
 - [string_to_array](#string_to_array)
 - [string_to_list](#string_to_list)
+- [transform](#transform)
 
 ### `any_match`
 
@@ -3721,6 +3723,7 @@ array_filter(array, x -> x > 2)
 #### Aliases
 
 - list_filter
+- filter
 
 ### `array_has`
 
@@ -4571,6 +4574,7 @@ array_transform(array, x -> x*2)
 #### Aliases
 
 - list_transform
+- transform
 
 ### `array_union`
 
@@ -4722,6 +4726,10 @@ empty(array)
 
 - array_empty
 - list_empty
+
+### `filter`
+
+_Alias of [array_filter](#array_filter)._
 
 ### `flatten`
 
@@ -5103,6 +5111,10 @@ string_to_array(str, delimiter[, null_str])
 ### `string_to_list`
 
 _Alias of [string_to_array](#string_to_array)._
+
+### `transform`
+
+_Alias of [array_transform](#array_transform)._
 
 ## Struct Functions
 


### PR DESCRIPTION
## Which issue does this PR close?

Partially addresses #14509 — adds `filter` and `transform` as additional aliases for `array_filter` and `array_transform`.

## Rationale for this change

Spark uses `filter` and `transform` as the primary names for these functions. Adding these aliases improves compatibility and discoverability for users coming from Spark.

## What changes are included in this PR?

- `array_filter`: adds `filter` alias (alongside existing `list_filter`)
- `array_transform`: adds `transform` alias (alongside existing `list_transform`)
- SQL logic tests for both new aliases

## Are these changes tested?

Yes — `array_filter.slt` and `array_transform.slt` each have a test for the new alias.

## Are there any user-facing changes?

Yes — `filter(array, lambda)` and `transform(array, lambda)` are now available as SQL functions.