### PR TITLE
parquet: cache per-file ArrowReaderMetadata for wide-schema scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,8 +165,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d285d16bce7d0be61912f7928342b673067b6b7d7ef6cc179258ba7de1fecf"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -188,8 +187,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -202,8 +200,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -222,8 +219,7 @@ dependencies = [
 [[package]]
 name = "arrow-avro"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb45cd6bd2b25c0965793b83200eaca82214273a8030fbbc2d783e4c7c65a61"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -246,8 +242,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "bytes",
  "half",
@@ -258,8 +253,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -280,8 +274,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25011b52b346407d497ef0030e12b45e4f2d0cc279efc09c4f3d09106db30e36"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -295,8 +288,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -308,8 +300,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bebfacc9d71f0728f6774164e4d4254b5e504d2b46812d0512d8290ec119a64"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -335,8 +326,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -351,8 +341,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18b9123ccfec418a663f821c9a034af339711678c11ffe00d3ec07da5ff9f7e"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -376,8 +365,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -389,8 +377,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -402,8 +389,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "bitflags",
  "serde",
@@ -414,8 +400,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -428,8 +413,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4490,8 +4474,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "59.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
+source = "git+https://github.com/pydantic/arrow-rs.git?branch=claude%2F9882-on-v59.2.0#660b0b9bf28c8833968c7963aa8683c93bec20e6"
 dependencies = [
  "ahash",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,3 +296,27 @@ debug = false
 debug-assertions = false
 strip = "debuginfo"
 incremental = false
+
+# TEMPORARY — DO NOT MERGE WITH THIS PRESENT.
+# Builds against a throwaway branch that is the parquet 59.2.0 release tag plus
+# the four commits from https://github.com/apache/arrow-rs/pull/9882, which this
+# PR depends on. Remove once #9882 has merged and DataFusion has bumped to a
+# parquet release containing it.
+[patch.crates-io]
+arrow = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-arith = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-array = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-avro = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-buffer = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-cast = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-csv = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-data = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-flight = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-ipc = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-json = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-ord = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-row = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-schema = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-select = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+arrow-string = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }
+parquet = { git = "https://github.com/pydantic/arrow-rs.git", branch = "claude/9882-on-v59.2.0" }

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -41,7 +41,11 @@ use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore};
 use parquet::DecodeResult;
 use parquet::arrow::arrow_reader::statistics::StatisticsConverter;
