### PR TITLE
Lower SLT HEADROOM_FACTOR 8.0 -> 5.0 to surface nested_loop_join_spill leak

### DIFF
--- a/datafusion/sqllogictest/src/accounting_pool.rs
+++ b/datafusion/sqllogictest/src/accounting_pool.rs
@@ -39,8 +39,10 @@ use std::sync::Arc;
 /// Headroom over the pool's declared limit. Anything past this is an
 /// untracked allocation — by definition, since DF's pool didn't see it.
 ///
-/// 800% high, but that's what it takes to pass the SLT suite right now. Goal should be ~10%
-const HEADROOM_FACTOR: f64 = 8.0;
+/// 400% high. Intentionally tighter than the value the SLT suite currently
+/// passes at — surfaces untracked allocation in `nested_loop_join_spill.slt`.
+/// Goal should be ~10%; raise the floor by fixing the operator, not this constant.
+const HEADROOM_FACTOR: f64 = 5.0;
 
 pub struct AccountingMemoryPool {
     inner: Arc<dyn MemoryPool>,


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #22626 (allocator-level memory tracking in SLTs).

## Rationale for this change

`HEADROOM_FACTOR` in the SLT accounting pool is currently 8.0 — i.e. we accept allocator usage up to 8× the pool's declared limit before failing. That's loose enough to hide real leaks. Lowering it to 5.0 surfaces an untracked allocation in `nested_loop_join_spill.slt`.

At 5× headroom, the first query in that suite allocates ~3.7 MB against a declared 150K limit. `NestedLoopJoinExec` has untracked allocation in at least three sites — `generate_next_batch` buffering, `concat_batches` at the spill boundary, and `take_native` during probe — plus the IPC reader path on spill re-read.

## What changes are included in this PR?

One constant change in `datafusion/sqllogictest/src/accounting_pool.rs`: `HEADROOM_FACTOR: f64 = 8.0` → `5.0`, with updated doc comment.

## Are these changes tested?

CI is the test — `nested_loop_join_spill.slt` is expected to fail until the operator-side leaks are fixed. That's the intended signal of this PR, not a regression.

## Are there any user-facing changes?

No. Test-infrastructure-only.