### PR TITLE
fix(spark): next_day should not trim whitespace from dayOfWeek

### DIFF
--- a/datafusion/spark/src/function/datetime/next_day.rs
+++ b/datafusion/spark/src/function/datetime/next_day.rs
@@ -210,7 +210,7 @@ where
 fn spark_next_day(days: i32, day_of_week: &str) -> Option<i32> {
     let date = Date32Type::to_naive_date_opt(days)?;
 
-    let day_of_week = day_of_week.trim().to_uppercase();
+    let day_of_week = day_of_week.to_uppercase();
     let day_of_week = match day_of_week.as_str() {
         "MO" | "MON" | "MONDAY" => Some("MONDAY"),
         "TU" | "TUE" | "TUESDAY" => Some("TUESDAY"),

--- a/datafusion/sqllogictest/test_files/spark/datetime/next_day.slt
+++ b/datafusion/sqllogictest/test_files/spark/datetime/next_day.slt
@@ -64,6 +64,22 @@ SELECT next_day('2020-01-01'::DATE, 'invalid_day'::string);
 ----
 NULL
 
+# Whitespace must NOT be trimmed — Spark does not accept padded day names (issue #22717)
+query D
+SELECT next_day('2024-01-01'::DATE, ' MO '::string);
+----
+NULL
+
+query D
+SELECT next_day('2024-01-01'::DATE, ' Monday '::string);
+----
+NULL
+
+query D
+SELECT next_day('2024-01-01'::DATE, '  sun  '::string);
+----
+NULL
+
 query error Cast error: Cannot cast string '2015-13-32' to value of Date32 type
 SELECT next_day('2015-13-32'::DATE, 'Sun'::string);
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22717

## Rationale for this change

Spark's `next_day` function performs exact (case-insensitive) matching on the `dayOfWeek` argument. Whitespace-padded values like `' MO '` are not valid day names in Spark and should return `NULL`. DataFusion was calling `.trim()` before matching, so `' MO '` was silently accepted and returned a date — diverging from Spark's behavior.

## What changes are included in this PR?

- `datafusion/spark/src/function/datetime/next_day.rs`: removed `.trim()` from the `spark_next_day` helper so whitespace-padded day names fall through to the `None` branch.
- `datafusion/sqllogictest/test_files/spark/datetime/next_day.slt`: added three regression tests (`' MO '`, `' Monday '`, `'  sun  '`) that all now correctly return `NULL`.

## Are there any user-facing changes?

Yes — `next_day(date, ' MO ')` now returns `NULL` instead of a date. This is a bug fix that aligns with Spark's actual behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)