### PR TITLE
Specialize right semi/anti hash joins

### DIFF
--- a/datafusion/physical-plan/src/joins/array_map.rs
+++ b/datafusion/physical-plan/src/joins/array_map.rs
@@ -264,6 +264,69 @@ impl ArrayMap {
         )
     }
 
+    pub fn get_probe_indices_with_match(
+        &self,
+        prob_side_keys: &[ArrayRef],
+        limit: usize,
+        current_offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+    ) -> Result<Option<MapOffset>> {
+        if prob_side_keys.len() != 1 {
+            return internal_err!(
+                "ArrayMap expects 1 join key, but got {}",
+                prob_side_keys.len()
+            );
+        }
+        let array = &prob_side_keys[0];
+
+        downcast_supported_integer!(
+            array.data_type() => (
+                lookup_and_get_probe_indices_with_match,
+                self,
+                array,
+                limit,
+                current_offset,
+                probe_indices
+            )
+        )
+    }
+
+    fn lookup_and_get_probe_indices_with_match<T: ArrowNumericType>(
+        &self,
+        array: &ArrayRef,
+        limit: usize,
+        current_offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+    ) -> Result<Option<MapOffset>>
+    where
+        T::Native: Copy + AsPrimitive<u64>,
+    {
+        probe_indices.clear();
+
+        let arr = array.as_primitive::<T>();
+        let have_null = arr.null_count() > 0;
+
+        for prob_idx in current_offset.0..arr.len() {
+            if probe_indices.len() == limit {
+                return Ok(Some((prob_idx, None)));
+            }
+
+            if have_null && arr.is_null(prob_idx) {
+                continue;
+            }
+
+            // SAFETY: prob_idx is guaranteed to be within bounds by the loop range.
+            let prob_val: u64 = unsafe { arr.value_unchecked(prob_idx) }.as_();
+            let idx_in_build_side = prob_val.wrapping_sub(self.offset) as usize;
+
+            if idx_in_build_side < self.data.len() && self.data[idx_in_build_side] != 0 {
+                probe_indices.push(prob_idx as u32);
+            }
+        }
+
+        Ok(None)
+    }
+
     fn lookup_and_get_indices<T: ArrowNumericType>(
         &self,
         array: &ArrayRef,

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -41,15 +41,16 @@ use crate::{
     hash_utils::create_hashes,
     joins::utils::{
         BuildProbeJoinMetrics, ColumnIndex, JoinFilter, JoinHashMapType,
-        StatefulStreamResult, adjust_indices_by_join_type, apply_join_filter_to_indices,
-        build_batch_empty_build_side, build_batch_from_indices,
-        need_produce_result_in_final,
+        JoinKeyComparator, StatefulStreamResult, adjust_indices_by_join_type,
+        apply_join_filter_to_indices, build_batch_empty_build_side,
+        build_batch_from_indices, get_anti_indices, need_produce_result_in_final,
     },
 };
 
 use arrow::array::{Array, ArrayRef, UInt32Array, UInt64Array};
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
+use arrow_schema::SortOptions;
 use datafusion_common::{
     JoinSide, JoinType, NullEquality, Result, internal_datafusion_err, internal_err,
 };
@@ -632,6 +633,12 @@ impl HashJoinStream {
     fn process_probe_batch(
         &mut self,
     ) -> Result<StatefulStreamResult<Option<RecordBatch>>> {
+        if self.filter.is_none()
+            && matches!(self.join_type, JoinType::RightSemi | JoinType::RightAnti)
+        {
+            return self.process_probe_batch_right_existence();
+        }
+
         let state = self.state.try_as_process_probe_batch_mut()?;
         let build_side = self.build_side.try_as_ready_mut()?;
 
@@ -845,6 +852,120 @@ impl HashJoinStream {
                 last_joined_right_idx,
             )
         };
+
+        Ok(StatefulStreamResult::Continue)
+    }
+
+    /// Specialized probe path for right semi/anti hash joins without residual
+    /// filters. In these joins the build side is only an existence side, so the
+    /// probe only needs to know whether at least one build row with equal join
+    /// keys exists. This avoids materializing every duplicate build-side match.
+    fn process_probe_batch_right_existence(
+        &mut self,
+    ) -> Result<StatefulStreamResult<Option<RecordBatch>>> {
+        let state = self.state.try_as_process_probe_batch_mut()?;
+        let build_side = self.build_side.try_as_ready_mut()?;
+
+        self.join_metrics
+            .probe_hit_rate
+            .add_total(state.batch.num_rows());
+
+        let timer = self.join_metrics.join_time.timer();
+
+        if build_side.left_data.map().is_empty() {
+            let result = build_batch_empty_build_side(
+                &self.schema,
+                build_side.left_data.batch(),
+                &state.batch,
+                &self.column_indices,
+                self.join_type,
+            )?;
+            timer.done();
+            self.output_buffer.push_batch(result)?;
+            self.state = HashJoinStreamState::FetchProbeBatch;
+            return Ok(StatefulStreamResult::Continue);
+        }
+
+        let limit = if self.join_type == JoinType::RightAnti {
+            state.batch.num_rows()
+        } else {
+            self.batch_size
+        };
+
+        let next_offset = match build_side.left_data.map() {
+            Map::HashMap(map) => {
+                let sort_options =
+                    vec![SortOptions::default(); build_side.left_data.values().len()];
+                let comparator = JoinKeyComparator::new(
+                    build_side.left_data.values(),
+                    &state.values,
+                    &sort_options,
+                    self.null_equality,
+                )?;
+                let mut is_match =
+                    |build_idx, probe_idx| comparator.is_equal(build_idx, probe_idx);
+                map.get_probe_indices_with_any_match(
+                    &self.hashes_buffer,
+                    limit,
+                    state.offset,
+                    &mut self.probe_indices_buffer,
+                    &mut is_match,
+                )
+            }
+            Map::ArrayMap(array_map) => array_map.get_probe_indices_with_match(
+                &state.values,
+                limit,
+                state.offset,
+                &mut self.probe_indices_buffer,
+            )?,
+        };
+
+        let matched_right_indices = UInt32Array::from(self.probe_indices_buffer.clone());
+        self.join_metrics
+            .probe_hit_rate
+            .add_part(matched_right_indices.len());
+        self.join_metrics
+            .avg_fanout
+            .add_part(matched_right_indices.len());
+        self.join_metrics
+            .avg_fanout
+            .add_total(matched_right_indices.len());
+
+        let right_indices = if self.join_type == JoinType::RightAnti {
+            get_anti_indices(0..state.batch.num_rows(), &matched_right_indices)
+        } else {
+            matched_right_indices
+        };
+
+        if !right_indices.is_empty() {
+            let left_indices = UInt64Array::from_iter_values(std::iter::empty::<u64>());
+            let batch = build_batch_from_indices(
+                &self.schema,
+                build_side.left_data.batch(),
+                &state.batch,
+                &left_indices,
+                &right_indices,
+                &self.column_indices,
+                JoinSide::Left,
+                self.join_type,
+            )?;
+
+            let push_status = self.output_buffer.push_batch(batch)?;
+            if push_status == PushBatchStatus::LimitReached {
+                timer.done();
+                self.output_buffer.finish()?;
+                self.state = HashJoinStreamState::Completed;
+                return Ok(StatefulStreamResult::Continue);
+            }
+        }
+
+        timer.done();
+
+        if let Some(next_offset) = next_offset {
+            state.advance(next_offset, None);
+        } else {
+            self.state = HashJoinStreamState::FetchProbeBatch;
+        }
 
         Ok(StatefulStreamResult::Continue)
     }

--- a/datafusion/physical-plan/src/joins/join_hash_map.rs
+++ b/datafusion/physical-plan/src/joins/join_hash_map.rs
@@ -126,6 +126,18 @@ pub trait JoinHashMapType: Send + Sync {
         match_indices: &mut Vec<u64>,
     ) -> Option<MapOffset>;
 
+    /// Returns probe-side row indices that have at least one matching build-side
+    /// row. The `is_match` callback verifies equality for candidates with the
+    /// same hash value and lets callers account for hash collisions.
+    fn get_probe_indices_with_any_match(
+        &self,
+        hash_values: &[u64],
+        limit: usize,
+        offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+        is_match: &mut dyn FnMut(usize, usize) -> bool,
+    ) -> Option<MapOffset>;
+
     /// Returns a BooleanArray indicating which of the provided hashes exist in the map.
     fn contain_hashes(&self, hash_values: &[u64]) -> BooleanArray;
 
@@ -198,6 +210,25 @@ impl JoinHashMapType for JoinHashMapU32 {
             offset,
             input_indices,
             match_indices,
+        )
+    }
+
+    fn get_probe_indices_with_any_match(
+        &self,
+        hash_values: &[u64],
+        limit: usize,
+        offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+        is_match: &mut dyn FnMut(usize, usize) -> bool,
+    ) -> Option<MapOffset> {
+        get_probe_indices_with_any_match::<u32>(
+            &self.map,
+            &self.next,
+            hash_values,
+            limit,
+            offset,
+            probe_indices,
+            is_match,
         )
     }
 
