### PR TITLE
Centralize unparser select-scope boundary logic and add characterization tests

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -101,19 +101,6 @@ pub fn plan_to_sql(plan: &LogicalPlan) -> Result<ast::Statement> {
     unparser.plan_to_sql(plan)
 }
 
-/// The parent-plan context for deciding whether a child plan must remain in
-/// its own SQL `SELECT` scope rather than being flattened into the parent.
-#[derive(Debug, Clone, Copy)]
-enum SelectScopeContext {
-    /// The child is the input of a `SubqueryAlias` that may become
-    /// `(SELECT ...) AS alias`.
-    SubqueryAliasInput,
-    /// The child is the input of a `Window` node. Some SQL clauses must remain
-    /// below window-function evaluation and cannot be merged into the same
-    /// `SELECT` block.
-    WindowInput,
-}
-
 impl Unparser<'_> {
     pub fn plan_to_sql(&self, plan: &LogicalPlan) -> Result<ast::Statement> {
         let mut plan = normalize_union_schema(plan)?;
@@ -555,9 +542,16 @@ impl Unparser<'_> {
     }
 
     fn window_input_requires_derived_subquery(plan: &LogicalPlan) -> bool {
-        Self::plan_requires_independent_select_scope(
+        // These operators either produce a SELECT list or apply SQL clauses
+        // evaluated after window functions in a single SELECT block. Keep them
+        // below the Window node by emitting a derived table.
+        matches!(
             plan,
-            SelectScopeContext::WindowInput,
+            LogicalPlan::Projection(_)
+                | LogicalPlan::Distinct(_)
+                | LogicalPlan::Limit(_)
+                | LogicalPlan::Sort(_)
+                | LogicalPlan::Union(_)
         )
     }
 
@@ -1903,47 +1897,17 @@ impl Unparser<'_> {
     /// Returns true if a plan, when used as the direct child of a SubqueryAlias,
     /// must be emitted as a derived subquery `(SELECT ...) AS alias`.
     fn requires_derived_subquery(plan: &LogicalPlan) -> bool {
-        Self::plan_requires_independent_select_scope(
+        // These operators build or constrain SELECT clauses whose scope belongs
+        // under the alias. Flattening them into the parent would lose the
+        // derived-table boundary.
+        matches!(
             plan,
-            SelectScopeContext::SubqueryAliasInput,
+            LogicalPlan::Aggregate(_)
+                | LogicalPlan::Window(_)
+                | LogicalPlan::Sort(_)
+                | LogicalPlan::Limit(_)
+                | LogicalPlan::Union(_)
         )
-    }
-
-    /// Returns true when flattening `plan` into its parent would merge SQL
-    /// clauses across a semantic `SELECT`-scope boundary.
-    fn plan_requires_independent_select_scope(
-        plan: &LogicalPlan,
-        context: SelectScopeContext,
-    ) -> bool {
-        match context {
-            SelectScopeContext::SubqueryAliasInput => {
-                // These operators build or constrain SELECT clauses whose scope
-                // belongs under the alias. Flattening them into the parent
-                // would lose the derived-table boundary.
-                matches!(
-                    plan,
-                    LogicalPlan::Aggregate(_)
-                        | LogicalPlan::Window(_)
-                        | LogicalPlan::Sort(_)
-                        | LogicalPlan::Limit(_)
-                        | LogicalPlan::Union(_)
-                )
-            }
-            SelectScopeContext::WindowInput => {
-                // These operators either produce a SELECT list or apply SQL
-                // clauses evaluated after window functions in a single SELECT
-                // block. Keep them below the Window node by emitting a derived
-                // table.
-                matches!(
-                    plan,
-                    LogicalPlan::Projection(_)
-                        | LogicalPlan::Distinct(_)
-                        | LogicalPlan::Limit(_)
-                        | LogicalPlan::Sort(_)
-                        | LogicalPlan::Union(_)
-                )
-            }
-        }
     }
 
     /// Try to unparse a table scan with pushdown operations into a new subquery plan.

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -101,6 +101,18 @@ pub fn plan_to_sql(plan: &LogicalPlan) -> Result<ast::Statement> {
     unparser.plan_to_sql(plan)
 }
 
+/// Context in which a child plan may need its own SQL SELECT scope.
+enum SelectScopeContext {
+    /// The direct input of a Window plan. Some inputs must remain below the
+    /// Window node because their SELECT clauses are evaluated after window
+    /// expressions in one SELECT block.
+    WindowInput,
+    /// The direct child of a SubqueryAlias. Some children must be emitted as a
+    /// derived table so clauses owned by the alias scope are not flattened into
+    /// the parent SELECT.
+    SubqueryAliasChild,
+}
+
 impl Unparser<'_> {
     pub fn plan_to_sql(&self, plan: &LogicalPlan) -> Result<ast::Statement> {
         let mut plan = normalize_union_schema(plan)?;
@@ -542,16 +554,9 @@ impl Unparser<'_> {
     }
 
     fn window_input_requires_derived_subquery(plan: &LogicalPlan) -> bool {
-        // These operators either produce a SELECT list or apply SQL clauses
-        // evaluated after window functions in a single SELECT block. Keep them
-        // below the Window node by emitting a derived table.
-        matches!(
+        Self::plan_requires_independent_select_scope(
             plan,
-            LogicalPlan::Projection(_)
-                | LogicalPlan::Distinct(_)
-                | LogicalPlan::Limit(_)
-                | LogicalPlan::Sort(_)
-                | LogicalPlan::Union(_)
+            SelectScopeContext::WindowInput,
         )
     }
 
@@ -1897,16 +1902,38 @@ impl Unparser<'_> {
     /// Returns true if a plan, when used as the direct child of a SubqueryAlias,
     /// must be emitted as a derived subquery `(SELECT ...) AS alias`.
     fn requires_derived_subquery(plan: &LogicalPlan) -> bool {
-        // These operators build or constrain SELECT clauses whose scope belongs
-        // under the alias. Flattening them into the parent would lose the
-        // derived-table boundary.
-        matches!(
+        Self::plan_requires_independent_select_scope(
             plan,
-            LogicalPlan::Aggregate(_)
-                | LogicalPlan::Window(_)
-                | LogicalPlan::Sort(_)
-                | LogicalPlan::Limit(_)
-                | LogicalPlan::Union(_)
+            SelectScopeContext::SubqueryAliasChild,
+        )
+    }
+
+    /// Returns true when `plan` must keep its own SELECT scope for `context`.
+    ///
+    /// Each context protects a different SQL boundary: window inputs preserve
+    /// child clauses evaluated after window expressions, while SubqueryAlias
+    /// children preserve clauses owned by the aliased derived-table scope.
+    fn plan_requires_independent_select_scope(
+        plan: &LogicalPlan,
+        context: SelectScopeContext,
+    ) -> bool {
+        matches!(
+            (context, plan),
+            (
+                SelectScopeContext::WindowInput,
+                LogicalPlan::Projection(_)
+                    | LogicalPlan::Distinct(_)
+                    | LogicalPlan::Limit(_)
+                    | LogicalPlan::Sort(_)
+                    | LogicalPlan::Union(_),
+            ) | (
+                SelectScopeContext::SubqueryAliasChild,
+                LogicalPlan::Aggregate(_)
+                    | LogicalPlan::Window(_)
+                    | LogicalPlan::Sort(_)
+                    | LogicalPlan::Limit(_)
+                    | LogicalPlan::Union(_),
+            )
         )
     }
 

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -101,6 +101,19 @@ pub fn plan_to_sql(plan: &LogicalPlan) -> Result<ast::Statement> {
     unparser.plan_to_sql(plan)
 }
 
+/// The parent-plan context for deciding whether a child plan must remain in
+/// its own SQL `SELECT` scope rather than being flattened into the parent.
+#[derive(Debug, Clone, Copy)]
+enum SelectScopeContext {
+    /// The child is the input of a `SubqueryAlias` that may become
+    /// `(SELECT ...) AS alias`.
+    SubqueryAliasInput,
+    /// The child is the input of a `Window` node. Some SQL clauses must remain
+    /// below window-function evaluation and cannot be merged into the same
+    /// `SELECT` block.
+    WindowInput,
+}
+
 impl Unparser<'_> {
     pub fn plan_to_sql(&self, plan: &LogicalPlan) -> Result<ast::Statement> {
         let mut plan = normalize_union_schema(plan)?;
@@ -542,16 +555,9 @@ impl Unparser<'_> {
     }
 
     fn window_input_requires_derived_subquery(plan: &LogicalPlan) -> bool {
-        // These operators either produce a SELECT list or apply SQL clauses
-        // that are evaluated after window functions in a single SELECT block.
-        // Keep them below the Window node by emitting a derived table.
-        matches!(
+        Self::plan_requires_independent_select_scope(
             plan,
-            LogicalPlan::Projection(_)
-                | LogicalPlan::Distinct(_)
-                | LogicalPlan::Limit(_)
-                | LogicalPlan::Sort(_)
-                | LogicalPlan::Union(_)
+            SelectScopeContext::WindowInput,
         )
     }
 
@@ -1896,18 +1902,48 @@ impl Unparser<'_> {
 
     /// Returns true if a plan, when used as the direct child of a SubqueryAlias,
     /// must be emitted as a derived subquery `(SELECT ...) AS alias`.
-    ///
-    /// Plans like Aggregate or Window build their own SELECT clauses (GROUP BY,
-    /// window functions).
     fn requires_derived_subquery(plan: &LogicalPlan) -> bool {
-        matches!(
+        Self::plan_requires_independent_select_scope(
             plan,
-            LogicalPlan::Aggregate(_)
-                | LogicalPlan::Window(_)
-                | LogicalPlan::Sort(_)
-                | LogicalPlan::Limit(_)
-                | LogicalPlan::Union(_)
+            SelectScopeContext::SubqueryAliasInput,
         )
+    }
+
+    /// Returns true when flattening `plan` into its parent would merge SQL
+    /// clauses across a semantic `SELECT`-scope boundary.
+    fn plan_requires_independent_select_scope(
+        plan: &LogicalPlan,
+        context: SelectScopeContext,
+    ) -> bool {
+        match context {
+            SelectScopeContext::SubqueryAliasInput => {
+                // These operators build or constrain SELECT clauses whose scope
+                // belongs under the alias. Flattening them into the parent
+                // would lose the derived-table boundary.
+                matches!(
+                    plan,
+                    LogicalPlan::Aggregate(_)
+                        | LogicalPlan::Window(_)
+                        | LogicalPlan::Sort(_)
+                        | LogicalPlan::Limit(_)
+                        | LogicalPlan::Union(_)
+                )
+            }
+            SelectScopeContext::WindowInput => {
+                // These operators either produce a SELECT list or apply SQL
+                // clauses evaluated after window functions in a single SELECT
+                // block. Keep them below the Window node by emitting a derived
+                // table.
+                matches!(
+                    plan,
+                    LogicalPlan::Projection(_)
+                        | LogicalPlan::Distinct(_)
+                        | LogicalPlan::Limit(_)
+                        | LogicalPlan::Sort(_)
+                        | LogicalPlan::Union(_)
+                )
+            }
+        }
     }
 
     /// Try to unparse a table scan with pushdown operations into a new subquery plan.

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -1527,6 +1527,87 @@ fn test_table_scan_alias() -> Result<()> {
 }
 
 #[test]
+fn test_unparse_subquery_alias_select_scope_boundaries() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("age", DataType::Int32, false),
+    ]);
+
+    let aggregate_child = table_scan(Some("t1"), &schema, None)?
+        .aggregate(vec![col("id")], vec![sum(col("age")).alias("total_age")])?
+        .alias("a")?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&aggregate_child)?,
+        @"SELECT * FROM (SELECT sum(t1.age) AS total_age, t1.id FROM t1 GROUP BY t1.id) AS a"
+    );
+
+    let window_expr = Expr::WindowFunction(Box::new(WindowFunction {
+        fun: WindowFunctionDefinition::WindowUDF(row_number_udwf()),
+        params: WindowFunctionParams {
+            args: vec![],
+            partition_by: vec![],
+            order_by: vec![col("age").sort(true, true)],
+            window_frame: WindowFrame::new(None),
+            null_treatment: None,
+            distinct: false,
+            filter: None,
+        },
+    }))
+    .alias("row_idx");
+    let window_child = table_scan(Some("t1"), &schema, None)?
+        .window(vec![window_expr])?
+        .alias("a")?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&window_child)?,
+        @"SELECT * FROM (SELECT *, row_number() OVER (ORDER BY t1.age ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS row_idx FROM t1) AS a"
+    );
+
+    let sort_child = table_scan(Some("t1"), &schema, None)?
+        .sort(vec![col("age").sort(false, false)])?
+        .alias("a")?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&sort_child)?,
+        @"SELECT * FROM (SELECT * FROM t1 ORDER BY t1.age DESC NULLS LAST) AS a"
+    );
+
+    let limit_child = table_scan(Some("t1"), &schema, None)?
+        .limit(0, Some(5))?
+        .alias("a")?
+        .build()?;
+    assert_snapshot!(
+        plan_to_sql(&limit_child)?,
+        @"SELECT * FROM (SELECT * FROM t1 LIMIT 5) AS a"
+    );
+
+    let union_schema = Arc::new(DFSchema::try_from(Schema::new(vec![Field::new(
+        "id",
+        DataType::Int32,
+        false,
+    )]))?);
+    let empty = LogicalPlan::EmptyRelation(EmptyRelation {
+        produce_one_row: true,
+        schema: union_schema.clone(),
+    });
+    let union_child = LogicalPlan::Union(Union {
+        inputs: vec![
+            project(empty.clone(), vec![lit(1).alias("id")])?.into(),
+            project(empty, vec![lit(2).alias("id")])?.into(),
+        ],
+        schema: union_schema,
+    });
+    let union_child = LogicalPlanBuilder::from(union_child).alias("a")?.build()?;
+    assert_snapshot!(
+        plan_to_sql(&union_child)?,
+        @"SELECT * FROM (SELECT 1 AS id UNION ALL SELECT 2 AS id) AS a"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_table_scan_pushdown() -> Result<()> {
     let schema = Schema::new(vec![
         Field::new("id", DataType::Utf8, false),
@@ -3123,6 +3204,82 @@ fn test_unparse_window_over_projection_without_projection() -> Result<()> {
     assert_snapshot!(
         sql,
         @"SELECT *, row_number() OVER (ORDER BY derived_window_input.v_alias ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS row_idx FROM (SELECT test.k, test.v AS v_alias FROM test) AS derived_window_input"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_unparse_window_over_sort_without_projection() -> Result<()> {
+    let schema = Schema::new(vec![
+        Field::new("k", DataType::Int32, false),
+        Field::new("v", DataType::Int32, false),
+    ]);
+    let window_expr = Expr::WindowFunction(Box::new(WindowFunction {
+        fun: WindowFunctionDefinition::WindowUDF(row_number_udwf()),
+        params: WindowFunctionParams {
+            args: vec![],
+            partition_by: vec![],
+            order_by: vec![col("v").sort(true, true)],
+            window_frame: WindowFrame::new(None),
+            null_treatment: None,
+            distinct: false,
+            filter: None,
+        },
+    }))
+    .alias("row_idx");
+    let plan = table_scan(Some("test"), &schema, None)?
+        .sort(vec![col("v").sort(false, false)])?
+        .window(vec![window_expr])?
+        .build()?;
+
+    let sql = Unparser::default().plan_to_sql(&plan)?;
+    assert_snapshot!(
+        sql,
+        @"SELECT *, row_number() OVER (ORDER BY derived_window_input.v ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS row_idx FROM (SELECT * FROM test ORDER BY test.v DESC NULLS LAST) AS derived_window_input"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_unparse_window_over_union_without_projection() -> Result<()> {
+    let schema = Arc::new(DFSchema::try_from(Schema::new(vec![
+        Field::new("k", DataType::Int32, false),
+        Field::new("v", DataType::Int32, false),
+    ]))?);
+    let empty = LogicalPlan::EmptyRelation(EmptyRelation {
+        produce_one_row: true,
+        schema: schema.clone(),
+    });
+    let union = LogicalPlan::Union(Union {
+        inputs: vec![
+            project(empty.clone(), vec![lit(1).alias("k"), lit(10).alias("v")])?.into(),
+            project(empty, vec![lit(2).alias("k"), lit(20).alias("v")])?.into(),
+        ],
+        schema,
+    });
+    let window_expr = Expr::WindowFunction(Box::new(WindowFunction {
+        fun: WindowFunctionDefinition::WindowUDF(row_number_udwf()),
+        params: WindowFunctionParams {
+            args: vec![],
+            partition_by: vec![],
+            order_by: vec![col("v").sort(true, true)],
+            window_frame: WindowFrame::new(None),
+            null_treatment: None,
+            distinct: false,
+            filter: None,
+        },
+    }))
+    .alias("row_idx");
+    let plan = LogicalPlanBuilder::from(union)
+        .window(vec![window_expr])?
+        .build()?;
+
+    let sql = Unparser::default().plan_to_sql(&plan)?;
+    assert_snapshot!(
+        sql,
+        @"SELECT *, row_number() OVER (ORDER BY derived_window_input.v ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS row_idx FROM (SELECT 1 AS k, 10 AS v UNION ALL SELECT 2 AS k, 20 AS v) AS derived_window_input"
     );
 
     Ok(())

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -27,7 +27,7 @@ use datafusion_expr::test::function_stub::{
 };
 use datafusion_expr::{
     ColumnarValue, EmptyRelation, Expr, Extension, LogicalPlan, LogicalPlanBuilder,
-    ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Union,
+    ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, SortExpr, Union,
     UserDefinedLogicalNode, UserDefinedLogicalNodeCore, Volatility, WindowFrame,
     WindowFunctionDefinition, cast, col, exists, in_subquery, lit, scalar_subquery,
     table_scan, wildcard,
@@ -69,6 +69,22 @@ use datafusion_sql::unparser::extension_unparser::{
 };
 use sqlparser::dialect::{Dialect, GenericDialect, MySqlDialect};
 use sqlparser::parser::Parser;
+
+fn row_number_over(order_by: SortExpr, alias: &str) -> Expr {
+    Expr::WindowFunction(Box::new(WindowFunction {
+        fun: WindowFunctionDefinition::WindowUDF(row_number_udwf()),
+        params: WindowFunctionParams {
+            args: vec![],
+            partition_by: vec![],
+            order_by: vec![order_by],
+            window_frame: WindowFrame::new(None),
+            null_treatment: None,
+            distinct: false,
+            filter: None,
+        },
+    }))
+    .alias(alias)
+}
 
 #[test]
 fn test_roundtrip_expr_1() {
@@ -1542,19 +1558,7 @@ fn test_unparse_subquery_alias_select_scope_boundaries() -> Result<()> {
         @"SELECT * FROM (SELECT sum(t1.age) AS total_age, t1.id FROM t1 GROUP BY t1.id) AS a"
     );
 
-    let window_expr = Expr::WindowFunction(Box::new(WindowFunction {
-        fun: WindowFunctionDefinition::WindowUDF(row_number_udwf()),
-        params: WindowFunctionParams {
-            args: vec![],
-            partition_by: vec![],
-            order_by: vec![col("age").sort(true, true)],
-            window_frame: WindowFrame::new(None),
-            null_treatment: None,
-            distinct: false,
-            filter: None,
-        },
-    }))
-    .alias("row_idx");
+    let window_expr = row_number_over(col("age").sort(true, true), "row_idx");
     let window_child = table_scan(Some("t1"), &schema, None)?
         .window(vec![window_expr])?
         .alias("a")?
@@ -3215,27 +3219,14 @@ fn test_unparse_window_over_sort_without_projection() -> Result<()> {
         Field::new("k", DataType::Int32, false),
         Field::new("v", DataType::Int32, false),
     ]);
-    let window_expr = Expr::WindowFunction(Box::new(WindowFunction {
-        fun: WindowFunctionDefinition::WindowUDF(row_number_udwf()),
-        params: WindowFunctionParams {
-            args: vec![],
-            partition_by: vec![],
-            order_by: vec![col("v").sort(true, true)],
-            window_frame: WindowFrame::new(None),
-            null_treatment: None,
-            distinct: false,
-            filter: None,
-        },
-    }))
-    .alias("row_idx");
+    let window_expr = row_number_over(col("v").sort(true, true), "row_idx");
     let plan = table_scan(Some("test"), &schema, None)?
         .sort(vec![col("v").sort(false, false)])?
         .window(vec![window_expr])?
         .build()?;
 
-    let sql = Unparser::default().plan_to_sql(&plan)?;
     assert_snapshot!(
-        sql,
+        Unparser::default().plan_to_sql(&plan)?,
         @"SELECT *, row_number() OVER (ORDER BY derived_window_input.v ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS row_idx FROM (SELECT * FROM test ORDER BY test.v DESC NULLS LAST) AS derived_window_input"
     );
 
@@ -3259,26 +3250,13 @@ fn test_unparse_window_over_union_without_projection() -> Result<()> {
         ],
         schema,
     });
-    let window_expr = Expr::WindowFunction(Box::new(WindowFunction {
-        fun: WindowFunctionDefinition::WindowUDF(row_number_udwf()),
-        params: WindowFunctionParams {
-            args: vec![],
-            partition_by: vec![],
-            order_by: vec![col("v").sort(true, true)],
-            window_frame: WindowFrame::new(None),
-            null_treatment: None,
-            distinct: false,
-            filter: None,
-        },
-    }))
-    .alias("row_idx");
+    let window_expr = row_number_over(col("v").sort(true, true), "row_idx");
     let plan = LogicalPlanBuilder::from(union)
         .window(vec![window_expr])?
         .build()?;
 
-    let sql = Unparser::default().plan_to_sql(&plan)?;
     assert_snapshot!(
-        sql,
+        Unparser::default().plan_to_sql(&plan)?,
         @"SELECT *, row_number() OVER (ORDER BY derived_window_input.v ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS row_idx FROM (SELECT 1 AS k, 10 AS v UNION ALL SELECT 2 AS k, 20 AS v) AS derived_window_input"
     );
 


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #22668

## Rationale for this change

The SQL unparser currently determines when a logical plan must preserve an independent `SELECT` scope in multiple places, with different operator sets depending on context. While those differences are intentional, the underlying rationale is not centralized or documented, making future changes harder to reason about.

This PR adds characterization tests for the current behavior and introduces a single helper that makes the context-specific boundary decisions explicit without changing generated SQL. 

## What changes are included in this PR?

* Introduce a private `SelectScopeContext` enum to describe the two select-scope boundary contexts:

  * `WindowInput`
  * `SubqueryAliasChild`
* Add a centralized helper:

  * `plan_requires_independent_select_scope(plan, context)`
* Refactor:

  * `window_input_requires_derived_subquery()`
  * `requires_derived_subquery()`

  so they delegate to the new helper while preserving existing behavior.
* Add characterization tests covering `SubqueryAlias` children that must remain derived:

  * aggregate child
  * window child
  * sort child
  * limit child
  * union child
* Add characterization tests covering `Window` inputs that must remain derived:

  * sort input
  * union input
* Add a shared helper for constructing `ROW_NUMBER()` window expressions used by the new tests.

No SQL output changes are intended by this refactor. 

## Are these changes tested?

Yes.

New tests added in `datafusion/sql/tests/cases/plan_to_sql.rs`:

* `test_unparse_subquery_alias_select_scope_boundaries`
* `test_unparse_window_over_sort_without_projection`
* `test_unparse_window_over_union_without_projection`

These tests validate the current derived-subquery boundary behavior and ensure the refactor remains behavior-preserving. 

## Are there any user-facing changes?

No.

This change is a refactor and test expansion that preserves existing SQL generation behavior and does not introduce user-facing functionality changes. 

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
