### PR TITLE
feat: Implement preimage for ceil and round functions

### DIFF
--- a/datafusion/functions/src/math/ceil.rs
+++ b/datafusion/functions/src/math/ceil.rs
@@ -18,20 +18,67 @@
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, AsArray};
+use arrow::compute::{DecimalCast, rescale_decimal};
 use arrow::datatypes::{
-    DataType, Decimal32Type, Decimal64Type, Decimal128Type, Decimal256Type, Float32Type,
-    Float64Type,
+    ArrowNativeTypeOp, DataType, Decimal32Type, Decimal64Type, Decimal128Type,
+    Decimal256Type, DecimalType, Float32Type, Float64Type,
 };
 use datafusion_common::{Result, ScalarValue, exec_err};
 use datafusion_expr::interval_arithmetic::Interval;
+use datafusion_expr::preimage::PreimageResult;
+use datafusion_expr::simplify::SimplifyContext;
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
 use datafusion_expr::{
-    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
-    TypeSignature, TypeSignatureClass, Volatility,
+    Coercion, ColumnarValue, Documentation, Expr, ScalarFunctionArgs, ScalarUDFImpl,
+    Signature, TypeSignature, TypeSignatureClass, Volatility,
 };
 use datafusion_macros::user_doc;
+use num_traits::{Float, One};
 
 use super::decimal::{apply_decimal_op, ceil_decimal_value};
+
+/// Extends `num_traits::Float` with `next_up()` so generic preimage helpers
+/// can call it without specializing per concrete float type.
+trait FloatExt: Float {
+    fn next_up(self) -> Self;
+}
+
+impl FloatExt for f64 {
+    #[inline]
+    fn next_up(self) -> f64 {
+        f64::next_up(self)
+    }
+}
+
+impl FloatExt for f32 {
+    #[inline]
+    fn next_up(self) -> f32 {
+        f32::next_up(self)
+    }
+}
+
+// ============ Macro for ceil preimage bounds ============
+/// Dispatches to the appropriate bounds helper and wraps results in ScalarValue.
+macro_rules! ceil_preimage_bounds {
+    (float: $variant:ident, $value:expr) => {
+        ceil_preimage_float($value).map(|(lo, hi)| {
+            (
+                ScalarValue::$variant(Some(lo)),
+                ScalarValue::$variant(Some(hi)),
+            )
+        })
+    };
+    (decimal: $variant:ident, $decimal_type:ty, $value:expr, $precision:expr, $scale:expr) => {
+        ceil_preimage_decimal::<$decimal_type>($value, $precision, $scale).map(
+            |(lo, hi)| {
+                (
+                    ScalarValue::$variant(Some(lo), $precision, $scale),
+                    ScalarValue::$variant(Some(hi), $precision, $scale),
+                )
+            },
+        )
+    };
+}
 
 #[user_doc(
     doc_section(label = "Math Functions"),
@@ -195,7 +242,320 @@ impl ScalarUDFImpl for CeilFunc {
         Interval::make_unbounded(&data_type)
     }
 
