### PR TITLE
fix: ln() of negative or zero should error to match PostgreSQL

### DIFF
--- a/datafusion/functions/src/math/mod.rs
+++ b/datafusion/functions/src/math/mod.rs
@@ -51,6 +51,16 @@ fn validate_sqrt_input(value: f64) -> Result<()> {
     }
 }
 
+fn validate_ln_input(value: f64) -> Result<()> {
+    if value < 0.0 {
+        exec_err!("cannot take logarithm of a negative number")
+    } else if value == 0.0 {
+        exec_err!("cannot take logarithm of zero")
+    } else {
+        Ok(())
+    }
+}
+
 // Create UDFs
 make_udf_function!(abs::AbsFunc, abs);
 make_math_unary_udf!(
@@ -163,7 +173,8 @@ make_math_unary_udf!(
     ln,
     super::ln_order,
     super::bounds::unbounded_bounds,
-    super::get_ln_doc
+    super::get_ln_doc,
+    Some(super::validate_ln_input)
 );
 make_math_unary_udf!(
     Log2Func,

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -593,21 +593,23 @@ select ln(null);
 ----
 NULL
 
-# ln scalar ops with zero edgecases
-# please see https://github.com/apache/datafusion/pull/5245#issuecomment-1426828382
-query R rowsort
+# ln(0) errors to match PostgreSQL behavior (issue #22271)
+statement error cannot take logarithm of zero
 select ln(0);
-----
--Infinity
 
-# ln with columns (round is needed to normalize the outputs of different operating systems)
+# ln of negative numbers errors to match PostgreSQL behavior (issue #22271)
+statement error cannot take logarithm of a negative number
+select ln(-1.0::double);
+
+statement error cannot take logarithm of a negative number
+select ln(-0.5::double);
+
+# ln with positive values (array path)
 query RRR rowsort
-select round(ln(a), 5), round(ln(b), 5), round(ln(c), 5) from signed_integers;
+select round(ln(a::double), 5), round(ln(b::double), 5), round(ln(c::double), 5)
+from (values (1, 2, 100)) as t(a, b, c);
 ----
-0.69315 NaN 4.81218
-1.38629 NULL NULL
-NaN 4.60517 NaN
-NaN 9.21034 NaN
+0 0.69315 4.60517
 
 ## log
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22271

## Rationale for this change

PostgreSQL raises an error when `ln()` receives a non-positive argument:
- `ln(0)` → `ERROR: cannot take logarithm of zero`
- `ln(-1)` → `ERROR: cannot take logarithm of a negative number`

DataFusion was silently returning `-Infinity` for zero and `NaN` for negatives, diverging from PostgreSQL semantics.

## What changes are included in this PR?

- `datafusion/functions/src/math/mod.rs`: Added `validate_ln_input` (same pattern as the existing `validate_sqrt_input`) and passed it as the `$VALIDATOR` argument to the `LnFunc` macro invocation.
- `datafusion/sqllogictest/test_files/scalar.slt`: Updated `ln(0)` and negative-value tests to expect errors; added explicit `ln(-1.0)` and `ln(-0.5)` error assertions; replaced the `signed_integers` column test (which contained negative values) with a simple positive-literal array test.

## Are there any user-facing changes?

Yes — `ln(0)` and `ln(<negative>)` now raise errors instead of returning `-Infinity` / `NaN`. This is a bug fix for PostgreSQL compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)