### PR TITLE
Disable memory-limited NLJ fallback for left-emitting joins with multi-partition right inputs

### DIFF
--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -3141,8 +3141,10 @@ pub(crate) mod tests {
         right: Arc<dyn ExecutionPlan>,
         join_type: &JoinType,
         join_filter: Option<JoinFilter>,
-        context: Arc<TaskContext>,
+        memory_limit: usize,
+        batch_size: usize,
     ) -> Result<()> {
+        let context = task_ctx_with_memory_limit(memory_limit, batch_size)?;
         let err =
             multi_partitioned_join_collect(left, right, join_type, join_filter, context)
                 .await
@@ -3565,17 +3567,13 @@ pub(crate) mod tests {
         ];
 
         for join_type in &left_final_join_types {
-            let runtime = RuntimeEnvBuilder::new()
-                .with_memory_limit(100, 1.0)
-                .build_arc()?;
-            let task_ctx = TaskContext::default().with_runtime(runtime);
-            let task_ctx = Arc::new(task_ctx);
             assert_multi_partition_join_oom(
                 Arc::clone(&left),
                 Arc::clone(&right),
                 join_type,
                 Some(filter.clone()),
-                task_ctx,
+                100,
+                16,
             )
             .await?;
         }
@@ -3794,7 +3792,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_nlj_memory_limited_left_join_multi_partition_fallback_disabled()
     -> Result<()> {
-        let task_ctx = task_ctx_with_memory_limit(50, 16)?;
         let left = build_left_table();
         let right = build_right_table();
         let filter = prepare_join_filter();
@@ -3804,7 +3801,8 @@ pub(crate) mod tests {
             Arc::clone(&right),
             &JoinType::Left,
             Some(filter.clone()),
-            task_ctx,
+            50,
+            16,
         )
         .await?;
 

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -646,22 +646,17 @@ impl ExecutionPlan for NestedLoopJoinExec {
         // Determine if OOM fallback to memory-limited mode is possible.
         // Conditions:
         // 1. Disk manager supports temp files (needed for spilling).
-        // 2. FULL join with multiple right partitions is not yet supported
-        //    in the fallback path. FULL join needs to track BOTH left-side
-        //    matches (for unmatched left rows) AND right-side matches (for
-        //    unmatched right rows). The fallback path builds a per-partition
-        //    `JoinLeftData` with `probe_threads_counter == 1`, so each
-        //    partition emits unmatched left rows based only on its own
-        //    right-side matches, producing incorrect duplicate output for
-        //    left rows that match in another partition. Other join types
-        //    that need only one-sided final emission (LEFT, LEFT SEMI,
-        //    LEFT ANTI, LEFT MARK) have a similar latent issue in the
-        //    fallback path which predates this change; tracking is out of
-        //    scope for this PR.
-        let full_join_multi_partition =
-            matches!(self.join_type, JoinType::Full) && right_partition_count > 1;
+        // 2. Joins that need final left-side emission are not supported when
+        //    the right side has multiple partitions. The fallback path builds
+        //    per-chunk `JoinLeftData` with `probe_threads_counter == 1`, so a
+        //    partition can emit unmatched/semi/anti/mark left rows using only
+        //    its local right-side matches. Without a global left bitmap across
+        //    all right partitions this can produce incorrect output. FULL join
+        //    is included because it also emits unmatched left rows.
+        let left_final_multi_partition =
+            need_produce_result_in_final(self.join_type) && right_partition_count > 1;
         let spill_state = if context.runtime_env().disk_manager.tmp_files_enabled()
-            && !full_join_multi_partition
+            && !left_final_multi_partition
         {
             SpillState::Pending {
                 left_plan: Arc::clone(&self.left),
@@ -3518,10 +3513,6 @@ pub(crate) mod tests {
         // even under tight memory limits (they spill to disk instead of OOM).
         let fallback_join_types = vec![
             JoinType::Inner,
-            JoinType::Left,
-            JoinType::LeftSemi,
-            JoinType::LeftAnti,
-            JoinType::LeftMark,
             JoinType::Right,
             JoinType::RightSemi,
             JoinType::RightAnti,
@@ -3546,24 +3537,35 @@ pub(crate) mod tests {
             .await?;
         }
 
-        // FULL JOIN with multiple right partitions is intentionally not
-        // supported in the fallback path yet (cross-partition left-bitmap
-        // coordination is missing). It should still OOM under tight memory.
-        let runtime = RuntimeEnvBuilder::new()
-            .with_memory_limit(100, 1.0)
-            .build_arc()?;
-        let task_ctx = TaskContext::default().with_runtime(runtime);
-        let task_ctx = Arc::new(task_ctx);
-        let err = multi_partitioned_join_collect(
-            Arc::clone(&left),
-            Arc::clone(&right),
-            &JoinType::Full,
-            Some(filter.clone()),
-            task_ctx,
-        )
-        .await
-        .unwrap_err();
-        assert_contains!(err.to_string(), "Resources exhausted");
+        // Joins that need final left-side emission with multiple right
+        // partitions are intentionally not supported in the fallback path yet
+        // (cross-partition left-bitmap coordination is missing). They should
+        // still OOM under tight memory rather than produce incorrect output.
+        let left_final_join_types = vec![
+            JoinType::Left,
+            JoinType::LeftSemi,
+            JoinType::LeftAnti,
+            JoinType::LeftMark,
+            JoinType::Full,
+        ];
+
+        for join_type in &left_final_join_types {
+            let runtime = RuntimeEnvBuilder::new()
+                .with_memory_limit(100, 1.0)
+                .build_arc()?;
+            let task_ctx = TaskContext::default().with_runtime(runtime);
+            let task_ctx = Arc::new(task_ctx);
+            let err = multi_partitioned_join_collect(
+                Arc::clone(&left),
+                Arc::clone(&right),
+                join_type,
+                Some(filter.clone()),
+                task_ctx,
+            )
+            .await
+            .unwrap_err();
+            assert_contains!(err.to_string(), "Resources exhausted");
+        }
 
         Ok(())
     }
@@ -3773,6 +3775,42 @@ pub(crate) mod tests {
             .unwrap_err();
 
         assert_contains!(err.to_string(), "Resources exhausted");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nlj_memory_limited_left_join_multi_partition_fallback_disabled()
+    -> Result<()> {
+        let task_ctx = task_ctx_with_memory_limit(50, 16)?;
+        let left = build_left_table();
+        let right = build_right_table();
+        let filter = prepare_join_filter();
+
+        let err = multi_partitioned_join_collect(
+            Arc::clone(&left),
+            Arc::clone(&right),
+            &JoinType::Left,
+            Some(filter.clone()),
+            task_ctx,
+        )
+        .await
+        .unwrap_err();
+        assert_contains!(err.to_string(), "Resources exhausted");
+
+        let single_partition_task_ctx = task_ctx_with_memory_limit(50, 16)?;
+        let (_columns, _batches, metrics) = join_collect(
+            left,
+            right,
+            &JoinType::Left,
+            Some(filter),
+            single_partition_task_ctx,
+        )
+        .await?;
+        assert!(
+            metrics.spill_count().unwrap_or(0) > 0,
+            "Expected single-partition LEFT join fallback to spill"
+        );
+
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -3136,6 +3136,21 @@ pub(crate) mod tests {
         Ok((columns, batches, metrics))
     }
 
+    async fn assert_multi_partition_join_oom(
+        left: Arc<dyn ExecutionPlan>,
+        right: Arc<dyn ExecutionPlan>,
+        join_type: &JoinType,
+        join_filter: Option<JoinFilter>,
+        context: Arc<TaskContext>,
+    ) -> Result<()> {
+        let err =
+            multi_partitioned_join_collect(left, right, join_type, join_filter, context)
+                .await
+                .unwrap_err();
+        assert_contains!(err.to_string(), "Resources exhausted");
+        Ok(())
+    }
+
     fn new_task_ctx(batch_size: usize) -> Arc<TaskContext> {
         let base = TaskContext::default();
         // limit max size of intermediate batch used in nlj to 1
@@ -3511,7 +3526,7 @@ pub(crate) mod tests {
 
         // Join types that support memory-limited fallback should succeed
         // even under tight memory limits (they spill to disk instead of OOM).
-        let fallback_join_types = vec![
+        let fallback_join_types = [
             JoinType::Inner,
             JoinType::Right,
             JoinType::RightSemi,
@@ -3541,7 +3556,7 @@ pub(crate) mod tests {
         // partitions are intentionally not supported in the fallback path yet
         // (cross-partition left-bitmap coordination is missing). They should
         // still OOM under tight memory rather than produce incorrect output.
-        let left_final_join_types = vec![
+        let left_final_join_types = [
             JoinType::Left,
             JoinType::LeftSemi,
             JoinType::LeftAnti,
@@ -3555,16 +3570,14 @@ pub(crate) mod tests {
                 .build_arc()?;
             let task_ctx = TaskContext::default().with_runtime(runtime);
             let task_ctx = Arc::new(task_ctx);
-            let err = multi_partitioned_join_collect(
+            assert_multi_partition_join_oom(
                 Arc::clone(&left),
                 Arc::clone(&right),
                 join_type,
                 Some(filter.clone()),
                 task_ctx,
             )
-            .await
-            .unwrap_err();
-            assert_contains!(err.to_string(), "Resources exhausted");
+            .await?;
         }
 
         Ok(())
@@ -3786,19 +3799,17 @@ pub(crate) mod tests {
         let right = build_right_table();
         let filter = prepare_join_filter();
 
-        let err = multi_partitioned_join_collect(
+        assert_multi_partition_join_oom(
             Arc::clone(&left),
             Arc::clone(&right),
             &JoinType::Left,
             Some(filter.clone()),
             task_ctx,
         )
-        .await
-        .unwrap_err();
-        assert_contains!(err.to_string(), "Resources exhausted");
+        .await?;
 
         let single_partition_task_ctx = task_ctx_with_memory_limit(50, 16)?;
-        let (_columns, _batches, metrics) = join_collect(
+        let (_, _, metrics) = join_collect(
             left,
             right,
             &JoinType::Left,


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #22641.

## Rationale for this change

The memory-limited NestedLoopJoin fallback path can produce incorrect results for joins that require final left-side emission when the right side has multiple partitions.

The fallback implementation tracks match state locally for each probe partition. Without global coordination across all right partitions, a partition may incorrectly emit unmatched, semi, anti, or mark results for left rows that actually match in another partition. This can lead to incorrect query results under memory pressure.

To preserve correctness, this change disables the memory-limited fallback for join types that depend on final left-side emission when the right side is partitioned. In these cases, the operator will continue to fail with resource exhaustion rather than produce incorrect output.

## What changes are included in this PR?

* Generalize the existing FULL JOIN fallback guard to cover all joins that require final left-side emission when `right_partition_count > 1`.
* Replace the previous `full_join_multi_partition` check with a `left_final_multi_partition` check based on `need_produce_result_in_final(join_type)`.
* Update comments to document why memory-limited fallback is unsafe for these join types without cross-partition left-match tracking.
* Adjust memory-limited join tests so that:

  * Supported join types continue to verify successful spill-based fallback.
  * `LEFT`, `LEFT SEMI`, `LEFT ANTI`, `LEFT MARK`, and `FULL` joins verify that fallback remains disabled and returns a resource exhaustion error under tight memory limits.
* Add a dedicated regression test:

  * `test_nlj_memory_limited_left_join_multi_partition_fallback_disabled`
  * Verifies that a multi-partition LEFT JOIN does not use the fallback path under memory pressure.
  * Verifies that a single-partition LEFT JOIN can still spill and complete successfully.

## Are these changes tested?

Yes.

The following tests were added or updated:

* Added:

  * `test_nlj_memory_limited_left_join_multi_partition_fallback_disabled`
  * `assert_multi_partition_join_oom`

* Updated memory-limited fallback coverage to verify:

  * Successful spill-based fallback for supported join types (`Inner`, `Right`, `RightSemi`, `RightAnti`, `RightMark`).
  * Resource exhaustion behavior for left-emitting join types with multi-partition right inputs (`Left`, `LeftSemi`, `LeftAnti`, `LeftMark`, `Full`).

## Are there any user-facing changes?

Yes.

Under memory pressure, NestedLoopJoin will no longer attempt the memory-limited fallback path for joins that require final left-side emission when the right side has multiple partitions. Instead of potentially returning incorrect results, these queries will fail with a resource exhaustion error until cross-partition coordination is implemented.

This change prioritizes correctness and ensures join results do not vary based on memory availability.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
