### PR TITLE
bench: shrink wide_schema benchmark defaults and make size tunable

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -630,7 +630,7 @@ dataset rather than with the number of columns the query references.
 
 The suite has two subgroups, selected via `BENCH_SUBGROUP`:
 
-- **`wide`** — runs against a 1024-col synthetic dataset. This is the
+- **`wide`** — runs against a 512-col synthetic dataset. This is the
   actual workload.
 - **`narrow`** — runs the same SQL against an 8-col version of the same
   dataset (same row count, file count, per-file row-group shape).
@@ -646,16 +646,30 @@ wide-vs-narrow pair.
 The data preparation step (`gen_wide_data`) synthesizes a generic
 8-column base schema (`id`, `value`, `count`, `ts`, `category`,
 `flag`, `status`, `text`) with deterministic data, then replicates it
-128× via suffix renaming (`_2`, `_3`, …) for 1024 columns total —
-written across 256 files at 50 k rows per file with one row group per
-file and ZSTD(1) compression. Copies 2..128 are zero-filled arrays so
+64× via suffix renaming (`_2`, `_3`, …) for 512 columns total —
+written across 64 files at 50 k rows per file with one row group per
+file and ZSTD(1) compression. Copies 2..64 are zero-filled arrays so
 the schema is wide (every column still has its own footer / page
 index / column-chunk metadata) but the on-disk size stays around
-225 MB. The narrow dataset is written the same way without the suffix
+55 MB. The narrow dataset is written the same way without the suffix
 copies. The only variable between wide and narrow is schema width.
 
+The dataset size is tunable via environment variables. Peak memory
+scales with `num_files × width_factor` (the total column-chunk metadata
+parsed per iteration), so dial these down on memory-constrained
+runners and up for a more aggressive signal:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `WIDE_SCHEMA_WIDTH_FACTOR` | `64` | column replication factor (8 base cols × N) |
+| `WIDE_SCHEMA_NUM_FILES` | `64` | number of parquet files |
+| `WIDE_SCHEMA_ROWS_PER_FILE` | `50000` | rows per file (one row group each) |
+
+(Clear `data/wide_schema/` before changing `WIDE_SCHEMA_WIDTH_FACTOR` —
+the data-reuse check only counts files, not schema width.)
+
 ```shell
-./benchmarks/bench.sh data wide_schema    # synthesizes wide (1024 cols × 256 files) + narrow (8 cols × 256 files), ~60 s, ~335 MB
+./benchmarks/bench.sh data wide_schema    # synthesizes wide (512 cols × 64 files) + narrow (8 cols × 64 files), ~55 MB
 ./benchmarks/bench.sh run  wide_schema    # runs both 'wide' and 'narrow' subgroups; compare the per-query times for the slowdown ratio
 ```
 

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -101,8 +101,9 @@ sort_tpch10:            Benchmark of sorting speed for end-to-end sort queries o
 topk_tpch:              Benchmark of top-k (sorting with limit) queries on TPC-H dataset (SF=1)
 push_down_topk:         Benchmark of ORDER BY ... LIMIT over outer joins on TPC-H dataset (SF=1) — exercises pushing TopK through a join
 external_aggr:          External aggregation benchmark on TPC-H dataset (SF=1)
-wide_schema:            Small-projection queries on a wide synthetic dataset (1024 cols × 256 files) — measures per-file metadata overhead
+wide_schema:            Small-projection queries on a wide synthetic dataset (512 cols × 64 files) — measures per-file metadata overhead
                           (runs both 'wide' and 'narrow' subgroups: narrow is an internal baseline; the wide-vs-narrow ratio is the signal)
+                          (override size with WIDE_SCHEMA_WIDTH_FACTOR / WIDE_SCHEMA_NUM_FILES / WIDE_SCHEMA_ROWS_PER_FILE)
 
 # ClickBench Benchmarks
 clickbench_1:           ClickBench queries against a single parquet file