-use parquet::arrow::{parquet_column, parquet_to_arrow_schema};
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+use parquet::arrow::{
+    ProjectionMask, parquet_column, parquet_to_arrow_schema,
+    parquet_to_arrow_schema_and_field_levels,
+};
 use parquet::file::metadata::{
     PageIndexPolicy, ParquetMetaData, ParquetMetaDataPushDecoder, ParquetMetaDataReader,
     RowGroupMetaData, SortingColumn,
@@ -49,7 +53,7 @@ use parquet::file::metadata::{
 use parquet::file::statistics::Statistics as ParquetStatistics;
 use parquet::schema::types::SchemaDescriptor;
 use std::any::Any;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// Minimum fraction of row groups that must report NDV statistics for the
 /// merged result to be `Inexact` rather than `Absent`, as the estimate
@@ -922,15 +926,90 @@ fn has_any_exact_match(
 }
 
 /// Wrapper to implement [`FileMetadata`] for [`ParquetMetaData`].
-pub struct CachedParquetMetaData(Arc<ParquetMetaData>);
+pub struct CachedParquetMetaData {
+    metadata: Arc<ParquetMetaData>,
+    /// Lazily-built [`ArrowReaderMetadata`] for this file. Constructing
+    /// this walks every leaf in the parquet schema (the "field-levels"
+    /// step), which is `O(N_columns)` work per file. Caching it lets
+    /// subsequent reader builds for the same file just `Clone` the result
+    /// (an `Arc` bump for the parquet metadata, the arrow schema, and the
+    /// dremel-level info) instead of redoing the walk.
+    arrow_reader_metadata: OnceLock<ArrowReaderMetadata>,
+    /// Single-slot cache for [`ArrowReaderMetadata`] built with a supplied
+    /// schema (e.g. after `apply_file_schema_type_coercions` produced one).
+    /// Keyed by the supplied schema's `Arc` pointer — different supplied
+    /// schemas miss and overwrite the slot. In typical workloads (one query
+    /// touches every file with the same coerced table schema) every file
+    /// pays this rebuild at most once per session.
+    coerced_arm: std::sync::Mutex<Option<(usize, ArrowReaderMetadata)>>,
+}
 
 impl CachedParquetMetaData {
     pub fn new(metadata: Arc<ParquetMetaData>) -> Self {
-        Self(metadata)
+        Self {
+            metadata,
+            arrow_reader_metadata: OnceLock::new(),
+            coerced_arm: std::sync::Mutex::new(None),
+        }
     }
 
     pub fn parquet_metadata(&self) -> &Arc<ParquetMetaData> {
-        &self.0
+        &self.metadata
+    }
+
+    /// Return the cached [`ArrowReaderMetadata`] for this file, building it
+    /// on first use.
+    ///
+    /// `ArrowReaderMetadata` stores its schema and field-levels behind
+    /// `Arc`s, so [`ArrowReaderMetadata::clone`] is cheap and is what
+    /// callers should use to consume the cached value.
+    pub fn arrow_reader_metadata(&self) -> Result<&ArrowReaderMetadata> {
+        if let Some(v) = self.arrow_reader_metadata.get() {
+            return Ok(v);
+        }
+        let file_meta = self.metadata.file_metadata();
+        let (schema, levels) = parquet_to_arrow_schema_and_field_levels(
+            file_meta.schema_descr(),
+            ProjectionMask::all(),
+            file_meta.key_value_metadata(),
+        )?;
+        let arm = ArrowReaderMetadata::from_field_levels(
+            Arc::clone(&self.metadata),
+            Arc::new(schema),
+            levels,
+        );
+        // Race: if another thread also computed it, theirs wins.
+        let _ = self.arrow_reader_metadata.set(arm);
+        Ok(self.arrow_reader_metadata.get().expect("just set"))
+    }
+
+    /// Get-or-build an [`ArrowReaderMetadata`] whose arrow schema is
+    /// `supplied_schema`. The result is memoised in a single-slot cache
+    /// keyed by `Arc::as_ptr(&supplied_schema)` — repeat calls with the
+    /// same schema (the common case: every file in a query coerces to the
+    /// same table schema) return a cheap [`ArrowReaderMetadata::clone`]
+    /// instead of re-walking the parquet schema.
+    pub fn coerced_arrow_reader_metadata(
+        &self,
+        supplied_schema: &SchemaRef,
+        options: ArrowReaderOptions,
+    ) -> Result<ArrowReaderMetadata> {
+        let key = Arc::as_ptr(supplied_schema) as usize;
+        {
+            let guard = self.coerced_arm.lock().unwrap();
+            if let Some((cached_key, cached)) = guard.as_ref()
+                && *cached_key == key
+            {
+                return Ok(cached.clone());
+            }
+        }
+        let arm = ArrowReaderMetadata::try_new(
+            Arc::clone(&self.metadata),
+            options.with_schema(Arc::clone(supplied_schema)),
+        )?;
+        let mut guard = self.coerced_arm.lock().unwrap();
+        *guard = Some((key, arm.clone()));
+        Ok(arm)
     }
 }
 
@@ -940,12 +1019,12 @@ impl FileMetadata for CachedParquetMetaData {
     }
 
     fn memory_size(&self) -> usize {
-        self.0.memory_size()
+        self.metadata.memory_size()
     }
 
     fn extra_info(&self) -> HashMap<String, String> {
-        let page_index =
-            self.0.column_index().is_some() && self.0.offset_index().is_some();
+        let page_index = self.metadata.column_index().is_some()
+            && self.metadata.offset_index().is_some();
         HashMap::from([("page_index".to_owned(), page_index.to_string())])
     }
 }

--- a/datafusion/datasource-parquet/src/reader.rs
+++ b/datafusion/datasource-parquet/src/reader.rs
@@ -20,21 +20,19 @@
 
 use crate::ParquetFileMetrics;
 use crate::metadata::DFParquetMetadata;
+use arrow::datatypes::SchemaRef;
 use bytes::Bytes;
-use datafusion_common::HashMap;
 use datafusion_datasource::PartitionedFile;
-use datafusion_execution::cache::cache_manager::FileMetadata;
 use datafusion_execution::cache::cache_manager::FileMetadataCache;
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
 use futures::FutureExt;
 use futures::TryFutureExt;
 use futures::future::BoxFuture;
 use object_store::{ObjectStore, ObjectStoreExt};
-use parquet::arrow::arrow_reader::ArrowReaderOptions;
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use parquet::arrow::async_reader::AsyncFileReader;
 use parquet::errors::ParquetError;
 use parquet::file::metadata::ParquetMetaData;
-use std::any::Any;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::Arc;
@@ -300,6 +298,105 @@ impl AsyncFileReader for ParquetFileReader {
         }
         .boxed()
     }