+    /// Compute the preimage for `ceil(col) = literal`.
+    ///
+    /// `ceil(x) = N` iff `x ∈ (N-1, N]`. Since the preimage API expects a
+    /// half-open `[lower, upper)` interval, both boundaries are shifted by
+    /// one ULP using `next_up()`:
+    ///
+    ///   `(N-1, N]  →  [next_up(N-1), next_up(N))`
+    ///
+    /// For decimal types the "ULP" is one scale unit (the smallest
+    /// representable step at the column's scale).
+    fn preimage(
+        &self,
+        args: &[Expr],
+        lit_expr: &Expr,
+        _info: &SimplifyContext,
+    ) -> Result<PreimageResult> {
+        debug_assert!(args.len() == 1, "ceil() takes exactly one argument");
+
+        let arg = args[0].clone();
+
+        let Expr::Literal(lit_value, _) = lit_expr else {
+            return Ok(PreimageResult::None);
+        };
+
+        let Some((lower, upper)) = (match lit_value {
+            ScalarValue::Float64(Some(n)) => {
+                ceil_preimage_bounds!(float: Float64, *n)
+            }
+            ScalarValue::Float32(Some(n)) => {
+                ceil_preimage_bounds!(float: Float32, *n)
+            }
+            ScalarValue::Decimal32(Some(n), precision, scale) => {
+                ceil_preimage_bounds!(decimal: Decimal32, Decimal32Type, *n, *precision, *scale)
+            }
+            ScalarValue::Decimal64(Some(n), precision, scale) => {
+                ceil_preimage_bounds!(decimal: Decimal64, Decimal64Type, *n, *precision, *scale)
+            }
+            ScalarValue::Decimal128(Some(n), precision, scale) => {
+                ceil_preimage_bounds!(decimal: Decimal128, Decimal128Type, *n, *precision, *scale)
+            }
+            ScalarValue::Decimal256(Some(n), precision, scale) => {
+                ceil_preimage_bounds!(decimal: Decimal256, Decimal256Type, *n, *precision, *scale)
+            }
+            _ => None,
+        }) else {
+            return Ok(PreimageResult::None);
+        };
+
+        Ok(PreimageResult::Range {
+            expr: arg,
+            interval: Box::new(Interval::try_new(lower, upper)?),
+        })
+    }
+
     fn documentation(&self) -> Option<&Documentation> {
         self.doc()
+    }
+}
+
+// ============ Helper functions for ceil preimage bounds ============
+
+/// Computes `[next_up(N-1), next_up(N))` for `ceil(x) = N` on floating-point types.
+///
+/// Returns `None` if:
+/// - `N` is non-finite (±∞, NaN)
+/// - `N` has a fractional part (ceil always returns integers)
+/// - `N - 1` underflows to `N` due to precision loss at extreme magnitudes
+fn ceil_preimage_float<F: Float + One + FloatExt>(n: F) -> Option<(F, F)> {
+    if !n.is_finite() || n.fract() != F::zero() {
+        return None;
+    }
+    let n_minus_one = n - F::one();
+    // Guard: at very large magnitudes N-1 == N due to precision loss.
+    // Mirroring floor's analogous guard for N+1 == N.
+    if n_minus_one >= n {
+        return None;
+    }
+    Some((n_minus_one.next_up(), n.next_up()))
+}
+
+/// Computes the preimage bounds for `ceil(x) = N` on decimal types.
+///
+/// `ceil(x) = N` iff `x ∈ (N-1, N]`. In decimal discrete steps the
+/// interval is `[N_raw - one_scaled + 1, N_raw + 1)`.
+///
+/// Returns `None` if:
+/// - `N` has a fractional part (ceil always returns integers)
+/// - Arithmetic would overflow the native integer
+fn ceil_preimage_decimal<D: DecimalType>(
+    n_raw: D::Native,
+    precision: u8,
+    scale: i8,
+) -> Option<(D::Native, D::Native)>
+where
+    D::Native: DecimalCast + ArrowNativeTypeOp + std::ops::Rem<Output = D::Native>,
+{
+    let one_scaled: D::Native =
+        rescale_decimal::<D, D>(D::Native::ONE, 1, 0, precision, scale)?;
+
+    // ceil always returns a whole-number decimal (raw value divisible by one_scaled).
+    // e.g. ceil(5.30) = 6.00 (raw 600), never 6.30. A literal like 5.30 (raw 530)
+    // cannot be a valid output, so its preimage is empty, thus return None.
+    if scale > 0 && n_raw % one_scaled != D::Native::ZERO {
+        return None;
+    }
+
+    // lower = N_raw - one_scaled + 1  (first decimal step strictly above N-1)
+    // upper = N_raw + 1               (first decimal step strictly above N)
+    let lower = n_raw
+        .sub_checked(one_scaled)
+        .ok()?
+        .add_checked(D::Native::ONE)
+        .ok()?;
+    let upper = n_raw.add_checked(D::Native::ONE).ok()?;
+
+    Some((lower, upper))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_buffer::i256;
+    use datafusion_expr::col;
+
+    fn assert_preimage_range(
+        input: ScalarValue,
+        expected_lower: ScalarValue,
+        expected_upper: ScalarValue,
+    ) {
+        let ceil_func = CeilFunc::new();
+        let args = vec![col("x")];
+        let lit_expr = Expr::Literal(input.clone(), None);
+        let info = SimplifyContext::default();
+
+        let result = ceil_func.preimage(&args, &lit_expr, &info).unwrap();
+
+        match result {
+            PreimageResult::Range { expr, interval } => {
+                assert_eq!(expr, col("x"));
+                assert_eq!(interval.lower().clone(), expected_lower);
+                assert_eq!(interval.upper().clone(), expected_upper);
+            }
+            PreimageResult::None => {
+                panic!("Expected Range, got None for input {input:?}")
+            }
+        }
+    }
+
+    fn assert_preimage_none(input: ScalarValue) {
+        let ceil_func = CeilFunc::new();
+        let args = vec![col("x")];
+        let lit_expr = Expr::Literal(input.clone(), None);
+        let info = SimplifyContext::default();
+
+        let result = ceil_func.preimage(&args, &lit_expr, &info).unwrap();
+        assert!(
+            matches!(result, PreimageResult::None),
+            "Expected None for input {input:?}"
+        );
+    }
+
+    #[test]
+    fn test_ceil_preimage_float_positive() {
+        // ceil(x) = 5 → x ∈ (4, 5] → [next_up(4), next_up(5))
+        assert_preimage_range(
+            ScalarValue::Float64(Some(5.0)),
+            ScalarValue::Float64(Some(4.0_f64.next_up())),
+            ScalarValue::Float64(Some(5.0_f64.next_up())),
+        );
+        assert_preimage_range(
+            ScalarValue::Float32(Some(5.0)),
+            ScalarValue::Float32(Some(4.0_f32.next_up())),
+            ScalarValue::Float32(Some(5.0_f32.next_up())),
+        );
+        // ceil(x) = 100
+        assert_preimage_range(
+            ScalarValue::Float64(Some(100.0)),
+            ScalarValue::Float64(Some(99.0_f64.next_up())),
+            ScalarValue::Float64(Some(100.0_f64.next_up())),
+        );
+    }
+
+    #[test]
+    fn test_ceil_preimage_float_negative() {
+        // ceil(x) = -4 → x ∈ (-5, -4] → [next_up(-5), next_up(-4))
+        assert_preimage_range(
+            ScalarValue::Float64(Some(-4.0)),
+            ScalarValue::Float64(Some((-5.0_f64).next_up())),
+            ScalarValue::Float64(Some((-4.0_f64).next_up())),
+        );
+    }
+
+    #[test]
+    fn test_ceil_preimage_float_zero() {
+        // ceil(x) = 0 → x ∈ (-1, 0] → [next_up(-1), next_up(0))
+        assert_preimage_range(
+            ScalarValue::Float64(Some(0.0)),
+            ScalarValue::Float64(Some((-1.0_f64).next_up())),
+            ScalarValue::Float64(Some(0.0_f64.next_up())),
+        );
+    }
+
+    #[test]
+    fn test_ceil_preimage_float_non_integer() {
+        // ceil always returns integers; non-integer literal has no preimage
+        assert_preimage_none(ScalarValue::Float64(Some(1.5)));
+        assert_preimage_none(ScalarValue::Float64(Some(-2.3)));
+        assert_preimage_none(ScalarValue::Float32(Some(3.7)));
+    }
+
+    #[test]
+    fn test_ceil_preimage_float_edge_cases() {
+        assert_preimage_none(ScalarValue::Float64(Some(f64::INFINITY)));
+        assert_preimage_none(ScalarValue::Float64(Some(f64::NEG_INFINITY)));
+        assert_preimage_none(ScalarValue::Float64(Some(f64::NAN)));
+        // At f64::MIN (most negative finite), N-1 == N (precision loss) → None
+        assert_preimage_none(ScalarValue::Float64(Some(f64::MIN)));
+        // At f64::MAX, N-1 == N for the same reason → None
+        assert_preimage_none(ScalarValue::Float64(Some(f64::MAX)));
+        assert_preimage_none(ScalarValue::Float32(Some(f32::INFINITY)));
+        assert_preimage_none(ScalarValue::Float32(Some(f32::NEG_INFINITY)));
+        assert_preimage_none(ScalarValue::Float32(Some(f32::NAN)));
+        assert_preimage_none(ScalarValue::Float32(Some(f32::MIN)));
+        assert_preimage_none(ScalarValue::Float32(Some(f32::MAX)));
+    }
+
+    #[test]
+    fn test_ceil_preimage_float_null() {
+        assert_preimage_none(ScalarValue::Float64(None));
+        assert_preimage_none(ScalarValue::Float32(None));
+    }
+
+    #[test]
+    fn test_ceil_preimage_decimal_positive() {
+        // ceil(x) = 5.00 (raw 500, scale=2) → x ∈ (4.00, 5.00] → [4.01, 5.01) raw [401, 501)
+        assert_preimage_range(
+            ScalarValue::Decimal128(Some(500), 10, 2),
+            ScalarValue::Decimal128(Some(401), 10, 2), // next above 4.00
+            ScalarValue::Decimal128(Some(501), 10, 2), // next above 5.00
+        );
+        // scale=0 (integer): ceil(x) = 42 → [42-1+1, 42+1) = [42, 43)
+        assert_preimage_range(
+            ScalarValue::Decimal128(Some(42), 10, 0),
+            ScalarValue::Decimal128(Some(42), 10, 0),
+            ScalarValue::Decimal128(Some(43), 10, 0),
+        );
+    }
+
+    #[test]
+    fn test_ceil_preimage_decimal_negative() {
+        // ceil(x) = -5.00 → x ∈ (-6.00, -5.00] → [-5.99, -4.99) raw [-599, -499)
+        assert_preimage_range(
+            ScalarValue::Decimal128(Some(-500), 10, 2),
+            ScalarValue::Decimal128(Some(-599), 10, 2),
+            ScalarValue::Decimal128(Some(-499), 10, 2),
+        );
+    }
+
+    #[test]
+    fn test_ceil_preimage_decimal_zero() {
+        // ceil(x) = 0.00 → x ∈ (-1.00, 0.00] → [-0.99, 0.01) raw [-99, 1)
+        assert_preimage_range(
+            ScalarValue::Decimal128(Some(0), 10, 2),
+            ScalarValue::Decimal128(Some(-99), 10, 2),
+            ScalarValue::Decimal128(Some(1), 10, 2),
+        );
+    }
+
+    #[test]
+    fn test_ceil_preimage_decimal_non_integer() {
+        // 5.50 has a fractional part → no preimage
+        assert_preimage_none(ScalarValue::Decimal128(Some(550), 10, 2));
+        assert_preimage_none(ScalarValue::Decimal128(Some(-275), 10, 2));
+        assert_preimage_none(ScalarValue::Decimal128(Some(1), 10, 2)); // 0.01
+    }
+
+    #[test]
+    fn test_ceil_preimage_decimal_overflow() {
+        // upper = N_raw + 1 overflows for MAX values
+        assert_preimage_none(ScalarValue::Decimal32(Some(i32::MAX), 10, 0));
+        assert_preimage_none(ScalarValue::Decimal64(Some(i64::MAX), 19, 0));
+        // lower = N_raw - one_scaled + 1 overflows for very negative aligned values
+        // i128::MIN is not divisible by 100 (scale=2), so use MIN + (MIN % 100).abs()
+        // The simplest aligned value that causes subtraction overflow at scale=0 is i128::MIN.
+        assert_preimage_none(ScalarValue::Decimal128(Some(i128::MIN), 38, 0));
+    }
+
+    #[test]
+    fn test_ceil_preimage_decimal_all_variants() {
+        // Decimal32
+        assert_preimage_range(
+            ScalarValue::Decimal32(Some(500), 9, 2),
+            ScalarValue::Decimal32(Some(401), 9, 2),
+            ScalarValue::Decimal32(Some(501), 9, 2),
+        );
+        // Decimal64
+        assert_preimage_range(
+            ScalarValue::Decimal64(Some(500), 18, 2),
+            ScalarValue::Decimal64(Some(401), 18, 2),
+            ScalarValue::Decimal64(Some(501), 18, 2),
+        );
+        // Decimal256
+        assert_preimage_range(
+            ScalarValue::Decimal256(Some(i256::from(500)), 76, 2),
+            ScalarValue::Decimal256(Some(i256::from(401)), 76, 2),
+            ScalarValue::Decimal256(Some(i256::from(501)), 76, 2),
+        );
+    }
+
+    #[test]
+    fn test_ceil_preimage_decimal_null() {
+        assert_preimage_none(ScalarValue::Decimal32(None, 9, 2));
+        assert_preimage_none(ScalarValue::Decimal64(None, 18, 2));
+        assert_preimage_none(ScalarValue::Decimal128(None, 38, 2));
+        assert_preimage_none(ScalarValue::Decimal256(None, 76, 2));
     }
 }