@@ -276,6 +307,25 @@ impl JoinHashMapType for JoinHashMapU64 {
             offset,
             input_indices,
             match_indices,
+        )
+    }
+
+    fn get_probe_indices_with_any_match(
+        &self,
+        hash_values: &[u64],
+        limit: usize,
+        offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+        is_match: &mut dyn FnMut(usize, usize) -> bool,
+    ) -> Option<MapOffset> {
+        get_probe_indices_with_any_match::<u64>(
+            &self.map,
+            &self.next,
+            hash_values,
+            limit,
+            offset,
+            probe_indices,
+            is_match,
         )
     }
 
@@ -464,6 +514,51 @@ where
     None
 }
 
+pub fn get_probe_indices_with_any_match<T>(
+    map: &HashTable<(u64, T)>,
+    next_chain: &[T],
+    hash_values: &[u64],
+    limit: usize,
+    offset: MapOffset,
+    probe_indices: &mut Vec<u32>,
+    is_match: &mut dyn FnMut(usize, usize) -> bool,
+) -> Option<MapOffset>
+where
+    T: Copy + TryFrom<usize> + PartialOrd + Into<u64> + Sub<Output = T>,
+    <T as TryFrom<usize>>::Error: Debug,
+    T: ArrowNativeType,
+{
+    probe_indices.clear();
+    let one = T::try_from(1).unwrap();
+
+    let start = offset.0;
+    for (i, &hash) in hash_values[start..].iter().enumerate() {
+        let probe_idx = start + i;
+        if probe_indices.len() == limit {
+            return Some((probe_idx, None));
+        }
+
+        if let Some((_, idx)) = map.find(hash, |(h, _)| hash == *h) {
+            let mut build_idx = *idx - one;
+            loop {
+                let build_idx_usize = build_idx.into() as usize;
+                if is_match(build_idx_usize, probe_idx) {
+                    probe_indices.push(probe_idx as u32);
+                    break;
+                }
+
+                let next_idx = next_chain[build_idx_usize];
+                if next_idx == T::usize_as(0) {
+                    break;
+                }
+                build_idx = next_idx - one;
+            }
+        }
+    }
+
+    None
+}
+
 pub fn contain_hashes<T>(map: &HashTable<(u64, T)>, hash_values: &[u64]) -> BooleanArray {
     let buffer = BooleanBuffer::collect_bool(hash_values.len(), |i| {
         let hash = hash_values[i];
@@ -493,5 +588,29 @@ mod tests {
                 assert!(!array.value(i), "Hash {hash} should NOT exist in the map");
             }
         }
+    }
+
+    #[test]
+    fn test_probe_indices_with_any_match_stops_after_first_match() {
+        let mut hash_map = JoinHashMapU32::with_capacity(3);
+        hash_map.update_from_iter(Box::new([10u64, 10u64, 10u64].iter().enumerate()), 0);
+
+        let mut probe_indices = vec![];
+        let mut calls = 0;
+        let mut is_match = |_build_idx: usize, _probe_idx: usize| {
+            calls += 1;
+            true
+        };
+        let next_offset = hash_map.get_probe_indices_with_any_match(
+            &[10],
+            10,
+            (0, None),
+            &mut probe_indices,
+            &mut is_match,
+        );
+
+        assert_eq!(next_offset, None);
+        assert_eq!(probe_indices, vec![0]);
+        assert_eq!(calls, 1);
     }
 }