+
+    fn get_arrow_reader_metadata<'a>(
+        &'a mut self,
+        options: ArrowReaderOptions,
+    ) -> BoxFuture<'a, parquet::errors::Result<ArrowReaderMetadata>> {
+        let object_meta = self.partitioned_file.object_meta.clone();
+        let metadata_cache = self.metadata_cache.clone();
+
+        async move {
+            // We can serve from cache when no embedded-schema-skip and no
+            // virtual columns are requested. A `supplied_schema` is OK —
+            // the wrapper has a separate cache slot for post-coercion
+            // builds keyed by the supplied schema's Arc identity.
+            let can_use_cache = metadata_cache.is_some()
+                && !options.skip_arrow_metadata()
+                && options.virtual_columns().is_empty();
+            let supplied = options.supplied_schema().cloned();
+
+            #[cfg(feature = "parquet_encryption")]
+            let file_decryption_properties =
+                options.file_decryption_properties().map(Arc::clone);
+            #[cfg(not(feature = "parquet_encryption"))]
+            let file_decryption_properties = None;
+
+            let try_serve_from_cache = |options: ArrowReaderOptions,
+                                        supplied: Option<SchemaRef>|
+             -> parquet::errors::Result<Option<ArrowReaderMetadata>> {
+                if !can_use_cache {
+                    return Ok(None);
+                }
+                let Some(cache) = metadata_cache.as_ref() else {
+                    return Ok(None);
+                };
+                let Some(cached) = cache.get(&object_meta.location) else {
+                    return Ok(None);
+                };
+                if !cached.is_valid_for(&object_meta) {
+                    return Ok(None);
+                }
+                let Some(cached_parquet) = cached
+                    .file_metadata
+                    .as_any()
+                    .downcast_ref::<CachedParquetMetaData>()
+                else {
+                    return Ok(None);
+                };
+                let arm = if let Some(schema) = supplied {
+                    cached_parquet
+                        .coerced_arrow_reader_metadata(&schema, options)
+                        .map_err(|e| {
+                            ParquetError::General(format!(
+                                "Failed to build coerced arrow reader metadata for {}: {e}",
+                                object_meta.location,
+                            ))
+                        })?
+                } else {
+                    cached_parquet
+                        .arrow_reader_metadata()
+                        .map_err(|e| {
+                            ParquetError::General(format!(
+                                "Failed to build arrow reader metadata for {}: {e}",
+                                object_meta.location,
+                            ))
+                        })?
+                        .clone()
+                };
+                Ok(Some(arm))
+            };
+
+            // Fast path: cache hit (already-fetched metadata).
+            if let Some(arm) = try_serve_from_cache(options.clone(), supplied.clone())? {
+                return Ok(arm);
+            }
+
+            // Slow path: fetch + cache the metadata, then retry. The page
+            // index policy must be honoured here exactly as in `get_metadata`
+            // — otherwise a caller that asked to skip the page index still
+            // gets it fetched, and the cached entry is polluted with it.
+            let metadata = DFParquetMetadata::new(&self.store, &object_meta)
+                .with_decryption_properties(file_decryption_properties)
+                .with_file_metadata_cache(metadata_cache.clone())
+                .with_metadata_size_hint(self.metadata_size_hint)
+                .with_page_index_policy(Some(options.column_index_policy()))
+                .fetch_metadata()
+                .await
+                .map_err(|e| {
+                    ParquetError::General(format!(
+                        "Failed to fetch metadata for file {}: {e}",
+                        object_meta.location,
+                    ))
+                })?;
+            if let Some(arm) = try_serve_from_cache(options.clone(), supplied)? {
+                return Ok(arm);
+            }
+
+            ArrowReaderMetadata::try_new(metadata, options)
+        }
+        .boxed()
+    }
 }
 
 impl Drop for ParquetFileReader {
@@ -314,31 +411,7 @@ impl Drop for ParquetFileReader {
     }
 }
 