--- a/datafusion/functions/src/math/round.rs
+++ b/datafusion/functions/src/math/round.rs
@@ -18,6 +18,7 @@
 use crate::utils::{calculate_binary_decimal_math, calculate_binary_math};
 
 use arrow::array::ArrayRef;
+use arrow::compute::{DecimalCast, rescale_decimal};
 use arrow::datatypes::DataType::{
     Decimal32, Decimal64, Decimal128, Decimal256, Float32, Float64,
 };
@@ -31,13 +32,33 @@ use datafusion_common::types::{
     NativeType, logical_float32, logical_float64, logical_int32,
 };
 use datafusion_common::{Result, ScalarValue, exec_err, internal_err};
+use datafusion_expr::interval_arithmetic::Interval;
+use datafusion_expr::preimage::PreimageResult;
+use datafusion_expr::simplify::SimplifyContext;
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
 use datafusion_expr::{
-    Coercion, ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs,
+    Coercion, ColumnarValue, Documentation, Expr, ReturnFieldArgs, ScalarFunctionArgs,
     ScalarUDFImpl, Signature, TypeSignature, TypeSignatureClass, Volatility,
 };
 use datafusion_macros::user_doc;
+use num_traits::Float;
 use std::sync::Arc;
+
+trait FloatExt: Float {
+    fn next_up(self) -> Self;
+}
+impl FloatExt for f64 {
+    #[inline]
+    fn next_up(self) -> f64 {
+        f64::next_up(self)
+    }
+}
+impl FloatExt for f32 {
+    #[inline]
+    fn next_up(self) -> f32 {
+        f32::next_up(self)
+    }
+}
 
 fn output_scale_for_decimal(precision: u8, input_scale: i8, decimal_places: i32) -> i8 {
     // `decimal_places` controls the maximum output scale, but scale cannot exceed the input scale.
@@ -451,6 +472,119 @@ impl ScalarUDFImpl for RoundFunc {
         }
     }
 
