### PR TITLE
Refactor post-aggregate clause rebasing and validation with shared helpers

### DIFF
--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -133,6 +133,56 @@ fn rebase_and_validate_optional_post_aggregate_expr(
     Ok(rebased_exprs.pop())
 }
 
+fn rebase_and_validate_post_aggregate_sort_exprs(
+    sort_exprs: &[SortExpr],
+    select_exprs_post_aggr: &[Expr],
+    aggr_projection_exprs: &[Expr],
+    input: &LogicalPlan,
+    valid_exprs: &[Expr],
+) -> Result<Vec<SortExpr>> {
+    let order_by_post_aggr = sort_exprs
+        .iter()
+        .map(|sort_expr| {
+            let rewritten_expr =
+                rebase_expr(&sort_expr.expr, aggr_projection_exprs, input)?;
+
+            // If this ORDER BY expression matches an aliased SELECT expression,
+            // use the SELECT alias instead of the raw expression.
+            let final_expr = select_exprs_post_aggr
+                .iter()
+                .find_map(|select_expr| {
+                    if let Expr::Alias(alias) = select_expr {
+                        let rewritten_unaliased = match &rewritten_expr {
+                            Expr::Alias(a) => a.expr.as_ref(),
+                            other => other,
+                        };
+                        if alias.expr.as_ref() == rewritten_unaliased {
+                            return Some(Expr::Column(Column::new_unqualified(
+                                alias.name.clone(),
+                            )));
+                        }
+                    }
+                    None
+                })
+                .unwrap_or(rewritten_expr);
+
+            Ok(sort_expr.with_expr(final_expr))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let order_by_exprs_only: Vec<Expr> =
+        order_by_post_aggr.iter().map(|s| s.expr.clone()).collect();
+    check_columns_satisfy_exprs(
+        valid_exprs,
+        &order_by_exprs_only,
+        CheckColumnsSatisfyExprsPurpose::Aggregate(
+            CheckColumnsMustReferenceAggregatePurpose::OrderBy,
+        ),
+    )?;
+
+    Ok(order_by_post_aggr)
+}
+
 impl<S: ContextProvider> SqlToRel<'_, S> {
     /// Generate a logic plan from an SQL select
     pub(super) fn select_to_plan(
@@ -1303,41 +1353,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             CheckColumnsMustReferenceAggregatePurpose::Qualify,
         )?;
 
-        // Rewrite the ORDER BY expressions to use the columns produced by the
-        // aggregation. If an ORDER BY expression matches a SELECT expression
-        // (ignoring aliases), use the SELECT's output column name to avoid
-        // duplication when the SELECT expression has an alias.
-        let order_by_post_aggr = order_by_exprs
-            .iter()
-            .map(|sort_expr| {
-                let rewritten_expr =
-                    rebase_expr(&sort_expr.expr, &aggr_projection_exprs, input)?;
-
-                // Check if this ORDER BY expression matches any aliased SELECT expression
-                // If so, use the SELECT's alias instead of the raw expression
-                let final_expr = select_exprs_post_aggr
-                    .iter()
-                    .find_map(|select_expr| {
-                        // Only consider aliased expressions
-                        if let Expr::Alias(alias) = select_expr {
-                            let rewritten_unaliased = match &rewritten_expr {
-                                Expr::Alias(a) => a.expr.as_ref(),
-                                other => other,
-                            };
-                            if alias.expr.as_ref() == rewritten_unaliased {
-                                return Some(Expr::Column(Column::new_unqualified(
-                                    alias.name.clone(),
-                                )));
-                            }
-                        }
-                        None
-                    })
-                    .unwrap_or(rewritten_expr);
-
-                Ok(sort_expr.with_expr(final_expr))
-            })
-            .collect::<Result<Vec<SortExpr>>>()?;
-
         let all_valid_exprs: Vec<Expr> = column_exprs_post_aggr
             .iter()
             .cloned()
@@ -1350,14 +1365,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             }))
             .collect();
 
