### PR TITLE
Optimize existence-only right semi and anti joins

### DIFF
--- a/datafusion/physical-plan/benches/hash_join_semi_anti.rs
+++ b/datafusion/physical-plan/benches/hash_join_semi_anti.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Criterion benchmarks for Hash Join with RightSemi/RightAnti joins with Int32 keys.
+//! Criterion benchmarks for Hash Join with RightSemi/RightAnti/RightMark joins with Int32 keys.
 //!
 //! ## Key Benchmark Axes
 //!
@@ -37,7 +37,7 @@
 //! - **Hit Rate**: The percentage of probe rows that find a match in the build side.
 //!   This controls how often the join produces output rows.
 //!
-//! Semi/anti joins can short-circuit after finding the first match, so these
+//! Semi/anti/mark joins can short-circuit after finding the first match, so these
 //! benchmarks help evaluate optimization strategies for existence checks.
 
 use std::sync::Arc;
@@ -287,6 +287,30 @@ fn bench_hash_join_semi_anti(c: &mut Criterion) {
                     let left = make_exec(&left_batches, &s);
                     let right = make_exec(&right_batches, &s);
                     do_hash_join(left, right, JoinType::RightSemi, &rt)
+                })
+            },
+        );
+    }
+
+    // =========================================================================
+    // RightMark Join benchmarks
+    // =========================================================================
+
+    // RightMark - 100% Density, ~1% hit rate, fanout ~100
+    // Build keys are duplicated: 100K rows over 1K distinct keys. Matching
+    // probe rows only need a boolean mark, so duplicate build matches can be
+    // skipped.
+    {
+        let fanout_keys = 1_000;
+        let left_batches = build_batches(build_rows, fanout_keys, 0, &s);
+        let right_batches = build_batches(probe_rows, build_rows, 0, &s);
+        group.bench_function(
+            BenchmarkId::new("right_mark_fanout100_h1", probe_rows),
+            |b| {
+                b.iter(|| {
+                    let left = make_exec(&left_batches, &s);
+                    let right = make_exec(&right_batches, &s);
+                    do_hash_join(left, right, JoinType::RightMark, &rt)
                 })
             },
         );

--- a/datafusion/physical-plan/src/joins/array_map.rs
+++ b/datafusion/physical-plan/src/joins/array_map.rs
@@ -264,6 +264,35 @@ impl ArrayMap {
         )
     }
 
+    pub fn get_matching_indices_with_limit_offset(
+        &self,
+        prob_side_keys: &[ArrayRef],
+        limit: usize,
+        current_offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+        build_indices: &mut Vec<u64>,
+    ) -> Result<Option<MapOffset>> {
+        if prob_side_keys.len() != 1 {
+            return internal_err!(
+                "ArrayMap expects 1 join key, but got {}",
+                prob_side_keys.len()
+            );
+        }
+        let array = &prob_side_keys[0];
+
+        downcast_supported_integer!(
+            array.data_type() => (
+                lookup_and_get_matching_indices,
+                self,
+                array,
+                limit,
+                current_offset,
+                probe_indices,
+                build_indices
+            )
+        )
+    }
+
     fn lookup_and_get_indices<T: ArrowNumericType>(
         &self,
         array: &ArrayRef,
@@ -368,6 +397,61 @@ impl ArrayMap {
             }
             Ok(None)
         }
