### PR TITLE
Align grouped `first_value`/`last_value` FILTER handling with shared `Some(true)` semantics

### DIFF
--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/nulls.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/nulls.rs
@@ -43,7 +43,7 @@ pub fn set_nulls<T: ArrowNumericType + Send>(
 ///
 /// The output is `true` for rows where the filter is `Some(true)`, and `false`
 /// for rows where the filter is `Some(false)` or `None`.
-pub(crate) fn filter_to_validity(filter: &BooleanArray) -> BooleanBuffer {
+pub fn filter_to_validity(filter: &BooleanArray) -> BooleanBuffer {
     let Some(filter_nulls) = filter.nulls() else {
         return filter.values().clone();
     };

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/nulls.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/nulls.rs
@@ -223,3 +223,43 @@ pub fn set_nulls_dyn(input: &dyn Array, nulls: Option<NullBuffer>) -> Result<Arr
 
     Ok(output)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_to_validity_rejects_null_filter_with_true_value_bit() {
+        let filter = BooleanArray::new(
+            BooleanBuffer::from(vec![true, true, false, false]),
+            Some(NullBuffer::from(vec![true, false, true, false])),
+        );
+
+        let validity = filter_to_validity(&filter);
+
+        assert_eq!(
+            validity.iter().collect::<Vec<_>>(),
+            vec![true, false, false, false]
+        );
+    }
+
+    #[test]
+    fn test_filter_to_validity_respects_sliced_filter_offsets() {
+        let filter = BooleanArray::new(
+            BooleanBuffer::from(vec![false, true, true, false, true, false]),
+            Some(NullBuffer::from(vec![true, true, false, true, true, false])),
+        );
+        let sliced_filter = filter.slice(1, 4);
+        let sliced_filter = sliced_filter
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+
+        let validity = filter_to_validity(sliced_filter);
+
+        assert_eq!(
+            validity.iter().collect::<Vec<_>>(),
+            vec![true, false, false, true]
+        );
+    }
+}

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -1693,23 +1693,6 @@ mod tests {
     }
 
     #[test]
-    fn test_first_group_acc_merge_rejects_null_filter_with_true_value_bit() -> Result<()>
-    {
-        let mut group_acc = new_int64_first_last_group_acc(true)?;
-
-        let states: Vec<ArrayRef> = vec![
-            Arc::new(Int64Array::from(vec![10, 20])),
-            Arc::new(Int64Array::from(vec![1, 2])),
-            Arc::new(BooleanArray::from(vec![true, true])),
-        ];
-        let filter = nullable_bool_filter(vec![true, true], vec![false, true]);
-
-        group_acc.merge_batch(&states, &[0, 0], Some(&filter), 1)?;
-
-        assert_group_acc_int64_result(&mut group_acc, Int64Array::from(vec![Some(20)]))
-    }
-
-    #[test]
     fn test_group_acc_size_of_ordering() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int64, true),

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -1448,8 +1448,21 @@ mod tests {
         )
     }
 
