### PR TITLE
examples/flight: add OomGuard allocator-level OOM circuit breaker to sql_server

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# The `flight` example uses `#![feature(alloc_error_hook)]` so that
+# `OomGuard` can convert process-wide OOMs into per-query panics via
+# `std::alloc::set_alloc_error_hook` (tracking issue rust-lang/rust#51245,
+# API-frozen since 2018 but still unstable). Setting `RUSTC_BOOTSTRAP=1`
+# unblocks the feature gate on stable toolchains; same trick used by
+# downstream crates like comet and the dataprime-query-engine executor.
+[env]
+RUSTC_BOOTSTRAP = "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,6 @@ dependencies = [
  "futures",
  "insta",
  "log",
- "mimalloc",
  "nix",
  "nom",
  "object_store",
@@ -2089,6 +2088,8 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "test-utils",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tonic",
  "tracing",
@@ -6156,6 +6157,37 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -59,7 +59,8 @@ env_logger = { workspace = true }
 futures = { workspace = true }
 insta = { workspace = true }
 log = { workspace = true }
-mimalloc = { version = "0.1", default-features = false }
+tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 object_store = { workspace = true, features = ["aws", "http"] }
 prost = { workspace = true }
 rand = { workspace = true }

--- a/datafusion-examples/examples/flight/README.md
+++ b/datafusion-examples/examples/flight/README.md
@@ -1,0 +1,196 @@
+# Arrow Flight Examples
+
+Three runnable subcommands of a single `flight` example:
+
+| Subcommand   | What it does                                                              |
+|--------------|---------------------------------------------------------------------------|
+| `server`     | Minimal Arrow Flight (not Flight SQL) server, backed by DataFusion        |
+| `client`     | Connects to `server`, walks a schema, runs a query                        |
+| `sql_server` | Arrow Flight **SQL** server wrapping DataFusion, with `OomGuard` wired in |
+
+## Building
+
+```bash
+cargo build --example flight
+```
+
+## Running a query against `sql_server`
+
+Start the server in one terminal:
+
+```bash
+cargo run --example flight -- sql_server
+```
+
+Binds `0.0.0.0:50051`. Speaks the Arrow Flight SQL protocol — any Flight SQL
+client works (JDBC driver, the `arrow-rs` CLI, etc.). The example accepts any
+username/password during handshake and mints a Bearer token for the session.
+
+The simplest off-the-shelf client is `arrow-rs`'s `flight_sql_client`:
+
+```bash
+git clone https://github.com/apache/arrow-rs.git
+cd arrow-rs
+cargo build --bin flight_sql_client --features cli,flight-sql,tls-ring
+```
+
+Then with `sql_server` running, send a query from another terminal:
+
+```bash
+./target/debug/flight_sql_client \
+  --host localhost --port 50051 \
+  --username admin --password admin \
+  prepared-statement-query "SELECT 42 AS answer"
+```
+
+The example only implements `get_flight_info_prepared_statement`, so use
+`prepared-statement-query` (not `statement-query`).
+
+## OomGuard
+
+`sql_server` wraps the global allocator with `OomGuard`, a `GlobalAlloc`
+wrapper that converts a process-wide OOM into a per-query panic *before* the
+kernel SIGKILLs the process.
+
+### Why it exists
+
+DataFusion's `MemoryPool` is voluntary. Operators that don't call `try_grow`
+— in-flight batches, `arrow-row` decode buffers, Arrow kernel scratch space —
+allocate freely past the declared budget. On a process with a hard memory
+ceiling (k8s pod cgroup, ulimit), the result is an OS-level kill that takes
+down every concurrent query, not just the offender.
+
+`OomGuard` is the backstop for that case.
+
+### How it works
+
+1. Wraps the global allocator (`OomGuard<Jemalloc>` here, but any
+   `GlobalAlloc` works).
+2. A dedicated OS thread polls jemalloc's `stats.resident` every 10 ms and
+   writes `BALANCE = threshold - resident` to a global atomic.
+3. Each Rust allocation also debits `BALANCE` locally (per-thread drift,
+   amortized into the global atomic every 64 KiB) to detect overdraft
+   between poll ticks.
+4. When `BALANCE` goes negative on a stamped thread (every tokio worker, via
+   `on_thread_start`), the wrapper's `alloc` returns `NULL`.
+5. Rust's runtime invokes the `alloc_error_hook` installed in `main.rs`. The
+   hook converts the `NULL` into `panic_any(OomGuardPanic)` from a clean
+   safe-Rust frame.
+6. A global panic hook logs `OomGuardPanic` distinctly.
+7. The panic unwinds through `df.collect()`, gets caught by the
+   `catch_unwind` wrapper in `sql_server.rs`, and is converted to
+   `Status::resource_exhausted` for the client. Drop chains release all
+   the memory the query was holding.
+8. The server keeps listening.
+
+When `OomGuard` is disabled or no cgroup memory limit is detected, the
+wrapper stays **disarmed**. Each allocation then costs one relaxed atomic
+load — effectively free.
+
+### Knobs (environment variables)
+
+| Variable                                  | Default     | Effect                                                                                          |
+|-------------------------------------------|-------------|-------------------------------------------------------------------------------------------------|
+| `OOM_GUARD`                               | unset (on)  | Set to `off` to skip arming the guard. Useful for A/B comparison on the same cgroup.            |
+| `OOM_GUARD_HEADROOM`                      | `0.05`      | Fraction of cgroup memory limit reserved as headroom. Clamped to `[0.0, 0.95]`. Tune as needed. |
+| `DATAFUSION_EXECUTION_TARGET_PARTITIONS`  | `num_cpus`  | Standard DataFusion env var. Lower values reduce per-query peak memory on high-core hosts.      |
+
+### Seeing it in action — A/B comparison
+
+Run `sql_server` under a memory cap so the guard actually has something to
+guard against. Unprivileged via `systemd-run`:
+
+```bash
+systemd-run --user --scope -p MemoryMax=1G -- \
+  cargo run --example flight -- sql_server
+```
+
+In Docker / k8s, use `--memory=1g` / `resources.limits.memory: 1Gi`.
+
+Pick a query that overflows the cgroup. The `GROUP BY` below on 8 million
+wide-key strings allocates a multi-GiB hash table:
+
+```sql
+SELECT k, count(*) FROM (
+  SELECT cast(v AS varchar) || repeat('x', 200) AS k
+  FROM generate_series(1, 8000000) AS t(v)
+) GROUP BY k LIMIT 5
+```
+
+**Without OomGuard** — the kernel kills the process:
+
+```bash
+OOM_GUARD=off \
+DATAFUSION_EXECUTION_TARGET_PARTITIONS=1 \
+systemd-run --user --scope -p MemoryMax=1G -- \
+  cargo run --example flight -- sql_server &
+
+flight_sql_client --host localhost --port 50051 \
+  --username admin --password admin \
+  prepared-statement-query "SELECT k, count(*) FROM (SELECT cast(v AS varchar) || repeat('x', 200) AS k FROM generate_series(1, 8000000) AS t(v)) GROUP BY k LIMIT 5"
+```
+
+Expected: client sees `transport error: broken pipe`. Server process is
+gone (SIGKILL, `Failed with result 'oom-kill'`).
+
+**With OomGuard** (default, just don't set `OOM_GUARD=off`):
+
+```bash
+DATAFUSION_EXECUTION_TARGET_PARTITIONS=1 \
+systemd-run --user --scope -p MemoryMax=1G -- \
+  cargo run --example flight -- sql_server &
+
+flight_sql_client --host localhost --port 50051 \
+  --username admin --password admin \
+  prepared-statement-query "SELECT k, count(*) FROM (SELECT cast(v AS varchar) || repeat('x', 200) AS k FROM generate_series(1, 8000000) AS t(v)) GROUP BY k LIMIT 5"
+```
+
+Expected: client sees
+```
+Status: ResourceExhausted, "OomGuard: query killed before process OOM (balance=...)"
+```
+Server logs an `OomGuard panic on thread "tokio-rt-worker": balance=...`
+line, then keeps listening. A follow-up query works:
+
+```bash
+flight_sql_client --host localhost --port 50051 \
+  --username admin --password admin \
+  prepared-statement-query "SELECT 'still alive' AS status"
+```
+
+returns `still alive`.
+
+### Relationship to `MemoryPool`
+
+`OomGuard` is complementary to `MemoryPool`, not a replacement:
+
+- `MemoryPool` is voluntary, fine-grained, and reports `ResourcesExhausted`
+  cleanly when operators that *do* call `try_grow` exceed their budget.
+  Use it for graceful, expected memory pressure.
+- `OomGuard` is mandatory, coarse-grained, and converts the *unexpected* —
+  allocations that bypass `MemoryPool` — into a per-query panic instead of
+  process death. Use it as a last line of defence.
+
+### Caveats
+
+The `alloc_error_hook` is currently an unstable Rust API
+(`#![feature(alloc_error_hook)]`, tracking issue rust-lang/rust#51245). The
+workspace `.cargo/config.toml` sets `RUSTC_BOOTSTRAP=1` to compile it on a
+stable toolchain.
+
+## Running `server` + `client`
+
+The pair predates `sql_server` and uses the lower-level Flight protocol (not
+Flight SQL).
+
+In one terminal:
+
+```bash
+cargo run --example flight -- server
+```
+
+In another:
+
+```bash
+cargo run --example flight -- client
+```

--- a/datafusion-examples/examples/flight/main.rs
+++ b/datafusion-examples/examples/flight/main.rs
@@ -109,6 +109,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::abort();
     });
 