-        let order_by_exprs_only: Vec<Expr> =
-            order_by_post_aggr.iter().map(|s| s.expr.clone()).collect();
-        check_columns_satisfy_exprs(
+        // Rewrite ORDER BY expressions to use the columns produced by the
+        // aggregation, preserve SELECT-alias remapping, and validate against
+        // aggregate outputs plus SELECT aliases.
+        let order_by_post_aggr = rebase_and_validate_post_aggregate_sort_exprs(
+            order_by_exprs,
+            &select_exprs_post_aggr,
+            &aggr_projection_exprs,
+            input,
             &all_valid_exprs,
-            &order_by_exprs_only,
-            CheckColumnsSatisfyExprsPurpose::Aggregate(
-                CheckColumnsMustReferenceAggregatePurpose::OrderBy,
-            ),
         )?;
 
         // Rewrite DISTINCT ON expressions to use the columns produced by the

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -111,6 +111,28 @@ fn rebase_and_validate_post_aggregate_exprs(
     Ok(rebased_exprs)
 }
 
+fn rebase_and_validate_optional_post_aggregate_expr(
+    expr: Option<&Expr>,
+    aggr_projection_exprs: &[Expr],
+    input: &LogicalPlan,
+    valid_column_exprs: &[Expr],
+    purpose: CheckColumnsMustReferenceAggregatePurpose,
+) -> Result<Option<Expr>> {
+    let Some(expr) = expr else {
+        return Ok(None);
+    };
+
+    let mut rebased_exprs = rebase_and_validate_post_aggregate_exprs(
+        std::slice::from_ref(expr),
+        aggr_projection_exprs,
+        input,
+        valid_column_exprs,
+        purpose,
+    )?;
+
+    Ok(rebased_exprs.pop())
+}
+
 impl<S: ContextProvider> SqlToRel<'_, S> {
     /// Generate a logic plan from an SQL select
     pub(super) fn select_to_plan(
@@ -1262,43 +1284,24 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             CheckColumnsMustReferenceAggregatePurpose::Projection,
         )?;
 
-        // Rewrite the HAVING expression to use the columns produced by the
-        // aggregation.
-        let having_expr_post_aggr = if let Some(having_expr) = having_expr_opt {
-            let having_expr_post_aggr =
-                rebase_expr(having_expr, &aggr_projection_exprs, input)?;
+        // Rewrite HAVING and QUALIFY to use the columns produced by the
+        // aggregation, and validate that they can be resolved from the
+        // aggregate output columns.
+        let having_expr_post_aggr = rebase_and_validate_optional_post_aggregate_expr(
+            having_expr_opt,
+            &aggr_projection_exprs,
+            input,
+            &column_exprs_post_aggr,
+            CheckColumnsMustReferenceAggregatePurpose::Having,
+        )?;
 
-            check_columns_satisfy_exprs(
-                &column_exprs_post_aggr,
-                std::slice::from_ref(&having_expr_post_aggr),
-                CheckColumnsSatisfyExprsPurpose::Aggregate(
-                    CheckColumnsMustReferenceAggregatePurpose::Having,
-                ),
-            )?;
-
-            Some(having_expr_post_aggr)
-        } else {
-            None
-        };
-
-        // Rewrite the QUALIFY expression to use the columns produced by the
-        // aggregation.
-        let qualify_expr_post_aggr = if let Some(qualify_expr) = qualify_expr_opt {
-            let qualify_expr_post_aggr =
-                rebase_expr(qualify_expr, &aggr_projection_exprs, input)?;
-
-            check_columns_satisfy_exprs(
-                &column_exprs_post_aggr,
-                std::slice::from_ref(&qualify_expr_post_aggr),
-                CheckColumnsSatisfyExprsPurpose::Aggregate(
-                    CheckColumnsMustReferenceAggregatePurpose::Qualify,
-                ),
-            )?;
-
-            Some(qualify_expr_post_aggr)
-        } else {
-            None
-        };
+        let qualify_expr_post_aggr = rebase_and_validate_optional_post_aggregate_expr(
+            qualify_expr_opt,
+            &aggr_projection_exprs,
+            input,
+            &column_exprs_post_aggr,
+            CheckColumnsMustReferenceAggregatePurpose::Qualify,
+        )?;
 
         // Rewrite the ORDER BY expressions to use the columns produced by the
         // aggregation. If an ORDER BY expression matches a SELECT expression

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -90,6 +90,27 @@ fn flatten_expr_groups(expr_groups: Vec<Vec<Expr>>) -> Vec<Expr> {
     expr_groups.into_iter().flatten().collect()
 }
 
+fn rebase_and_validate_post_aggregate_exprs(
+    exprs: &[Expr],
+    aggr_projection_exprs: &[Expr],
+    input: &LogicalPlan,
+    valid_exprs: &[Expr],
+    purpose: CheckColumnsMustReferenceAggregatePurpose,
+) -> Result<Vec<Expr>> {
+    let rebased_exprs = exprs
+        .iter()
+        .map(|expr| rebase_expr(expr, aggr_projection_exprs, input))
+        .collect::<Result<Vec<Expr>>>()?;
+
+    check_columns_satisfy_exprs(
+        valid_exprs,
+        &rebased_exprs,
+        CheckColumnsSatisfyExprsPurpose::Aggregate(purpose),
+    )?;
+
+    Ok(rebased_exprs)
+}
+
 impl<S: ContextProvider> SqlToRel<'_, S> {
     /// Generate a logic plan from an SQL select
     pub(super) fn select_to_plan(
@@ -1230,20 +1251,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             .map(|expr| expr_as_column_expr(expr, input))
             .collect::<Result<Vec<Expr>>>()?;
 
-        // next we re-write the projection
-        let select_exprs_post_aggr = select_exprs
-            .iter()
-            .map(|expr| rebase_expr(expr, &aggr_projection_exprs, input))
-            .collect::<Result<Vec<Expr>>>()?;
-
-        // finally, we have some validation that the re-written projection can be resolved
-        // from the aggregate output columns
-        check_columns_satisfy_exprs(
+        // Rewrite the projection to use the columns produced by the
+        // aggregation, and validate that it can be resolved from the
+        // aggregate output columns.
+        let select_exprs_post_aggr = rebase_and_validate_post_aggregate_exprs(
+            select_exprs,
+            &aggr_projection_exprs,
+            input,
             &column_exprs_post_aggr,
-            &select_exprs_post_aggr,
-            CheckColumnsSatisfyExprsPurpose::Aggregate(
-                CheckColumnsMustReferenceAggregatePurpose::Projection,
-            ),
+            CheckColumnsMustReferenceAggregatePurpose::Projection,
         )?;
 
         // Rewrite the HAVING expression to use the columns produced by the

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -122,15 +122,37 @@ fn rebase_and_validate_optional_post_aggregate_expr(
         return Ok(None);
     };
 
-    let mut rebased_exprs = rebase_and_validate_post_aggregate_exprs(
+    let rebased_expr = rebase_and_validate_post_aggregate_exprs(
         std::slice::from_ref(expr),
         aggr_projection_exprs,
         input,
         valid_column_exprs,
         purpose,
-    )?;
+    )?
+    .into_iter()
+    .next()
+    .expect("single input expression returns one rebased expression");
 
-    Ok(rebased_exprs.pop())
+    Ok(Some(rebased_expr))
+}
+
+fn order_by_select_alias_expr(
+    rewritten_expr: &Expr,
+    select_exprs_post_aggr: &[Expr],
+) -> Option<Expr> {
+    select_exprs_post_aggr.iter().find_map(|select_expr| {
+        let Expr::Alias(alias) = select_expr else {
+            return None;
+        };
+
+        let rewritten_unaliased = match rewritten_expr {
+            Expr::Alias(a) => a.expr.as_ref(),
+            other => other,
+        };
+
+        (alias.expr.as_ref() == rewritten_unaliased)
+            .then(|| Expr::Column(Column::new_unqualified(alias.name.clone())))
+    })
 }
 
 fn rebase_and_validate_post_aggregate_sort_exprs(
@@ -146,25 +168,9 @@ fn rebase_and_validate_post_aggregate_sort_exprs(
             let rewritten_expr =
                 rebase_expr(&sort_expr.expr, aggr_projection_exprs, input)?;
 
-            // If this ORDER BY expression matches an aliased SELECT expression,
-            // use the SELECT alias instead of the raw expression.
-            let final_expr = select_exprs_post_aggr
-                .iter()
-                .find_map(|select_expr| {
-                    if let Expr::Alias(alias) = select_expr {
-                        let rewritten_unaliased = match &rewritten_expr {
-                            Expr::Alias(a) => a.expr.as_ref(),
-                            other => other,
-                        };
-                        if alias.expr.as_ref() == rewritten_unaliased {
-                            return Some(Expr::Column(Column::new_unqualified(
-                                alias.name.clone(),
-                            )));
-                        }
-                    }
-                    None
-                })
-                .unwrap_or(rewritten_expr);
+            let final_expr =
+                order_by_select_alias_expr(&rewritten_expr, select_exprs_post_aggr)
+                    .unwrap_or(rewritten_expr);
 
             Ok(sort_expr.with_expr(final_expr))
         })
@@ -1356,17 +1362,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         let all_valid_exprs: Vec<Expr> = column_exprs_post_aggr
             .iter()
             .cloned()
-            .chain(select_exprs_post_aggr.iter().filter_map(|e| {
-                if let Expr::Alias(alias) = e {
+            .chain(select_exprs_post_aggr.iter().filter_map(|expr| match expr {
+                Expr::Alias(alias) => {
                     Some(Expr::Column(Column::new_unqualified(alias.name.clone())))
-                } else {
-                    None
                 }
+                _ => None,
             }))
             .collect();
 
-        // Rewrite ORDER BY expressions to use the columns produced by the
-        // aggregation, preserve SELECT-alias remapping, and validate against
+        // Preserve ORDER BY SELECT-alias remapping and validate against
         // aggregate outputs plus SELECT aliases.
         let order_by_post_aggr = rebase_and_validate_post_aggregate_sort_exprs(
             order_by_exprs,

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -1360,19 +1360,16 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             ),
         )?;
 
-        // Rewrite the DISTINCT ON expressions to use the columns produced by
-        // the aggregation. Same shape as ORDER BY rewriting so a hidden
-        // grouping column or a raw aggregate expression in ON is resolved.
-        let on_exprs_post_aggr = on_exprs
-            .iter()
-            .map(|expr| rebase_expr(expr, &aggr_projection_exprs, input))
-            .collect::<Result<Vec<Expr>>>()?;
-        check_columns_satisfy_exprs(
+        // Rewrite DISTINCT ON expressions to use the columns produced by the
+        // aggregation. Validate against aggregate outputs plus SELECT aliases
+        // so a hidden grouping column, raw aggregate expression, or allowed
+        // top-level SELECT alias in ON is resolved.
+        let on_exprs_post_aggr = rebase_and_validate_post_aggregate_exprs(
+            on_exprs,
+            &aggr_projection_exprs,
+            input,
             &all_valid_exprs,
-            &on_exprs_post_aggr,
-            CheckColumnsSatisfyExprsPurpose::Aggregate(
-                CheckColumnsMustReferenceAggregatePurpose::DistinctOn,
-            ),
+            CheckColumnsMustReferenceAggregatePurpose::DistinctOn,
         )?;
 
         Ok(AggregatePlanResult {

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -94,16 +94,16 @@ fn rebase_and_validate_post_aggregate_exprs(
     exprs: &[Expr],
     aggr_projection_exprs: &[Expr],
     input: &LogicalPlan,
-    valid_exprs: &[Expr],
+    valid_column_exprs: &[Expr],
     purpose: CheckColumnsMustReferenceAggregatePurpose,
 ) -> Result<Vec<Expr>> {
     let rebased_exprs = exprs
         .iter()
         .map(|expr| rebase_expr(expr, aggr_projection_exprs, input))
-        .collect::<Result<Vec<Expr>>>()?;
+        .collect::<Result<Vec<_>>>()?;
 
     check_columns_satisfy_exprs(
-        valid_exprs,
+        valid_column_exprs,
         &rebased_exprs,
         CheckColumnsSatisfyExprsPurpose::Aggregate(purpose),
     )?;

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -9160,3 +9160,50 @@ SET datafusion.execution.target_partitions = 4;
 
 statement ok
 DROP TABLE hits_raw;
+
+# Post-aggregate clause rebasing / validation coverage for future refactors.
+# These queries intentionally cover the clause-specific diagnostics produced by
+# CheckColumnsMustReferenceAggregatePurpose in datafusion/sql/src/utils.rs.
+
+# SELECT projection rejects non-grouped, non-aggregate input columns.
+query error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function
+WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
+SELECT a, b, sum(c) FROM t GROUP BY a;
+
+# HAVING rejects non-grouped, non-aggregate input columns.
+query error DataFusion error: Error during planning: Column in HAVING must be in GROUP BY or an aggregate function
+WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
+SELECT a, sum(c) FROM t GROUP BY a HAVING b > 10;
+
+# QUALIFY rejects non-grouped, non-aggregate input columns while preserving
+# QUALIFY-specific aggregate-boundary diagnostics.
+query error DataFusion error: Error during planning: Column in QUALIFY must be in GROUP BY or an aggregate function
+WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
+SELECT a, sum(c) FROM t GROUP BY a
+QUALIFY row_number() OVER (ORDER BY a) = 1 AND b > 10;
+
+# ORDER BY rejects non-grouped, non-aggregate input columns.
+query error DataFusion error: Error during planning: Column in ORDER BY must be in GROUP BY or an aggregate function
+WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
+SELECT a, sum(c) FROM t GROUP BY a ORDER BY b;
+
+# DISTINCT ON rejects non-grouped, non-aggregate input columns.
+query error DataFusion error: Error during planning: Column in DISTINCT ON must be in GROUP BY or an aggregate function
+WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
+SELECT DISTINCT ON (b) a, sum(c) FROM t GROUP BY a;
+
+# ORDER BY still accepts a top-level SELECT aggregate alias after aggregation.
+query II
+WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 400))
+SELECT a, sum(c) AS total FROM t GROUP BY a ORDER BY total, a;
+----
+1 300
+2 400
+
+# DISTINCT ON still accepts a top-level SELECT aggregate alias after aggregation.
+query II
+WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 400))
+SELECT DISTINCT ON (total) a, sum(c) AS total FROM t GROUP BY a ORDER BY total, a;
+----
+1 300
+2 400

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -9164,46 +9164,46 @@ DROP TABLE hits_raw;
 # Post-aggregate clause rebasing / validation coverage for future refactors.
 # These queries intentionally cover the clause-specific diagnostics produced by
 # CheckColumnsMustReferenceAggregatePurpose in datafusion/sql/src/utils.rs.
+statement ok
+CREATE TABLE post_aggregate_clause_validation(a int, b int, c int) AS
+VALUES (1, 10, 100), (1, 20, 200), (2, 30, 400);
 
 # SELECT projection rejects non-grouped, non-aggregate input columns.
 query error DataFusion error: Error during planning: Column in SELECT must be in GROUP BY or an aggregate function
-WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
-SELECT a, b, sum(c) FROM t GROUP BY a;
+SELECT a, b, sum(c) FROM post_aggregate_clause_validation GROUP BY a;
 
 # HAVING rejects non-grouped, non-aggregate input columns.
 query error DataFusion error: Error during planning: Column in HAVING must be in GROUP BY or an aggregate function
-WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
-SELECT a, sum(c) FROM t GROUP BY a HAVING b > 10;
+SELECT a, sum(c) FROM post_aggregate_clause_validation GROUP BY a HAVING b > 10;
 
 # QUALIFY rejects non-grouped, non-aggregate input columns while preserving
 # QUALIFY-specific aggregate-boundary diagnostics.
 query error DataFusion error: Error during planning: Column in QUALIFY must be in GROUP BY or an aggregate function
-WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
-SELECT a, sum(c) FROM t GROUP BY a
+SELECT a, sum(c) FROM post_aggregate_clause_validation GROUP BY a
 QUALIFY row_number() OVER (ORDER BY a) = 1 AND b > 10;
 
 # ORDER BY rejects non-grouped, non-aggregate input columns.
 query error DataFusion error: Error during planning: Column in ORDER BY must be in GROUP BY or an aggregate function
-WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
-SELECT a, sum(c) FROM t GROUP BY a ORDER BY b;
+SELECT a, sum(c) FROM post_aggregate_clause_validation GROUP BY a ORDER BY b;
 
 # DISTINCT ON rejects non-grouped, non-aggregate input columns.
 query error DataFusion error: Error during planning: Column in DISTINCT ON must be in GROUP BY or an aggregate function
-WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 300))
-SELECT DISTINCT ON (b) a, sum(c) FROM t GROUP BY a;
+SELECT DISTINCT ON (b) a, sum(c) FROM post_aggregate_clause_validation GROUP BY a;
 
 # ORDER BY still accepts a top-level SELECT aggregate alias after aggregation.
 query II
-WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 400))
-SELECT a, sum(c) AS total FROM t GROUP BY a ORDER BY total, a;
+SELECT a, sum(c) AS total FROM post_aggregate_clause_validation GROUP BY a ORDER BY total, a;
 ----
 1 300
 2 400
 
 # DISTINCT ON still accepts a top-level SELECT aggregate alias after aggregation.
 query II
-WITH t(a, b, c) AS (VALUES (1, 10, 100), (1, 20, 200), (2, 30, 400))
-SELECT DISTINCT ON (total) a, sum(c) AS total FROM t GROUP BY a ORDER BY total, a;
+SELECT DISTINCT ON (total) a, sum(c) AS total
+FROM post_aggregate_clause_validation GROUP BY a ORDER BY total, a;
 ----
 1 300
 2 400
+
+statement ok
+DROP TABLE post_aggregate_clause_validation;

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -9197,6 +9197,14 @@ SELECT a, sum(c) AS total FROM post_aggregate_clause_validation GROUP BY a ORDER
 1 300
 2 400
 
+# ORDER BY preserves sort direction and null ordering when remapping a SELECT aggregate alias.
+query II
+SELECT a, sum(c) AS total
+FROM post_aggregate_clause_validation GROUP BY a ORDER BY total DESC NULLS LAST, a;
+----
+2 400
+1 300
+
 # DISTINCT ON still accepts a top-level SELECT aggregate alias after aggregation.
 query II
 SELECT DISTINCT ON (total) a, sum(c) AS total


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22684

## Rationale for this change

`SqlToRel::aggregate` contained several implementations of the same post-aggregate workflow across SELECT, HAVING, QUALIFY, ORDER BY, and DISTINCT ON:

1. Rebase expressions against aggregate output expressions.
2. Validate rebased expressions at the aggregate boundary.
3. Apply clause-specific diagnostics via `CheckColumnsMustReferenceAggregatePurpose`.

Maintaining this logic in multiple places increases the risk of behavioral drift during future planner changes. This change consolidates the shared mechanics into private helper functions while preserving existing SQL semantics, alias handling, sort behavior, and clause-specific error messages. 

## What changes are included in this PR?

* Added private helper functions for post-aggregate expression processing:

  * `rebase_and_validate_post_aggregate_exprs`
  * `rebase_and_validate_optional_post_aggregate_expr`
  * `rebase_and_validate_post_aggregate_sort_exprs`
  * `order_by_select_alias_expr`
* Migrated SELECT projection post-aggregate rebasing and validation to shared helper logic.
* Migrated HAVING and QUALIFY post-aggregate rebasing and validation to shared helper logic.
* Migrated DISTINCT ON post-aggregate rebasing and validation to shared helper logic while continuing to validate against aggregate outputs plus valid SELECT aliases.
* Migrated ORDER BY post-aggregate rebasing and validation to a dedicated helper that:

  * Preserves existing SELECT-alias remapping behavior.
  * Preserves sort direction and NULL ordering via `SortExpr::with_expr`.
  * Continues validating with ORDER BY-specific aggregate-boundary diagnostics.
* Simplified aggregate planning code by removing duplicated rebasing and validation logic. 

## Are these changes tested?

Yes.

Added SQLLogicTest coverage in `aggregate.slt` for:

* SELECT projection aggregate-boundary validation errors.
* HAVING aggregate-boundary validation errors.
* QUALIFY aggregate-boundary validation errors.
* ORDER BY aggregate-boundary validation errors.
* DISTINCT ON aggregate-boundary validation errors.
* ORDER BY using a top-level SELECT aggregate alias after aggregation.
* Preservation of ORDER BY sort direction and NULL ordering when remapping a SELECT alias.
* DISTINCT ON using a top-level SELECT aggregate alias after aggregation. 

## Are there any user-facing changes?

No intended user-facing behavior changes.

This PR is a refactor that preserves existing aggregate planning semantics while adding regression coverage for clause-specific validation diagnostics and alias-handling behavior. 

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed and tested.
