### PR TITLE
Support lower and upper scalar udf on dict arrays

### DIFF
--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -24,7 +24,7 @@ use crate::strings::{
     StringViewArrayBuilder, append_view,
 };
 use arrow::array::{
-    Array, ArrayRef, GenericStringArray, NullBufferBuilder, OffsetSizeTrait,
+    Array, ArrayRef, AsArray, GenericStringArray, NullBufferBuilder, OffsetSizeTrait,
     StringViewArray, new_null_array,
 };
 use arrow::buffer::{Buffer, OffsetBuffer, ScalarBuffer};
@@ -386,6 +386,21 @@ fn case_conversion(
                 }
 
                 Ok(ColumnarValue::Array(Arc::new(builder.finish(nulls)?)))
+            }
+            DataType::Dictionary(_, _) => {
+                let dict = array.as_any_dictionary();
+                let values = dict.values();
+                let converted = case_conversion(
+                    &[ColumnarValue::Array(Arc::clone(values))],
+                    lower,
+                    name,
+                )?;
+                match converted {
+                    ColumnarValue::Array(new_values) => {
+                        Ok(ColumnarValue::Array(dict.with_values(new_values)))
+                    }
+                    _ => unreachable!("Array input should produce Array output"),
+                }
             }
             other => exec_err!("Unsupported data type {other:?} for function {name}"),
         },

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -91,7 +91,9 @@ impl ScalarUDFImpl for LowerFunc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Array, ArrayRef, StringArray, StringViewArray};
+    use arrow::array::{
+        Array, ArrayRef, DictionaryArray, StringArray, StringViewArray, UInt8Array,
+    };
     use arrow::datatypes::Field;
     use datafusion_common::config::ConfigOptions;
     use std::sync::Arc;
@@ -368,6 +370,24 @@ mod tests {
         // The slice's addressed bytes are "HELLO" + "WORLD" = 10; the ASCII
         // fast path must produce a tight output buffer (not the parent's).
         assert_eq!(result_sa.value_data().len(), 10);
+        Ok(())
+    }
+
+    #[test]
+    fn test_dict() -> Result<()> {
+        let input = Arc::new(DictionaryArray::new(
+            UInt8Array::from_iter_values([0, 1, 1, 0, 1, 0]),
+            Arc::new(StringArray::from_iter_values(["A", "b"])),
+        ));
+
+        let result = invoke_lower(input)?;
+
+        let expected = DictionaryArray::new(
+            UInt8Array::from_iter_values([0, 1, 1, 0, 1, 0]),
+            Arc::new(StringArray::from_iter_values(["a", "b"])),
+        );
+
+        assert_eq!(result.as_ref(), &expected);
         Ok(())
     }
 }

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -90,7 +90,9 @@ impl ScalarUDFImpl for UpperFunc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Array, ArrayRef, StringArray, StringViewArray};
+    use arrow::array::{
+        Array, ArrayRef, DictionaryArray, StringArray, StringViewArray, UInt8Array,
+    };
     use arrow::datatypes::Field;
     use datafusion_common::config::ConfigOptions;
     use std::sync::Arc;
@@ -367,6 +369,24 @@ mod tests {
         // The slice's addressed bytes are "hello" + "world" = 10; the ASCII
         // fast path must produce a tight output buffer (not the parent's).
         assert_eq!(result_sa.value_data().len(), 10);
+        Ok(())
+    }
+
+    #[test]
+    fn test_dict() -> Result<()> {
+        let input = Arc::new(DictionaryArray::new(
+            UInt8Array::from_iter_values([0, 1, 1, 0, 1, 0]),
+            Arc::new(StringArray::from_iter_values(["A", "b"])),
+        ));
+
+        let result = invoke_upper(input)?;
+
+        let expected = DictionaryArray::new(
+            UInt8Array::from_iter_values([0, 1, 1, 0, 1, 0]),
+            Arc::new(StringArray::from_iter_values(["A", "B"])),
+        );
+
+        assert_eq!(result.as_ref(), &expected);
         Ok(())
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to #20935.

(if we need a dedicated issue for this PR specifically, happy to create one)

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Have the `lower` and `upper` scalar UDFs capable of converting the case of dictionary arrays.

Before this change, callers of these scalar UDFs would have to convert their columns to non-dictionary encoded arrays, where they may wish to avoid the overhead.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Calls the `case_conversion` function recursively on dictionary values if the input is a dictionary array.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes unit tests

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