+    // Install a global panic hook to log `OomGuardPanic` distinctly.
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if let Some(g) = info.payload().downcast_ref::<oom_guard::OomGuardPanic>() {
+            log::error!(
+                "OomGuard panic on thread {:?}: balance={} bytes",
+                std::thread::current().name().unwrap_or("?"),
+                g.balance,
+            );
+        } else {
+            default_hook(info);
+        }
+    }));
+
     // Manual runtime construction so we can `on_thread_start` to stamp
     // worker threads as eligible for the OomGuard overdraft panic.
     // Unstamped threads (control plane, the poll task itself) still debit

--- a/datafusion-examples/examples/flight/main.rs
+++ b/datafusion-examples/examples/flight/main.rs
@@ -38,8 +38,18 @@
 //!
 //! - `sql_server`
 //!   (file: sql_server.rs, desc: Standalone SQL server for JDBC clients)
+//!
+//! ## OomGuard
+//!
+//! `sql_server` wraps the global allocator with [`oom_guard::OomGuard`]
+//! to convert process-wide OOM kills into per-query panics. The guard
+//! installs an `alloc_error_hook`, which is currently an unstable Rust
+//! API (`#![feature(alloc_error_hook)]`); the workspace `.cargo/config.toml`
+//! sets `RUSTC_BOOTSTRAP=1` so this builds on stable.
+#![feature(alloc_error_hook)]
 
 mod client;
+mod oom_guard;
 mod server;
 mod sql_server;
 
@@ -83,19 +93,48 @@ impl ExampleKind {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let usage = format!(
-        "Usage: cargo run --example {} -- [{}]",
-        ExampleKind::EXAMPLE_NAME,
-        ExampleKind::VARIANTS.join("|")
-    );
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Install the alloc-error hook BEFORE building the runtime so even
+    // early allocations on the main thread benefit. When OomGuard returns
+    // NULL on overdraft, the Rust runtime invokes this hook from a clean
+    // safe-Rust frame *outside* the `unsafe impl GlobalAlloc` block.
+    // Panicking here gives us per-query isolation without the unwind-ABI
+    // corruption we'd hit firing `panic_any` from inside the allocator.
+    // Non-OomGuard nulls (genuine allocator OOM) fall through to `abort`.
+    std::alloc::set_alloc_error_hook(|_layout| {
+        if oom_guard::take_kill_pending() {
+            let balance = oom_guard::balance();
+            std::panic::panic_any(oom_guard::OomGuardPanic { balance });
+        }
+        std::process::abort();
+    });
 
-    let example: ExampleKind = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| ExampleKind::All.to_string())
-        .parse()
-        .map_err(|_| DataFusionError::Execution(format!("Unknown example. {usage}")))?;
+    // Manual runtime construction so we can `on_thread_start` to stamp
+    // worker threads as eligible for the OomGuard overdraft panic.
+    // Unstamped threads (control plane, the poll task itself) still debit
+    // the bank but are exempt from the kill.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .on_thread_start(|| {
+            oom_guard::stamp_current_thread();
+        })
+        .build()?;
 
-    example.run().await
+    runtime.block_on(async {
+        let usage = format!(
+            "Usage: cargo run --example {} -- [{}]",
+            ExampleKind::EXAMPLE_NAME,
+            ExampleKind::VARIANTS.join("|")
+        );
+
+        let example: ExampleKind = std::env::args()
+            .nth(1)
+            .unwrap_or_else(|| ExampleKind::All.to_string())
+            .parse()
+            .map_err(|_| {
+                DataFusionError::Execution(format!("Unknown example. {usage}"))
+            })?;
+
+        example.run().await
+    })
 }

--- a/datafusion-examples/examples/flight/main.rs
+++ b/datafusion-examples/examples/flight/main.rs
@@ -122,7 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Manual runtime construction so we can `on_thread_start` to stamp
     // worker threads as eligible for the OomGuard overdraft panic.
-    // Unstamped threads (control plane, the poll task itself) still debit
+    // Unstamped threads still debit
     // the bank but are exempt from the kill.
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/datafusion-examples/examples/flight/main.rs
+++ b/datafusion-examples/examples/flight/main.rs
@@ -98,9 +98,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // early allocations on the main thread benefit. When OomGuard returns
     // NULL on overdraft, the Rust runtime invokes this hook from a clean
     // safe-Rust frame *outside* the `unsafe impl GlobalAlloc` block.
