### PR TITLE
slt+accounting: surface GroupValuesRows::emit untracked decode (closes #22739)

### DIFF
--- a/datafusion/sqllogictest/src/accounting_pool.rs
+++ b/datafusion/sqllogictest/src/accounting_pool.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 /// untracked allocation — by definition, since DF's pool didn't see it.
 ///
 /// 800% high, but that's what it takes to pass the SLT suite right now. Goal should be ~10%
-const HEADROOM_FACTOR: f64 = 8.0;
+const HEADROOM_FACTOR: f64 = 5.0;
 
 pub struct AccountingMemoryPool {
     inner: Arc<dyn MemoryPool>,

--- a/datafusion/sqllogictest/test_files/group_by_spill_row_decode.slt
+++ b/datafusion/sqllogictest/test_files/group_by_spill_row_decode.slt
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# `GroupedHashAggregateStream` spill path: `GroupValuesRows::emit` →
+# `RowConverter::convert_rows` → `decode_column` allocates per-column
+# buffers without `MemoryReservation::try_grow`.
+#
+# A `List<Utf8>` key forces the row-encoded `GroupValuesRows` impl
+# (single-column `Utf8` routes through `GroupValuesBytes` instead).
+# Pool=1M is in the goldilocks zone: above DF's tracked-alloc floor
+# (agg enters spill), below the framework's slack ceiling on the
+# decode buffer.
+#
+# Surfaced by apache/datafusion#22626. Sibling: nested_loop_join_spill.slt.
+
+statement ok
+SET datafusion.execution.target_partitions = 1
+
+statement ok
+CREATE TABLE list_keys AS
+SELECT make_array(cast(v AS varchar) || repeat('x', 200)) AS k
+FROM generate_series(1, 50000) AS t(v)
+
+statement ok
+SET datafusion.runtime.memory_limit = '1M'
+
+query I nosort
+SELECT count(*) FROM (
+  SELECT k, count(*) AS c
+  FROM list_keys
+  GROUP BY k
+)
+----
+50000
+
+statement ok
+RESET datafusion.runtime.memory_limit
+
+statement ok
+DROP TABLE list_keys
+
+statement ok
+SET datafusion.execution.target_partitions = 4

--- a/datafusion/sqllogictest/test_files/group_by_spill_row_decode.slt
+++ b/datafusion/sqllogictest/test_files/group_by_spill_row_decode.slt
@@ -16,11 +16,18 @@
 # under the License.
 
 # `GroupedHashAggregateStream` spill path: `GroupValuesRows::emit` →
-# `RowConverter::convert_rows` → `decode_column` allocates per-column
-# buffers without `MemoryReservation::try_grow`.
+# `RowConverter::convert_rows` → `decode_column` → `decode_string` /
+# `decode_binary` allocates per-column buffers without
+# `MemoryReservation::try_grow`.
 #
-# A `List<Utf8>` key forces the row-encoded `GroupValuesRows` impl
-# (single-column `Utf8` routes through `GroupValuesBytes` instead).
+# Plain single-column `Utf8` routes to `GroupValuesBytes`, not
+# `GroupValuesRows`. Pairing the wide Utf8 key with a small `List<Int>`
+# column ("schema poisoner") makes the schema fall outside
+# `multi_group_by::supported_type`, forcing `GroupValuesRows`. The wide
+# Utf8 column carries the data; its decode hits `decode_string` →
+# `decode_binary` — the exact path the production OOM at one
+# DataFusion-based log analytics deployment took on 2026-05-20.
+#
 # Pool=1M is in the goldilocks zone: above DF's tracked-alloc floor
 # (agg enters spill), below the framework's slack ceiling on the
 # decode buffer.
@@ -31,8 +38,9 @@ statement ok
 SET datafusion.execution.target_partitions = 1
 
 statement ok
-CREATE TABLE list_keys AS
-SELECT make_array(cast(v AS varchar) || repeat('x', 200)) AS k
+CREATE TABLE utf8_keys AS
+SELECT cast(v AS varchar) || repeat('x', 200) AS k,
+       make_array(1) AS _force_rows
 FROM generate_series(1, 50000) AS t(v)
 
 statement ok
@@ -40,9 +48,9 @@ SET datafusion.runtime.memory_limit = '1M'
 
 query I nosort
 SELECT count(*) FROM (
-  SELECT k, count(*) AS c
-  FROM list_keys
-  GROUP BY k
+  SELECT k, _force_rows, count(*) AS c
+  FROM utf8_keys
+  GROUP BY k, _force_rows
 )
 ----
 50000
@@ -51,7 +59,7 @@ statement ok
 RESET datafusion.runtime.memory_limit
 
 statement ok
-DROP TABLE list_keys
+DROP TABLE utf8_keys
 
 statement ok
 SET datafusion.execution.target_partitions = 4


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22739. Follow-up in the family of #22721 / #22723 — same framework (#22626), different operator.

## Rationale for this change

Described in issue.

## What changes are included in this PR?

Two changes:

1. **`HEADROOM_FACTOR: f64 = 8.0` → `5.0`** in `datafusion/sqllogictest/src/accounting_pool.rs`. Tighter framework slack so untracked allocations surface as test failures sooner. Same shape as #22721.

2. **New SLT `group_by_spill_row_decode.slt`** that exercises the row-encoded `GroupValues` path. Uses a wide Utf8 key paired with a small `List<Int>` "schema poisoner" so the schema falls outside `multi_group_by::supported_type` and routes through `GroupValuesRows` (single-column Utf8 alone would route to `GroupValuesBytes`). At pool=1M with `HEADROOM_FACTOR=5.0` the test fails with `allocator overdraft: account balance at panic = -1344326 bytes`, stack frames pointing at `arrow_row::variable::decode_binary_view_inner` ← `decode_string_view` ← `decode_column` ← `RowConverter::convert_rows` ← `GroupValuesRows::emit` ← `GroupedHashAggregateStream::emit` ← `spill`.

## Are these changes tested?

By the SLT, yes.

## Are there any user-facing changes?

Less OOMs

