### PR TITLE
perf: Optimize semi-, anti-join index alignment

### DIFF
--- a/benchmarks/src/hj.rs
+++ b/benchmarks/src/hj.rs
@@ -405,6 +405,27 @@ const HASH_QUERIES: &[HashJoinQuery] = &[
         build_size: "100K",
         probe_size: "60M_RightAnti",
     },
+    // Q22: RightSemi, Medium build (100K rows), ~1% Hit rate, fanout ~100
+    //
+    // Build Side: supplier (100K rows) collapsed onto 1K distinct keys
+    // Probe Side: lineitem (60M rows). Each matching probe row produces many
+    // duplicate probe indices before RightSemi deduplication.
+    HashJoinQuery {
+        sql: r###"SELECT l.k
+        FROM (
+          SELECT CAST(((s_suppkey - 1) % 1000) + 1 AS INT) as k
+          FROM supplier
+        ) s
+        RIGHT SEMI JOIN (
+          SELECT CAST(l_suppkey AS INT) as k
+          FROM lineitem
+        ) l
+        ON s.k = l.k"###,
+        density: 1.0,
+        prob_hit: 0.01,
+        build_size: "100K_(fanout_100)",
+        probe_size: "60M_RightSemi",
+    },
 ];
 
 impl RunOpt {

--- a/datafusion/physical-plan/benches/hash_join_semi_anti.rs
+++ b/datafusion/physical-plan/benches/hash_join_semi_anti.rs
@@ -272,6 +272,26 @@ fn bench_hash_join_semi_anti(c: &mut Criterion) {
         });
     }
 
