### PR TITLE
fix(array_agg): reverse ordering_values in state() when accumulator is reversed

### DIFF
--- a/datafusion/functions-aggregate/src/array_agg.rs
+++ b/datafusion/functions-aggregate/src/array_agg.rs
@@ -1008,7 +1008,13 @@ impl OrderSensitiveArrayAggAccumulator {
         } else {
             (0..fields.len())
                 .map(|i| {
-                    let column_values = self.ordering_values.iter().map(|x| x[i].clone());
+                    let column_values: Box<dyn Iterator<Item = ScalarValue>> = if self
+                        .reverse
+                    {
+                        Box::new(self.ordering_values.iter().rev().map(|x| x[i].clone()))
+                    } else {
+                        Box::new(self.ordering_values.iter().map(|x| x[i].clone()))
+                    };
                     ScalarValue::iter_to_array(column_values)
                 })
                 .collect::<Result<_>>()?
@@ -1509,6 +1515,115 @@ mod tests {
         // without compaction, the size is 17112
         assert_eq!(acc.size(), 2224);
 
+        Ok(())
+    }
+
+    // Reproduces the bug where `state()` emits reversed values but non-reversed
+    // orderings when the optimizer sets is_input_pre_ordered=true + reverse=true
+    // (DESC aggregate with ASC pre-sorted input). The partial states are fed into
+    // a final accumulator via merge_batch; without the fix the ordering keys and
+    // values are mismatched so the final sort produces wrong order.
+    #[test]
+    fn desc_order_partial_final_merge_correct() -> Result<()> {
+        use arrow::array::Int64Array;
+        use datafusion_physical_expr::expressions::Column;
+
+        let schema = Schema::new(vec![
+            Field::new("val", DataType::Int64, true),
+            Field::new("ord", DataType::Int64, true),
+        ]);
+        let ord_expr = Arc::new(
+            Column::new_with_schema("ord", &schema).expect("column not in schema"),
+        ) as Arc<dyn PhysicalExpr>;
+
+        // ordering_req for partial = [ord ASC] (reversed, because input is pre-sorted ASC
+        // and the user wants DESC — the optimizer reverses the requirement)
+        let asc_opts = SortOptions {
+            descending: false,
+            nulls_first: false,
+        };
+        let desc_opts = SortOptions {
+            descending: true,
+            nulls_first: false,
+        };
+
+        let asc_ordering = LexOrdering::new(vec![PhysicalSortExpr::new(
+            Arc::clone(&ord_expr),
+            asc_opts,
+        )])
+        .unwrap();
+        let desc_ordering = LexOrdering::new(vec![PhysicalSortExpr::new(
+            Arc::clone(&ord_expr),
+            desc_opts,
+        )])
+        .unwrap();
+
+        let ordering_dtype = DataType::Int64;
+
+        // Partial acc A: sees rows [0,1,2] arriving in ASC order (pre-ordered).
+        // is_input_pre_ordered=true, reverse=true, ordering_req=[ASC].
+        let mut partial_a = OrderSensitiveArrayAggAccumulator::try_new(
+            &DataType::Int64,
+            std::slice::from_ref(&ordering_dtype),
+            asc_ordering.clone(),
+            /*is_input_pre_ordered=*/ true,
+            /*reverse=*/ true,
+            /*ignore_nulls=*/ false,
+        )?;
+        let vals_a = Arc::new(Int64Array::from(vec![0i64, 1, 2])) as ArrayRef;
+        let ords_a = Arc::new(Int64Array::from(vec![0i64, 1, 2])) as ArrayRef;
+        partial_a.update_batch(&[vals_a, ords_a])?;
+        let state_a = partial_a
+            .state()?
+            .iter()
+            .map(|v| v.to_array())
+            .collect::<Result<Vec<_>>>()?;
+
+        // Partial acc B: sees rows [3,4,5] arriving in ASC order.
+        let mut partial_b = OrderSensitiveArrayAggAccumulator::try_new(
+            &DataType::Int64,
+            std::slice::from_ref(&ordering_dtype),
+            asc_ordering,
+            /*is_input_pre_ordered=*/ true,
+            /*reverse=*/ true,
+            /*ignore_nulls=*/ false,
+        )?;
+        let vals_b = Arc::new(Int64Array::from(vec![3i64, 4, 5])) as ArrayRef;
+        let ords_b = Arc::new(Int64Array::from(vec![3i64, 4, 5])) as ArrayRef;
+        partial_b.update_batch(&[vals_b, ords_b])?;
+        let state_b = partial_b
+            .state()?
+            .iter()
+            .map(|v| v.to_array())
+            .collect::<Result<Vec<_>>>()?;
+
+        // Final acc: not optimized — ordering_req=[DESC], reverse=false.
+        let mut final_acc = OrderSensitiveArrayAggAccumulator::try_new(
+            &DataType::Int64,
+            std::slice::from_ref(&ordering_dtype),
+            desc_ordering,
+            /*is_input_pre_ordered=*/ false,
+            /*reverse=*/ false,
+            /*ignore_nulls=*/ false,
+        )?;
+        final_acc.merge_batch(&state_a)?;
+        final_acc.merge_batch(&state_b)?;
+        let result = final_acc.evaluate()?;
+
+        let ScalarValue::List(list) = result else {
+            return datafusion_common::internal_err!("expected List");
+        };
+        let result_vals: Vec<i64> = list
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .iter()
+            .map(|v| v.unwrap())
+            .collect();
+
+        // Expected DESC: [5, 4, 3, 2, 1, 0]
+        assert_eq!(result_vals, vec![5i64, 4, 3, 2, 1, 0]);
         Ok(())
     }
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -322,6 +322,31 @@ physical_plan
 05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
 06)----------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/aggregate_agg_multi_order.csv]]}, projection=[c1, c2, c3], file_type=csv, has_header=true
 
