### PR TITLE
Optimize ArrayMap right semi joins

### DIFF
--- a/datafusion/physical-plan/src/joins/array_map.rs
+++ b/datafusion/physical-plan/src/joins/array_map.rs
@@ -264,6 +264,35 @@ impl ArrayMap {
         )
     }
 
+    pub fn get_matching_probe_indices_with_limit_offset(
+        &self,
+        prob_side_keys: &[ArrayRef],
+        limit: usize,
+        current_offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+        build_indices: &mut Vec<u64>,
+    ) -> Result<Option<MapOffset>> {
+        if prob_side_keys.len() != 1 {
+            return internal_err!(
+                "ArrayMap expects 1 join key, but got {}",
+                prob_side_keys.len()
+            );
+        }
+        let array = &prob_side_keys[0];
+
+        downcast_supported_integer!(
+            array.data_type() => (
+                lookup_and_get_probe_indices,
+                self,
+                array,
+                limit,
+                current_offset,
+                probe_indices,
+                build_indices
+            )
+        )
+    }
+
     fn lookup_and_get_indices<T: ArrowNumericType>(
         &self,
         array: &ArrayRef,
@@ -368,6 +397,57 @@ impl ArrayMap {
             }
             Ok(None)
         }
+    }
+
+    fn lookup_and_get_probe_indices<T: ArrowNumericType>(
+        &self,
+        array: &ArrayRef,
+        limit: usize,
+        current_offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+        build_indices: &mut Vec<u64>,
+    ) -> Result<Option<MapOffset>>
+    where
+        T::Native: Copy + AsPrimitive<u64>,
+    {
+        probe_indices.clear();
+        build_indices.clear();
+
+        if limit == 0 {
+            return Ok(Some(current_offset));
+        }
+
+        debug_assert!(
+            current_offset.1.is_none(),
+            "existence lookup should only resume between probe rows"
+        );
+
+        let arr = array.as_primitive::<T>();
+        let mut remaining_output = limit;
+
+        for prob_idx in current_offset.0..arr.len() {
+            if arr.is_null(prob_idx) {
+                continue;
+            }
+
+            // SAFETY: prob_idx is guaranteed to be within bounds by the loop range.
+            let prob_val: u64 = unsafe { arr.value_unchecked(prob_idx) }.as_();
+            let idx_in_build_side = prob_val.wrapping_sub(self.offset) as usize;
+
+            if idx_in_build_side >= self.data.len() || self.data[idx_in_build_side] == 0 {
+                continue;
+            }
+
+            build_indices.push((self.data[idx_in_build_side] - 1) as u64);
+            probe_indices.push(prob_idx as u32);
+            remaining_output -= 1;
+
+            if remaining_output == 0 {
+                return Ok((prob_idx + 1 < arr.len()).then_some((prob_idx + 1, None)));
+            }
+        }
+
+        Ok(None)
     }
 
     pub fn contain_keys(&self, probe_side_keys: &[ArrayRef]) -> Result<BooleanArray> {
@@ -503,6 +583,43 @@ mod tests {
         assert_eq!(prob_indices, vec![1, 1, 3]);
         assert_eq!(build_indices, vec![0, 1, 0]);
         assert_eq!(result_offset, Some((3, Some(2))));
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_map_matching_probe_indices_omits_build_duplicates() -> Result<()> {
+        let build_array: ArrayRef = Arc::new(Int32Array::from(vec![1, 1, 2]));
+        let array_map = ArrayMap::try_new(&build_array, 1, 2)?;
+        let probe_array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 1]));
+        let prob_side_keys = [probe_array];
+
+        let mut prob_indices = Vec::new();
+        let mut build_indices = Vec::new();
+
+        let result_offset = array_map.get_matching_probe_indices_with_limit_offset(
+            &prob_side_keys,
+            2,
+            (0, None),
+            &mut prob_indices,
+            &mut build_indices,
+        )?;
+
+        assert_eq!(prob_indices, vec![0, 1]);
+        assert_eq!(build_indices, vec![0, 2]);
+        assert_eq!(result_offset, Some((2, None)));
+
+        let result_offset = array_map.get_matching_probe_indices_with_limit_offset(
+            &prob_side_keys,
+            2,
+            result_offset.unwrap(),
+            &mut prob_indices,
+            &mut build_indices,
+        )?;
+
+        assert_eq!(prob_indices, vec![3]);
+        assert_eq!(build_indices, vec![0]);
+        assert_eq!(result_offset, None);
+
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -429,6 +429,13 @@ pub(super) fn lookup_join_hashmap(
     Ok((build_indices, probe_indices, next_offset))
 }
 
+fn can_use_array_map_right_semi_fast_path(
+    join_type: JoinType,
+    filter: &Option<JoinFilter>,
+) -> bool {
+    matches!(join_type, JoinType::RightSemi) && filter.is_none()
+}
+
 /// Counts the number of distinct elements in the input array.
 ///
 /// The input array must be sorted (e.g., `[0, 1, 1, 2, 2, ...]`) and contain no null values.
@@ -781,6 +788,9 @@ impl HashJoinStream {
             return Ok(StatefulStreamResult::Continue);
         }
 
+        let use_array_map_right_semi_fast_path =
+            can_use_array_map_right_semi_fast_path(self.join_type, &self.filter);
+
         // get the matched by join keys indices
         let (left_indices, right_indices, next_offset) = match build_side.left_data.map()
         {
@@ -795,6 +805,27 @@ impl HashJoinStream {
                 &mut self.probe_indices_buffer,
                 &mut self.build_indices_buffer,
             )?,
+            Map::ArrayMap(array_map) if use_array_map_right_semi_fast_path => {
+                let next_offset = array_map
+                    .get_matching_probe_indices_with_limit_offset(
+                        &state.values,
+                        self.batch_size,
+                        state.offset,
+                        &mut self.probe_indices_buffer,
+                        &mut self.build_indices_buffer,
+                    )?;
+                (
+                    UInt64Array::from(std::mem::replace(
+                        &mut self.build_indices_buffer,
+                        Vec::with_capacity(self.batch_size),
+                    )),
+                    UInt32Array::from(std::mem::replace(
+                        &mut self.probe_indices_buffer,
+                        Vec::with_capacity(self.batch_size),
+                    )),
+                    next_offset,
+                )
+            }
             Map::ArrayMap(array_map) => {
                 let next_offset = array_map.get_matched_indices_with_limit_offset(
                     &state.values,


### PR DESCRIPTION
## Which issue does this PR close?

N/A.

## Rationale for this change

Right semi hash joins backed by ArrayMap only need to know whether each probe-side row has at least one build-side match. The previous path materialized every duplicate build-side match and then deduplicated probe indices, which is expensive for fanout-heavy keys.

On this machine, `right_semi_fanout100_h1` went from about `4.20 ms` to about `920 us`, a roughly 78% reduction.

## What changes are included in this PR?

- Add an ArrayMap lookup that emits one matching probe index per probe row.
- Use that lookup for unfiltered HashJoinExec RightSemi joins when the build map is ArrayMap.
- Add coverage for duplicate build keys and limited-offset continuation.

## Are these changes tested?

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p datafusion-physical-plan --lib test_array_map_matching_probe_indices_omits_build_duplicates`
- `cargo test -p datafusion-physical-plan --lib join_right_semi`
- `cargo bench -p datafusion-physical-plan --features test_utils --bench hash_join_semi_anti -- right_semi_fanout100_h1 --sample-size 10 --warm-up-time 1 --measurement-time 3`

## Are there any user-facing changes?

No.