-    fn nullable_bool_filter(values: Vec<bool>, valid: Vec<bool>) -> BooleanArray {
-        BooleanArray::new(BooleanBuffer::from(values), Some(NullBuffer::from(valid)))
+    fn nullable_bool_filter(values: Vec<bool>, validity: Vec<bool>) -> BooleanArray {
+        BooleanArray::new(
+            BooleanBuffer::from(values),
+            Some(NullBuffer::from(validity)),
+        )
+    }
+
+    fn assert_group_acc_int64_result(
+        group_acc: &mut FirstLastGroupsAccumulator<PrimitiveValueState<Int64Type>>,
+        expected: Int64Array,
+    ) -> Result<()> {
+        let result = group_acc.evaluate(EmitTo::All)?;
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(result, &expected);
+        Ok(())
     }
 
     #[test]
@@ -1660,12 +1673,7 @@ mod tests {
 
         group_acc.update_batch(&values_and_orderings, &[0, 0], Some(&filter), 1)?;
 
-        let result = group_acc.evaluate(EmitTo::All)?;
-        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
-        let expected = Int64Array::from(vec![None]);
-        assert_eq!(result, &expected);
-
-        Ok(())
+        assert_group_acc_int64_result(&mut group_acc, Int64Array::from(vec![None]))
     }
 
     #[test]
@@ -1681,12 +1689,7 @@ mod tests {
 
         group_acc.update_batch(&values_and_orderings, &[0, 0, 0], Some(&filter), 1)?;
 
-        let result = group_acc.evaluate(EmitTo::All)?;
-        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
-        let expected = Int64Array::from(vec![Some(20)]);
-        assert_eq!(result, &expected);
-
-        Ok(())
+        assert_group_acc_int64_result(&mut group_acc, Int64Array::from(vec![Some(20)]))
     }
 
     #[test]
@@ -1703,12 +1706,7 @@ mod tests {
 
         group_acc.merge_batch(&states, &[0, 0], Some(&filter), 1)?;
 
-        let result = group_acc.evaluate(EmitTo::All)?;
-        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
-        let expected = Int64Array::from(vec![Some(20)]);
-        assert_eq!(result, &expected);
-
-        Ok(())
+        assert_group_acc_int64_result(&mut group_acc, Int64Array::from(vec![Some(20)]))
     }
 
     #[test]

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -45,6 +45,7 @@ use datafusion_expr::{
     Accumulator, AggregateUDFImpl, Documentation, EmitTo, Expr, ExprFunctionExt,
     GroupsAccumulator, ReversedUDAF, Signature, SortExpr, Volatility,
 };
+use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::filter_to_validity;
 use datafusion_functions_aggregate_common::utils::get_sort_options;
 use datafusion_macros::user_doc;
 use datafusion_physical_expr_common::sort_expr::LexOrdering;
@@ -552,10 +553,14 @@ impl<S: ValueState> FirstLastGroupsAccumulator<S> {
             LexicographicalComparator::try_new(&sort_columns)?
         };
 
+        let filter_validity = opt_filter.map(filter_to_validity);
+
         for (idx_in_val, group_idx) in group_indices.iter().enumerate() {
             let group_idx = *group_idx;
 
-            let passed_filter = opt_filter.is_none_or(|x| x.value(idx_in_val));
+            let passed_filter = filter_validity
+                .as_ref()
+                .is_none_or(|validity| validity.value(idx_in_val));
             let is_set = is_set_arr.is_none_or(|x| x.value(idx_in_val));
 
             if !passed_filter || !is_set {
@@ -1415,6 +1420,7 @@ mod tests {
 
     use arrow::{
         array::{BooleanArray, Int64Array, ListArray, PrimitiveArray, StringArray},
+        buffer::NullBuffer,
         compute::SortOptions,
         datatypes::Schema,
     };
@@ -1614,6 +1620,125 @@ mod tests {
             group_acc.size_of_orderings,
             group_acc.compute_size_of_orderings()
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_first_group_acc_rejects_null_filter_with_true_value_bit() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("c", DataType::Int64, true),
+        ]));
+
+        let sort_keys = [PhysicalSortExpr {
+            expr: col("c", &schema).unwrap(),
+            options: SortOptions::default(),
+        }];
+
+        let mut group_acc = FirstLastGroupsAccumulator::try_new(
+            PrimitiveValueState::<Int64Type>::new(DataType::Int64),
+            sort_keys.into(),
+            true,
+            &[DataType::Int64],
+            true,
+        )?;
+
+        let values_and_orderings: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![10, 20])),
+            Arc::new(Int64Array::from(vec![1, 2])),
+        ];
+        let filter = BooleanArray::new(
+            BooleanBuffer::from(vec![true, false]),
+            Some(NullBuffer::from(vec![false, true])),
+        );
+
+        group_acc.update_batch(&values_and_orderings, &[0, 0], Some(&filter), 1)?;
+
+        let result = group_acc.evaluate(EmitTo::All)?;
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        let expected = Int64Array::from(vec![None]);
+        assert_eq!(result, &expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_last_group_acc_rejects_null_filter_with_true_value_bit() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("c", DataType::Int64, true),
+        ]));
+
+        let sort_keys = [PhysicalSortExpr {
+            expr: col("c", &schema).unwrap(),
+            options: SortOptions::default(),
+        }];
+
+        let mut group_acc = FirstLastGroupsAccumulator::try_new(
+            PrimitiveValueState::<Int64Type>::new(DataType::Int64),
+            sort_keys.into(),
+            true,
+            &[DataType::Int64],
+            false,
+        )?;
+
+        let values_and_orderings: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![10, 20, 30])),
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+        ];
+        let filter = BooleanArray::new(
+            BooleanBuffer::from(vec![true, true, false]),
+            Some(NullBuffer::from(vec![false, true, true])),
+        );
+
+        group_acc.update_batch(&values_and_orderings, &[0, 0, 0], Some(&filter), 1)?;
+
+        let result = group_acc.evaluate(EmitTo::All)?;
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        let expected = Int64Array::from(vec![Some(20)]);
+        assert_eq!(result, &expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_first_group_acc_merge_rejects_null_filter_with_true_value_bit() -> Result<()>
+    {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("c", DataType::Int64, true),
+        ]));
+
+        let sort_keys = [PhysicalSortExpr {
+            expr: col("c", &schema).unwrap(),
+            options: SortOptions::default(),
+        }];
+
+        let mut group_acc = FirstLastGroupsAccumulator::try_new(
+            PrimitiveValueState::<Int64Type>::new(DataType::Int64),
+            sort_keys.into(),
+            true,
+            &[DataType::Int64],
+            true,
+        )?;
+
+        let states: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![10, 20])),
+            Arc::new(Int64Array::from(vec![1, 2])),
+            Arc::new(BooleanArray::from(vec![true, true])),
+        ];
+        let filter = BooleanArray::new(
+            BooleanBuffer::from(vec![true, true]),
+            Some(NullBuffer::from(vec![false, true])),
+        );
+
+        group_acc.merge_batch(&states, &[0, 0], Some(&filter), 1)?;
+
+        let result = group_acc.evaluate(EmitTo::All)?;
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        let expected = Int64Array::from(vec![Some(20)]);
+        assert_eq!(result, &expected);
 
         Ok(())
     }