+    /// Compute the preimage for `round(col[, dp]) = literal`.
+    ///
+    /// `round` uses **round-half-away-from-zero** (Rust's `.round()` for floats;
+    /// analogous for decimals). The preimage of N depends on the sign of N:
+    ///
+    /// | N     | Preimage     |
+    /// |-------|--------------|
+    /// | N > 0 | `[N−h, N+h)` |
+    /// | N = 0 | `(−h, h)`    |
+    /// | N < 0 | `(N−h, N+h]` |
+    ///
+    /// where `h = 0.5 × 10^(−dp)` (defaults to `0.5` when `dp = 0`). For N ≤ 0
+    /// the preimage is not naturally half-open, so `next_up()` shifts the
+    /// affected bound by one ULP.
+    ///
+    /// For decimal types the same pattern applies using discrete scale units,
+    /// but only when `dp = 0`; non-zero `dp` reduces the output scale so the
+    /// literal type differs from the column type, which is not yet supported.
+    /// Returns `None` when `dp` is not a literal, when the literal has a
+    /// fractional part incompatible with `dp`, or at overflow extremes.
+    fn preimage(
+        &self,
+        args: &[Expr],
+        lit_expr: &Expr,
+        _info: &SimplifyContext,
+    ) -> Result<PreimageResult> {
+        let dp: i32 = match args.get(1) {
+            None => 0,
+            Some(Expr::Literal(sv, _)) => match decimal_places_from_scalar(sv) {
+                Ok(v) => v,
+                Err(_) => return Ok(PreimageResult::None),
+            },
+            Some(_) => return Ok(PreimageResult::None),
+        };
+
+        let Expr::Literal(lit_value, _) = lit_expr else {
+            return Ok(PreimageResult::None);
+        };
+
+        let half_f64 = 0.5 * 10_f64.powi(-dp);
+        if half_f64 == 0.0 || half_f64.is_infinite() {
+            return Ok(PreimageResult::None);
+        }
+        let half_f32 = half_f64 as f32;
+
+        let Some((lower, upper)) = (match lit_value {
+            ScalarValue::Float64(Some(n)) => {
+                round_preimage_float(*n, half_f64).map(|(lo, hi)| {
+                    (
+                        ScalarValue::Float64(Some(lo)),
+                        ScalarValue::Float64(Some(hi)),
+                    )
+                })
+            }
+            ScalarValue::Float32(Some(n)) => {
+                round_preimage_float(*n, half_f32).map(|(lo, hi)| {
+                    (
+                        ScalarValue::Float32(Some(lo)),
+                        ScalarValue::Float32(Some(hi)),
+                    )
+                })
+            }
+            ScalarValue::Decimal32(Some(n), precision, scale) if dp == 0 => {
+                round_preimage_decimal::<Decimal32Type>(*n, *precision, *scale).map(
+                    |(lo, hi)| {
+                        (
+                            ScalarValue::Decimal32(Some(lo), *precision, *scale),
+                            ScalarValue::Decimal32(Some(hi), *precision, *scale),
+                        )
+                    },
+                )
+            }
+            ScalarValue::Decimal64(Some(n), precision, scale) if dp == 0 => {
+                round_preimage_decimal::<Decimal64Type>(*n, *precision, *scale).map(
+                    |(lo, hi)| {
+                        (
+                            ScalarValue::Decimal64(Some(lo), *precision, *scale),
+                            ScalarValue::Decimal64(Some(hi), *precision, *scale),
+                        )
+                    },
+                )
+            }
+            ScalarValue::Decimal128(Some(n), precision, scale) if dp == 0 => {
+                round_preimage_decimal::<Decimal128Type>(*n, *precision, *scale).map(
+                    |(lo, hi)| {
+                        (
+                            ScalarValue::Decimal128(Some(lo), *precision, *scale),
+                            ScalarValue::Decimal128(Some(hi), *precision, *scale),
+                        )
+                    },
+                )
+            }
+            ScalarValue::Decimal256(Some(n), precision, scale) if dp == 0 => {
+                round_preimage_decimal::<Decimal256Type>(*n, *precision, *scale).map(
+                    |(lo, hi)| {
+                        (
+                            ScalarValue::Decimal256(Some(lo), *precision, *scale),
+                            ScalarValue::Decimal256(Some(hi), *precision, *scale),
+                        )
+                    },
+                )
+            }
+            _ => None,
+        }) else {
+            return Ok(PreimageResult::None);
+        };
+
+        Ok(PreimageResult::Range {
+            expr: args[0].clone(),
+            interval: Box::new(Interval::try_new(lower, upper)?),
+        })
+    }
+
     fn documentation(&self) -> Option<&Documentation> {
         self.doc()
     }