-/// Wrapper to implement [`FileMetadata`] for [`ParquetMetaData`].
-pub struct CachedParquetMetaData(Arc<ParquetMetaData>);
-
-impl CachedParquetMetaData {
-    pub fn new(metadata: Arc<ParquetMetaData>) -> Self {
-        Self(metadata)
-    }
-
-    pub fn parquet_metadata(&self) -> &Arc<ParquetMetaData> {
-        &self.0
-    }
-}
-
-impl FileMetadata for CachedParquetMetaData {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn memory_size(&self) -> usize {
-        self.0.memory_size()
-    }
-
-    fn extra_info(&self) -> HashMap<String, String> {
-        let page_index =
-            self.0.column_index().is_some() && self.0.offset_index().is_some();
-        HashMap::from([("page_index".to_owned(), page_index.to_string())])
-    }
-}
+// `CachedParquetMetaData` lives in `crate::metadata` (where it carries the
+// lazily-built, cached `ArrowReaderMetadata`). Re-export it here so the
+// `pub use reader::*` in `mod.rs` keeps exposing it at the crate root.
+pub use crate::metadata::CachedParquetMetaData;


### PR DESCRIPTION
> ## ⚠️ Green CI here does not mean this is mergeable
>
> The second commit is a **temporary `[patch.crates-io]`** redirecting all 17 arrow-rs crates to a throwaway fork branch, because this PR uses parquet API that is not in any release yet (see *Dependencies* below). CI is therefore green **against that fork**, not against anything on crates.io. The patch must be reverted before merge. Please read the checkmarks as "the change works against the proposed API", nothing more.

## Which issue does this PR close?

- Part of #21968.

## Rationale for this change

Building an `ArrowReaderMetadata` walks every leaf of the parquet schema to produce the arrow `Schema` and dremel field levels. For wide-schema files this `O(N_columns)` walk runs on every file open, once per query, even though the result is identical across queries for the same file.

For scale: at 1024 columns the footer decode is ~385 µs/file, of which ~147 µs (38%) is the schema walk this PR caches.

## What changes are included in this PR?

Cache the built `ArrowReaderMetadata` on `CachedParquetMetaData`, which already lives in the file metadata cache:

- `arrow_reader_metadata()` lazily builds the base metadata via `parquet_to_arrow_schema_and_field_levels` + `from_field_levels` and memoises it in a `OnceLock`; warm hits are a cheap `Arc`-bump clone.
- `coerced_arrow_reader_metadata()` memoises a single post-coercion build, keyed by the supplied schema's `Arc` identity.
- `CachedParquetFileReader` overrides `AsyncFileReader::get_arrow_reader_metadata` to serve both from cache.

## Dependencies, and why the patch points where it does

This needs the parquet primitives in **apache/arrow-rs#9882** (`from_field_levels`, `parquet_to_arrow_schema_and_field_levels`, the `ArrowReaderOptions` accessors, and `AsyncFileReader::get_arrow_reader_metadata`). That PR is open and unmerged, so the API is in no parquet release and this PR cannot compile against crates.io.

The temporary patch therefore points at a fork branch that is the **parquet 59.2.0 release tag plus #9882's four commits**. Deliberately *not* arrow-rs `main`: `main` carries post-release changes — notably `arrow_schema::Metadata` replacing `HashMap<String, String>`, plus a new `arrow-cmp` crate — that DataFusion has not absorbed, and which fail to compile in `datafusion-common` before parquet is even reached.

**To merge:** revert the `TEMPORARY:` commit once #9882 has merged and DataFusion has bumped to a parquet release containing it.

The arrow-rs-independent pieces of the #21968 investigation are split out separately: #22829 (`memory_size` caching, coercion early-return) and #21987 (O(1) parquet leaf lookup in statistics collection, which needs no arrow-rs change).

## Are these changes tested?

Yes, now that it builds. Existing suites pass against the patched dependency: `-p datafusion-datasource-parquet --lib` (194), `-p datafusion --test parquet_integration` (218), `-p datafusion --test core_integration` (1064). `./ci/scripts/rust_clippy.sh` and `cargo fmt --check` are clean.

Rebasing onto current `main` surfaced a genuine bug in the original commit, now fixed: `get_arrow_reader_metadata` fetched metadata without propagating the page-index policy from `options`, so a caller that asked to skip the page index got it fetched anyway and the cached entry was polluted with it. `test_page_index_skipped_with_cached_reader_factory` catches this. It matters more than it sounds on the target workload — at 1024 columns the page index is 424 KiB/file and ~37% of total metadata decode.

No new tests are added for the caching itself; that gap is worth closing before this leaves draft.

## Are there any user-facing changes?

No public API changes — `CachedParquetMetaData` gains internal caching fields and methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