--- a/datafusion/physical-plan/src/joins/stream_join_utils.rs
+++ b/datafusion/physical-plan/src/joins/stream_join_utils.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use crate::joins::MapOffset;
 use crate::joins::join_hash_map::{
     contain_hashes, get_matched_indices, get_matched_indices_with_limit_offset,
-    update_from_iter,
+    get_probe_indices_with_any_match, update_from_iter,
 };
 use crate::joins::utils::{JoinFilter, JoinHashMapType};
 use crate::metrics::{
@@ -95,6 +95,27 @@ impl JoinHashMapType for PruningJoinHashMap {
             offset,
             input_indices,
             match_indices,
+        )
+    }
+
+    fn get_probe_indices_with_any_match(
+        &self,
+        hash_values: &[u64],
+        limit: usize,
+        offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+        is_match: &mut dyn FnMut(usize, usize) -> bool,
+    ) -> Option<MapOffset> {
+        // Flatten the deque
+        let next: Vec<u64> = self.next.iter().copied().collect();
+        get_probe_indices_with_any_match::<u64>(
+            &self.map,
+            &next,
+            hash_values,
+            limit,
+            offset,
+            probe_indices,
+            is_match,
         )
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Not applicable.

## Rationale for this change

Right semi and right anti joins only need to know whether each probe-side row has at least one matching build-side row when there is no residual join filter. The generic hash join path currently materializes every duplicate build-side match and later deduplicates or inverts probe indices, doing unnecessary work for duplicated existence-side keys.

In a focused local throwaway benchmark with 10,000 duplicate build rows and 10,000 probe rows, the old lookup path enumerated 100,000,000 candidate pairs in 183.872 ms, while the new existence lookup returned 10,000 probe matches in 45.791 us.

## What changes are included in this PR?

- Add a hash-map existence probe that stops walking a duplicate chain after the first equality-confirmed match.
- Add an ArrayMap membership probe for the same right semi/anti use case.
- Route `RightSemi` and `RightAnti` hash joins without residual filters through the existence path.
- Keep the generic path for joins with residual filters, where duplicate build rows may affect filter results.
- Add a unit test covering early stop behavior for duplicate build-side matches.

## Are these changes tested?

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p datafusion-physical-plan hash_join --lib`
- `cargo test -p datafusion-physical-plan joins::join_hash_map::tests::test_probe_indices_with_any_match_stops_after_first_match --lib`

## Are there any user-facing changes?

No API or behavior changes expected. This is a physical execution optimization for right semi/anti hash joins without residual filters.