@@ -632,7 +766,7 @@ fn round_columnar(
 
 fn round_float<T>(value: T, decimal_places: i32) -> Result<T, ArrowError>
 where
-    T: num_traits::Float,
+    T: Float,
 {
     let factor = T::from(10_f64.powi(decimal_places)).ok_or_else(|| {
         ArrowError::ComputeError(format!(
@@ -839,5 +973,334 @@ mod test {
             result,
             Err(DataFusionError::ArrowError(_, _)) | Err(DataFusionError::Execution(_))
         ));
+    }
+}
+
+/// Computes the half-open preimage interval for `round(x, dp) = N` on floats.
+///
+/// Uses **round-half-away-from-zero** semantics (Rust's `.round()`). The
+/// interval boundary that falls on exactly `±half` is exclusive for the side
+/// where that value rounds *away* from N, so `next_up()` shifts it inward:
+///
+/// | N     | interval    |
+/// |-------|-------------|
+/// | N > 0 | `[N−h, N+h)` |
+/// | N = 0 | `[next_up(−h), h)` |
+/// | N < 0 | `[next_up(N−h), next_up(N+h))` |
+///
+/// Returns `None` if N is non-finite, has a fractional part incompatible with
+/// `half`, or if the interval would degenerate (overflow).
+fn round_preimage_float<F: Float + FloatExt>(n: F, half: F) -> Option<(F, F)> {
+    if !n.is_finite() {
+        return None;
+    }
+    let two = F::one() + F::one();
+    let unit_scaled = n / (two * half); // = n * 10^dp; must be an integer
+    if !unit_scaled.is_finite() || unit_scaled.fract() != F::zero() {
+        return None;
+    }
+
+    let lo = n - half;
+    let hi = n + half;
+    if !lo.is_finite() || !hi.is_finite() {
+        return None;
+    }
+
+    if n > F::zero() {
+        // N > 0: [N-h, N+h)
+        Some((lo, hi))
+    } else if n == F::zero() {
+        // N = 0: (-h, h) — lower exclusive, shift by one ULP
+        Some((lo.next_up(), hi))
+    } else {
+        // N < 0: (N-h, N+h] — both exclusive after ULP shift
+        Some((lo.next_up(), hi.next_up()))
+    }
+}
+
+/// Computes the preimage bounds for `round(x) = N` (dp=0) on decimal types.
+///
+/// The decimal interval mirrors the float formula using discrete scale units.
+/// `half_scaled = one_scaled / 2` is the half-unit at this scale; scale must
+/// be ≥ 1 for this to be representable.
+///
+/// | N_raw    | lower_raw              | upper_raw            |
+/// |----------|------------------------|----------------------|
+/// | > 0      | N_raw − half_scaled    | N_raw + half_scaled  |
+/// | = 0      | −half_scaled + 1       | half_scaled          |
+/// | < 0      | N_raw−half_scaled + 1  | N_raw+half_scaled+1  |
+///
+/// Returns `None` for scale ≤ 0 (0.5 not representable), non-integer N, or
+/// overflow.
+fn round_preimage_decimal<D: DecimalType>(
+    n_raw: D::Native,
+    precision: u8,
+    scale: i8,
+) -> Option<(D::Native, D::Native)>
+where
+    D::Native: DecimalCast + ArrowNativeTypeOp + std::ops::Rem<Output = D::Native>,
+{
+    if scale <= 0 {
+        return None;
+    }
+
+    let one_scaled: D::Native =
+        rescale_decimal::<D, D>(D::Native::ONE, 1, 0, precision, scale)?;
+
+    // N must be a valid round output: divisible by one_scaled (integer decimal).
+    if n_raw % one_scaled != D::Native::ZERO {
+        return None;
+    }
+
+    let two = D::Native::ONE.add_checked(D::Native::ONE).ok()?;
+    let half_scaled = one_scaled.div_wrapping(two);
+    if half_scaled == D::Native::ZERO {
+        return None;
+    }
+
+    let one = D::Native::ONE;
+    let zero = D::Native::ZERO;
+
+    let (lower, upper) = if n_raw > zero {
+        // N > 0: [N − half, N + half)
+        let lo = n_raw.sub_checked(half_scaled).ok()?;
+        let hi = n_raw.add_checked(half_scaled).ok()?;
+        (lo, hi)
+    } else if n_raw == zero {
+        // N = 0: (−half, half) — lower exclusive, shift by +1 scale unit
+        let lo = zero.sub_checked(half_scaled).ok()?.add_checked(one).ok()?;
+        let hi = half_scaled;
+        (lo, hi)
+    } else {
+        // N < 0: (N − half, N + half] — both exclusive after shift
+        let lo = n_raw.sub_checked(half_scaled).ok()?.add_checked(one).ok()?;
+        let hi = n_raw.add_checked(half_scaled).ok()?.add_checked(one).ok()?;
+        (lo, hi)
+    };
+
+    Some((lower, upper))
+}
+
+#[cfg(test)]
+mod preimage_tests {
+    use super::*;
+    use arrow_buffer::i256;
+    use datafusion_expr::col;
+
+    fn assert_preimage_range(
+        input: ScalarValue,
+        expected_lower: ScalarValue,
+        expected_upper: ScalarValue,
+    ) {
+        let round_func = RoundFunc::new();
+        let args = vec![col("x")];
+        let lit_expr = Expr::Literal(input.clone(), None);
+        let info = SimplifyContext::default();
+
+        let result = round_func.preimage(&args, &lit_expr, &info).unwrap();
+
+        match result {
+            PreimageResult::Range { expr, interval } => {
+                assert_eq!(expr, col("x"));
+                assert_eq!(interval.lower().clone(), expected_lower);
+                assert_eq!(interval.upper().clone(), expected_upper);
+            }
+            PreimageResult::None => {
+                panic!("Expected Range, got None for input {input:?}")
+            }
+        }
+    }
+
+    fn assert_preimage_none(input: ScalarValue) {
+        let round_func = RoundFunc::new();
+        let args = vec![col("x")];
+        let lit_expr = Expr::Literal(input.clone(), None);
+        let info = SimplifyContext::default();
+
+        let result = round_func.preimage(&args, &lit_expr, &info).unwrap();
+        assert!(
+            matches!(result, PreimageResult::None),
+            "Expected None for input {input:?}"
+        );
+    }
+
+    #[test]
+    fn test_round_preimage_float_positive() {
+        // round(x) = 5 → x ∈ [4.5, 5.5)
+        assert_preimage_range(
+            ScalarValue::Float64(Some(5.0)),
+            ScalarValue::Float64(Some(4.5)),
+            ScalarValue::Float64(Some(5.5)),
+        );
+        assert_preimage_range(
+            ScalarValue::Float32(Some(5.0)),
+            ScalarValue::Float32(Some(4.5)),
+            ScalarValue::Float32(Some(5.5)),
+        );
+    }
+
+    #[test]
+    fn test_round_preimage_float_negative() {
+        // round(x) = -5 → x ∈ (-5.5, -4.5] → [next_up(-5.5), next_up(-4.5))
+        assert_preimage_range(
+            ScalarValue::Float64(Some(-5.0)),
+            ScalarValue::Float64(Some((-5.5_f64).next_up())),
+            ScalarValue::Float64(Some((-4.5_f64).next_up())),
+        );
+        assert_preimage_range(
+            ScalarValue::Float32(Some(-5.0)),
+            ScalarValue::Float32(Some((-5.5_f32).next_up())),
+            ScalarValue::Float32(Some((-4.5_f32).next_up())),
+        );
+    }
+
+    #[test]
+    fn test_round_preimage_float_zero() {
+        // round(x) = 0 → x ∈ (-0.5, 0.5) → [next_up(-0.5), 0.5)
+        assert_preimage_range(
+            ScalarValue::Float64(Some(0.0)),
+            ScalarValue::Float64(Some((-0.5_f64).next_up())),
+            ScalarValue::Float64(Some(0.5)),
+        );
+        assert_preimage_range(
+            ScalarValue::Float32(Some(0.0)),
+            ScalarValue::Float32(Some((-0.5_f32).next_up())),
+            ScalarValue::Float32(Some(0.5)),
+        );
+    }
+
+    #[test]
+    fn test_round_preimage_float_with_dp() {
+        // round(x, 2) = 2.50 → x ∈ [2.50 − 0.005, 2.50 + 0.005)
+        // Bounds use computed f64 arithmetic to match what the implementation produces.
+        let round_func = RoundFunc::new();
+        let args = vec![col("x"), Expr::Literal(ScalarValue::Int32(Some(2)), None)];
+        let lit_expr = Expr::Literal(ScalarValue::Float64(Some(2.50)), None);
+        let info = SimplifyContext::default();
+
+        let result = round_func.preimage(&args, &lit_expr, &info).unwrap();
+        match result {
+            PreimageResult::Range { expr, interval } => {
+                assert_eq!(expr, col("x"));
+                let half = 0.005_f64;
+                assert_eq!(
+                    interval.lower().clone(),
+                    ScalarValue::Float64(Some(2.50_f64 - half))
+                );
+                assert_eq!(
+                    interval.upper().clone(),
+                    ScalarValue::Float64(Some(2.50_f64 + half))
+                );
+            }
+            PreimageResult::None => panic!("Expected Range for round(x,2)=2.50"),
+        }
+    }
+
+    #[test]
+    fn test_round_preimage_float_non_integer() {
+        assert_preimage_none(ScalarValue::Float64(Some(3.5)));
+        assert_preimage_none(ScalarValue::Float64(Some(-2.7)));
+    }
+
+    #[test]
+    fn test_round_preimage_float_edge_cases() {
+        assert_preimage_none(ScalarValue::Float64(Some(f64::INFINITY)));
+        assert_preimage_none(ScalarValue::Float64(Some(f64::NEG_INFINITY)));
+        assert_preimage_none(ScalarValue::Float64(Some(f64::NAN)));
+        assert_preimage_none(ScalarValue::Float32(Some(f32::NAN)));
+    }
+
+    #[test]
+    fn test_round_preimage_float_null() {
+        assert_preimage_none(ScalarValue::Float64(None));
+        assert_preimage_none(ScalarValue::Float32(None));
+    }
+
+    #[test]
+    fn test_round_preimage_decimal_positive() {
+        // round(x) = 5.00 (raw 500, scale=2) → [4.50, 5.50) raw [450, 550)
+        assert_preimage_range(
+            ScalarValue::Decimal128(Some(500), 10, 2),
+            ScalarValue::Decimal128(Some(450), 10, 2),
+            ScalarValue::Decimal128(Some(550), 10, 2),
+        );
+    }
+
+    #[test]
+    fn test_round_preimage_decimal_negative() {
+        // round(x) = -5.00 (raw -500, scale=2) → (-5.50, -4.50] raw → [-549, -449)
+        assert_preimage_range(
+            ScalarValue::Decimal128(Some(-500), 10, 2),
+            ScalarValue::Decimal128(Some(-549), 10, 2),
+            ScalarValue::Decimal128(Some(-449), 10, 2),
+        );
+    }
+
+    #[test]
+    fn test_round_preimage_decimal_zero() {
+        // round(x) = 0.00 (raw 0, scale=2) → (-0.50, 0.50) raw → [-49, 50)
+        assert_preimage_range(
+            ScalarValue::Decimal128(Some(0), 10, 2),
+            ScalarValue::Decimal128(Some(-49), 10, 2),
+            ScalarValue::Decimal128(Some(50), 10, 2),
+        );
+    }
+
+    #[test]
+    fn test_round_preimage_decimal_scale_zero_returns_none() {
+        assert_preimage_none(ScalarValue::Decimal128(Some(5), 10, 0));
+        assert_preimage_none(ScalarValue::Decimal128(Some(0), 10, 0));
+    }
+
+    #[test]
+    fn test_round_preimage_decimal_non_integer_returns_none() {
+        assert_preimage_none(ScalarValue::Decimal128(Some(550), 10, 2)); // 5.50
+        assert_preimage_none(ScalarValue::Decimal128(Some(51), 10, 2)); // 0.51
+    }
+
+    #[test]
+    fn test_round_preimage_decimal_overflow_returns_none() {
+        assert_preimage_none(ScalarValue::Decimal64(Some(i64::MAX), 19, 2));
+    }
+
+    #[test]
+    fn test_round_preimage_decimal_all_variants() {
+        // Decimal32
+        assert_preimage_range(
+            ScalarValue::Decimal32(Some(500), 9, 2),
+            ScalarValue::Decimal32(Some(450), 9, 2),
+            ScalarValue::Decimal32(Some(550), 9, 2),
+        );
+        // Decimal64
+        assert_preimage_range(
+            ScalarValue::Decimal64(Some(500), 18, 2),
+            ScalarValue::Decimal64(Some(450), 18, 2),
+            ScalarValue::Decimal64(Some(550), 18, 2),
+        );
+        // Decimal256
+        assert_preimage_range(
+            ScalarValue::Decimal256(Some(i256::from(500)), 76, 2),
+            ScalarValue::Decimal256(Some(i256::from(450)), 76, 2),
+            ScalarValue::Decimal256(Some(i256::from(550)), 76, 2),
+        );
+    }
+
+    #[test]
+    fn test_round_preimage_decimal_null() {
+        assert_preimage_none(ScalarValue::Decimal32(None, 9, 2));
+        assert_preimage_none(ScalarValue::Decimal64(None, 18, 2));
+        assert_preimage_none(ScalarValue::Decimal128(None, 38, 2));
+        assert_preimage_none(ScalarValue::Decimal256(None, 76, 2));
+    }
+
+    #[test]
+    fn test_round_preimage_non_literal_dp_returns_none() {
+        let round_func = RoundFunc::new();
+        let args = vec![col("x"), col("dp")];
+        let lit_expr = Expr::Literal(ScalarValue::Float64(Some(5.0)), None);
+        let info = SimplifyContext::default();
+
+        let result = round_func.preimage(&args, &lit_expr, &info).unwrap();
+        assert!(matches!(result, PreimageResult::None));
     }
 }

--- a/datafusion/sqllogictest/test_files/ceil_preimage.slt
+++ b/datafusion/sqllogictest/test_files/ceil_preimage.slt
@@ -1,0 +1,265 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## Ceil Preimage Tests
+##
+## ceil(col) = N rewrites to col > N-1 AND col <= N
+## expressed as [next_up(N-1), next_up(N)) in the half-open preimage API.
+##########
+
+statement ok
+CREATE TABLE test_data (
+    id   INT,
+    fval DOUBLE,
+    dval DECIMAL(10,2)
+) AS VALUES
+    (1, 4.1,   4.10),
+    (2, 5.0,   5.00),
+    (3, 5.0001, 5.01),
+    (4, 6.0,   6.00),
+    (5, -4.9,  -4.90),
+    (6, -5.0,  -5.00),
+    (7, NULL,  NULL);
+
+##########
+## Data Correctness Tests
+##########
+
+# ceil(x) = 5 — 4.1→5, 5.0→5
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) = arrow_cast(5, 'Float64');
+----
+1
+2
+
+# ceil(x) = 6 — 5.0001→6, 6.0→6
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) = arrow_cast(6, 'Float64');
+----
+3
+4
+
+# Negative: ceil(x) = -4 — -4.9→-4
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) = arrow_cast(-4, 'Float64');
+----
+5
+
+# Negative: ceil(x) = -5
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) = arrow_cast(-5, 'Float64');
+----
+6
+
+# Decimal128: ceil(x) = 5.00 — 4.10→5.00, 5.00→5.00
+query I rowsort
+SELECT id FROM test_data WHERE ceil(dval) = arrow_cast(5.00, 'Decimal128(10,2)');
+----
+1
+2
+
+# Non-integer literal: no rows
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) = arrow_cast(5.5, 'Float64');
+----
+
+# Column on RHS
+query I rowsort
+SELECT id FROM test_data WHERE arrow_cast(5, 'Float64') = ceil(fval);
+----
+1
+2
+
+# IN list
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) IN (arrow_cast(5, 'Float64'), arrow_cast(6, 'Float64'));
+----
+1
+2
+3
+4
+
+# NOT IN list
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) NOT IN (arrow_cast(5, 'Float64'), arrow_cast(6, 'Float64'));
+----
+5
+6
+
+# IS NOT DISTINCT FROM
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) IS NOT DISTINCT FROM arrow_cast(5, 'Float64');
+----
+1
+2
+
+# IS DISTINCT FROM — NULL row (id=7) is included
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) IS DISTINCT FROM arrow_cast(5, 'Float64');
+----
+3
+4
+5
+6
+7
+
+# ceil(x) > 5
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) > arrow_cast(5, 'Float64');
+----
+3
+4
+
+# ceil(x) >= 5
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) >= arrow_cast(5, 'Float64');
+----
+1
+2
+3
+4
+
+# ceil(x) < 5
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) < arrow_cast(5, 'Float64');
+----
+5
+6
+
+# ceil(x) <= 5
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) <= arrow_cast(5, 'Float64');
+----
+1
+2
+5
+6
+
+# ceil(x) != 5
+query I rowsort
+SELECT id FROM test_data WHERE ceil(fval) != arrow_cast(5, 'Float64');
+----
+3
+4
+5
+6
+
+##########
+## EXPLAIN Tests
+##########
+
+statement ok
+set datafusion.explain.logical_plan_only = true;
+
+# Float64 equality — rewritten to [next_up(4), next_up(5))
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) = arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(4.000000000000001) AND test_data.fval < Float64(5.000000000000001)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# Decimal128 equality
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(dval) = arrow_cast(5.00, 'Decimal128(10,2)');
+----
+logical_plan
+01)Filter: test_data.dval >= Decimal128(4.01,10,2) AND test_data.dval < Decimal128(5.01,10,2)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# Negative N
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) = arrow_cast(-5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(-5.999999999999999) AND test_data.fval < Float64(-4.999999999999999)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# IS NOT DISTINCT FROM — adds IS NOT NULL check
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) IS NOT DISTINCT FROM arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval IS NOT NULL AND test_data.fval >= Float64(4.000000000000001) AND test_data.fval < Float64(5.000000000000001)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# IS DISTINCT FROM — adds OR IS NULL branch
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) IS DISTINCT FROM arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval < Float64(4.000000000000001) OR test_data.fval >= Float64(5.000000000000001) OR test_data.fval IS NULL
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# NOT IN — each item inverted and ANDed
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) NOT IN (arrow_cast(5, 'Float64'), arrow_cast(6, 'Float64'));
+----
+logical_plan
+01)Filter: (test_data.fval < Float64(4.000000000000001) OR test_data.fval >= Float64(5.000000000000001)) AND (test_data.fval < Float64(5.000000000000001) OR test_data.fval >= Float64(6.000000000000001))
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# Non-integer literal — predicate preserved
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) = arrow_cast(5.5, 'Float64');
+----
+logical_plan
+01)Filter: ceil(test_data.fval) = Float64(5.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# ceil(x) > 5 → fval >= next_up(5)
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) > arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(5.000000000000001)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# ceil(x) <= 5 → fval < next_up(5)
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) <= arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval < Float64(5.000000000000001)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# ceil(x) < 5 → fval < next_up(4)
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) < arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval < Float64(4.000000000000001)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# ceil(x) >= 5 → fval >= next_up(4)
+query TT
+EXPLAIN SELECT * FROM test_data WHERE ceil(fval) >= arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(4.000000000000001)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+statement ok
+RESET datafusion.explain.logical_plan_only;
+
+##########
+## Cleanup
+##########
+
+statement ok
+DROP TABLE test_data;

