### PR TITLE
test: make ensure_requirements tests deterministic

### DIFF
--- a/datafusion/core/tests/physical_optimizer/ensure_requirements.rs
+++ b/datafusion/core/tests/physical_optimizer/ensure_requirements.rs
@@ -55,6 +55,8 @@ use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 
+const TEST_TARGET_PARTITIONS: usize = 8;
+
 /// Mock ExecutionPlan with configurable partition count and output ordering.
 #[derive(Debug)]
 struct MockMultiPartitionExec {
@@ -124,11 +126,18 @@ impl ExecutionPlan for MockMultiPartitionExec {
     }
 }
 
+fn test_config() -> ConfigOptions {
+    let mut config = ConfigOptions::default();
+    // Keep plan-shape tests deterministic across machines with different CPU counts.
+    config.execution.target_partitions = TEST_TARGET_PARTITIONS;
+    config
+}
+
 /// Helper: run EnsureRequirements and verify SanityCheckPlan passes
 fn optimize_and_sanity_check(
     plan: Arc<dyn ExecutionPlan>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
-    let config = ConfigOptions::default();
+    let config = test_config();
     let optimized = EnsureRequirements::new().optimize(plan, &config)?;
     // SanityCheckPlan must pass
     SanityCheckPlan::new().optimize(Arc::clone(&optimized), &config)?;
@@ -137,7 +146,7 @@ fn optimize_and_sanity_check(
 
 /// Helper: verify idempotency — running twice produces the same plan
 fn assert_idempotent(plan: Arc<dyn ExecutionPlan>) {
-    let config = ConfigOptions::default();
+    let config = test_config();
     let p1 = EnsureRequirements::new()
         .optimize(plan, &config)
         .expect("first optimize failed");
@@ -195,7 +204,7 @@ fn plan_string(plan: &Arc<dyn ExecutionPlan>) -> String {
 /// updating an intentional plan change is a single `cargo insta accept`.
 macro_rules! assert_ensure_requirements_plan {
     ($plan:expr, @ $snapshot:literal $(,)?) => {{
-        let config = ConfigOptions::default();
+        let config = test_config();
         let p1 = EnsureRequirements::new()
             .optimize($plan, &config)
             .expect("EnsureRequirements::optimize failed (pass 1)");
@@ -655,7 +664,7 @@ fn test_issue_21973_idempotent_spm_sort_multi_partition() {
     // No-extra-SPM property: count SortPreservingMergeExec occurrences in
     // the first optimisation pass — must be ≤ 1 (the original SPM survives,
     // none are added).
-    let config = ConfigOptions::default();
+    let config = test_config();
     let optimized = EnsureRequirements::new()
         .optimize(Arc::clone(&limit), &config)
         .expect("optimize failed");
@@ -688,7 +697,7 @@ fn test_issue_21973_parallel_sort_survives_multiple_passes() {
     let sort: Arc<dyn ExecutionPlan> = Arc::new(SortExec::new(sort_expr, coalesce));
     let limit: Arc<dyn ExecutionPlan> = Arc::new(GlobalLimitExec::new(sort, 0, Some(10)));
 
-    let config = ConfigOptions::default();
+    let config = test_config();
 
     let p1 = EnsureRequirements::new()
         .optimize(Arc::clone(&limit), &config)
@@ -816,7 +825,7 @@ fn test_issue_14150_fetch_survives_multiple_passes() {
     let sort = Arc::new(SortExec::new(sort_expr, repartition as _).with_fetch(Some(5)));
     let limit: Arc<dyn ExecutionPlan> = Arc::new(GlobalLimitExec::new(sort, 0, Some(5)));
 
-    let config = ConfigOptions::default();
+    let config = test_config();
 
     // Pass 1
     let p1 = EnsureRequirements::new()
@@ -885,7 +894,7 @@ fn test_issue_14150_fetch_survives_with_input_spm() {
 
     let limit: Arc<dyn ExecutionPlan> = Arc::new(GlobalLimitExec::new(spm, 0, Some(5)));
 
-    let config = ConfigOptions::default();
+    let config = test_config();
 
     let p1 = EnsureRequirements::new()
         .optimize(Arc::clone(&limit), &config)
@@ -1018,7 +1027,7 @@ fn test_idempotent_parallelize_sorts() {
     let limit: Arc<dyn ExecutionPlan> = Arc::new(GlobalLimitExec::new(sort, 0, Some(10)));
 
     // First pass should parallelize the sort (Sort+SPM replaces Coalesce+Sort)
-    let config = ConfigOptions::default();
+    let config = test_config();
     let p1 = EnsureRequirements::new()
         .optimize(Arc::clone(&limit), &config)
         .expect("first optimize failed");
@@ -1194,7 +1203,7 @@ fn test_enforce_distribution_idempotent_hash_join() {
         .expect("HashJoinExec creation failed"),
     );
 
-    let config = ConfigOptions::default();
+    let config = test_config();
     let p1 = EnsureRequirements::new()
         .optimize(Arc::clone(&join), &config)
         .expect("first EnsureRequirements pass failed");


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #22782.

## Rationale for this change

  The `ensure_requirements` plan tests were using `ConfigOptions::default()`.
  That makes `target_partitions` depend on the machine CPU count.

  Because of that, the same test could build a different physical plan on a
  runner with more CPUs. In the failing case, `EnsureRequirements` added an
  extra `RepartitionExec`, so the snapshot changed even though the optimizer was
  doing the right thing.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

  - Add a small test-only config helper with a fixed `target_partitions`
  - Use that helper in the `ensure_requirements` test helpers and the tests in
    this module that directly build a config
  - Keep the plan snapshots and idempotency checks stable across machines with
    different CPU counts

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