-    // Panicking here gives us per-query isolation without the unwind-ABI
-    // corruption we'd hit firing `panic_any` from inside the allocator.
-    // Non-OomGuard nulls (genuine allocator OOM) fall through to `abort`.
     std::alloc::set_alloc_error_hook(|_layout| {
         if oom_guard::take_kill_pending() {
             let balance = oom_guard::balance();

--- a/datafusion-examples/examples/flight/oom_guard.rs
+++ b/datafusion-examples/examples/flight/oom_guard.rs
@@ -83,7 +83,7 @@ thread_local! {
 }
 
 /// Stamp the current thread as a query worker. Only stamped threads panic
-/// on overdraft; everything else (poll task, gRPC server, control plane)
+/// on overdraft; everything else (i.e. gRPC server)
 /// is exempt. Intended for `on_thread_start` of a per-query / per-task
 /// tokio runtime.
 ///
@@ -178,7 +178,7 @@ fn track(delta: isize) -> bool {
             if std::thread::panicking() {
                 return false;
             }
-            // Unstamped threads (poll task, control plane) still debit the
+            // Unstamped threads still debit the
             // bank above so its value stays honest, but they're exempt from
             // the kill.
             if !STAMPED.with(|stamped| stamped.get()) {

--- a/datafusion-examples/examples/flight/oom_guard.rs
+++ b/datafusion-examples/examples/flight/oom_guard.rs
@@ -30,9 +30,12 @@
 //! - A single global `AtomicIsize BALANCE` represents bytes of headroom
 //!   remaining before a threshold. Every thread's allocations debit it
 //!   and frees credit it.
-//! - A periodic poll overwrites `BALANCE` with `threshold - resident`,
-//!   resyncing the bank to ground truth (read from `/proc/self/statm`)
-//!   so per-alloc drift can't accumulate forever.
+//! - A dedicated OS thread polls jemalloc's `stats.resident` at a fixed
+//!   interval (see [`spawn_balance_poll`]) and writes
+//!   `BALANCE = threshold - resident`. Per-allocation tracking refines
+//!   the bank between ticks; the poll's job is to inject the
+//!   allocator's slab-overhead delta into the bank before per-alloc
+//!   tracking would discover it.
 //! - When the bank goes negative *on a stamped thread* (typically a
 //!   query worker), `alloc` returns NULL. The `alloc_error_hook` then
 //!   originates a `panic_any(OomGuardPanic)` from a clean safe-Rust
@@ -50,6 +53,8 @@ use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 use std::time::Duration;
 
+use tikv_jemalloc_ctl::{epoch, stats};
+
 /// Per-thread drift settles into the global bank when `|drift|` crosses this.
 /// 64 KB keeps per-thread error tight (≤1 MB on a 16-core box) while still
 /// amortizing the atomic op across thousands of allocations.
@@ -61,8 +66,8 @@ const SETTLE_THRESHOLD: isize = 64 * 1024;
 static ARMED: AtomicBool = AtomicBool::new(false);
 
 /// Headroom remaining (bytes) before a stamped thread will panic.
-/// `isize::MAX` until the first poll runs — the guard is effectively off
-/// until then.
+/// `isize::MAX` until [`seed_balance`] runs — the guard is effectively
+/// off until then.
 static BALANCE: AtomicIsize = AtomicIsize::new(isize::MAX);
 
 thread_local! {
@@ -105,9 +110,8 @@ pub fn is_armed() -> bool {
     ARMED.load(Ordering::Relaxed)
 }
 
-/// Overwrite the bank with `value`. The poll task uses this to resync from
-/// real RSS each tick.
-pub fn set_balance(value: isize) {
+/// Overwrite the bank with `value`. Only `seed_balance` calls this.
+fn set_balance(value: isize) {
     BALANCE.store(value, Ordering::Relaxed);
 }
 
@@ -188,35 +192,40 @@ fn track(delta: isize) -> bool {
         .unwrap_or(false)
 }
 
-/// Read the process's resident set size (anon + file pages) in bytes,
-/// straight from `/proc/self/statm`. Avoids any allocator-specific
-/// dependency (jemalloc, mimalloc, etc.) — the cost is a small file
-/// read on each poll tick.
-fn read_resident_bytes() -> Option<u64> {
-    let content = std::fs::read_to_string("/proc/self/statm").ok()?;
-    let mut parts = content.split_ascii_whitespace();
-    // Fields: size resident shared text lib data dt (all in pages)
-    let _size = parts.next()?;
-    let resident_pages: u64 = parts.next()?.parse().ok()?;
-    // Page size — `sysconf(_SC_PAGESIZE)` would be nicer but adds a
-    // libc dep; assume 4 KiB on the platforms this example runs on.
-    Some(resident_pages * 4096)
-}
-
 /// Read the process's cgroup memory limit, if any. Returns `None` for
 /// "no limit set" (cgroup v2 reports `max`; cgroup v1 reports a sentinel
 /// value near `u64::MAX`).
 pub fn cgroup_memory_max() -> Option<u64> {
-    // cgroup v2 (modern Linux distros, k8s nodes).
-    if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
+    fn parse_v2(content: &str) -> Option<u64> {
         let trimmed = content.trim();
-        if trimmed != "max" {
-            if let Ok(value) = trimmed.parse::<u64>() {
-                return Some(value);
+        if trimmed == "max" {
+            None
+        } else {
+            trimmed.parse::<u64>().ok()
+        }
+    }
+
+    // (1) Namespaced cgroup v2 mount.
+    if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
+        if let Some(value) = parse_v2(&content) {
+            return Some(value);
+        }
+    }
+    // (2) Full-hierarchy cgroup v2: discover our own path. `/proc/self/cgroup`
+    //     on v2 looks like `0::/user.slice/.../foo.service`.
+    if let Ok(proc_cgroup) = std::fs::read_to_string("/proc/self/cgroup") {
+        for line in proc_cgroup.lines() {
+            if let Some(rest) = line.strip_prefix("0::") {
+                let path = format!("/sys/fs/cgroup{}/memory.max", rest.trim_end());
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    if let Some(value) = parse_v2(&content) {
+                        return Some(value);
+                    }
+                }
             }
         }
     }
-    // cgroup v1 fallback.
+    // (3) cgroup v1 fallback.
     if let Ok(content) =
         std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes")
     {
@@ -230,31 +239,58 @@ pub fn cgroup_memory_max() -> Option<u64> {
     None
 }
 
-/// Spawn a tokio task that periodically resyncs the bank from real RSS.
-/// Between ticks, per-alloc tracking drifts could accumulate; this task
-/// keeps it in line with the kernel's ground truth.
+/// Spawn a dedicated OS thread that periodically resyncs `BALANCE` from
+/// jemalloc's `stats.resident`. Sets `BALANCE = threshold - resident` on
+/// every tick.
+///
+/// Performs an initial synchronous read before returning so the guard
+/// is fully armed by the time the caller continues.
 pub fn spawn_balance_poll(threshold_bytes: usize, interval: Duration) {
+    let resident_mib = match stats::resident::mib() {
+        Ok(m) => m,
+        Err(e) => {
+            log::error!(
+                "OomGuard: cannot resolve jemalloc resident MIB ({e}); guard disarmed"
+            );
+            return;
+        }
+    };
+    let epoch_mib = match epoch::mib() {
+        Ok(m) => m,
+        Err(e) => {
+            log::error!(
+                "OomGuard: cannot resolve jemalloc epoch MIB ({e}); guard disarmed"
+            );
+            return;
+        }
+    };
+
+    // Initial sync so the bank starts in a meaningful state.
+    let _ = epoch_mib.advance();
+    if let Ok(resident) = resident_mib.read() {
+        let initial = (threshold_bytes as isize).saturating_sub(resident as isize);
+        set_balance(initial);
+    }
+
     log::info!(
-        "OomGuard: starting balance poll (threshold={} bytes, interval={:?})",
-        threshold_bytes,
-        interval
+        "OomGuard: starting balance poll (threshold={threshold_bytes} bytes, interval={interval:?}, initial_balance={} bytes)",
+        balance(),
     );
 
-    tokio::spawn(async move {
-        let mut timer =
-            tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
-        // If tokio is busy and we miss a tick, don't hammer /proc with a
-        // backlog — just skip to the next.
-        timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            timer.tick().await;
-            if let Some(resident) = read_resident_bytes() {
-                let new_balance =
-                    (threshold_bytes as isize).saturating_sub(resident as isize);
-                set_balance(new_balance);
+    std::thread::Builder::new()
+        .name("oom-guard-poll".into())
+        .spawn(move || {
+            loop {
+                std::thread::sleep(interval);
+                let _ = epoch_mib.advance();
+                if let Ok(resident) = resident_mib.read() {
+                    let new_balance =
+                        (threshold_bytes as isize).saturating_sub(resident as isize);
+                    BALANCE.store(new_balance, Ordering::Relaxed);
+                }
             }
-        }
-    });
+        })
+        .expect("failed to spawn oom-guard-poll thread");
 }
 
 /// `GlobalAlloc` wrapper. Forwards every op unchanged to `inner`; the

--- a/datafusion-examples/examples/flight/oom_guard.rs
+++ b/datafusion-examples/examples/flight/oom_guard.rs
@@ -165,8 +165,7 @@ fn track(delta: isize) -> bool {
                 .fetch_add(drift, Ordering::Relaxed)
                 .wrapping_add(drift);
             drift_cell.set(0);
-            // Credits never fire the kill — they happen during Drop chains
-            // in unwind, where aborting an alloc inside a Drop invites UB.
+            // Credits never fire the kill
             if delta >= 0 {
                 return false;
             }

--- a/datafusion-examples/examples/flight/oom_guard.rs
+++ b/datafusion-examples/examples/flight/oom_guard.rs
@@ -1,0 +1,328 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! `OomGuard` — `GlobalAlloc` wrapper that converts a process-wide OOM
+//! into a per-query panic *before* the kernel SIGKILLs the process.
+//!
+//! Motivation: DataFusion's [`MemoryPool`] is voluntary — operators
+//! that don't call `try_grow` (e.g. in-flight batches, `arrow-row`
+//! decode buffers, Arrow kernel scratch space) allocate freely past
+//! the declared budget. On a process with a hard memory ceiling
+//! (k8s pod cgroup, ulimit, etc.) the result is an OS-level kill,
+//! which takes down every concurrent query running on the process.
+//!
+//! `OomGuard` solves this at the allocator layer:
+//!
+//! - A single global `AtomicIsize BALANCE` represents bytes of headroom
+//!   remaining before a threshold. Every thread's allocations debit it
+//!   and frees credit it.
+//! - A periodic poll overwrites `BALANCE` with `threshold - resident`,
+//!   resyncing the bank to ground truth (read from `/proc/self/statm`)
+//!   so per-alloc drift can't accumulate forever.
+//! - When the bank goes negative *on a stamped thread* (typically a
+//!   query worker), `alloc` returns NULL. The `alloc_error_hook` then
+//!   originates a `panic_any(OomGuardPanic)` from a clean safe-Rust
+//!   frame outside the allocator, which unwinds only the offending
+//!   query task. The rest of the process survives.
+//!
+//! Only threads that have called [`stamp_current_thread`] can panic —
+//! the poll task, gRPC server task, etc. are exempt.
+//!
+//! The wrapper costs one relaxed atomic load per allocation when
+//! [`disarm`]ed (which is the default). [`arm`] flips the gate.
+
+use std::alloc::{GlobalAlloc, Layout};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
+use std::time::Duration;
+
+/// Per-thread drift settles into the global bank when `|drift|` crosses this.
+/// 64 KB keeps per-thread error tight (≤1 MB on a 16-core box) while still
+/// amortizing the atomic op across thousands of allocations.
+const SETTLE_THRESHOLD: isize = 64 * 1024;
+
+/// Runtime kill-switch. When `false`, every `track()` call short-circuits on
+/// a single relaxed atomic load — same cost as no wrapper at all on every
+/// path through every allocator op. Stays `false` until [`arm`] is called.
+static ARMED: AtomicBool = AtomicBool::new(false);
+
+/// Headroom remaining (bytes) before a stamped thread will panic.
+/// `isize::MAX` until the first poll runs — the guard is effectively off
+/// until then.
+static BALANCE: AtomicIsize = AtomicIsize::new(isize::MAX);
+
+thread_local! {
+    static LOCAL_DRIFT: Cell<isize> = const { Cell::new(0) };
+    static STAMPED: Cell<bool> = const { Cell::new(false) };
+    /// Set by `track()` just before signalling NULL-PTR back to the
+    /// `GlobalAlloc` caller. Read-and-cleared by `take_kill_pending()`
+    /// from inside the `alloc_error_hook` so the hook knows whether
+    /// to `panic_any(OomGuardPanic)` (our kill) or fall back to
+    /// `process::abort()` (a genuine allocator OOM the runtime asked
+    /// the hook to handle).
+    static KILL_PENDING: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Stamp the current thread as a query worker. Only stamped threads panic
+/// on overdraft; everything else (poll task, gRPC server, control plane)
+/// is exempt. Intended for `on_thread_start` of a per-query / per-task
+/// tokio runtime.
+///
+/// No effect until [`arm`] flips the runtime gate.
+pub fn stamp_current_thread() {
+    STAMPED.with(|stamped| stamped.set(true));
+}
+
+/// Arm the guard. Until this is called, every `track()` short-circuits on a
+/// single relaxed atomic load and the wrapper costs effectively nothing.
+pub fn arm() {
+    ARMED.store(true, Ordering::Relaxed);
+}
+
+/// Disarm the guard. `track()` reverts to the no-op fast path.
+#[allow(dead_code)] // public API; unused by the flight example itself.
+pub fn disarm() {
+    ARMED.store(false, Ordering::Relaxed);
+}
+
+/// Whether the guard is currently armed.
+#[allow(dead_code)] // public API; unused by the flight example itself.
+pub fn is_armed() -> bool {
+    ARMED.load(Ordering::Relaxed)
+}
+
+/// Overwrite the bank with `value`. The poll task uses this to resync from
+/// real RSS each tick.
+pub fn set_balance(value: isize) {
+    BALANCE.store(value, Ordering::Relaxed);
+}
+
+/// Current bank balance — bytes remaining before overdraft. Negative means
+/// the next stamped allocation will panic.
+pub fn balance() -> isize {
+    BALANCE.load(Ordering::Relaxed)
+}
+
+/// Payload attached to overdraft panics. Fired from the `alloc_error_hook`
+/// installed by the binary, which is the only safe seam to originate the
+/// panic from — calling `panic_any` from inside the `unsafe impl GlobalAlloc`
+/// corrupts the unwind ABI.
+#[derive(Debug, Clone)]
+pub struct OomGuardPanic {
+    /// Balance at the moment the panic fired (negative — that's the point).
+    pub balance: isize,
+}
+
+/// Read-and-clear the current thread's `KILL_PENDING` flag. Called by the
+/// `alloc_error_hook` to distinguish OomGuard-induced NULL returns (we
+/// want `panic_any`) from genuine allocator OOM (the hook should fall
+/// back to `process::abort()`).
+#[must_use]
+pub fn take_kill_pending() -> bool {
+    KILL_PENDING.with(|f| f.replace(false))
+}
+
+/// Returns `true` when the caller's `GlobalAlloc` op should fail with
+/// `NULL_PTR` instead of returning a real pointer. The caller is
+/// responsible for refunding the bank if it takes the abort path.
+#[inline(always)]
+#[must_use]
+fn track(delta: isize) -> bool {
+    // Fast path when disarmed: one relaxed load and we're out. Compiles to
+    // a single `mov` on x86 with no fence. This is the path every alloc in
+    // every binary takes by default; performance must be indistinguishable
+    // from the inner allocator.
+    if !ARMED.load(Ordering::Relaxed) {
+        return false;
+    }
+    LOCAL_DRIFT
+        .try_with(|drift_cell| {
+            let drift = drift_cell.get() + delta;
+            // Hot path: drift fits — accumulate locally and bail.
+            if -SETTLE_THRESHOLD < drift && drift < SETTLE_THRESHOLD {
+                drift_cell.set(drift);
+                return false;
+            }
+            let new_balance = BALANCE
+                .fetch_add(drift, Ordering::Relaxed)
+                .wrapping_add(drift);
+            drift_cell.set(0);
+            // Credits never fire the kill — they happen during Drop chains
+            // in unwind, where aborting an alloc inside a Drop invites UB.
+            if delta >= 0 {
+                return false;
+            }
+            if new_balance >= 0 {
+                return false;
+            }
+            // Returning null to a Drop body inside an ongoing unwind is
+            // unsafe — caller may not be coded to handle the failure path.
+            if std::thread::panicking() {
+                return false;
+            }
+            // Unstamped threads (poll task, control plane) still debit the
+            // bank above so its value stays honest, but they're exempt from
+            // the kill.
+            if !STAMPED.with(|stamped| stamped.get()) {
+                return false;
+            }
+            // Flag the upcoming `alloc_error_hook` invocation as ours so
+            // it fires `panic_any` instead of falling back to abort.
+            KILL_PENDING.with(|f| f.set(true));
+            true
+        })
+        .unwrap_or(false)
+}
+
+/// Read the process's resident set size (anon + file pages) in bytes,
+/// straight from `/proc/self/statm`. Avoids any allocator-specific
+/// dependency (jemalloc, mimalloc, etc.) — the cost is a small file
+/// read on each poll tick.
+fn read_resident_bytes() -> Option<u64> {
+    let content = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let mut parts = content.split_ascii_whitespace();
+    // Fields: size resident shared text lib data dt (all in pages)
+    let _size = parts.next()?;
+    let resident_pages: u64 = parts.next()?.parse().ok()?;
+    // Page size — `sysconf(_SC_PAGESIZE)` would be nicer but adds a
+    // libc dep; assume 4 KiB on the platforms this example runs on.
+    Some(resident_pages * 4096)
+}
+
+/// Read the process's cgroup memory limit, if any. Returns `None` for
+/// "no limit set" (cgroup v2 reports `max`; cgroup v1 reports a sentinel
+/// value near `u64::MAX`).
+pub fn cgroup_memory_max() -> Option<u64> {
+    // cgroup v2 (modern Linux distros, k8s nodes).
+    if let Ok(content) = std::fs::read_to_string("/sys/fs/cgroup/memory.max") {
+        let trimmed = content.trim();
+        if trimmed != "max" {
+            if let Ok(value) = trimmed.parse::<u64>() {
+                return Some(value);
+            }
+        }
+    }
+    // cgroup v1 fallback.
+    if let Ok(content) =
+        std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+    {
+        if let Ok(value) = content.trim().parse::<u64>() {
+            // Kernels report a near-u64::MAX sentinel for "no limit".
+            if value < u64::MAX / 2 {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+/// Spawn a tokio task that periodically resyncs the bank from real RSS.
+/// Between ticks, per-alloc tracking drifts could accumulate; this task
+/// keeps it in line with the kernel's ground truth.
+pub fn spawn_balance_poll(threshold_bytes: usize, interval: Duration) {
+    log::info!(
+        "OomGuard: starting balance poll (threshold={} bytes, interval={:?})",
+        threshold_bytes,
+        interval
+    );
+
+    tokio::spawn(async move {
+        let mut timer =
+            tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
+        // If tokio is busy and we miss a tick, don't hammer /proc with a
+        // backlog — just skip to the next.
+        timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            timer.tick().await;
+            if let Some(resident) = read_resident_bytes() {
+                let new_balance =
+                    (threshold_bytes as isize).saturating_sub(resident as isize);
+                set_balance(new_balance);
+            }
+        }
+    });
+}
+
+/// `GlobalAlloc` wrapper. Forwards every op unchanged to `inner`; the
+/// accounting is a thread-local update + amortized atomic settle.
+pub struct OomGuard<A: GlobalAlloc> {
+    inner: A,
+}
+
+impl<A: GlobalAlloc> OomGuard<A> {
+    /// Wrap `inner`. `const` so it can be assigned to a `#[global_allocator]` static.
+    pub const fn new(inner: A) -> Self {
+        Self { inner }
+    }
+}
+
+unsafe impl<A: GlobalAlloc> GlobalAlloc for OomGuard<A> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let delta = -(layout.size() as isize);
+        if track(delta) {
+            // Caller will get null, call `handle_alloc_error`, and abort cleanly.
+            // Refund the accounting since no allocation actually happened.
+            let _ = track(-delta);
+            return std::ptr::null_mut();
+        }
+        // SAFETY: layout is forwarded unchanged.
+        let ptr = unsafe { self.inner.alloc(layout) };
+        if ptr.is_null() {
+            let _ = track(-delta);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: caller upholds GlobalAlloc invariants; forwarded unchanged.
+        unsafe { self.inner.dealloc(ptr, layout) };
+        // Credit only; `track()` short-circuits on `delta >= 0` so this can
+        // never request an abort.
+        let _ = track(layout.size() as isize);
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let delta = -(layout.size() as isize);
+        if track(delta) {
+            let _ = track(-delta);
+            return std::ptr::null_mut();
+        }
+        // SAFETY: layout is forwarded unchanged.
+        let ptr = unsafe { self.inner.alloc_zeroed(layout) };
+        if ptr.is_null() {
+            let _ = track(-delta);
+        }
+        ptr
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let delta = layout.size() as isize - new_size as isize;
+        if track(delta) {
+            // Returning null is the documented way to signal realloc failure;
+            // the caller's old `ptr` remains valid (we never called
+            // `inner.realloc`), so no double-free risk.
+            let _ = track(-delta);
+            return std::ptr::null_mut();
+        }
+        // SAFETY: caller upholds GlobalAlloc invariants; forwarded unchanged.
+        let new_ptr = unsafe { self.inner.realloc(ptr, layout, new_size) };
+        if new_ptr.is_null() {
+            let _ = track(-delta);
+        }
+        new_ptr
+    }
+}

--- a/datafusion-examples/examples/flight/oom_guard.rs
+++ b/datafusion-examples/examples/flight/oom_guard.rs
@@ -28,14 +28,25 @@
 //! `OomGuard` solves this at the allocator layer:
 //!
 //! - A single global `AtomicIsize BALANCE` represents bytes of headroom
-//!   remaining before a threshold. Every thread's allocations debit it
-//!   and frees credit it.
-//! - A dedicated OS thread polls jemalloc's `stats.resident` at a fixed
-//!   interval (see [`spawn_balance_poll`]) and writes
-//!   `BALANCE = threshold - resident`. Per-allocation tracking refines
-//!   the bank between ticks; the poll's job is to inject the
-//!   allocator's slab-overhead delta into the bank before per-alloc
-//!   tracking would discover it.
+//!   remaining before the kernel would OOMKill us. Every thread's
+//!   allocations debit it and frees credit it.
+//! - A dedicated OS thread polls the kernel's `memory.current` and
+//!   jemalloc's own counters at a fixed interval (see
+//!   [`spawn_balance_poll`]) and writes
+//!   `BALANCE = memory.max − memory.current − anon_debt − headroom`,
+//!   where `anon_debt = max(0, jemalloc::allocated − jemalloc::resident)`
+//!   is the bytes the application has been handed by the allocator but
+//!   hasn't yet caused the kernel to back with physical pages — i.e.
+//!   pages a `for` loop could turn into `memory.current` growth without
+//!   any further allocator call we'd intercept. The kernel itself kills
+//!   on `memory.current > memory.max`; the poll's formula directly
+//!   predicts whether the *next* tick could face that. Per-allocation
+//!   tracking refines the bank between ticks. (We deliberately use
+//!   jemalloc's `allocated` rather than `VmData − RssAnon` from
+//!   `/proc/self/status`, because jemalloc reserves multi-GiB of
+//!   virtual at startup for its arenas — none of which is reachable by
+//!   application writes without going through an `alloc()` we already
+//!   debit.)
 //! - When the bank goes negative *on a stamped thread* (typically a
 //!   query worker), `alloc` returns NULL. The `alloc_error_hook` then
 //!   originates a `panic_any(OomGuardPanic)` from a clean safe-Rust
@@ -50,10 +61,13 @@
 
 use std::alloc::{GlobalAlloc, Layout};
 use std::cell::Cell;
+use std::fs::File;
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 use std::time::Duration;
 
-use tikv_jemalloc_ctl::{epoch, stats};
+use tikv_jemalloc_ctl::{epoch, epoch_mib as EpochMib, stats};
 
 /// Per-thread drift settles into the global bank when `|drift|` crosses this.
 /// 64 KB keeps per-thread error tight (≤1 MB on a 16-core box) while still
@@ -238,58 +252,131 @@ pub fn cgroup_memory_max() -> Option<u64> {
     None
 }
 
-/// Spawn a dedicated OS thread that periodically resyncs `BALANCE` from
-/// jemalloc's `stats.resident`. Sets `BALANCE = threshold - resident` on
-/// every tick.
-///
-/// Performs an initial synchronous read before returning so the guard
-/// is fully armed by the time the caller continues.
-pub fn spawn_balance_poll(threshold_bytes: usize, interval: Duration) {
-    let resident_mib = match stats::resident::mib() {
-        Ok(m) => m,
-        Err(e) => {
-            log::error!(
-                "OomGuard: cannot resolve jemalloc resident MIB ({e}); guard disarmed"
-            );
-            return;
+/// Discover the path to this cgroup's `memory.current` file. Mirror of
+/// [`cgroup_memory_max`] but for the live charge against the limit.
+/// Returns `None` if no memory controller is reachable.
+pub fn cgroup_memory_current_path() -> Option<PathBuf> {
+    // (1) Namespaced cgroup v2 mount.
+    let direct = Path::new("/sys/fs/cgroup/memory.current");
+    if direct.exists() {
+        return Some(direct.to_path_buf());
+    }
+    // (2) Full-hierarchy cgroup v2: derive from `/proc/self/cgroup`.
+    if let Ok(proc_cgroup) = std::fs::read_to_string("/proc/self/cgroup") {
+        for line in proc_cgroup.lines() {
+            if let Some(rest) = line.strip_prefix("0::") {
+                let path = PathBuf::from(format!(
+                    "/sys/fs/cgroup{}/memory.current",
+                    rest.trim_end()
+                ));
+                if path.exists() {
+                    return Some(path);
+                }
+            }
         }
-    };
-    let epoch_mib = match epoch::mib() {
-        Ok(m) => m,
-        Err(e) => {
-            log::error!(
-                "OomGuard: cannot resolve jemalloc epoch MIB ({e}); guard disarmed"
-            );
-            return;
-        }
-    };
+    }
+    // (3) cgroup v1 fallback.
+    let v1 = Path::new("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+    if v1.exists() {
+        return Some(v1.to_path_buf());
+    }
+    None
+}
 
-    // Initial sync so the bank starts in a meaningful state.
+/// `pread` a kernfs/procfs file whose contents are a single integer in
+/// bytes, possibly trailed by whitespace.
+fn read_u64_file(file: &File) -> Option<u64> {
+    let mut buf = [0u8; 32];
+    let n = file.read_at(&mut buf, 0).ok()?;
+    std::str::from_utf8(&buf[..n]).ok()?.trim().parse().ok()
+}
+
+/// Compute the poll-tick balance:
+/// `BALANCE = memory.max − memory.current − anon_debt − headroom`,
+fn compute_balance(
+    memory_max: u64,
+    headroom_bytes: u64,
+    memory_current_file: &File,
+    epoch_mib: &EpochMib,
+    allocated_mib: &stats::allocated_mib,
+    resident_mib: &stats::resident_mib,
+) -> Option<isize> {
     let _ = epoch_mib.advance();
-    if let Ok(resident) = resident_mib.read() {
-        let initial = (threshold_bytes as isize).saturating_sub(resident as isize);
+    let memory_current = read_u64_file(memory_current_file)?;
+    let allocated = allocated_mib.read().ok()? as u64;
+    let resident = resident_mib.read().ok()? as u64;
+    let anon_debt = allocated.saturating_sub(resident);
+    let balance = (memory_max as i128)
+        - (memory_current as i128)
+        - (anon_debt as i128)
+        - (headroom_bytes as i128);
+    Some(balance.clamp(isize::MIN as i128, isize::MAX as i128) as isize)
+}
+
+/// Spawn a dedicated OS thread that periodically resyncs `BALANCE`
+/// against the kernel's `memory.current` (the truth the OOM-killer
+/// uses) and jemalloc's view of allocated-but-not-yet-resident bytes.
+/// Holds open a `pread`-able handle to `/sys/fs/cgroup/.../memory.current`
+/// and pre-resolved jemalloc MIBs so each tick is one syscall + a
+/// jemalloc epoch advance + two stats reads.
+///
+/// `memory_max` is the cgroup hard ceiling; `headroom_bytes` is the
+/// fixed slack carved out below it. The kill threshold is implicit
+/// as `memory_max − headroom_bytes`.
+///
+/// Returns once the poll thread is spawned. Performs an initial sync
+/// best-effort so the bank starts in a meaningful state; if that read
+/// fails, `BALANCE` stays at `isize::MAX` until the first tick lands.
+pub fn spawn_balance_poll(
+    memory_max: u64,
+    headroom_bytes: u64,
+    interval: Duration,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let memory_current_path =
+        cgroup_memory_current_path().ok_or("cannot locate cgroup memory.current")?;
+    let memory_current_file = File::open(&memory_current_path)
+        .map_err(|e| format!("opening {}: {e}", memory_current_path.display()))?;
+    let epoch_mib = epoch::mib().map_err(|e| format!("jemalloc epoch MIB: {e}"))?;
+    let allocated_mib =
+        stats::allocated::mib().map_err(|e| format!("jemalloc allocated MIB: {e}"))?;
+    let resident_mib =
+        stats::resident::mib().map_err(|e| format!("jemalloc resident MIB: {e}"))?;
+
+    if let Some(initial) = compute_balance(
+        memory_max,
+        headroom_bytes,
+        &memory_current_file,
+        &epoch_mib,
+        &allocated_mib,
+        &resident_mib,
+    ) {
         set_balance(initial);
     }
 
     log::info!(
-        "OomGuard: starting balance poll (threshold={threshold_bytes} bytes, interval={interval:?}, initial_balance={} bytes)",
+        "OomGuard: starting balance poll (memory_max={memory_max} bytes, \
+         headroom={headroom_bytes} bytes, interval={interval:?}, \
+         initial_balance={} bytes, source={})",
         balance(),
+        memory_current_path.display(),
     );
 
     std::thread::Builder::new()
         .name("oom-guard-poll".into())
-        .spawn(move || {
-            loop {
-                std::thread::sleep(interval);
-                let _ = epoch_mib.advance();
-                if let Ok(resident) = resident_mib.read() {
-                    let new_balance =
-                        (threshold_bytes as isize).saturating_sub(resident as isize);
-                    BALANCE.store(new_balance, Ordering::Relaxed);
-                }
+        .spawn(move || loop {
+            std::thread::sleep(interval);
+            if let Some(new_balance) = compute_balance(
+                memory_max,
+                headroom_bytes,
+                &memory_current_file,
+                &epoch_mib,
+                &allocated_mib,
+                &resident_mib,
+            ) {
+                BALANCE.store(new_balance, Ordering::Relaxed);
             }
-        })
-        .expect("failed to spawn oom-guard-poll thread");
+        })?;
+    Ok(())
 }
 
 /// `GlobalAlloc` wrapper. Forwards every op unchanged to `inner`; the

--- a/datafusion-examples/examples/flight/sql_server.rs
+++ b/datafusion-examples/examples/flight/sql_server.rs
@@ -42,17 +42,21 @@ use dashmap::DashMap;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::prelude::{DataFrame, ParquetReadOptions, SessionConfig, SessionContext};
 use datafusion_examples::utils::{datasets::ExampleDataset, write_csv_to_parquet};
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use log::info;
 use mimalloc::MiMalloc;
 use prost::Message;
+use std::panic::AssertUnwindSafe;
+use std::time::Duration;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 use uuid::Uuid;
 
+use crate::oom_guard::{self, OomGuard, OomGuardPanic};
+
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: OomGuard<MiMalloc> = OomGuard::new(MiMalloc);
 
 macro_rules! status {
     ($desc:expr, $err:expr) => {
@@ -74,6 +78,25 @@ macro_rules! status {
 /// and the example in arrow-rs: https://github.com/apache/arrow-rs/blob/master/arrow-flight/examples/flight_sql_server.rs
 pub async fn sql_server() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
+
+    // Arm OomGuard against the process's cgroup limit (if one is set —
+    // e.g. running under `systemd-run --scope -p MemoryMax=…` or inside
+    // a Kubernetes pod). With no cgroup limit, the guard stays disarmed
+    // and the wrapper costs one relaxed atomic load per allocation.
+    if let Some(cgroup_limit) = oom_guard::cgroup_memory_max() {
+        // Trip the guard with 5% headroom — leaves room for the unwind
+        // and Drop chains to actually allocate as they tear down.
+        let threshold = ((cgroup_limit as f64) * 0.95) as usize;
+        info!(
+            "OomGuard: arming for cgroup memory.max={} bytes, threshold={} bytes",
+            cgroup_limit, threshold
+        );
+        oom_guard::spawn_balance_poll(threshold, Duration::from_millis(500));
+        oom_guard::arm();
+    } else {
+        info!("OomGuard: no cgroup memory limit found; staying disarmed");
+    }
+
     let addr = "0.0.0.0:50051".parse()?;
     let service = FlightSqlServiceImpl {
         contexts: Default::default(),
@@ -295,10 +318,27 @@ impl FlightSqlService for FlightSqlServiceImpl {
 
         let state = ctx.state();
         let df = DataFrame::new(state, plan);
-        let result = df
-            .collect()
-            .await
-            .map_err(|e| status!("Error executing query", e))?;
+        // Catch OomGuard panics here so an overdraft kills the query instead
+        // of the server. Non-OomGuard panics are re-raised (they indicate a
+        // real bug, not a memory-pressure response).
+        let result = match AssertUnwindSafe(df.collect()).catch_unwind().await {
+            Ok(Ok(batches)) => batches,
+            Ok(Err(e)) => return Err(status!("Error executing query", e)),
+            Err(panic_payload) => {
+                if let Some(g) = panic_payload.downcast_ref::<OomGuardPanic>() {
+                    log::error!(
+                        "OomGuard fired: query killed before process OOM \
+                         (balance={} bytes)",
+                        g.balance
+                    );
+                    return Err(Status::resource_exhausted(format!(
+                        "OomGuard: query killed before process OOM (balance={} bytes)",
+                        g.balance
+                    )));
+                }
+                std::panic::resume_unwind(panic_payload);
+            }
+        };
 
         // if we get an empty result, create an empty schema
         let schema = match result.first() {

--- a/datafusion-examples/examples/flight/sql_server.rs
+++ b/datafusion-examples/examples/flight/sql_server.rs
@@ -99,10 +99,16 @@ pub async fn sql_server() -> Result<(), Box<dyn std::error::Error>> {
                 .and_then(|s| s.parse::<f64>().ok())
                 .unwrap_or(0.05)
                 .clamp(0.0, 0.95);
-            let threshold =
-                ((cgroup_limit as f64) * (1.0 - headroom_fraction)) as usize;
-            oom_guard::spawn_balance_poll(threshold, Duration::from_millis(10));
-            oom_guard::arm();
+            let headroom_bytes =
+                ((cgroup_limit as f64) * headroom_fraction) as u64;
+            match oom_guard::spawn_balance_poll(
+                cgroup_limit,
+                headroom_bytes,
+                Duration::from_millis(10),
+            ) {
+                Ok(()) => oom_guard::arm(),
+                Err(e) => log::error!("OomGuard: {e}; guard disarmed"),
+            }
         }
         (false, _) => {
             info!("OomGuard: disabled via OOM_GUARD=off");

--- a/datafusion-examples/examples/flight/sql_server.rs
+++ b/datafusion-examples/examples/flight/sql_server.rs
@@ -44,10 +44,10 @@ use datafusion::prelude::{DataFrame, ParquetReadOptions, SessionConfig, SessionC
 use datafusion_examples::utils::{datasets::ExampleDataset, write_csv_to_parquet};
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use log::info;
-use mimalloc::MiMalloc;
 use prost::Message;
 use std::panic::AssertUnwindSafe;
 use std::time::Duration;
+use tikv_jemallocator::Jemalloc;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
@@ -56,7 +56,7 @@ use uuid::Uuid;
 use crate::oom_guard::{self, OomGuard, OomGuardPanic};
 
 #[global_allocator]
-static GLOBAL: OomGuard<MiMalloc> = OomGuard::new(MiMalloc);
+static GLOBAL: OomGuard<Jemalloc> = OomGuard::new(Jemalloc);
 
 macro_rules! status {
     ($desc:expr, $err:expr) => {
@@ -79,22 +79,37 @@ macro_rules! status {
 pub async fn sql_server() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    // Arm OomGuard against the process's cgroup limit (if one is set —
-    // e.g. running under `systemd-run --scope -p MemoryMax=…` or inside
-    // a Kubernetes pod). With no cgroup limit, the guard stays disarmed
-    // and the wrapper costs one relaxed atomic load per allocation.
-    if let Some(cgroup_limit) = oom_guard::cgroup_memory_max() {
-        // Trip the guard with 5% headroom — leaves room for the unwind
-        // and Drop chains to actually allocate as they tear down.
-        let threshold = ((cgroup_limit as f64) * 0.95) as usize;
-        info!(
-            "OomGuard: arming for cgroup memory.max={} bytes, threshold={} bytes",
-            cgroup_limit, threshold
-        );
-        oom_guard::spawn_balance_poll(threshold, Duration::from_millis(500));
-        oom_guard::arm();
-    } else {
-        info!("OomGuard: no cgroup memory limit found; staying disarmed");
+    // Arm OomGuard against the process's cgroup limit. Demo flag:
+    //   OOM_GUARD=off  → wrapper stays disarmed (allocator behaves
+    //                    transparently; A/B against the armed run on
+    //                    the same cgroup to see the difference)
+    //   unset or any other value → arm if a cgroup limit is detected
+    //
+    // With no cgroup limit at all (raw shell run), the guard also stays
+    // disarmed — there's nothing meaningful to compare against.
+    let oom_guard_enabled = std::env::var("OOM_GUARD")
+        .map(|v| v.to_ascii_lowercase() != "off")
+        .unwrap_or(true);
+    match (oom_guard_enabled, oom_guard::cgroup_memory_max()) {
+        (true, Some(cgroup_limit)) => {
+            // Headroom: fraction of the cgroup limit reserved between
+            // the threshold and the kernel's hard ceiling.
+            let headroom_fraction = std::env::var("OOM_GUARD_HEADROOM")
+                .ok()
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(0.05)
+                .clamp(0.0, 0.95);
+            let threshold =
+                ((cgroup_limit as f64) * (1.0 - headroom_fraction)) as usize;
+            oom_guard::spawn_balance_poll(threshold, Duration::from_millis(10));
+            oom_guard::arm();
+        }
+        (false, _) => {
+            info!("OomGuard: disabled via OOM_GUARD=off");
+        }
+        (true, None) => {
+            info!("OomGuard: no cgroup memory limit found; staying disarmed");
+        }
     }
 
     let addr = "0.0.0.0:50051".parse()?;


### PR DESCRIPTION
## Which issue does this PR close?

Not closing an issue directly. This is a follow-up to the
`MemoryPool` accounting discussion (#22723, #22758) — demonstrates an alternative approach.
Instead of catching `MemoryPool` divergences from allocations, this uses the `flight_sql_server` example
to demonstrate how downstream applications can install a custom allocator to abort queries rather
than OOMing when `MemoryTracker` under-reports.

## Rationale for this change

`MemoryPool` is voluntary. Operators that don't call `try_grow` —
in-flight batches, `arrow-row` decode buffers, Arrow kernel scratch
space, allocator slab overhead — allocate freely past the declared
budget. On a process with a hard memory ceiling (k8s pod cgroup,
ulimit), the result is an OS-level kill that takes down every
concurrent query, not just the offender.

This PR adds `OomGuard`, a `GlobalAlloc` wrapper. Implementation details:

1. Every Rust allocation is debited from a global `BALANCE` atomic.
2. A dedicated OS thread polls jemalloc's `stats.resident` every 10ms
   and syncs `BALANCE = threshold - resident`, catching slab pages
   that the kernel sees but `GlobalAlloc` doesn't.
3. When `BALANCE` goes negative on a stamped query worker, the
   wrapper returns `NULL` from `alloc`.
4. An `alloc_error_hook` originates `panic_any(OomGuardPanic)` from
   a safe-Rust frame outside the allocator.
5. The panic unwinds through `df.collect()`, gets caught in the
   example, and is converted to `Status::resource_exhausted`. The
   query dies; the server survives.

A/B demo on the same 1GiB cgroup:
- `OOM_GUARD=off`: client sees broken pipe, server SIGKILLed.
- `OOM_GUARD` on (default): client sees `ResourceExhausted`,
  follow-up `SELECT 1` against the same server returns immediately.

## What changes are included in this PR?

Everything is scoped to `datafusion-examples/examples/flight/`:

- `oom_guard.rs` (new) — the `GlobalAlloc` wrapper, per-thread
  drift settling, jemalloc-stats-based poll,
  cgroup-v2/v1 memory-limit discovery.
- `sql_server.rs` — wraps the global allocator with
  `OomGuard<Jemalloc>`, arms via `OOM_GUARD` env var with
  configurable headroom (`OOM_GUARD_HEADROOM`, default 5%), wraps
  `df.collect()` in `catch_unwind` to convert `OomGuardPanic` to
  a `Status::resource_exhausted` response.
- `main.rs` — installs the `alloc_error_hook`, installs a global
  panic hook that logs `OomGuardPanic` distinctly
- `.cargo/config.toml` (new) — sets `RUSTC_BOOTSTRAP=1` so
  `#![feature(alloc_error_hook)]` (tracking rust-lang/rust#51245)
  builds on stable.
- `README.md` (new) — A/B walkthrough.

## Are these changes tested?

Manually via the A/B in the README. No automated tests
added: the example's behavior depends on a cgroup limit being in
effect, which doesn't fit the existing test harness.

## Are there any user-facing changes?

Only to the `flight` example. No core / library API surface changed.

## Caveats

- `alloc_error_hook` is currently unstable. The workspace
  `.cargo/config.toml` sets `RUSTC_BOOTSTRAP=1` to compile it on a
  stable toolchain.
- The poll currently reads jemalloc-specific stats. Making it
  allocator-agnostic by reading cgroup's `memory.current` instead is
  a straightforward follow-up if there's interest.