### PR TITLE
fix: Coerce aggregate FILTER predicates to boolean

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -715,6 +715,12 @@ impl TreeNodeRewriter for TypeCoercionRewriter<'_> {
             }) => {
                 let new_expr =
                     coerce_arguments_for_signature(args, self.schema, func.as_ref())?;
+
+                let filter = filter
+                    .map(|filter| filter.cast_to(&DataType::Boolean, self.schema))
+                    .transpose()?
+                    .map(Box::new);
+
                 Ok(Transformed::yes(Expr::AggregateFunction(
                     expr::AggregateFunction::new_udf(
                         func,
@@ -751,6 +757,11 @@ impl TreeNodeRewriter for TypeCoercionRewriter<'_> {
                         coerce_arguments_for_signature(args, self.schema, udf.as_ref())?
                     }
                 };
+
+                let filter = filter
+                    .map(|filter| filter.cast_to(&DataType::Boolean, self.schema))
+                    .transpose()?
+                    .map(Box::new);
 
                 let new_expr = Expr::from(WindowFunction {
                     fun,

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -6266,6 +6266,40 @@ GROUP BY g
 ----
 0 0
 
+# query_with_untyped_null_filter
+query I
+SELECT count(*) FILTER (WHERE NULL)
+----
+0
+
+query I
+SELECT count(1) FILTER (WHERE NULL)
+----
+0
+
+query I
+SELECT sum(1) FILTER (WHERE NULL)
+----
+NULL
+
+query R
+SELECT avg(1) FILTER (WHERE NULL)
+----
+NULL
+
+# window_aggregate_with_untyped_null_filter
+query I
+SELECT count(*) FILTER (WHERE NULL) OVER ()
+FROM (VALUES (1)) AS t(x)
+----
+0
+
+query I
+SELECT sum(1) FILTER (WHERE NULL) OVER ()
+FROM (VALUES (1)) AS t(x)
+----
+NULL
+
 # query_with_and_without_filter
 query III rowsort
 SELECT


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22773 .

## Rationale for this change

Aggregate and window aggregate `FILTER` clauses currently fail with an internal error when the filter condition is `NULL`, even though the equivalent boolean-typed expression (e.g. `CAST(NULL AS BOOLEAN)`) works correctly.

This occurs because `FILTER` predicates are not being coerced to `BOOLEAN` during type coercion.

## What changes are included in this PR?

* Coerce aggregate `FILTER` predicates to `BOOLEAN` during type coercion.
* Apply the same coercion to window aggregate `FILTER` predicates.
* Add SQL logic tests covering `FILTER (WHERE NULL)` for both aggregate and window aggregate functions.

## Are these changes tested?

Yes.

Added SQL logic tests covering:

* `COUNT(*) FILTER (WHERE NULL)`
* `COUNT(1) FILTER (WHERE NULL)`
* `SUM(1) FILTER (WHERE NULL)`
* `AVG(1) FILTER (WHERE NULL)`
* Window aggregate variants using `FILTER (WHERE NULL)`

## Are there any user-facing changes?

Yes.

Queries using `FILTER (WHERE NULL)` no longer fail with an internal error and now return the expected results. Also, no changes were made to any public APIs