### PR TITLE
refactor: cache schema_without_virtual_columns and remove TableSchema::with_virtual_columns

### DIFF
--- a/datafusion/datasource-parquet/src/source.rs
+++ b/datafusion/datasource-parquet/src/source.rs
@@ -770,7 +770,7 @@ impl FileSource for ParquetSource {
         let filters: Vec<PushedDownPredicate> = filters
             .into_iter()
             .map(|filter| {
-                if can_expr_be_pushed_down_with_schemas(&filter, &pushable_schema) {
+                if can_expr_be_pushed_down_with_schemas(&filter, pushable_schema) {
                     PushedDownPredicate::supported(filter)
                 } else {
                     PushedDownPredicate::unsupported(filter)

--- a/datafusion/datasource/src/table_schema.rs
+++ b/datafusion/datasource/src/table_schema.rs
@@ -102,6 +102,13 @@ pub struct TableSchema {
     /// This is pre-computed during construction by concatenating the three
     /// parts, so it can be returned as a cheap reference.
     table_schema: SchemaRef,
+
+    /// Schema of file + partition columns, excluding virtual columns.
+    ///
+    /// Pre-computed during construction so [`Self::schema_without_virtual_columns`]
+    /// can return a cheap reference. When there are no virtual columns this
+    /// shares the same `Arc` as `table_schema`.
+    schema_without_virtual_columns: SchemaRef,
 }
 
 impl TableSchema {
@@ -173,21 +180,6 @@ impl TableSchema {
             .build()
     }
 
-    /// Return a new `TableSchema` with `virtual_columns` as its virtual columns,
-    /// replacing any existing ones. Existing partition columns are preserved.
-    ///
-    /// Virtual columns are produced by the file reader (e.g. a Parquet
-    /// `row_number` column) rather than stored in the files or derived from
-    /// partition paths. Each field must carry an arrow virtual extension type so
-    /// the reader can recognize it; `ParquetOpener` forwards these fields to
-    /// `parquet::arrow::arrow_reader::ArrowReaderOptions::with_virtual_columns`.
-    pub fn with_virtual_columns(self, virtual_columns: Vec<FieldRef>) -> Self {
-        TableSchemaBuilder::new(self.file_schema)
-            .with_table_partition_cols(self.table_partition_cols)
-            .with_virtual_columns(virtual_columns)
-            .build()
-    }
-
     /// Get the file schema (without partition columns).
     ///
     /// This is the schema of the actual data files on disk.
@@ -232,13 +224,8 @@ impl TableSchema {
     ///
     /// When there are no virtual columns this returns the same schema as
     /// [`Self::table_schema`].
-    pub fn schema_without_virtual_columns(&self) -> SchemaRef {
-        if self.virtual_columns.is_empty() {
-            return Arc::clone(&self.table_schema);
-        }
-        let mut builder = SchemaBuilder::from(self.file_schema.as_ref());
-        builder.extend(self.table_partition_cols.iter().cloned());
-        Arc::new(builder.finish())
+    pub fn schema_without_virtual_columns(&self) -> &SchemaRef {
+        &self.schema_without_virtual_columns
     }
 }
 
@@ -329,12 +316,22 @@ impl TableSchemaBuilder {
 
         let mut builder = SchemaBuilder::from(self.file_schema.as_ref());
         builder.extend(self.table_partition_cols.iter().cloned());
-        builder.extend(self.virtual_columns.iter().cloned());
+        let (table_schema, schema_without_virtual_columns) =
+            if self.virtual_columns.is_empty() {
+                let schema = Arc::new(builder.finish());
+                (Arc::clone(&schema), schema)
+            } else {
+                let without_virtual = Arc::new(builder.finish());
+                let mut builder = SchemaBuilder::from(without_virtual.as_ref());
+                builder.extend(self.virtual_columns.iter().cloned());
+                (Arc::new(builder.finish()), without_virtual)
+            };
         TableSchema {
             file_schema: self.file_schema,
             table_partition_cols: self.table_partition_cols,
             virtual_columns: self.virtual_columns,
-            table_schema: Arc::new(builder.finish()),
+            table_schema,
+            schema_without_virtual_columns,
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Followup to #22026 — addresses two review comments from @adriangb that landed after the PR was already in the merge queue.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Two pieces of feedback on the `TableSchema` API introduced in #22026:

1. https://github.com/apache/datafusion/pull/22026#discussion_r3319225261 — `TableSchema::with_virtual_columns` shouldn't exist as a non-deprecated counterpart to the already-deprecated `TableSchema::with_table_partition_cols`. Callers should use `TableSchemaBuilder` directly. Every existing call site already does, so the method has no users.
2. https://github.com/apache/datafusion/pull/22026#discussion_r3319230237 — `schema_without_virtual_columns` was rebuilding the schema on every call. It can be computed once at construction and returned by reference, matching the convention used by every other accessor on `TableSchema` (`file_schema`, `table_schema`, `table_partition_cols`, `virtual_columns` all return `&`).

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Remove `TableSchema::with_virtual_columns`. Callers must use `TableSchemaBuilder::with_virtual_columns` (no in-tree callers needed updating).
- Cache `schema_without_virtual_columns` on `TableSchema`, computed once in `TableSchemaBuilder::build`. When there are no virtual columns the cached field shares the same `Arc` as `table_schema`.
- Accessor `schema_without_virtual_columns(&self)` now returns `&SchemaRef` instead of an owned `SchemaRef`, matching the rest of the struct's accessors. Updated the one in-tree caller in `datasource-parquet/src/source.rs`.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes — covered by the existing `table_schema` unit tests and the `datasource-parquet` test suite, all of which still pass. The change is a refactor with no behavioral difference: the cached schema produced in `build()` is byte-for-byte identical to what the previous accessor allocated on each call.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Two API changes against the `TableSchema` surface added in #22026 (which has not been released):

- `TableSchema::with_virtual_columns` removed. Use `TableSchemaBuilder::with_virtual_columns` instead.
- `TableSchema::schema_without_virtual_columns` return type changed from `SchemaRef` to `&SchemaRef`. Callers that need an owned value should `Arc::clone` the result.
