### PR TITLE
Avoid TopK sort-key work for rejected batches

### DIFF
--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -237,44 +237,56 @@ impl TopK {
         let baseline = self.metrics.baseline.clone();
         let _timer = baseline.elapsed_compute().timer();
 
+        let mut selected_rows = None;
+        let num_rows = batch.num_rows();
+
+        // If a filter is provided, update it with the new rows
+        let filter = self.filter.read().expr.current()?;
+        let filtered = filter.evaluate(&batch)?;
+        match filtered {
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => {}
+            ColumnarValue::Scalar(ScalarValue::Boolean(_)) => {
+                // Nothing can pass this batch, so avoid evaluating sort keys.
+                return Ok(());
+            }
+            filtered => {
+                let array = filtered.into_array(num_rows)?;
+                let mut filter = array.as_boolean().clone();
+                if !filter.has_true() {
+                    // nothing to filter, so no need to update
+                    return Ok(());
+                }
+                // only update the keys / rows if the filter does not match all rows
+                if filter.null_count() > 0 || filter.has_false() {
+                    // Indices in `set_indices` should be correct if filter contains nulls
+                    // So we prepare the filter here. Note this is also done in the `FilterBuilder`
+                    // so there is no overhead to do this here.
+                    if filter.nulls().is_some() {
+                        filter = prep_null_mask_filter(&filter);
+                    }
+
+                    selected_rows = Some(filter);
+                }
+            }
+        }
+
         let mut sort_keys: Vec<ArrayRef> = self
             .expr
             .iter()
             .map(|expr| {
                 let value = expr.expr.evaluate(&batch)?;
-                value.into_array(batch.num_rows())
+                value.into_array(num_rows)
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let mut selected_rows = None;
-
-        // If a filter is provided, update it with the new rows
-        let filter = self.filter.read().expr.current()?;
-        let filtered = filter.evaluate(&batch)?;
-        let num_rows = batch.num_rows();
-        let array = filtered.into_array(num_rows)?;
-        let mut filter = array.as_boolean().clone();
-        if !filter.has_true() {
-            // nothing to filter, so no need to update
-            return Ok(());
-        }
-        // only update the keys / rows if the filter does not match all rows
-        if filter.null_count() > 0 || filter.has_false() {
-            // Indices in `set_indices` should be correct if filter contains nulls
-            // So we prepare the filter here. Note this is also done in the `FilterBuilder`
-            // so there is no overhead to do this here.
-            if filter.nulls().is_some() {
-                filter = prep_null_mask_filter(&filter);
-            }
-
-            let filter_predicate = FilterBuilder::new(&filter);
+        if let Some(filter) = &selected_rows {
+            let filter_predicate = FilterBuilder::new(filter);
             let filter_predicate = if sort_keys.len() > 1 {
                 // Optimize filter when it has multiple sort keys
                 filter_predicate.optimize().build()
             } else {
                 filter_predicate.build()
             };
-            selected_rows = Some(filter);
             sort_keys = sort_keys
                 .iter()
                 .map(|key| filter_predicate.filter(key).map_err(|x| x.into()))
@@ -1240,6 +1252,41 @@ mod tests {
         // After emit is called, the dynamic filter should be marked as complete
         // wait_complete() should return immediately
         dynamic_filter_clone.wait_complete().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topk_scalar_false_dynamic_filter_skips_batch() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        let sort_expr = PhysicalSortExpr {
+            expr: col("a", schema.as_ref())?,
+            options: SortOptions::default(),
+        };
+
+        let runtime = Arc::new(RuntimeEnv::default());
+        let metrics = ExecutionPlanMetricsSet::new();
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(vec![], lit(false)));
+
+        let mut topk = TopK::try_new(
+            0,
+            Arc::clone(&schema),
+            vec![],
+            LexOrdering::from([sort_expr]),
+            2,
+            10,
+            runtime,
+            &metrics,
+            Arc::new(RwLock::new(TopKDynamicFilters::new(dynamic_filter))),
+        )?;
+
+        let array: ArrayRef = Arc::new(Int32Array::from(vec![Some(3), Some(1), Some(2)]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![array])?;
+        topk.insert_batch(batch)?;
+
+        let results: Vec<_> = topk.emit()?.try_collect().await?;
+        assert!(results.is_empty());
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Follow-up performance cleanup found while profiling ClickBench TopK queries.

## Rationale for this change

`TopK::insert_batch` evaluated sort expressions before checking its dynamic filter. When the dynamic filter rejected the whole batch, this still allocated sort-key arrays and row-conversion scratch that would never be used. Scalar dynamic filters were also expanded into full boolean arrays before the all-true/all-false check.

## What changes are included in this PR?

- Evaluate the TopK dynamic filter before building sort keys.
- Fast-path scalar boolean dynamic filters so scalar true does not allocate a boolean array, and scalar false/null returns before sort-key evaluation.
- Keep existing array-filter behavior for partial matches, including null-mask preparation and filter predicate reuse.
- Add a unit test for the scalar-false dynamic-filter path.

## Are these changes tested?

- `cargo fmt --all`
- `cargo test -p datafusion-physical-plan topk -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run --profile release-nonlto --bin dfbench -- clickbench -q 21 -i 1 -n 8`
- `cargo run --profile release-nonlto --bin dfbench -- clickbench -q 22 -i 1 -n 8`
- `cargo run --profile release-nonlto --bin dfbench -- clickbench -q 23 -i 1 -n 8`
- `cargo run --profile release-nonlto --bin dfbench -- clickbench -q 33 -i 1 -n 8`
- `cargo run --profile release-nonlto --bin dfbench -- clickbench -q 34 -i 1 -n 8`
- `cargo run --profile release-nonlto --bin mem_profile -- --bench-profile release-nonlto clickbench --query 23 -i 1 -n 8`

Local non-LTO smoke results: q21 1179.87 ms, q22 2206.03 ms, q23 5718.53 ms on repeat, q33 2413.82 ms on repeat, q34 2259.08 ms. q23 mem_profile reported 5753.62 ms, peak RSS 2.2 GB, peak commit 2.3 GB.

## Are there any user-facing changes?

No. This is an execution-time allocation/performance cleanup.