+    }
+
+    fn lookup_and_get_matching_indices<T: ArrowNumericType>(
+        &self,
+        array: &ArrayRef,
+        limit: usize,
+        current_offset: MapOffset,
+        probe_indices: &mut Vec<u32>,
+        build_indices: &mut Vec<u64>,
+    ) -> Result<Option<MapOffset>>
+    where
+        T::Native: Copy + AsPrimitive<u64>,
+    {
+        probe_indices.clear();
+        build_indices.clear();
+
+        debug_assert!(
+            current_offset.1.is_none(),
+            "existence lookup never resumes within a single probe row"
+        );
+
+        let arr = array.as_primitive::<T>();
+        let have_null = arr.null_count() > 0;
+
+        for prob_idx in current_offset.0..arr.len() {
+            if have_null && arr.is_null(prob_idx) {
+                continue;
+            }
+
+            // SAFETY: prob_idx is guaranteed to be within bounds by the loop range.
+            let prob_val: u64 = unsafe { arr.value_unchecked(prob_idx) }.as_();
+            let idx_in_build_side = prob_val.wrapping_sub(self.offset) as usize;
+
+            if idx_in_build_side >= self.data.len() {
+                continue;
+            }
+
+            let build_idx = self.data[idx_in_build_side];
+            if build_idx == 0 {
+                continue;
+            }
+
+            probe_indices.push(prob_idx as u32);
+            build_indices.push((build_idx - 1) as u64);
+
+            if probe_indices.len() == limit {
+                return if prob_idx + 1 == arr.len() {
+                    Ok(None)
+                } else {
+                    Ok(Some((prob_idx + 1, None)))
+                };
+            }
+        }
+
+        Ok(None)
     }
 
     pub fn contain_keys(&self, probe_side_keys: &[ArrayRef]) -> Result<BooleanArray> {
@@ -503,6 +587,40 @@ mod tests {
         assert_eq!(prob_indices, vec![1, 1, 3]);
         assert_eq!(build_indices, vec![0, 1, 0]);
         assert_eq!(result_offset, Some((3, Some(2))));
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_map_matching_indices_emit_once_per_probe_key() -> Result<()> {
+        let build: ArrayRef = Arc::new(Int32Array::from(vec![1, 1, 2]));
+        let map = ArrayMap::try_new(&build, 1, 2)?;
+        let probe = [Arc::new(Int32Array::from(vec![1, 2, 3, 1])) as ArrayRef];
+
+        let mut prob_idx = Vec::new();
+        let mut build_idx = Vec::new();
+        let next = map.get_matching_indices_with_limit_offset(
+            &probe,
+            2,
+            (0, None),
+            &mut prob_idx,
+            &mut build_idx,
+        )?;
+
+        assert_eq!(prob_idx, vec![0, 1]);
+        assert_eq!(build_idx, vec![0, 2]);
+        assert_eq!(next, Some((2, None)));
+
+        let next = map.get_matching_indices_with_limit_offset(
+            &probe,
+            2,
+            next.unwrap(),
+            &mut prob_idx,
+            &mut build_idx,
+        )?;
+
+        assert_eq!(prob_idx, vec![3]);
+        assert_eq!(build_idx, vec![0]);
+        assert_eq!(next, None);
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -458,6 +458,16 @@ fn count_distinct_sorted_indices(indices: &UInt32Array) -> usize {
     count
 }
 
+fn can_use_probe_existence_fast_path(
+    join_type: JoinType,
+    filter: &Option<JoinFilter>,
+) -> bool {
+    matches!(
+        join_type,
+        JoinType::RightSemi | JoinType::RightAnti | JoinType::RightMark
+    ) && filter.is_none()
+}
+
 impl HashJoinStream {
     #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
@@ -781,9 +791,37 @@ impl HashJoinStream {
             return Ok(StatefulStreamResult::Continue);
         }
 
+        let use_probe_existence_fast_path =
+            can_use_probe_existence_fast_path(self.join_type, &self.filter);
+
         // get the matched by join keys indices
         let (left_indices, right_indices, next_offset) = match build_side.left_data.map()
         {
+            Map::HashMap(map)
+                if use_probe_existence_fast_path && map.may_contain_hash_chains() =>
+            {
+                let next_offset = map.get_matching_indices_with_limit_offset(
+                    &self.hashes_buffer,
+                    build_side.left_data.values(),
+                    &state.values,
+                    self.null_equality,
+                    self.batch_size,
+                    state.offset,
+                    &mut self.probe_indices_buffer,
+                    &mut self.build_indices_buffer,
+                )?;
+                (
+                    UInt64Array::from(std::mem::replace(
+                        &mut self.build_indices_buffer,
+                        Vec::with_capacity(self.batch_size),
+                    )),
+                    UInt32Array::from(std::mem::replace(
+                        &mut self.probe_indices_buffer,
+                        Vec::with_capacity(self.batch_size),
+                    )),
+                    next_offset,
+                )
+            }
             Map::HashMap(map) => lookup_join_hashmap(
                 map.as_ref(),
                 build_side.left_data.values(),
@@ -795,6 +833,26 @@ impl HashJoinStream {
                 &mut self.probe_indices_buffer,
                 &mut self.build_indices_buffer,
             )?,
+            Map::ArrayMap(array_map) if use_probe_existence_fast_path => {
+                let next_offset = array_map.get_matching_indices_with_limit_offset(
+                    &state.values,
+                    self.batch_size,
+                    state.offset,
+                    &mut self.probe_indices_buffer,
+                    &mut self.build_indices_buffer,
+                )?;
+                (
+                    UInt64Array::from(std::mem::replace(
+                        &mut self.build_indices_buffer,
+                        Vec::with_capacity(self.batch_size),
+                    )),
+                    UInt32Array::from(std::mem::replace(
+                        &mut self.probe_indices_buffer,
+                        Vec::with_capacity(self.batch_size),
+                    )),
+                    next_offset,
+                )
+            }
             Map::ArrayMap(array_map) => {
                 let next_offset = array_map.get_matched_indices_with_limit_offset(
                     &state.values,

--- a/datafusion/physical-plan/src/joins/join_hash_map.rs
+++ b/datafusion/physical-plan/src/joins/join_hash_map.rs
@@ -22,11 +22,15 @@
 use std::fmt::{self, Debug};
 use std::ops::Sub;
 
-use arrow::array::BooleanArray;
+use arrow::array::{ArrayRef, BooleanArray};
 use arrow::buffer::BooleanBuffer;
 use arrow::datatypes::ArrowNativeType;
+use arrow_schema::SortOptions;
+use datafusion_common::{NullEquality, Result};
 use hashbrown::HashTable;
 use hashbrown::hash_table::Entry::{Occupied, Vacant};
+
+use crate::joins::utils::JoinKeyComparator;
 
 /// Maps a `u64` hash value based on the build side ["on" values] to a list of indices with this key's value.
 ///
@@ -126,11 +130,27 @@ pub trait JoinHashMapType: Send + Sync {
         match_indices: &mut Vec<u64>,
     ) -> Option<MapOffset>;
 
+    #[expect(clippy::too_many_arguments)]
+    fn get_matching_indices_with_limit_offset(
+        &self,
+        hash_values: &[u64],
+        build_values: &[ArrayRef],
+        probe_values: &[ArrayRef],
+        null_equality: NullEquality,
+        limit: usize,
+        offset: MapOffset,
+        input_indices: &mut Vec<u32>,
+        match_indices: &mut Vec<u64>,
+    ) -> Result<Option<MapOffset>>;
+
     /// Returns a BooleanArray indicating which of the provided hashes exist in the map.
     fn contain_hashes(&self, hash_values: &[u64]) -> BooleanArray;
 
     /// Returns `true` if the join hash map contains no entries.
     fn is_empty(&self) -> bool;
+
+    /// Returns `true` if the join hash map may contain chained indices for a hash.
+    fn may_contain_hash_chains(&self) -> bool;
 
     /// Returns the number of entries in the join hash map.
     fn len(&self) -> usize;
@@ -205,8 +225,37 @@ impl JoinHashMapType for JoinHashMapU32 {
         contain_hashes(&self.map, hash_values)
     }
 
+    fn get_matching_indices_with_limit_offset(
+        &self,
+        hash_values: &[u64],
+        build_values: &[ArrayRef],
+        probe_values: &[ArrayRef],
+        null_equality: NullEquality,
+        limit: usize,
+        offset: MapOffset,
+        input_indices: &mut Vec<u32>,
+        match_indices: &mut Vec<u64>,
+    ) -> Result<Option<MapOffset>> {
+        get_matching_indices_with_limit_offset::<u32>(
+            &self.map,
+            &self.next,
+            hash_values,
+            build_values,
+            probe_values,
+            null_equality,
+            limit,
+            offset,
+            input_indices,
+            match_indices,
+        )
+    }
+
     fn is_empty(&self) -> bool {
         self.map.is_empty()
+    }
+
+    fn may_contain_hash_chains(&self) -> bool {
+        self.map.len() != self.next.len()
     }
 
     fn len(&self) -> usize {
@@ -283,8 +332,37 @@ impl JoinHashMapType for JoinHashMapU64 {
         contain_hashes(&self.map, hash_values)
     }
 
+    fn get_matching_indices_with_limit_offset(
+        &self,
+        hash_values: &[u64],
+        build_values: &[ArrayRef],
+        probe_values: &[ArrayRef],
+        null_equality: NullEquality,
+        limit: usize,
+        offset: MapOffset,
+        input_indices: &mut Vec<u32>,
+        match_indices: &mut Vec<u64>,
+    ) -> Result<Option<MapOffset>> {
+        get_matching_indices_with_limit_offset::<u64>(
+            &self.map,
+            &self.next,
+            hash_values,
+            build_values,
+            probe_values,
+            null_equality,
+            limit,
+            offset,
+            input_indices,
+            match_indices,
+        )
+    }
+
     fn is_empty(&self) -> bool {
         self.map.is_empty()
+    }
+
+    fn may_contain_hash_chains(&self) -> bool {
+        self.map.len() != self.next.len()
     }
 
     fn len(&self) -> usize {
@@ -472,9 +550,77 @@ pub fn contain_hashes<T>(map: &HashTable<(u64, T)>, hash_values: &[u64]) -> Bool
     BooleanArray::new(buffer, None)
 }
 
+#[expect(clippy::too_many_arguments)]
+pub fn get_matching_indices_with_limit_offset<T>(
+    map: &HashTable<(u64, T)>,
+    next_chain: &[T],
+    hash_values: &[u64],
+    build_values: &[ArrayRef],
+    probe_values: &[ArrayRef],
+    null_equality: NullEquality,
+    limit: usize,
+    offset: MapOffset,
+    input_indices: &mut Vec<u32>,
+    match_indices: &mut Vec<u64>,
+) -> Result<Option<MapOffset>>
+where
+    T: Copy + TryFrom<usize> + PartialOrd + Into<u64> + Sub<Output = T>,
+    <T as TryFrom<usize>>::Error: Debug,
+    T: ArrowNativeType,
+{
+    input_indices.clear();
+    match_indices.clear();
+
+    debug_assert!(
+        offset.1.is_none(),
+        "existence lookup never resumes within a single probe row"
+    );
+
+    let sort_options = vec![SortOptions::default(); build_values.len()];
+    let comparator =
+        JoinKeyComparator::new(build_values, probe_values, &sort_options, null_equality)?;
+    let zero = T::usize_as(0);
+    let one = T::usize_as(1);
+
+    for row_idx in offset.0..hash_values.len() {
+        let hash = hash_values[row_idx];
+        let Some((_, chain_idx)) = map.find(hash, |(h, _)| hash == *h) else {
+            continue;
+        };
+
+        let mut match_row_idx = *chain_idx - one;
+        loop {
+            let build_idx = match_row_idx.into() as usize;
+            if comparator.is_equal(build_idx, row_idx) {
+                input_indices.push(row_idx as u32);
+                match_indices.push(build_idx as u64);
+
+                if input_indices.len() == limit {
+                    return if row_idx + 1 == hash_values.len() {
+                        Ok(None)
+                    } else {
+                        Ok(Some((row_idx + 1, None)))
+                    };
+                }
+                break;
+            }
+
+            let next = next_chain[build_idx];
+            if next == zero {
+                break;
+            }
+            match_row_idx = next - one;
+        }
+    }
+
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::{ArrayRef, Int32Array};
+    use std::sync::Arc;
 
     #[test]
     fn test_contain_hashes() {
@@ -493,5 +639,49 @@ mod tests {
                 assert!(!array.value(i), "Hash {hash} should NOT exist in the map");
             }
         }
+    }
+
+    #[test]
+    fn test_get_matching_indices_checks_key_equality_on_hash_collision() -> Result<()> {
+        let mut hash_map = JoinHashMapU32::with_capacity(2);
+        hash_map.update_from_iter(Box::new([7u64, 7u64].iter().enumerate()), 0);
+
+        let build_values = vec![Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef];
+        let probe_values = vec![Arc::new(Int32Array::from(vec![2, 3, 1])) as ArrayRef];
+        let hash_values = vec![7, 7, 7];
+
+        let mut input_indices = Vec::new();
+        let mut match_indices = Vec::new();
+        let next_offset = hash_map.get_matching_indices_with_limit_offset(
+            &hash_values,
+            &build_values,
+            &probe_values,
+            NullEquality::NullEqualsNothing,
+            1,
+            (0, None),
+            &mut input_indices,
+            &mut match_indices,
+        )?;
+
+        assert_eq!(input_indices, vec![0]);
+        assert_eq!(match_indices, vec![1]);
+        assert_eq!(next_offset, Some((1, None)));
+
+        let next_offset = hash_map.get_matching_indices_with_limit_offset(
+            &hash_values,
+            &build_values,
+            &probe_values,
+            NullEquality::NullEqualsNothing,
+            10,
+            next_offset.unwrap(),
+            &mut input_indices,
+            &mut match_indices,
+        )?;
+
+        assert_eq!(input_indices, vec![2]);
+        assert_eq!(match_indices, vec![0]);
+        assert_eq!(next_offset, None);
+
+        Ok(())
     }
 }

--- a/datafusion/physical-plan/src/joins/stream_join_utils.rs
+++ b/datafusion/physical-plan/src/joins/stream_join_utils.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use crate::joins::MapOffset;
 use crate::joins::join_hash_map::{
     contain_hashes, get_matched_indices, get_matched_indices_with_limit_offset,
-    update_from_iter,
+    get_matching_indices_with_limit_offset, update_from_iter,
 };
 use crate::joins::utils::{JoinFilter, JoinHashMapType};
 use crate::metrics::{
@@ -34,14 +34,16 @@ use crate::metrics::{
 use crate::{ExecutionPlan, metrics};
 
 use arrow::array::{
-    ArrowPrimitiveType, BooleanArray, BooleanBufferBuilder, NativeAdapter,
+    ArrayRef, ArrowPrimitiveType, BooleanArray, BooleanBufferBuilder, NativeAdapter,
     PrimitiveArray, RecordBatch,
 };
 use arrow::compute::concat_batches;
 use arrow::datatypes::{ArrowNativeType, Schema, SchemaRef};
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_common::utils::memory::estimate_memory_size;
-use datafusion_common::{HashSet, JoinSide, Result, ScalarValue, arrow_datafusion_err};
+use datafusion_common::{
+    HashSet, JoinSide, NullEquality, Result, ScalarValue, arrow_datafusion_err,
+};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_expr::intervals::cp_solver::ExprIntervalGraph;
@@ -102,8 +104,38 @@ impl JoinHashMapType for PruningJoinHashMap {
         contain_hashes(&self.map, hash_values)
     }
 
+    fn get_matching_indices_with_limit_offset(
+        &self,
+        hash_values: &[u64],
+        build_values: &[ArrayRef],
+        probe_values: &[ArrayRef],
+        null_equality: NullEquality,
+        limit: usize,
+        offset: MapOffset,
+        input_indices: &mut Vec<u32>,
+        match_indices: &mut Vec<u64>,
+    ) -> Result<Option<MapOffset>> {
+        let next: Vec<u64> = self.next.iter().copied().collect();
+        get_matching_indices_with_limit_offset::<u64>(
+            &self.map,
+            &next,
+            hash_values,
+            build_values,
+            probe_values,
+            null_equality,
+            limit,
+            offset,
+            input_indices,
+            match_indices,
+        )
+    }
+
     fn is_empty(&self) -> bool {
         self.map.is_empty()
+    }
+
+    fn may_contain_hash_chains(&self) -> bool {
+        self.map.len() != self.next.len()
     }
 
     fn len(&self) -> usize {


### PR DESCRIPTION
## Which issue does this PR close?

- None.

## Rationale for this change

Right semi, right anti, and right mark joins only need to know whether each probe-side row has at least one build-side match. The existing hash join probe path can materialize every build-side match before the semi/anti/mark output projection, which is unnecessarily expensive for high-fanout build keys.

## What changes are included in this PR?

- Add existence-only lookup helpers for `JoinHashMap` and `ArrayMap` that return at most one build-side match per probe row.
- Use those helpers for unfiltered `RightSemi`, `RightAnti`, and `RightMark` hash joins.
- Keep unique-hash `JoinHashMap` probes on the existing path to avoid comparator overhead when there are no chains to skip.
- Keep filtered joins on the existing path because join filters must evaluate candidate pairs.
- Add focused tests for hash collisions and `ArrayMap` duplicate-key behavior.
- Add a `RightMark` high-fanout benchmark case.

## Are these changes tested?

- `cargo fmt --all`
- `cargo test -p datafusion-physical-plan --lib join_right -- --nocapture`
- `cargo test -p datafusion-physical-plan --lib matching_indices -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo bench -p datafusion-physical-plan --features test_utils --bench hash_join_semi_anti -- --baseline main-inplace --sample-size 10 --warm-up-time 1 --measurement-time 2`
- `cargo bench -p datafusion-physical-plan --features test_utils --bench hash_join_semi_anti -- right_mark_fanout100_h1 --sample-size 10 --warm-up-time 1 --measurement-time 2`

Selected Criterion results:

| Benchmark | main median | PR median | change |
| --- | ---: | ---: | ---: |
| right_semi_d100_h10 | 1.5872 ms | 1.5070 ms | -3.70% |
| right_semi_d50_h10 | 1.6041 ms | 1.4900 ms | -7.03% |
| right_semi_fanout100_h1 | 3.9918 ms | 820.04 us | -79.47% |
| right_mark_fanout100_h1 | 10.940 ms | 5.6948 ms | -47.94% |
| right_anti_d100_h100 | 2.6888 ms | 2.4691 ms | -8.49% |
| right_anti_d50_h100 | 2.7308 ms | 2.4674 ms | -9.86% |
| right_anti_d50_h10 | 6.4212 ms | 6.3363 ms | -2.32% |
| sparse d10 cases | unchanged | unchanged | no change detected |

## Are there any user-facing changes?

No.