### PR TITLE
docs: clarify difference between try_cast_literal_to_type and ScalarValue::cast_to

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4216,28 +4216,28 @@ impl ScalarValue {
     /// default [`CastOptions`].
     ///
     /// This is a general-purpose cast with the same semantics as the Arrow
-    /// [`cast_with_options`] kernel, including ones that **lose information**
-    /// -- for example casting floating point values such as `123.45` into the
-    /// integer `123`.
+    /// [`cast_with_options`] kernel and can therefore **lose information** --
+    /// for example casting the floating point value `123.45` to the integer
+    /// `123`.
     ///
     /// Returns an error for casts the Arrow kernel cannot perform.
     ///
-    /// # See also
-    /// - [try_cast_literal_to_type`]: for a *value-preserving* cast
+    /// # See Also
+    /// - [`try_cast_literal_to_type`]: for a *value-preserving* cast
     ///
     /// [`try_cast_literal_to_type`]: https://docs.rs/datafusion/latest/datafusion/logical_expr_common/casts/fn.try_cast_literal_to_type.html
     pub fn cast_to(&self, target_type: &DataType) -> Result<Self> {
         self.cast_to_with_options(target_type, &DEFAULT_CAST_OPTIONS)
     }
 
-    /// Cast this value type `target_type` with the given [`CastOptions`].
+    /// Cast this value to type `target_type` with the given [`CastOptions`].
     ///
     /// # See Also
     /// - [`ScalarValue::cast_to`] for more details.
     /// - [`try_cast_literal_to_type`]: for a *value-preserving* cast
     ///
     /// [`try_cast_literal_to_type`]: https://docs.rs/datafusion/latest/datafusion/logical_expr_common/casts/fn.try_cast_literal_to_type.html
-     pub fn cast_to_with_options(
+    pub fn cast_to_with_options(
         &self,
         target_type: &DataType,
         cast_options: &CastOptions<'static>,

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4212,12 +4212,30 @@ impl ScalarValue {
         Some(v.as_ref().map(|v| v.as_str()))
     }
 
-    /// Try to cast this value to a ScalarValue of type `data_type`
+    /// Cast this value to a `ScalarValue` of type `target_type` using the
+    /// default [`CastOptions`].
+    ///
+    /// This is a general-purpose cast backed by the Arrow cast kernels. It
+    /// performs any cast Arrow supports, which means it may **lose information
+    /// or change a value's meaning** -- for example parsing the string `"123"`
+    /// into the integer `123`, formatting a number as a string, truncating the
+    /// decimal `1.5` to the integer `1`, or converting a `Date` into a
+    /// `Timestamp`. It returns an error for casts Arrow cannot perform.
+    ///
+    /// If instead you need a *value-preserving* cast -- one that returns `None`
+    /// rather than performing a lossy or cross-kind conversion, for example
+    /// when unwrapping `CAST(col AS T) = literal` comparisons -- use
+    /// `datafusion_expr_common::casts::try_cast_literal_to_type` instead.
     pub fn cast_to(&self, target_type: &DataType) -> Result<Self> {
         self.cast_to_with_options(target_type, &DEFAULT_CAST_OPTIONS)
     }
 
-    /// Try to cast this value to a ScalarValue of type `data_type` with [`CastOptions`]
+    /// Cast this value to a `ScalarValue` of type `target_type` with the given
+    /// [`CastOptions`].
+    ///
+    /// See [`ScalarValue::cast_to`] for the semantics (in particular, this is a
+    /// general-purpose, possibly lossy cast, unlike
+    /// `datafusion_expr_common::casts::try_cast_literal_to_type`).
     pub fn cast_to_with_options(
         &self,
         target_type: &DataType,

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4215,28 +4215,29 @@ impl ScalarValue {
     /// Cast this value to a `ScalarValue` of type `target_type` using the
     /// default [`CastOptions`].
     ///
-    /// This is a general-purpose cast backed by the Arrow cast kernels. It
-    /// performs any cast Arrow supports, which means it may **lose information
-    /// or change a value's meaning** -- for example parsing the string `"123"`
-    /// into the integer `123`, formatting a number as a string, truncating the
-    /// decimal `1.5` to the integer `1`, or converting a `Date` into a
-    /// `Timestamp`. It returns an error for casts Arrow cannot perform.
+    /// This is a general-purpose cast with the same semantics as the Arrow
+    /// [`cast_with_options`] kernel, including ones that **lose information**
+    /// -- for example casting floating point values such as `123.45` into the
+    /// integer `123`.
     ///
-    /// If instead you need a *value-preserving* cast -- one that returns `None`
-    /// rather than performing a lossy or cross-kind conversion, for example
-    /// when unwrapping `CAST(col AS T) = literal` comparisons -- use
-    /// `datafusion_expr_common::casts::try_cast_literal_to_type` instead.
+    /// Returns an error for casts the Arrow kernel cannot perform.
+    ///
+    /// # See also
+    /// - [try_cast_literal_to_type`]: for a *value-preserving* cast
+    ///
+    /// [`try_cast_literal_to_type`]: https://docs.rs/datafusion/latest/datafusion/logical_expr_common/casts/fn.try_cast_literal_to_type.html
     pub fn cast_to(&self, target_type: &DataType) -> Result<Self> {
         self.cast_to_with_options(target_type, &DEFAULT_CAST_OPTIONS)
     }
 
-    /// Cast this value to a `ScalarValue` of type `target_type` with the given
-    /// [`CastOptions`].
+    /// Cast this value type `target_type` with the given [`CastOptions`].
     ///
-    /// See [`ScalarValue::cast_to`] for the semantics (in particular, this is a
-    /// general-purpose, possibly lossy cast, unlike
-    /// `datafusion_expr_common::casts::try_cast_literal_to_type`).
-    pub fn cast_to_with_options(
+    /// # See Also
+    /// - [`ScalarValue::cast_to`] for more details.
+    /// - [`try_cast_literal_to_type`]: for a *value-preserving* cast
+    ///
+    /// [`try_cast_literal_to_type`]: https://docs.rs/datafusion/latest/datafusion/logical_expr_common/casts/fn.try_cast_literal_to_type.html
+     pub fn cast_to_with_options(
         &self,
         target_type: &DataType,
         cast_options: &CastOptions<'static>,

--- a/datafusion/expr-common/src/casts.rs
+++ b/datafusion/expr-common/src/casts.rs
@@ -31,7 +31,47 @@ use arrow::datatypes::{
 use arrow::temporal_conversions::{MICROSECONDS, MILLISECONDS, NANOSECONDS};
 use datafusion_common::ScalarValue;
 
-/// Convert a literal value from one data type to another
+/// Convert a literal [`ScalarValue`] to `target_type`, returning `None` if the
+/// value cannot be represented in `target_type` *exactly*.
+///
+/// This is a restricted, value-preserving cast used to rewrite comparison
+/// predicates of the form `CAST(col AS target_type) <op> literal` into
+/// `col <op> try_cast_literal_to_type(literal, col_type)` (see the
+/// `unwrap_cast` optimizer rules). That rewrite is only valid when casting the
+/// literal is exact and reversible, so this function deliberately refuses any
+/// cast that could change the comparison result.
+///
+/// # How it differs from [`ScalarValue::cast_to`]
+///
+/// [`ScalarValue::cast_to`] is the general-purpose cast: it is backed by the
+/// Arrow cast kernels, returns a `Result`, and performs *any* cast Arrow
+/// supports -- including ones that lose information or change the value's
+/// meaning. For example, `cast_to` will parse the string `"123"` into the
+/// integer `123`, format a number as a string, truncate the decimal `1.5` to
+/// the integer `1`, or convert a `Date` into a `Timestamp`.
+///
+/// `try_cast_literal_to_type` never errors, never returns a value that differs
+/// from its input, and returns `None` instead of performing such a lossy or
+/// cross-kind conversion. It only attempts:
+///
+/// * numeric → numeric, including integers, decimals, `Date32`/`Date64` and
+///   `Timestamp`s, rejecting values outside the target's range or that would
+///   lose decimal digits
+/// * string → string between `Utf8`, `LargeUtf8` and `Utf8View`
+/// * wrapping a value into, or unwrapping it out of, a `Dictionary` whose value
+///   type matches the literal's type
+/// * `Binary` → `FixedSizeBinary` of the matching length
+///
+/// Conversely it returns `None` for casts Arrow would happily perform but that
+/// are not safe to unwrap: parsing/formatting between strings and non-strings,
+/// anything involving floating point (which is not supported at all), and lossy
+/// `Date` ↔ `Timestamp` conversions.
+///
+/// # Notable exception
+///
+/// A `Timestamp` → `Timestamp` cast between different time units is allowed even
+/// though it can truncate (for example nanoseconds → seconds), and a unit
+/// conversion that overflows yields a `NULL` literal rather than `None`.
 pub fn try_cast_literal_to_type(
     lit_value: &ScalarValue,
     target_type: &DataType,

--- a/datafusion/expr-common/src/casts.rs
+++ b/datafusion/expr-common/src/casts.rs
@@ -37,9 +37,9 @@ use datafusion_common::ScalarValue;
 /// *exactly*.
 ///
 /// This is a restricted, value-preserving cast used to rewrite comparison
-/// predicates of the form `CAST(col AS target_type) <op> literal` into `col
-/// <op> literal` which is not valid if for any cast that could change the
-/// comparison result.
+/// predicates of the form `CAST(col AS target_type) <op> literal` into
+/// `col <op> try_cast_literal_to_type(literal, col_type)`. That rewrite is
+/// only valid when the cast cannot change the comparison result.
 ///
 /// # Supported Casts
 /// * numeric → numeric, including integers, decimals, `Date32`/`Date64` and
@@ -49,14 +49,13 @@ use datafusion_common::ScalarValue;
 /// * wrapping a value into, or unwrapping it out of, a `Dictionary` whose value
 ///   type matches the literal's type
 /// * `Binary` → `FixedSizeBinary` of the matching length
-/// *  `Timestamp` → `Timestamp` cast between different time units is allowed even
+/// * `Timestamp` → `Timestamp` cast between different time units is allowed even
 ///   though it can truncate (for example nanoseconds → seconds), and a unit
 ///   conversion that overflows yields a `NULL` literal rather than `None`.
 ///
 /// # See Also
-/// - [`ScalarValue::cast_to`]: general-purpose cast can also lose information or change the value's
-/// meaning.
-
+/// - [`ScalarValue::cast_to`]: a general-purpose cast that can lose information
+///   or change a value's meaning.
 pub fn try_cast_literal_to_type(
     lit_value: &ScalarValue,
     target_type: &DataType,

--- a/datafusion/expr-common/src/casts.rs
+++ b/datafusion/expr-common/src/casts.rs
@@ -31,29 +31,17 @@ use arrow::datatypes::{
 use arrow::temporal_conversions::{MICROSECONDS, MILLISECONDS, NANOSECONDS};
 use datafusion_common::ScalarValue;
 
-/// Convert a literal [`ScalarValue`] to `target_type`, returning `None` if the
-/// value cannot be represented in `target_type` *exactly*.
+/// Convert a literal [`ScalarValue`] to `target_type`, preserving the exact value.
+///
+/// Returns `None` if the value cannot be represented in `target_type`
+/// *exactly*.
 ///
 /// This is a restricted, value-preserving cast used to rewrite comparison
-/// predicates of the form `CAST(col AS target_type) <op> literal` into
-/// `col <op> try_cast_literal_to_type(literal, col_type)` (see the
-/// `unwrap_cast` optimizer rules). That rewrite is only valid when casting the
-/// literal is exact and reversible, so this function deliberately refuses any
-/// cast that could change the comparison result.
+/// predicates of the form `CAST(col AS target_type) <op> literal` into `col
+/// <op> literal` which is not valid if for any cast that could change the
+/// comparison result.
 ///
-/// # How it differs from [`ScalarValue::cast_to`]
-///
-/// [`ScalarValue::cast_to`] is the general-purpose cast: it is backed by the
-/// Arrow cast kernels, returns a `Result`, and performs *any* cast Arrow
-/// supports -- including ones that lose information or change the value's
-/// meaning. For example, `cast_to` will parse the string `"123"` into the
-/// integer `123`, format a number as a string, truncate the decimal `1.5` to
-/// the integer `1`, or convert a `Date` into a `Timestamp`.
-///
-/// `try_cast_literal_to_type` never errors, never returns a value that differs
-/// from its input, and returns `None` instead of performing such a lossy or
-/// cross-kind conversion. It only attempts:
-///
+/// # Supported Casts
 /// * numeric → numeric, including integers, decimals, `Date32`/`Date64` and
 ///   `Timestamp`s, rejecting values outside the target's range or that would
 ///   lose decimal digits
@@ -61,17 +49,14 @@ use datafusion_common::ScalarValue;
 /// * wrapping a value into, or unwrapping it out of, a `Dictionary` whose value
 ///   type matches the literal's type
 /// * `Binary` → `FixedSizeBinary` of the matching length
+/// *  `Timestamp` → `Timestamp` cast between different time units is allowed even
+///   though it can truncate (for example nanoseconds → seconds), and a unit
+///   conversion that overflows yields a `NULL` literal rather than `None`.
 ///
-/// Conversely it returns `None` for casts Arrow would happily perform but that
-/// are not safe to unwrap: parsing/formatting between strings and non-strings,
-/// anything involving floating point (which is not supported at all), and lossy
-/// `Date` ↔ `Timestamp` conversions.
-///
-/// # Notable exception
-///
-/// A `Timestamp` → `Timestamp` cast between different time units is allowed even
-/// though it can truncate (for example nanoseconds → seconds), and a unit
-/// conversion that overflows yields a `NULL` literal rather than `None`.
+/// # See Also
+/// - [`ScalarValue::cast_to`]: general-purpose cast can also lose information or change the value's
+/// meaning.
+
 pub fn try_cast_literal_to_type(
     lit_value: &ScalarValue,
     target_type: &DataType,


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #22577 (consolidate `ScalarValue` cast implementations).

## Rationale for this change

I have been confused about the difference between `ScalarValue::cast_to` and `try_cast_literal_to_type`  -- so after some research I would like to make the difference clearer


## What changes are included in this PR?

Document on each function how it differs from the other, so the choice is obvious from the docs alone.

## Are these changes tested?

by CI

## Are there any user-facing changes?

Doc comments only. No code or API changes.

Partially 🤖 Generated with [Claude Code](https://claude.com/claude-code)