+    // RightSemi - 100% Density, ~1% hit rate, fanout ~100
+    // Build keys are duplicated: 100K rows over 1K distinct keys. Matching
+    // probe rows produce many duplicate probe indices before RightSemi
+    // deduplication.
+    {
+        let fanout_keys = 1_000;
+        let left_batches = build_batches(build_rows, fanout_keys, 0, &s);
+        let right_batches = build_batches(probe_rows, build_rows, 0, &s);
+        group.bench_function(
+            BenchmarkId::new("right_semi_fanout100_h1", probe_rows),
+            |b| {
+                b.iter(|| {
+                    let left = make_exec(&left_batches, &s);
+                    let right = make_exec(&right_batches, &s);
+                    do_hash_join(left, right, JoinType::RightSemi, &rt)
+                })
+            },
+        );
+    }
+
     // =========================================================================
     // RightAnti Join benchmarks
     // =========================================================================

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -42,8 +42,8 @@ pub use crate::joins::{JoinOn, JoinOnRef};
 
 use arrow::array::{
     Array, ArrowPrimitiveType, BooleanBufferBuilder, NativeAdapter, PrimitiveArray,
-    PrimitiveBuilder, RecordBatch, RecordBatchOptions, UInt32Array, UInt32Builder,
-    UInt64Array, builder::UInt64Builder, downcast_array, new_null_array,
+    RecordBatch, RecordBatchOptions, UInt32Array, UInt32Builder, UInt64Array,
+    builder::UInt64Builder, downcast_array, new_null_array,
 };
 use arrow::array::{
     ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array,
@@ -1557,7 +1557,7 @@ pub(crate) fn append_right_indices(
 
 /// Returns `range` indices which are not present in `input_indices`.
 ///
-/// `input_indices` must be sorted ascending.
+/// `input_indices` must be sorted ascending and contain no nulls.
 pub(crate) fn get_anti_indices<T: ArrowPrimitiveType>(
     range: Range<usize>,
     input_indices: &PrimitiveArray<T>,
@@ -1565,6 +1565,11 @@ pub(crate) fn get_anti_indices<T: ArrowPrimitiveType>(
 where
     NativeAdapter<T>: From<<T as ArrowPrimitiveType>::Native>,
 {
+    debug_assert_eq!(
+        input_indices.null_count(),
+        0,
+        "get_anti_indices requires non-null input_indices"
+    );
     debug_assert!(
         input_indices
             .values()
@@ -1574,9 +1579,9 @@ where
     );
 
     let mut next_unmatched_idx = range.start;
-    let mut output = PrimitiveBuilder::<T>::new();
+    let mut output: Vec<T::Native> = Vec::with_capacity(range.len());
 
-    for v in input_indices.iter().flatten() {
+    for &v in input_indices.values() {
         let idx = v.as_usize();
 
         if idx < range.start {
@@ -1587,24 +1592,24 @@ where
         }
 
         if next_unmatched_idx < idx {
-            for value in next_unmatched_idx..idx {
-                output.append_option(T::Native::from_usize(value));
-            }
+            output.extend((next_unmatched_idx..idx).map(|idx| {
+                T::Native::from_usize(idx).expect("join index exceeds output index type")
+            }));
         }
         next_unmatched_idx = idx + 1;
     }
 
     if next_unmatched_idx < range.end {
-        for value in next_unmatched_idx..range.end {
-            output.append_option(T::Native::from_usize(value));
-        }
+        output.extend((next_unmatched_idx..range.end).map(|idx| {
+            T::Native::from_usize(idx).expect("join index exceeds output index type")
+        }));
     }
-    output.finish()
+    PrimitiveArray::<T>::new(output.into(), None)
 }
 
 /// Returns the intersection of `range` and `input_indices`, omitting duplicates.
 ///
-/// `input_indices` must be sorted ascending.
+/// `input_indices` must be sorted ascending and contain no nulls.
 pub(crate) fn get_semi_indices<T: ArrowPrimitiveType>(
     range: Range<usize>,
     input_indices: &PrimitiveArray<T>,
@@ -1612,6 +1617,11 @@ pub(crate) fn get_semi_indices<T: ArrowPrimitiveType>(
 where
     NativeAdapter<T>: From<<T as ArrowPrimitiveType>::Native>,
 {
+    debug_assert_eq!(
+        input_indices.null_count(),
+        0,
+        "get_semi_indices requires non-null input_indices"
+    );
     debug_assert!(
         input_indices
             .values()
@@ -1621,14 +1631,24 @@ where
     );
 
     let mut prev_idx: Option<usize> = None;
-    input_indices
-        .iter()
-        .flatten()
-        .filter_map(|v| {
-            let idx = v.as_usize();
-            (range.contains(&idx) && prev_idx.replace(idx) != Some(idx)).then_some(v)
-        })
-        .collect()
+    let mut output = Vec::with_capacity(input_indices.len().min(range.len()));
+
+    for &v in input_indices.values() {
+        let idx = v.as_usize();
+
+        if idx < range.start {
+            continue;
+        }
+        if idx >= range.end {
+            break;
+        }
+
+        if prev_idx.replace(idx) != Some(idx) {
+            output.push(v);
+        }
+    }
+
+    PrimitiveArray::<T>::new(output.into(), None)
 }
 
 pub(crate) fn get_mark_indices<T: ArrowPrimitiveType>(

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -42,8 +42,8 @@ pub use crate::joins::{JoinOn, JoinOnRef};
 
 use arrow::array::{
     Array, ArrowPrimitiveType, BooleanBufferBuilder, NativeAdapter, PrimitiveArray,
-    RecordBatch, RecordBatchOptions, UInt32Array, UInt32Builder, UInt64Array,
-    builder::UInt64Builder, downcast_array, new_null_array,
+    PrimitiveBuilder, RecordBatch, RecordBatchOptions, UInt32Array, UInt32Builder,
+    UInt64Array, builder::UInt64Builder, downcast_array, new_null_array,
 };
 use arrow::array::{
     ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array,
@@ -1555,7 +1555,9 @@ pub(crate) fn append_right_indices(
     }
 }
 
-/// Returns `range` indices which are not present in `input_indices`
+/// Returns `range` indices which are not present in `input_indices`.
+///
+/// `input_indices` must be sorted ascending.
 pub(crate) fn get_anti_indices<T: ArrowPrimitiveType>(
     range: Range<usize>,
     input_indices: &PrimitiveArray<T>,
@@ -1563,18 +1565,46 @@ pub(crate) fn get_anti_indices<T: ArrowPrimitiveType>(
 where
     NativeAdapter<T>: From<<T as ArrowPrimitiveType>::Native>,
 {
-    let bitmap = build_range_bitmap(&range, input_indices);
-    let offset = range.start;
+    debug_assert!(
+        input_indices
+            .values()
+            .windows(2)
+            .all(|w| w[0].as_usize() <= w[1].as_usize()),
+        "get_anti_indices requires ascending input_indices"
+    );
 
-    // get the anti index
-    (range)
-        .filter_map(|idx| {
-            (!bitmap.get_bit(idx - offset)).then_some(T::Native::from_usize(idx))
-        })
-        .collect()
+    let mut next_unmatched_idx = range.start;
+    let mut output = PrimitiveBuilder::<T>::new();
+
+    for v in input_indices.iter().flatten() {
+        let idx = v.as_usize();
+
+        if idx < range.start {
+            continue;
+        }
+        if idx >= range.end {
+            break;
+        }
+
+        if next_unmatched_idx < idx {
+            for value in next_unmatched_idx..idx {
+                output.append_option(T::Native::from_usize(value));
+            }
+        }
+        next_unmatched_idx = idx + 1;
+    }
+
+    if next_unmatched_idx < range.end {
+        for value in next_unmatched_idx..range.end {
+            output.append_option(T::Native::from_usize(value));
+        }
+    }
+    output.finish()
 }
 
-/// Returns intersection of `range` and `input_indices` omitting duplicates
+/// Returns the intersection of `range` and `input_indices`, omitting duplicates.
+///
+/// `input_indices` must be sorted ascending.
 pub(crate) fn get_semi_indices<T: ArrowPrimitiveType>(
     range: Range<usize>,
     input_indices: &PrimitiveArray<T>,
@@ -1582,12 +1612,21 @@ pub(crate) fn get_semi_indices<T: ArrowPrimitiveType>(
 where
     NativeAdapter<T>: From<<T as ArrowPrimitiveType>::Native>,
 {
-    let bitmap = build_range_bitmap(&range, input_indices);
-    let offset = range.start;
-    // get the semi index
-    (range)
-        .filter_map(|idx| {
-            (bitmap.get_bit(idx - offset)).then_some(T::Native::from_usize(idx))
+    debug_assert!(
+        input_indices
+            .values()
+            .windows(2)
+            .all(|w| w[0].as_usize() <= w[1].as_usize()),
+        "get_semi_indices requires ascending input_indices"
+    );
+
+    let mut prev_idx: Option<usize> = None;
+    input_indices
+        .iter()
+        .flatten()
+        .filter_map(|v| {
+            let idx = v.as_usize();
+            (range.contains(&idx) && prev_idx.replace(idx) != Some(idx)).then_some(v)
         })
         .collect()
 }
@@ -2352,6 +2391,82 @@ mod tests {
     use datafusion_physical_expr::PhysicalSortExpr;
 
     use rstest::rstest;
+
+    fn assert_u32_values(array: &UInt32Array, expected: &[u32]) {
+        assert_eq!(array.values().as_ref(), expected);
+    }
+
+    #[test]
+    fn get_anti_indices_returns_unmatched_range_indices() {
+        let input = UInt32Array::from(vec![3, 5, 5]);
+
+        let result = get_anti_indices(2..8, &input);
+
+        assert_u32_values(&result, &[2, 4, 6, 7]);
+    }
+
+    #[test]
+    fn get_anti_indices_ignores_out_of_range_indices() {
+        let input = UInt32Array::from(vec![0, 1, 3, 5, 8, 12]);
+
+        let result = get_anti_indices(2..8, &input);
+
+        assert_u32_values(&result, &[2, 4, 6, 7]);
+    }
+
+    #[test]
+    fn get_anti_indices_handles_dense_matches() {
+        let input = UInt32Array::from(vec![2, 3, 4, 5]);
+
+        let result = get_anti_indices(2..6, &input);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn get_anti_indices_handles_sparse_matches() {
+        let input = UInt32Array::from(vec![0, 8]);
+
+        let result = get_anti_indices(2..6, &input);
+
+        assert_u32_values(&result, &[2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn get_semi_indices_returns_distinct_matches_in_range() {
+        let input = UInt32Array::from(vec![1, 3, 3, 3, 5, 8]);
+
+        let result = get_semi_indices(2..7, &input);
+
+        assert_u32_values(&result, &[3, 5]);
+    }
+
+    #[test]
+    fn get_semi_indices_ignores_out_of_range_indices() {
+        let input = UInt32Array::from(vec![0, 1, 3, 5, 8, 12]);
+
+        let result = get_semi_indices(2..8, &input);
+
+        assert_u32_values(&result, &[3, 5]);
+    }
+
+    #[test]
+    fn get_semi_indices_handles_dense_matches() {
+        let input = UInt32Array::from(vec![2, 3, 4, 5]);
+
+        let result = get_semi_indices(2..6, &input);
+
+        assert_u32_values(&result, &[2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn get_semi_indices_handles_empty_input() {
+        let input = UInt32Array::from(Vec::<u32>::new());
+
+        let result = get_semi_indices(2..6, &input);
+
+        assert!(result.is_empty());
+    }
 
     fn check(
         left: &[Column],


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22793
- related to https://github.com/apache/datafusion/pull/22652

## Rationale for this change

`get_semi_indices` computes the duplicate-free intersection between a `Range` and a `PrimitiveArray` of integer indices (containing probe matches). The previous algorithm constructs a bitmap from the `Range` and then probes the bitmap for every element in the range. This does work linear in the size of the range and also allocates an intermediate data structure.

We can do better by leveraging the fact that the input index array is sorted: iterate over the inputs, check membership in the `Range`, and do duplicate elimination by just comparing with the previous member of the array. This does work linear in the number of matches and avoids the intermediate data structure.

We can optimize `get_anti_indices` in a similar manner, except we just need to emit the in-range gaps between array elements instead of the array elements themselves.

This improves the performance of `RightSemi` and `RightAnti` joins, as well as outer joins (since those also call `get_anti_indices`).

## Benchmarks

Criterion: hash_join_semi_anti

```
    RightSemi
      right_semi_d100_h100       8.559 ms -> 5.639 ms   34.1% faster
      right_semi_d100_h10        1.726 ms -> 0.949 ms   45.0% faster
      right_semi_d50_h100        8.567 ms -> 5.623 ms   34.4% faster
      right_semi_d50_h10         1.734 ms -> 0.943 ms   45.6% faster
      right_semi_d10_h100       10.860 ms -> 7.894 ms   27.3% faster
      right_semi_d10_h10         8.475 ms -> 7.363 ms   13.1% faster
      right_semi_fanout100_h1    4.834 ms -> 2.840 ms   41.2% faster

    RightAnti
      right_anti_d100_h100       3.464 ms -> 1.877 ms   45.8% faster
      right_anti_d100_h10        5.764 ms -> 3.691 ms   36.0% faster
      right_anti_d50_h100        3.475 ms -> 1.904 ms   45.2% faster
      right_anti_d50_h10         5.769 ms -> 3.693 ms   36.0% faster
      right_anti_d10_h100        5.757 ms -> 4.195 ms   27.1% faster
      right_anti_d10_h10        12.481 ms -> 10.252 ms  17.9% faster
```

dfbench hj, SF10, partitions=1, batch_size=8192

```
      Q16 RightSemi              9.486 ms -> 5.519 ms    41.8% faster
      Q17 RightSemi            675.164 ms -> 516.952 ms  23.4% faster
      Q18 RightSemi            687.759 ms -> 636.913 ms   7.4% faster
      Q22 RightSemi fanout     868.412 ms -> 735.980 ms  15.2% faster
```

## What changes are included in this PR?

* Optimize `get_semi_indices` and `get_anti_indices` as described above
* Unit tests
* Add benchmark cases to cover high-fanout workloads

## Are these changes tested?

Yes; new tests added.

## Are there any user-facing changes?

No.