--- a/datafusion/functions-aggregate/src/first_last.rs
+++ b/datafusion/functions-aggregate/src/first_last.rs
@@ -555,9 +555,7 @@ impl<S: ValueState> FirstLastGroupsAccumulator<S> {
 
         let filter_validity = opt_filter.map(filter_to_validity);
 
-        for (idx_in_val, group_idx) in group_indices.iter().enumerate() {
-            let group_idx = *group_idx;
-
+        for (idx_in_val, &group_idx) in group_indices.iter().enumerate() {
             let passed_filter = filter_validity
                 .as_ref()
                 .is_none_or(|validity| validity.value(idx_in_val));
@@ -1428,6 +1426,32 @@ mod tests {
 
     use super::*;
 
+    fn new_int64_first_last_group_acc(
+        pick_first_in_group: bool,
+    ) -> Result<FirstLastGroupsAccumulator<PrimitiveValueState<Int64Type>>> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("c", DataType::Int64, true),
+        ]));
+
+        let sort_keys = [PhysicalSortExpr {
+            expr: col("c", &schema).unwrap(),
+            options: SortOptions::default(),
+        }];
+
+        FirstLastGroupsAccumulator::try_new(
+            PrimitiveValueState::<Int64Type>::new(DataType::Int64),
+            sort_keys.into(),
+            true,
+            &[DataType::Int64],
+            pick_first_in_group,
+        )
+    }
+
+    fn nullable_bool_filter(values: Vec<bool>, valid: Vec<bool>) -> BooleanArray {
+        BooleanArray::new(BooleanBuffer::from(values), Some(NullBuffer::from(valid)))
+    }
+
     #[test]
     fn test_first_last_value_value() -> Result<()> {
         let mut first_accumulator =
@@ -1626,32 +1650,13 @@ mod tests {
 
     #[test]
     fn test_first_group_acc_rejects_null_filter_with_true_value_bit() -> Result<()> {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int64, true),
-            Field::new("c", DataType::Int64, true),
-        ]));
-
-        let sort_keys = [PhysicalSortExpr {
-            expr: col("c", &schema).unwrap(),
-            options: SortOptions::default(),
-        }];
-
-        let mut group_acc = FirstLastGroupsAccumulator::try_new(
-            PrimitiveValueState::<Int64Type>::new(DataType::Int64),
-            sort_keys.into(),
-            true,
-            &[DataType::Int64],
-            true,
-        )?;
+        let mut group_acc = new_int64_first_last_group_acc(true)?;
 
         let values_and_orderings: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![10, 20])),
             Arc::new(Int64Array::from(vec![1, 2])),
         ];