+# Regression test: ARRAY_AGG with conflicting ASC/DESC ORDER BY in the same query.
+# get_finer_aggregate_exprs_requirement picks ASC as the common requirement and
+# reverses the DESC aggregate (is_reversed=true, ordering_req=[ASC]).
+# The optimizer then sets is_input_pre_ordered=true on both. Without the fix,
+# state() emits values reversed to DESC but ordering keys still in ASC order,
+# causing merge_batch to pair each value with the wrong key (silent wrong results).
+query TT
+explain select array_agg(c1 order by c1), array_agg(c1 order by c1 desc) from agg_order;
+----
+logical_plan
+01)Aggregate: groupBy=[[]], aggr=[[array_agg(agg_order.c1) ORDER BY [agg_order.c1 ASC NULLS LAST], array_agg(agg_order.c1) ORDER BY [agg_order.c1 DESC NULLS FIRST]]]
+02)--TableScan: agg_order projection=[c1]
+physical_plan
+01)AggregateExec: mode=Final, gby=[], aggr=[array_agg(agg_order.c1) ORDER BY [agg_order.c1 ASC NULLS LAST], array_agg(agg_order.c1) ORDER BY [agg_order.c1 DESC NULLS FIRST]]
+02)--CoalescePartitionsExec
+03)----AggregateExec: mode=Partial, gby=[], aggr=[array_agg(agg_order.c1) ORDER BY [agg_order.c1 ASC NULLS LAST], array_agg(agg_order.c1) ORDER BY [agg_order.c1 DESC NULLS FIRST]]
+04)------SortExec: expr=[c1@0 ASC NULLS LAST], preserve_partitioning=[true]
+05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/aggregate_agg_multi_order.csv]]}, projection=[c1], file_type=csv, has_header=true
+
+query ??
+select array_agg(c1 order by c1), array_agg(c1 order by c1 desc) from agg_order;
+----
+[1, 2, 3, 4, 5, 6, 7, 8, 9, 10] [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+
 # test array_agg_order with list data type
 statement ok
 CREATE TABLE array_agg_order_list_table AS VALUES


### PR DESCRIPTION
## Which issue does this PR close?

No existing issue. Discovered while investigating incorrect results from `ARRAY_AGG(x ORDER BY y DESC)` in a multi-partition query.

## Rationale for this change

### Bug description

When multiple `ARRAY_AGG` expressions with conflicting `ORDER BY` directions (ASC and DESC) appear in the same query, results for the DESC variant are silently wrong.

### How the optimizer creates the bug path

The bug is triggered deterministically by a well-defined optimizer pipeline. Take this query:

```sql
SELECT
  ARRAY_AGG(c1 ORDER BY c1 ASC),
  ARRAY_AGG(c1 ORDER BY c1 DESC)
FROM t
```

**Step 1 — `get_finer_aggregate_exprs_requirement` (runs at `AggregateExec` construction)**

This function iterates the aggregate expressions to find a single common ordering requirement that the input sort can satisfy:

1. Takes the first aggregate's requirement → `common = [c1 ASC]`
2. Second aggregate needs `[c1 DESC]` — conflicts with `[c1 ASC]`
3. Checks reverse of second: `reverse(DESC) = ASC` → `[c1 ASC]` satisfies it
4. **Mutates `aggr_expr[1]` in-place**: flips `ARRAY_AGG(c1 DESC)` → `ARRAY_AGG(c1 ASC, is_reversed=true)`
5. `AggregateExec::required_input_ordering` is set to `[c1 ASC]` (soft requirement)

The DESC aggregate is already reversed to ASC before any other rule runs.

**Step 2 — `EnsureRequirements` optimizer**

Sees `required_input_ordering = [c1 ASC]` → inserts `SortExec [c1 ASC]` before the partial aggregate.

**Step 3 — `OptimizeAggregateOrder` optimizer**

Runs on the partial aggregate (input mode = Raw). Input is now sorted `[c1 ASC]`. For each aggregate:

- `ARRAY_AGG(c1 ASC)`: direct match → `is_input_pre_ordered=true, reverse=false` ✓
- `ARRAY_AGG(c1 ASC, is_reversed=true)` (already mutated): direct match → `is_input_pre_ordered=true, reverse=true` ← **bug path**

The DESC accumulator ends up with `ordering_req=[c1 ASC]`, `is_input_pre_ordered=true`, `reverse=true`.

### Root cause

In `OrderSensitiveArrayAggAccumulator::state()`:

```rust
let mut result = vec![self.evaluate()?];   // reverses values list → DESC order ✓
result.push(self.evaluate_orderings()?);    // ordering keys stay in original ASC order ✗
```

`evaluate()` reverses `self.values` (ASC input → DESC output), but `evaluate_orderings()` always iterated `self.ordering_values` forward. The partial state emits a **mismatched** pair: values in DESC order, ordering keys in ASC order.

The final accumulator's `merge_batch` uses `merge_ordered_arrays` with the ordering keys to decide k-way merge priority. Because the keys are paired with the wrong values, the merge produces the wrong order — silently, no error or panic.

Note: if DESC is listed first and ASC second, the roles are swapped — the ASC aggregate gets reversed and its result is wrong instead. The bug always hits whichever aggregate `get_finer_aggregate_exprs_requirement` reverses.

## What changes are included in this PR?

Single change in `evaluate_orderings()` inside `OrderSensitiveArrayAggAccumulator`:

```rust
// Before
let column_values = self.ordering_values.iter().map(|x| x[i].clone());

// After
let column_values: Box<dyn Iterator<Item = ScalarValue>> = if self.reverse {
    Box::new(self.ordering_values.iter().rev().map(|x| x[i].clone()))
} else {
    Box::new(self.ordering_values.iter().map(|x| x[i].clone()))
};
```

When `reverse=true`, ordering keys are iterated in reverse to match the reversed values emitted by `evaluate()`, so `merge_batch` receives correctly paired `(value, ordering_key)` entries.

## Are these changes tested?

**Unit test** — `desc_order_partial_final_merge_correct` in `array_agg.rs` directly exercises the partial→final merge path with a reversed accumulator (`is_input_pre_ordered=true, reverse=true`). Before fix: `[3, 4, 5, 0, 1, 2]`. After fix: `[5, 4, 3, 2, 1, 0]`.

**SQL logic test** — regression test in `aggregate.slt` runs the exact bug-triggering query against a real 10-row table:

```sql
SELECT array_agg(c1 ORDER BY c1), array_agg(c1 ORDER BY c1 DESC) FROM agg_order;
```

The EXPLAIN confirms `SortExec [c1 ASC]` + `Partial`/`Final` stages (the optimizer path that triggers the bug). The result assertion catches the wrong output:

```
-- without fix (wrong):
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

-- with fix (correct):
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
```

## Are there any user-facing changes?

Yes — `ARRAY_AGG(x ORDER BY y DESC)` now returns correct results when the query uses multi-partition execution and the optimizer reverses the partial accumulator.