### PR TITLE
fix: Projection stats Absent for columns referenced >1 time

### DIFF
--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -2868,7 +2868,6 @@ pub(crate) mod tests {
 
     #[test]
     fn test_project_statistics_duplicate_column() -> Result<()> {
-        // SELECT col0 AS a, col0 AS b: both outputs carry col0's statistics.
         let input_stats = get_stats();
         let col0 = input_stats.column_statistics[0].clone();
         let projection = ProjectionExprs::new([
@@ -2885,8 +2884,6 @@ pub(crate) mod tests {
 
     #[test]
     fn test_project_statistics_column_and_cast() -> Result<()> {
-        // SELECT col0 AS num, CAST(col0 AS Int32) AS casted: the passthrough
-        // copies col0's stats; the cast keeps them with min/max cast to Int32.
         let input_stats = get_stats();
         let col0 = input_stats.column_statistics[0].clone();
         let projection = ProjectionExprs::new([

--- a/datafusion/physical-expr/src/projection.rs
+++ b/datafusion/physical-expr/src/projection.rs
@@ -661,7 +661,7 @@ impl ProjectionExprs {
         for proj_expr in self.exprs.iter() {
             let expr = &proj_expr.expr;
             let col_stats = if let Some(col) = expr.downcast_ref::<Column>() {
-                std::mem::take(&mut stats.column_statistics[col.index()])
+                stats.column_statistics[col.index()].clone()
             } else if let Some(literal) = expr.downcast_ref::<Literal>() {
                 // Handle literal expressions (constants) by calculating proper statistics
                 let data_type = expr.data_type(output_schema)?;
@@ -2863,6 +2863,59 @@ pub(crate) mod tests {
             Precision::Exact(ScalarValue::Int32(Some(21)))
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_project_statistics_duplicate_column() -> Result<()> {
+        // SELECT col0 AS a, col0 AS b: both outputs carry col0's statistics.
+        let input_stats = get_stats();
+        let col0 = input_stats.column_statistics[0].clone();
+        let projection = ProjectionExprs::new([
+            ProjectionExpr::new(Arc::new(Column::new("col0", 0)), "a"),
+            ProjectionExpr::new(Arc::new(Column::new("col0", 0)), "b"),
+        ]);
+
+        let output_schema = projection.project_schema(&get_schema())?;
+        let output_stats = projection.project_statistics(input_stats, &output_schema)?;
+
+        assert_eq!(output_stats.column_statistics, vec![col0.clone(), col0]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_project_statistics_column_and_cast() -> Result<()> {
+        // SELECT col0 AS num, CAST(col0 AS Int32) AS casted: the passthrough
+        // copies col0's stats; the cast keeps them with min/max cast to Int32.
+        let input_stats = get_stats();
+        let col0 = input_stats.column_statistics[0].clone();
+        let projection = ProjectionExprs::new([
+            ProjectionExpr::new(Arc::new(Column::new("col0", 0)), "num"),
+            ProjectionExpr::new(
+                Arc::new(CastExpr::new(
+                    Arc::new(Column::new("col0", 0)),
+                    DataType::Int32,
+                    None,
+                )),
+                "casted",
+            ),
+        ]);
+
+        let output_schema = projection.project_schema(&get_schema())?;
+        let output_stats = projection.project_statistics(input_stats, &output_schema)?;
+
+        assert_eq!(output_stats.column_statistics[0], col0);
+        assert_eq!(
+            output_stats.column_statistics[1],
+            ColumnStatistics {
+                min_value: Precision::Exact(ScalarValue::Int32(Some(-4))),
+                max_value: Precision::Exact(ScalarValue::Int32(Some(21))),
+                distinct_count: Precision::Exact(5),
+                null_count: Precision::Exact(0),
+                sum_value: Precision::Absent,
+                byte_size: Precision::Absent,
+            }
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22678.

## Rationale for this change

`ProjectionExprs::project_statistics` uses `std::mem::take` to move an input column's `ColumnStatistics` into the output when given a direct column reference. This means if the column is referenced again (either directly or in a `CAST` expression), the statistics are `Absent`. The simple fix is to just `clone` instead of `take`.

This pattern crops up in TPC-DS q54, which includes a CTE that projects both `d_date_sk` and `CAST(d_date_sk AS Float64)`, but it's a more general bug.

## What changes are included in this PR?

* Fix bug
* Add unit tests

## Are these changes tested?

Yes; new test added.

## Are there any user-facing changes?

No.