-        let filter = BooleanArray::new(
-            BooleanBuffer::from(vec![true, false]),
-            Some(NullBuffer::from(vec![false, true])),
-        );
+        let filter = nullable_bool_filter(vec![true, false], vec![false, true]);
 
         group_acc.update_batch(&values_and_orderings, &[0, 0], Some(&filter), 1)?;
 
@@ -1665,32 +1670,14 @@ mod tests {
 
     #[test]
     fn test_last_group_acc_rejects_null_filter_with_true_value_bit() -> Result<()> {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int64, true),
-            Field::new("c", DataType::Int64, true),
-        ]));
-
-        let sort_keys = [PhysicalSortExpr {
-            expr: col("c", &schema).unwrap(),
-            options: SortOptions::default(),
-        }];
-
-        let mut group_acc = FirstLastGroupsAccumulator::try_new(
-            PrimitiveValueState::<Int64Type>::new(DataType::Int64),
-            sort_keys.into(),
-            true,
-            &[DataType::Int64],
-            false,
-        )?;
+        let mut group_acc = new_int64_first_last_group_acc(false)?;
 
         let values_and_orderings: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![10, 20, 30])),
             Arc::new(Int64Array::from(vec![1, 2, 3])),
         ];
-        let filter = BooleanArray::new(
-            BooleanBuffer::from(vec![true, true, false]),
-            Some(NullBuffer::from(vec![false, true, true])),
-        );
+        let filter =
+            nullable_bool_filter(vec![true, true, false], vec![false, true, true]);
 
         group_acc.update_batch(&values_and_orderings, &[0, 0, 0], Some(&filter), 1)?;
 
@@ -1705,33 +1692,14 @@ mod tests {
     #[test]
     fn test_first_group_acc_merge_rejects_null_filter_with_true_value_bit() -> Result<()>
     {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int64, true),
-            Field::new("c", DataType::Int64, true),
-        ]));
-
-        let sort_keys = [PhysicalSortExpr {
-            expr: col("c", &schema).unwrap(),
-            options: SortOptions::default(),
-        }];
-
-        let mut group_acc = FirstLastGroupsAccumulator::try_new(
-            PrimitiveValueState::<Int64Type>::new(DataType::Int64),
-            sort_keys.into(),
-            true,
-            &[DataType::Int64],
-            true,
-        )?;
+        let mut group_acc = new_int64_first_last_group_acc(true)?;
 
         let states: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![10, 20])),
             Arc::new(Int64Array::from(vec![1, 2])),
             Arc::new(BooleanArray::from(vec![true, true])),
         ];
-        let filter = BooleanArray::new(
-            BooleanBuffer::from(vec![true, true]),
-            Some(NullBuffer::from(vec![false, true])),
-        );
+        let filter = nullable_bool_filter(vec![true, true], vec![false, true]);
 
         group_acc.merge_batch(&states, &[0, 0], Some(&filter), 1)?;
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -6491,6 +6491,50 @@ FROM (VALUES (1)) AS t(x)
 ----
 NULL
 
