### PR TITLE
fix: preserve Spark next_day whitespace validation

### DIFF
--- a/datafusion/spark/src/function/datetime/next_day.rs
+++ b/datafusion/spark/src/function/datetime/next_day.rs
@@ -210,7 +210,7 @@ where
 fn spark_next_day(days: i32, day_of_week: &str) -> Option<i32> {
     let date = Date32Type::to_naive_date_opt(days)?;
 
-    let day_of_week = day_of_week.trim().to_uppercase();
+    let day_of_week = day_of_week.to_uppercase();
     let day_of_week = match day_of_week.as_str() {
         "MO" | "MON" | "MONDAY" => Some("MONDAY"),
         "TU" | "TUE" | "TUESDAY" => Some("TUESDAY"),
@@ -278,5 +278,11 @@ mod tests {
 
         assert_eq!(field.data_type(), &DataType::Date32);
         assert!(field.is_nullable());
+    }
+
+    #[test]
+    fn next_day_rejects_whitespace_padded_day_names() {
+        let monday = 19723; // 2024-01-01
+        assert_eq!(spark_next_day(monday, " MO "), None);
     }
 }

--- a/datafusion/sqllogictest/test_files/spark/datetime/next_day.slt
+++ b/datafusion/sqllogictest/test_files/spark/datetime/next_day.slt
@@ -36,6 +36,12 @@ SELECT next_day('2015-07-27'::DATE, 'Sat'::string);
 ----
 2015-08-01
 
+# Whitespace-padded day names should be rejected (return NULL) per Spark behavior
+query D
+SELECT next_day('2015-01-14'::DATE, ' MO '::string);
+----
+NULL
+
 query error Failed to coerce arguments to satisfy a call to 'next_day' function
 SELECT next_day('2015-07-27'::DATE);
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22717.

## Rationale for this change

Spark does not trim `dayOfWeek` before matching it in `next_day`, but `datafusion-spark` currently does. That makes values like `' MO '` succeed in DataFusion even though Spark treats them as invalid.

## What changes are included in this PR?

- remove the `.trim()` call from `spark_next_day`
- add a regression test proving whitespace-padded day names are rejected

## Are these changes tested?

- `cargo test -p datafusion-spark next_day_rejects_whitespace_padded_day_names -- --nocapture`
- `cargo test -p datafusion-spark`
- `cargo fmt --all --check`
- `cargo clippy -p datafusion-spark --all-targets --all-features --no-deps -- -D warnings`

Note: the broader package clippy invocation still reports an existing unused import warning in untouched `datafusion/core/src/execution/session_state.rs` on current main.

## Are there any user-facing changes?

Behavior now matches Spark for whitespace-padded `dayOfWeek` inputs in `next_day`.