--- a/datafusion/sqllogictest/test_files/round_preimage.slt
+++ b/datafusion/sqllogictest/test_files/round_preimage.slt
@@ -1,0 +1,275 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## Round Preimage Tests
+##
+## round(col) = N uses half-away-from-zero rounding:
+##   N > 0:  [N − 0.5, N + 0.5)
+##   N = 0:  [next_up(−0.5), 0.5)
+##   N < 0:  [next_up(N−0.5), next_up(N+0.5))
+##########
+
+statement ok
+CREATE TABLE test_data (
+    id   INT,
+    fval DOUBLE,
+    dval DECIMAL(10,2)
+) AS VALUES
+    (1, 4.4,   4.40),
+    (2, 4.5,   4.50),
+    (3, 5.4,   5.40),
+    (4, 5.5,   5.50),
+    (5, 0.0,   0.00),
+    (6, -4.5, -4.50),
+    (7, -4.6, -4.60),
+    (8, NULL,  NULL);
+
+##########
+## Data Correctness Tests
+##########
+
+# round(x) = 5 — 4.5→5, 5.4→5
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) = arrow_cast(5, 'Float64');
+----
+2
+3
+
+# 5.5 rounds to 6 (away from zero), not 5
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) = arrow_cast(6, 'Float64');
+----
+4
+
+# round(x) = 0
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) = arrow_cast(0, 'Float64');
+----
+5
+
+# Negative: round(x) = -5 — -4.5→-5, -4.6→-5
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) = arrow_cast(-5, 'Float64');
+----
+6
+7
+
+# Non-integer literal: no rows
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) = arrow_cast(4.5, 'Float64');
+----
+
+# Decimal128: round(x) = 5.00 — 4.50→5.00, 5.40→5.00
+query I rowsort
+SELECT id FROM test_data WHERE round(dval) = arrow_cast(5.00, 'Decimal128(10,2)');
+----
+2
+3
+
+# IN list
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) IN (arrow_cast(5, 'Float64'), arrow_cast(6, 'Float64'));
+----
+2
+3
+4
+
+# NOT IN list
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) NOT IN (arrow_cast(5, 'Float64'), arrow_cast(6, 'Float64'));
+----
+1
+5
+6
+7
+
+# IS NOT DISTINCT FROM
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) IS NOT DISTINCT FROM arrow_cast(5, 'Float64');
+----
+2
+3
+
+# IS DISTINCT FROM — NULL row (id=8) is included
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) IS DISTINCT FROM arrow_cast(5, 'Float64');
+----
+1
+4
+5
+6
+7
+8
+
+# round(x) > 5
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) > arrow_cast(5, 'Float64');
+----
+4
+
+# round(x) >= 5
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) >= arrow_cast(5, 'Float64');
+----
+2
+3
+4
+
+# round(x) < 5
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) < arrow_cast(5, 'Float64');
+----
+1
+5
+6
+7
+
+# round(x) <= 5
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) <= arrow_cast(5, 'Float64');
+----
+1
+2
+3
+5
+6
+7
+
+# round(x) != 5
+query I rowsort
+SELECT id FROM test_data WHERE round(fval) != arrow_cast(5, 'Float64');
+----
+1
+4
+5
+6
+7
+
+##########
+## EXPLAIN Tests
+##########
+
+statement ok
+set datafusion.explain.logical_plan_only = true;
+
+# round(col) = 5 → naturally half-open
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) = arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(4.5) AND test_data.fval < Float64(5.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# round(col) = 0 — lower bound shifted by next_up
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) = arrow_cast(0, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(-0.49999999999999994) AND test_data.fval < Float64(0.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# round(col) = -5 — both bounds shifted by next_up
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) = arrow_cast(-5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(-5.499999999999999) AND test_data.fval < Float64(-4.499999999999999)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# Decimal with no dp reduces output scale to 0; half-unit 0.5 is not
+# representable at scale 0 so preimage bails and the predicate is preserved.
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(dval) = arrow_cast(5.00, 'Decimal128(10,2)');
+----
+logical_plan
+01)Filter: round(test_data.dval) = Decimal128(5,10,0)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# Non-integer literal — predicate preserved
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) = arrow_cast(4.5, 'Float64');
+----
+logical_plan
+01)Filter: round(test_data.fval) = Float64(4.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# IS NOT DISTINCT FROM — adds IS NOT NULL check
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) IS NOT DISTINCT FROM arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval IS NOT NULL AND test_data.fval >= Float64(4.5) AND test_data.fval < Float64(5.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# IS DISTINCT FROM — adds OR IS NULL branch
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) IS DISTINCT FROM arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval < Float64(4.5) OR test_data.fval >= Float64(5.5) OR test_data.fval IS NULL
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# NOT IN — each item inverted and ANDed
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) NOT IN (arrow_cast(5, 'Float64'), arrow_cast(6, 'Float64'));
+----
+logical_plan
+01)Filter: (test_data.fval < Float64(4.5) OR test_data.fval >= Float64(5.5)) AND (test_data.fval < Float64(5.5) OR test_data.fval >= Float64(6.5))
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# round(x) > 5 → fval >= 5.5
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) > arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(5.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# round(x) <= 5 → fval < 5.5
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) <= arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval < Float64(5.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# round(x) < 5 → fval < 4.5
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) < arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval < Float64(4.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+# round(x) >= 5 → fval >= 4.5
+query TT
+EXPLAIN SELECT * FROM test_data WHERE round(fval) >= arrow_cast(5, 'Float64');
+----
+logical_plan
+01)Filter: test_data.fval >= Float64(4.5)
+02)--TableScan: test_data projection=[id, fval, dval]
+
+statement ok
+RESET datafusion.explain.logical_plan_only;
+
+##########
+## Cleanup
+##########
+
+statement ok
+DROP TABLE test_data;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #20197.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
`floor(col) = N` is already rewritten via `ScalarUDFImpl::preimage` so that
predicates push into Parquet row-group statistics. `ceil` and `round` admit
the same rewrite but have boundary conventions that don't fit the API's
half-open `[lower, upper)` form: `ceil(x) = N` is `(N-1, N]`, and `round(x) = N`
is sign-dependent under half-away-from-zero. Both can be expressed in
`[lower, upper)` form by shifting closed boundaries with `f::next_up()`

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- `CeilFunc::preimage` - Float32/Float64 and all four Decimal variants.
- `RoundFunc::preimage` - Float32/Float64 (with optional literal `dp`) and all
  four Decimal variants for `dp = 0`.
- Helper functions `ceil_preimage_float` / `ceil_preimage_decimal` in `ceil.rs`,
  `round_preimage_float` / `round_preimage_decimal` in `round.rs`.
- A small `FloatExt` trait in each file bridging `num_traits::Float` to
  `f32::next_up()` / `f64::next_up()`.

No changes to the preimage API, the simplifier, or any optimizer rule.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes.

- Unit tests cover positive / negative / zero / non-integer / null / overflow /
  non-finite cases for both float and decimal variants.
- SLT tests (`ceil_preimage.slt`, `round_preimage.slt`) cover data correctness
  and `EXPLAIN` output for all six comparison operators plus
  `IS (NOT) DISTINCT FROM` and `IN`/`NOT IN`.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No public API change. The optimization is transparent and predicate semantics
are preserved exactly.