+# Grouped first_value/last_value must apply aggregate FILTER with Some(true)
+# semantics: a row passes only when the predicate is TRUE. Rows where the
+# predicate evaluates to NULL or FALSE must be excluded.
+#
+# Rows per group (predicate is b < 1):
+#   g=1: (a=10, b=NULL -> NULL), (a=20, b=2 -> FALSE)        => no rows pass
+#   g=2: (a=30, b=0 -> TRUE), (a=40, b=NULL -> NULL),
+#        (a=50, b=-5 -> TRUE)                                => a=30 and a=50 pass
+#   g=3: (a=60, b=NULL -> NULL)                              => no rows pass
+statement ok
+CREATE TABLE first_last_filter_null_tests(g INT, a INT, b INT) AS VALUES
+(1, 10, CAST(NULL AS INT)),
+(1, 20, 2),
+(2, 30, 0),
+(2, 40, CAST(NULL AS INT)),
+(2, 50, -5),
+(3, 60, CAST(NULL AS INT));
+
+# Groups 1 and 3 have no rows passing the filter -> NULL.
+# Group 2 has a=30 and a=50 passing -> first_value ORDER BY a = 30.
+query II
+SELECT g, first_value(a ORDER BY a) FILTER (WHERE b < 1) AS fv
+FROM first_last_filter_null_tests
+GROUP BY g
+ORDER BY g;
+----
+1 NULL
+2 30
+3 NULL
+
+# Same groups via last_value: group 2 picks the largest passing a = 50.
+query II
+SELECT g, last_value(a ORDER BY a) FILTER (WHERE b < 1) AS lv
+FROM first_last_filter_null_tests
+GROUP BY g
+ORDER BY g;
+----
+1 NULL
+2 50
+3 NULL
+
+statement ok
+DROP TABLE first_last_filter_null_tests;
+
 # query_with_and_without_filter
 query III rowsort
 SELECT


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #22665

## Rationale for this change

Grouped `first_value` / `last_value` used a local filter check based on `BooleanArray::value(idx)`. This reads only the value bit and does not enforce aggregate `FILTER` semantics, where a row should pass only when the predicate is `Some(true)`.

DataFusion already has a shared helper, `filter_to_validity`, that converts a nullable boolean filter into a validity bitmap implementing the correct semantics (`Some(true)` passes; `Some(false)` and `None` do not). Other grouped aggregate helper paths already use this helper.

This change aligns grouped `first_value` / `last_value` with the existing shared implementation and avoids semantic drift in nullable `FILTER` handling. 

## What changes are included in this PR?

* Make `filter_to_validity` publicly accessible from `datafusion-functions-aggregate-common`.
* Update `FirstLastGroupsAccumulator::get_filtered_extreme_of_each_group` to:

  * precompute filter validity once per batch using `filter_to_validity`
  * evaluate aggregate `FILTER` pass/fail decisions from the resulting validity bitmap rather than directly reading `BooleanArray::value(idx)`
* Minor cleanup in the grouped accumulator loop by destructuring `group_idx` directly.
* Add targeted grouped accumulator regression tests covering nullable filters where the underlying value bit is `true` but the filter validity is `NULL`:

  * grouped `first_value`
  * grouped `last_value`
  * grouped `merge_batch`
* Add SQLLogicTest coverage for grouped `first_value` and `last_value` with nullable `FILTER` predicates, including:

  * groups where all rows are rejected and the result is `NULL`
  * groups where only rows with `TRUE` predicates participate in the aggregate

## Are these changes tested?

Yes.

Added Rust unit tests in `datafusion/functions-aggregate/src/first_last.rs`:

* `test_first_group_acc_rejects_null_filter_with_true_value_bit`
* `test_last_group_acc_rejects_null_filter_with_true_value_bit`
* `test_first_group_acc_merge_rejects_null_filter_with_true_value_bit`

Added SQLLogicTest coverage in:

* `datafusion/sqllogictest/test_files/aggregate.slt`

Validation performed:

```bash
cargo test -p datafusion-functions-aggregate first_last --lib
cargo test -p datafusion-functions-aggregate-common test_accumulate_indices_with_null_filter --lib
cargo test -p datafusion-sqllogictest --test sqllogictests -- aggregate.slt
```

## Are there any user-facing changes?

Yes.

This fixes aggregate `FILTER` behavior for grouped `first_value` and `last_value` when nullable filter predicates are involved. Rows with a `NULL` filter predicate are now consistently treated as filtered out, matching aggregate `FILTER` semantics and the behavior already implemented by the shared helper.

No SQL syntax or public user-facing APIs are changed. The only API change is that `filter_to_validity` is made public within the aggregate-common crate to enable reuse by grouped aggregate implementations.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
