### PR TITLE
bench: make wide_schema honor DATA_DIR like the other sql_benchmarks

### DIFF
--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -775,12 +775,14 @@ data_wide_schema() {
 run_wide_schema() {
     echo "Running wide_schema benchmark (wide subgroup)..."
     debug_run env BENCH_NAME=wide_schema BENCH_SUBGROUP=wide \
+      DATA_DIR="${DATA_DIR}" \
       SIMULATE_LATENCY="${SIMULATE_LATENCY}" \
       ${QUERY:+BENCH_QUERY="${QUERY}"}  \
       bash -c "$SQL_CARGO_COMMAND"
 
     echo "Running wide_schema benchmark (narrow baseline subgroup)..."
     debug_run env BENCH_NAME=wide_schema BENCH_SUBGROUP=narrow \
+      DATA_DIR="${DATA_DIR}" \
       SIMULATE_LATENCY="${SIMULATE_LATENCY}" \
       ${QUERY:+BENCH_QUERY="${QUERY}"}  \
       bash -c "$SQL_CARGO_COMMAND"

--- a/benchmarks/sql_benchmarks/wide_schema/init/load.sql
+++ b/benchmarks/sql_benchmarks/wide_schema/init/load.sql
@@ -3,4 +3,4 @@
 --   BENCH_SUBGROUP=wide   → 1024-col synthetic dataset (the actual benchmark)
 --   BENCH_SUBGROUP=narrow → 8-col baseline (companion only — meaningful
 --                           only when compared to the wide numbers)
-CREATE EXTERNAL TABLE events STORED AS PARQUET LOCATION 'data/wide_schema/${BENCH_SUBGROUP:-wide}/';
+CREATE EXTERNAL TABLE events STORED AS PARQUET LOCATION '${DATA_DIR:-data}/wide_schema/${BENCH_SUBGROUP:-wide}/';


### PR DESCRIPTION
## Which issue does this PR close?

- Relates to #21968 (wide-schema benchmark work).

## Rationale for this change

Every `sql_benchmarks` suite declares its external-table `LOCATION` as `${DATA_DIR:-data}/...`, and the matching `bench.sh run_*` forwards `DATA_DIR="${DATA_DIR}"` to the benchmark process — e.g. `clickbench`, `imdb`, `tpch`, `push_down_topk`, `h2o` all do this.

`wide_schema` (added in #21970) diverged on **both** counts:
- `wide_schema/init/load.sql` hardcoded `LOCATION 'data/wide_schema/...'` (no `${DATA_DIR}`)
- `run_wide_schema` did not forward `DATA_DIR`

Run from inside the repo this happens to work, because the process CWD is the repo's `benchmarks/` and the relative `data/` path resolves. But it breaks whenever the data directory is not under the current directory — for example the CI benchmark runner builds/runs the benchmark from a separate source checkout while staging the dataset elsewhere and pointing at it via `DATA_DIR`. There, wide_schema fails at load:

```
initialization failed: No files found at file:///.../benchmarks/data/wide_schema/wide/.
Cannot infer schema from an empty location; either add data files or declare an explicit schema for the table.
```

(The `bench.sh` variable `DATA_DIR` is set but not exported, so it only reaches the benchmark when a `run_*` function passes it explicitly — which `run_tpch` etc. do and `run_wide_schema` did not.)

## What changes are included in this PR?

Two one-line fixes bringing `wide_schema` in line with the convention used by every other suite:
- `load.sql`: `data/wide_schema/...` → `${DATA_DIR:-data}/wide_schema/...`
- `run_wide_schema`: forward `DATA_DIR="${DATA_DIR}"` for both the `wide` and `narrow` subgroups

## Are these changes tested?

Benchmark tooling only. The substitution path is the same one every other suite already relies on: the SQL harness's `process_replacements` resolves `${DATA_DIR:-data}` from the env (falling back to `data`), and `run_wide_schema` now forwards `DATA_DIR` exactly as `run_tpch` does. Verified `bench.sh` still parses (`bash -n`). Default in-repo behavior is unchanged (CWD-relative `data/`).

## Are there any user-facing changes?

No. Benchmark harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)