@@ -727,16 +728,28 @@ run_tpch() {
 # Synthesizes two parquet datasets used to measure per-file metadata
 # overhead of a wide schema:
 #
-#   - data/wide_schema/wide/    1024-col events × 256 files (~225 MB)
-#   - data/wide_schema/narrow/    8-col events × 256 files (~110 MB)
+#   - data/wide_schema/wide/    512-col events × 64 files (~55 MB)
+#   - data/wide_schema/narrow/    8-col events × 64 files (~28 MB)
 #
 # Both share row count, file count, and per-file row-group shape; only
 # schema width differs. No external data source required — gen_wide_data
-# synthesizes everything from scratch in ~60 s.
+# synthesizes everything from scratch in a few seconds.
+#
+# Size is tunable via environment variables so the suite can be dialed
+# down for memory-constrained runners (the original 1024×256 default
+# drove peak RSS into tens of GB on 12-core runners through per-iteration
+# allocator churn — memory scales with num_files × width_factor):
+#
+#   WIDE_SCHEMA_WIDTH_FACTOR   column replication factor (8 base cols × N)
+#   WIDE_SCHEMA_NUM_FILES      number of parquet files
+#   WIDE_SCHEMA_ROWS_PER_FILE  rows per file (one row group each)
+#
+# NOTE: the "data already exists" check below only counts files, not
+# schema width — clear data/wide_schema before changing WIDTH_FACTOR.
 data_wide_schema() {
-    NUM_FILES=256
-    ROWS_PER_FILE=50000
-    WIDTH_FACTOR=128
+    NUM_FILES="${WIDE_SCHEMA_NUM_FILES:-64}"
+    ROWS_PER_FILE="${WIDE_SCHEMA_ROWS_PER_FILE:-50000}"
+    WIDTH_FACTOR="${WIDE_SCHEMA_WIDTH_FACTOR:-64}"
 
     DST_DIR="${DATA_DIR}/wide_schema"
     WIDE_DIR="${DST_DIR}/wide"


### PR DESCRIPTION
## Which issue does this PR close?

- Relates to the wide-schema metadata-overhead work (#21968).

## Rationale for this change

The `wide_schema` benchmark (added in #21970) defaults to **1024 columns × 256 files**. On memory-constrained CI runners this drives peak RSS into the tens of GB and OOMs the bench bot.

The cause is not working set — a full local run of all four wide queries at the original default peaks at only ~1 GB. It's **per-iteration allocator churn**: criterion runs the fast queries hundreds of thousands of times (e.g. `Q02 ... LIMIT 1` runs 1000s of iterations per sample window), and each iteration opens every file and parses its column-chunk metadata across all worker threads. The retained/fragmented memory scales with `num_files × width_factor`.

## What changes are included in this PR?

- Reduce the defaults to **512 columns × 64 files** (8× less metadata churn). Local peak RSS for the full run drops from ~1.08 GB to ~0.70 GB; on a 12-thread runner the proportional reduction brings it well within budget.
- Expose the generator parameters as environment variables so runners can dial size up or down without editing `bench.sh`:
  - `WIDE_SCHEMA_WIDTH_FACTOR`
  - `WIDE_SCHEMA_NUM_FILES`
  - `WIDE_SCHEMA_ROWS_PER_FILE`
- Update `bench.sh` and `benchmarks/README.md` accordingly.

## Are these changes tested?

This is benchmark tooling only (no library code). Verified manually:

- The full suite runs at the new defaults and produces valid results.
- The benchmark's signal — the wide-vs-narrow ratio — is preserved at the smaller size:

  | Query | wide | narrow | ratio |
  | --- | --- | --- | --- |
  | Q01 (TopK) | 22.5 ms | 19.4 ms | 1.16× |
  | Q02 (`LIMIT 1`) | 3.13 ms | 1.55 ms | 2.02× |
  | Q03 | 3.57 ms | 1.86 ms | 1.92× |
  | Q04 | 13.1 ms | 7.09 ms | 1.85× |

## Are there any user-facing changes?

No public API changes. Benchmark defaults and docs change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)