### PR TITLE
sqllogictest: account before alloc to avoid panic-after-alloc hazards

### DIFF
--- a/datafusion/sqllogictest/src/accounting.rs
+++ b/datafusion/sqllogictest/src/accounting.rs
@@ -276,11 +276,17 @@ impl AccountingAllocator<System> {
 
 unsafe impl<A: GlobalAlloc> GlobalAlloc for AccountingAllocator<A> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // Account BEFORE the inner alloc. If we panicked AFTER `inner.alloc`
+        // succeeded, the bytes are physically allocated but no caller ever
+        // sees the pointer → unwind leaks the very bytes that pushed us
+        // over the budget — the opposite of what the kill panic is for.
+        let delta = -(layout.size() as isize);
+        track(delta);
         // SAFETY: layout is forwarded unchanged.
         let ptr = unsafe { self.inner.alloc(layout) };
-        if !ptr.is_null() {
-            // Allocation debits the bank.
-            track(-(layout.size() as isize));
+        if ptr.is_null() {
+            // Allocator refused — refund so the bank matches reality.
+            track(-delta);
         }
         ptr
     }
@@ -288,25 +294,36 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for AccountingAllocator<A> {
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         // SAFETY: caller upholds GlobalAlloc invariants; we forward unchanged.
         unsafe { self.inner.dealloc(ptr, layout) };
-        // Free credits the bank.
+        // Credit only; `track()` short-circuits on `delta >= 0` and never
+        // panics, so ordering relative to `inner.dealloc` doesn't matter.
         track(layout.size() as isize);
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // Same panic-then-leak hazard as `alloc`; account first.
+        let delta = -(layout.size() as isize);
+        track(delta);
         // SAFETY: layout is forwarded unchanged.
         let ptr = unsafe { self.inner.alloc_zeroed(layout) };
-        if !ptr.is_null() {
-            track(-(layout.size() as isize));
+        if ptr.is_null() {
+            track(-delta);
         }
         ptr
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // Account BEFORE the inner realloc so a kill panic doesn't strand the
+        // caller with a freed `ptr`. `inner.realloc` frees `ptr` on success;
+        // if we panicked after that, the caller's `Vec`-or-similar would
+        // still hold the old pointer and double-free on unwind (glibc
+        // "double free or corruption (out)" + SIGABRT).
+        let delta = layout.size() as isize - new_size as isize;
+        track(delta);
         // SAFETY: caller upholds GlobalAlloc invariants; we forward unchanged.
         let new_ptr = unsafe { self.inner.realloc(ptr, layout, new_size) };
-        if !new_ptr.is_null() {
-            // Growth debits, shrink credits.
-            track(layout.size() as isize - new_size as isize);
+        if new_ptr.is_null() {
+            // Allocator refused — refund so the bank matches reality.
+            track(-delta);
         }
         new_ptr
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

Follow-up defect fix in the allocator-level accounting framework added by #22626.

## Rationale for this change

`AccountingAllocator::realloc` (introduced in #22626) called `inner.realloc` first — which frees the caller's old pointer on success — then called `track`, which can `panic_any` on overdraft. The unwind starts with the caller's `Vec` (or similar growing container) still holding the now-freed old pointer; the next `Drop` produces glibc's `double free or corruption (out)` and SIGABRT, masking the underlying untracked-allocation panic the framework was trying to surface.

The same hazard does not apply to `alloc` / `alloc_zeroed` / `dealloc`:
- `alloc` / `alloc_zeroed` — the caller has no preexisting pointer to be invalidated; panicking after the inner alloc just leaks the new allocation, which is fine on the kill path.
- `dealloc` — credits the bank, never panics.

Only `realloc` has a live caller-side pointer that gets invalidated by the inner operation before the panic decision.

## What changes are included in this PR?

Reorder `AccountingAllocator::realloc` to account first, forward to `inner.realloc` second:

- `track(delta)` first — on overdraft we panic with the caller's pointer still valid; unwind drops the live container cleanly, no abort.
- If `inner.realloc` returns null after a successful track, refund the delta so the bank stays consistent with what actually got allocated.

## Are these changes tested?

Manually verified using a `GroupedHashAggregateStream` + `List<Utf8>` group-key reproducer (routes through `GroupValuesRows::intern` → `RowConverter::append` → `Vec::resize` → `__rust_realloc`, which is one of the untracked-allocation sites this framework is meant to catch):

- before: exit 101, `double free or corruption (out)`, signal 6 SIGABRT
- after:  exit 1, clean `allocator overdraft: account balance at panic = -1.7 MB` at the same `RowConverter::append` stack frame

A regression test for "panic from inside `realloc` does not double-free" would require constructing the precise realloc-mid-grow scenario plus a `catch_unwind` harness; deferred as follow-up.

## Are there any user-facing changes?

No. Confined to `sqllogictest`'s `memory-accounting` feature, which is internal CI tooling.