### PR TITLE
feat: make `date_part` always return Float64

### DIFF
--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use arrow::array::timezone::Tz;
 use arrow::array::{Array, ArrayRef, Float64Array, Int32Array, Int64Array};
 use arrow::compute::kernels::cast_utils::IntervalUnit;
-use arrow::compute::{DatePart, binary, date_part};
+use arrow::compute::{DatePart, binary, cast, date_part};
 use arrow::datatypes::DataType::{
     Date32, Date64, Duration, Interval, Time32, Time64, Timestamp,
 };
@@ -58,7 +58,9 @@ use datafusion_macros::user_doc;
 
 #[user_doc(
     doc_section(label = "Time and Date Functions"),
-    description = "Returns the specified part of the date as an integer.",
+    description = "Returns the specified part of the date as a double precision \
+    floating-point value. Matches PostgreSQL's `date_part` return type \
+    (https://www.postgresql.org/docs/current/functions-datetime.html).",
     syntax_example = "date_part(part, expression)",
     alternative_syntax = "extract(field FROM source)",
     argument(
@@ -92,13 +94,13 @@ use datafusion_macros::user_doc;
 +-----------------------------------------------------+
 | date_part(Utf8("year"),Utf8("2024-05-01T00:00:00")) |
 +-----------------------------------------------------+
-| 2024                                                |
+| 2024.0                                              |
 +-----------------------------------------------------+
 > SELECT extract(day FROM timestamp '2024-05-01T00:00:00');
 +----------------------------------------------------+
 | date_part(Utf8("DAY"),Utf8("2024-05-01T00:00:00")) |
 +----------------------------------------------------+
-| 1                                                  |
+| 1.0                                                |
 +----------------------------------------------------+
 ```"#
 )]
@@ -169,21 +171,14 @@ impl ScalarUDFImpl for DatePartFunc {
         let [field, _] = take_function_args(self.name(), args.scalar_arguments)?;
         let nullable = args.arg_fields[1].is_nullable();
 
+        // Always return Float64 to match PostgreSQL's `date_part`, which is
+        // defined to return `double precision` regardless of the part.
         field
             .and_then(|sv| {
                 sv.try_as_str()
                     .flatten()
                     .filter(|s| !s.is_empty())
-                    .map(|part| {
-                        if is_epoch(part) {
-                            Field::new(self.name(), DataType::Float64, nullable)
-                        } else if is_nanosecond(part) {
-                            // See notes on [seconds_ns] for rationale
-                            Field::new(self.name(), DataType::Int64, nullable)
-                        } else {
-                            Field::new(self.name(), DataType::Int32, nullable)
-                        }
-                    })
+                    .map(|_| Field::new(self.name(), DataType::Float64, nullable))
             })
             .map(Arc::new)
             .map_or_else(
@@ -256,6 +251,16 @@ impl ScalarUDFImpl for DatePartFunc {
             }
         };
 
+        // Cast the kernel result to Float64 so this function always returns a
+        // double precision value, matching PostgreSQL's `date_part`. The
+        // underlying arrow kernels still produce Int32/Int64 (or already-
+        // Float64 for `epoch`), so this is a no-op cast in the Float64 case.
+        let arr = if arr.data_type() == &DataType::Float64 {
+            arr
+        } else {
+            cast(arr.as_ref(), &DataType::Float64)?
+        };
+
         Ok(if is_scalar {
             ColumnarValue::Scalar(ScalarValue::try_from_array(arr.as_ref(), 0)?)
         } else {
@@ -293,9 +298,14 @@ impl ScalarUDFImpl for DatePartFunc {
             return Ok(PreimageResult::None);
         };
 
-        // Extract i32 year from Scalar value
+        // Extract the year from the literal scalar. `date_part` now always
+        // returns Float64, so the type-coerced binary expression will compare
+        // against a Float64 literal. We still accept Int32/Int64 for callers
+        // that bypass type coercion.
         let year = match argument_literal {
+            ScalarValue::Float64(Some(y)) if y.fract() == 0.0 => *y as i32,
             ScalarValue::Int32(Some(y)) => *y,
+            ScalarValue::Int64(Some(y)) if i32::try_from(*y).is_ok() => *y as i32,
             _ => return Ok(PreimageResult::None),
         };
 
@@ -335,17 +345,6 @@ impl ScalarUDFImpl for DatePartFunc {
     fn documentation(&self) -> Option<&Documentation> {
         self.doc()
     }
-}
-
-fn is_epoch(part: &str) -> bool {
-    let part = part_normalization(part);
-    matches!(part.to_lowercase().as_str(), "epoch")
-}
-
-fn is_nanosecond(part: &str) -> bool {
-    IntervalUnit::from_str(part_normalization(part))
-        .map(|p| matches!(p, IntervalUnit::Nanosecond))
-        .unwrap_or(false)
 }
 
 fn date_to_scalar(date: NaiveDate, target_type: &DataType) -> Option<ScalarValue> {

--- a/datafusion/spark/src/function/datetime/date_part.rs
+++ b/datafusion/spark/src/function/datetime/date_part.rs
@@ -119,9 +119,15 @@ impl ScalarUDFImpl for SparkDatePart {
 
         let part_expr = Expr::Literal(ScalarValue::new_utf8(part), None);
 
-        let date_part_expr = Expr::ScalarFunction(ScalarFunction::new_udf(
-            datafusion_functions::datetime::date_part(),
-            vec![part_expr, date_expr],
+        // DataFusion's `date_part` follows PostgreSQL and returns
+        // `Float64`. Spark's `date_part` returns `Int32` for the parts we
+        // handle here, so cast the result back to preserve Spark semantics.
+        let date_part_expr = Expr::Cast(datafusion_expr::expr::Cast::new(
+            Box::new(Expr::ScalarFunction(ScalarFunction::new_udf(
+                datafusion_functions::datetime::date_part(),
+                vec![part_expr, date_expr],
+            ))),
+            DataType::Int32,
         ));
 
         match part {

--- a/datafusion/sqllogictest/test_files/clickbench.slt
+++ b/datafusion/sqllogictest/test_files/clickbench.slt
@@ -528,7 +528,7 @@ physical_plan
 06)----------AggregateExec: mode=Partial, gby=[UserID@1 as UserID, date_part(MINUTE, to_timestamp_seconds(EventTime@0)) as date_part(Utf8("MINUTE"),to_timestamp_seconds(hits.EventTime)), SearchPhrase@2 as SearchPhrase], aggr=[count(Int64(1))]
 07)------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/clickbench_hits_10.parquet]]}, projection=[EventTime, UserID, SearchPhrase], file_type=parquet
 
-query IITI rowsort
+query IRTI rowsort
 SELECT "UserID", extract(minute FROM to_timestamp_seconds("EventTime")) AS m, "SearchPhrase", COUNT(*) FROM hits GROUP BY "UserID", m, "SearchPhrase" ORDER BY COUNT(*) DESC LIMIT 10;
 ----
 -2461439046089301801 18 (empty) 1

--- a/datafusion/sqllogictest/test_files/datetime/date_part.slt
+++ b/datafusion/sqllogictest/test_files/datetime/date_part.slt
@@ -68,7 +68,7 @@ SELECT * FROM source_ts;
 2020-01-01T00:00:00.123456789 2020-01-01T00:00:00.123456789 2020-01-01T00:00:00.123456789Z 2019-12-31T19:00:00.123456789-05:00 2020-01-01T00:00:00.123 2020-01-01T00:00:00.123 2020-01-01T00:00:00.123Z 2019-12-31T19:00:00.123-05:00
 
 # date_part (year) with columns and explicit timestamp
-query IIIIII
+query RRRRRR
 SELECT date_part('year', ts_nano_no_tz), date_part('year', ts_nano_utc), date_part('year', ts_nano_eastern), date_part('year', ts_milli_no_tz), date_part('year', ts_milli_utc), date_part('year', ts_milli_eastern)  FROM source_ts;
 ----
 2020 2020 2019 2020 2020 2019
@@ -84,7 +84,7 @@ SELECT date_part('year', ts_nano_no_tz), date_part('year', ts_nano_utc), date_pa
 2020 2020 2019 2020 2020 2019
 
 # date_part (isoyear) with columns and explicit timestamp
-query IIIIII
+query RRRRRR
 SELECT date_part('isoyear', ts_nano_no_tz), date_part('isoyear', ts_nano_utc), date_part('isoyear', ts_nano_eastern), date_part('isoyear', ts_milli_no_tz), date_part('isoyear', ts_milli_utc), date_part('isoyear', ts_milli_eastern)  FROM source_ts;
 ----
 2020 2020 2020 2020 2020 2020
@@ -101,7 +101,7 @@ SELECT date_part('isoyear', ts_nano_no_tz), date_part('isoyear', ts_nano_utc), d
 
 
 # date_part (month)
-query IIIIII
+query RRRRRR
 SELECT date_part('month', ts_nano_no_tz), date_part('month', ts_nano_utc), date_part('month', ts_nano_eastern), date_part('month', ts_milli_no_tz), date_part('month', ts_milli_utc), date_part('month', ts_milli_eastern)  FROM source_ts;
 ----
 1 1 12 1 1 12
@@ -117,7 +117,7 @@ SELECT date_part('month', ts_nano_no_tz), date_part('month', ts_nano_utc), date_
 1 1 12 1 1 12
 
 # date_part (day)
-query IIIIII
+query RRRRRR
 SELECT date_part('day', ts_nano_no_tz), date_part('day', ts_nano_utc), date_part('day', ts_nano_eastern), date_part('day', ts_milli_no_tz), date_part('day', ts_milli_utc), date_part('day', ts_milli_eastern)  FROM source_ts;
 ----
 1 1 31 1 1 31
@@ -133,7 +133,7 @@ SELECT date_part('day', ts_nano_no_tz), date_part('day', ts_nano_utc), date_part
 1 1 31 1 1 31
 
 # date_part (hour)
-query IIIIII
+query RRRRRR
 SELECT date_part('hour', ts_nano_no_tz), date_part('hour', ts_nano_utc), date_part('hour', ts_nano_eastern), date_part('hour', ts_milli_no_tz), date_part('hour', ts_milli_utc), date_part('hour', ts_milli_eastern)  FROM source_ts;
 ----
 0 0 19 0 0 19
@@ -149,7 +149,7 @@ SELECT date_part('hour', ts_nano_no_tz), date_part('hour', ts_nano_utc), date_pa
 0 0 19 0 0 19
 
 # date_part (minute)
-query IIIIII
+query RRRRRR
 SELECT date_part('minute', ts_nano_no_tz), date_part('minute', ts_nano_utc), date_part('minute', ts_nano_eastern), date_part('minute', ts_milli_no_tz), date_part('minute', ts_milli_utc), date_part('minute', ts_milli_eastern)  FROM source_ts;
 ----
 0 0 0 0 0 0
@@ -165,7 +165,7 @@ SELECT date_part('minute', ts_nano_no_tz), date_part('minute', ts_nano_utc), dat
 0 0 0 0 0 0
 
 # date_part (second)
-query IIIIII
+query RRRRRR
 SELECT date_part('second', ts_nano_no_tz), date_part('second', ts_nano_utc), date_part('second', ts_nano_eastern), date_part('second', ts_milli_no_tz), date_part('second', ts_milli_utc), date_part('second', ts_milli_eastern)  FROM source_ts;
 ----
 0 0 0 0 0 0
@@ -181,7 +181,7 @@ SELECT date_part('second', ts_nano_no_tz), date_part('second', ts_nano_utc), dat
 0 0 0 0 0 0
 
 # date_part (millisecond)
-query IIIIII
+query RRRRRR
 SELECT date_part('millisecond', ts_nano_no_tz), date_part('millisecond', ts_nano_utc), date_part('millisecond', ts_nano_eastern), date_part('millisecond', ts_milli_no_tz), date_part('millisecond', ts_milli_utc), date_part('millisecond', ts_milli_eastern)  FROM source_ts;
 ----
 0 0 0 0 0 0
@@ -197,7 +197,7 @@ SELECT date_part('millisecond', ts_nano_no_tz), date_part('millisecond', ts_nano
 123 123 123 123 123 123
 
 # date_part (microsecond)
-query IIIIII
+query RRRRRR
 SELECT date_part('microsecond', ts_nano_no_tz), date_part('microsecond', ts_nano_utc), date_part('microsecond', ts_nano_eastern), date_part('microsecond', ts_milli_no_tz), date_part('microsecond', ts_milli_utc), date_part('microsecond', ts_milli_eastern)  FROM source_ts;
 ----
 0 0 0 0 0 0
@@ -213,7 +213,7 @@ SELECT date_part('microsecond', ts_nano_no_tz), date_part('microsecond', ts_nano
 123456 123456 123456 123000 123000 123000
 
 # date_part (nanosecond)
-query IIIIII
+query RRRRRR
 SELECT date_part('nanosecond', ts_nano_no_tz), date_part('nanosecond', ts_nano_utc), date_part('nanosecond', ts_nano_eastern), date_part('nanosecond', ts_milli_no_tz), date_part('nanosecond', ts_milli_utc), date_part('nanosecond', ts_milli_eastern)  FROM source_ts;
 ----
 0 0 0 0 0 0
@@ -243,202 +243,202 @@ SELECT EXTRACT("'''year'''" FROM  timestamp '2020-09-08T12:00:00+00:00')
 query error
 SELECT EXTRACT("'year'" FROM  timestamp '2020-09-08T12:00:00+00:00')
 
-query I
+query R
 SELECT date_part('YEAR', CAST('2000-01-01' AS DATE))
 ----
 2000
 
-query I
+query R
 SELECT EXTRACT(year FROM  timestamp '2020-09-08T12:00:00+00:00')
 ----
 2020
 
-query I
+query R
 SELECT EXTRACT("year" FROM  timestamp '2020-09-08T12:00:00+00:00')
 ----
 2020
 
-query I
+query R
 SELECT EXTRACT('year' FROM  timestamp '2020-09-08T12:00:00+00:00')
 ----
 2020
 
-query I
+query R
 SELECT date_part('ISOYEAR', CAST('2000-01-01' AS DATE))
 ----
 1999
 
-query I
+query R
 SELECT EXTRACT(isoyear FROM  timestamp '2020-09-08T12:00:00+00:00')
 ----
 2020
 
-query I
+query R
 SELECT EXTRACT("isoyear" FROM  timestamp '2020-09-08T12:00:00+00:00')
 ----
 2020
 
-query I
+query R
 SELECT EXTRACT('isoyear' FROM  timestamp '2020-09-08T12:00:00+00:00')
 ----
 2020
 
-query I
+query R
 SELECT date_part('QUARTER', CAST('2000-01-01' AS DATE))
 ----
 1
 
-query I
+query R
 SELECT EXTRACT(quarter FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 3
 
-query I
+query R
 SELECT EXTRACT("quarter" FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 3
 
-query I
+query R
 SELECT EXTRACT('quarter' FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 3
 
-query I
+query R
 SELECT date_part('MONTH', CAST('2000-01-01' AS DATE))
 ----
 1
 
-query I
+query R
 SELECT EXTRACT(month FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 9
 
-query I
+query R
 SELECT EXTRACT("month" FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 9
 
-query I
+query R
 SELECT EXTRACT('month' FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 9
 
-query I
+query R
 SELECT date_part('WEEK', CAST('2003-01-01' AS DATE))
 ----
 1
 
-query I
+query R
 SELECT EXTRACT(WEEK FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 37
 
-query I
+query R
 SELECT EXTRACT("WEEK" FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 37
 
-query I
+query R
 SELECT EXTRACT('WEEK' FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 37
 
-query I
+query R
 SELECT date_part('DAY', CAST('2000-01-01' AS DATE))
 ----
 1
 
-query I
+query R
 SELECT EXTRACT(day FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 8
 
-query I
+query R
 SELECT EXTRACT("day" FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 8
 
-query I
+query R
 SELECT EXTRACT('day' FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 8
 
-query I
+query R
 SELECT date_part('DOY', CAST('2000-01-01' AS DATE))
 ----
 1
 
-query I
+query R
 SELECT EXTRACT(doy FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 252
 
-query I
+query R
 SELECT EXTRACT("doy" FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 252
 
-query I
+query R
 SELECT EXTRACT('doy' FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 252
 
-query I
+query R
 SELECT date_part('DOW', CAST('2000-01-01' AS DATE))
 ----
 6
 
-query I
+query R
 SELECT EXTRACT(dow FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 2
 
-query I
+query R
 SELECT EXTRACT("dow" FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 2
 
-query I
+query R
 SELECT EXTRACT('dow' FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 2
 
-query I
+query R
 SELECT date_part('HOUR', CAST('2000-01-01' AS DATE))
 ----
 0
 
-query I
+query R
 SELECT EXTRACT(hour FROM to_timestamp('2020-09-08T12:03:03+00:00'))
 ----
 12
 
-query I
+query R
 SELECT EXTRACT("hour" FROM to_timestamp('2020-09-08T12:03:03+00:00'))
 ----
 12
 
-query I
+query R
 SELECT EXTRACT('hour' FROM to_timestamp('2020-09-08T12:03:03+00:00'))
 ----
 12
 
-query I
+query R
 SELECT EXTRACT(minute FROM to_timestamp('2020-09-08T12:12:00+00:00'))
 ----
 12
 
-query I
+query R
 SELECT EXTRACT("minute" FROM to_timestamp('2020-09-08T12:12:00+00:00'))
 ----
 12
 
-query I
+query R
 SELECT EXTRACT('minute' FROM to_timestamp('2020-09-08T12:12:00+00:00'))
 ----
 12
 
-query I
+query R
 SELECT date_part('minute', to_timestamp('2020-09-08T12:12:00+00:00'))
 ----
 12
@@ -447,117 +447,117 @@ SELECT date_part('minute', to_timestamp('2020-09-08T12:12:00+00:00'))
 query T
 SELECT arrow_typeof(date_part('minute', to_timestamp('2020-09-08T12:12:00+00:00')))
 ----
-Int32
+Float64
 
 # nanosecond can exceed Int32 and returns Int64
 query T
 SELECT arrow_typeof(date_part('nanosecond', to_timestamp('2020-09-08T12:12:00+00:00')))
 ----
-Int64
+Float64
 
-query I
+query R
 SELECT EXTRACT(second FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12
 
-query I
+query R
 SELECT EXTRACT(millisecond FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123
 
-query I
+query R
 SELECT EXTRACT(microsecond FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456
 
 # note the output is more than Int32 can store
-query I
+query R
 SELECT EXTRACT(nanosecond FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456780
 
-query I
+query R
 SELECT EXTRACT("second" FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12
 
-query I
+query R
 SELECT EXTRACT("millisecond" FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123
 
-query I
+query R
 SELECT EXTRACT("microsecond" FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456
 
-query I
+query R
 SELECT EXTRACT("nanosecond" FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456780
 
-query I
+query R
 SELECT EXTRACT('second' FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12
 
-query I
+query R
 SELECT EXTRACT('millisecond' FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123
 
-query I
+query R
 SELECT EXTRACT('microsecond' FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456
 
-query I
+query R
 SELECT EXTRACT('nanosecond' FROM timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456780
 
 # Keep precision when coercing Utf8 to Timestamp
-query I
+query R
 SELECT date_part('second', timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12
 
-query I
+query R
 SELECT date_part('millisecond', timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123
 
-query I
+query R
 SELECT date_part('microsecond', timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456
 
-query I
+query R
 SELECT date_part('nanosecond', timestamp '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456780
 
-query I
+query R
 SELECT date_part('second', '2020-09-08T12:00:12.12345678+00:00')
 ----
 12
 
-query I
+query R
 SELECT date_part('millisecond', '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123
 
-query I
+query R
 SELECT date_part('microsecond', '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456
 
-query I
+query R
 SELECT date_part('nanosecond', '2020-09-08T12:00:12.12345678+00:00')
 ----
 12123456780
 
-query I
+query R
 SELECT EXTRACT(nanosecond FROM ts)
 FROM (VALUES
   (timestamp '2020-09-08T12:00:12.12345678+00:00'),
@@ -567,7 +567,7 @@ FROM (VALUES
 12123456780
 NULL
 
-query I
+query R
 SELECT date_part('nanosecond', ts)
 FROM (VALUES
   (timestamp '2020-09-08T12:00:12.12345678+00:00'),
@@ -580,57 +580,57 @@ NULL
 # test_date_part_time
 
 ## time32 seconds
-query I
+query R
 SELECT date_part('hour', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 23
 
-query I
+query R
 SELECT extract(hour from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 23
 
-query I
+query R
 SELECT date_part('minute', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 32
 
-query I
+query R
 SELECT extract(minute from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 32
 
-query I
+query R
 SELECT date_part('second', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50
 
-query I
+query R
 SELECT extract(second from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50
 
-query I
+query R
 SELECT date_part('millisecond', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50000
 
-query I
+query R
 SELECT extract(millisecond from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50000
 
-query I
+query R
 SELECT date_part('microsecond', arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50000000
 
-query I
+query R
 SELECT extract(microsecond from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50000000
 
-query I
+query R
 SELECT extract(nanosecond from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 ----
 50000000000
@@ -646,57 +646,57 @@ SELECT extract(epoch from arrow_cast('23:32:50'::time, 'Time32(Second)'))
 84770
 
 ## time32 milliseconds
-query I
+query R
 SELECT date_part('hour', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 23
 
-query I
+query R
 SELECT extract(hour from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 23
 
-query I
+query R
 SELECT date_part('minute', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 32
 
-query I
+query R
 SELECT extract(minute from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 32
 
-query I
+query R
 SELECT date_part('second', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50
 
-query I
+query R
 SELECT extract(second from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50
 
-query I
+query R
 SELECT date_part('millisecond', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50123
 
-query I
+query R
 SELECT extract(millisecond from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50123
 
-query I
+query R
 SELECT date_part('microsecond', arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50123000
 
-query I
+query R
 SELECT extract(microsecond from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50123000
 
-query I
+query R
 SELECT extract(nanosecond from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'))
 ----
 50123000000
@@ -712,57 +712,57 @@ SELECT extract(epoch from arrow_cast('23:32:50.123'::time, 'Time32(Millisecond)'
 84770.123
 
 ## time64 microseconds
-query I
+query R
 SELECT date_part('hour', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 23
 
-query I
+query R
 SELECT extract(hour from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 23
 
-query I
+query R
 SELECT date_part('minute', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 32
 
-query I
+query R
 SELECT extract(minute from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 32
 
-query I
+query R
 SELECT date_part('second', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50
 
-query I
+query R
 SELECT extract(second from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50
 
-query I
+query R
 SELECT date_part('millisecond', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50123
 
-query I
+query R
 SELECT extract(millisecond from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50123
 
-query I
+query R
 SELECT date_part('microsecond', arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50123456
 
-query I
+query R
 SELECT extract(microsecond from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50123456
 
-query I
+query R
 SELECT extract(nanosecond from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecond)'))
 ----
 50123456000
@@ -778,83 +778,83 @@ SELECT extract(epoch from arrow_cast('23:32:50.123456'::time, 'Time64(Microsecon
 84770.123456
 
 ## time64 nanoseconds
-query I
+query R
 SELECT date_part('hour', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 23
 
-query I
+query R
 SELECT extract(hour from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 23
 
-query I
+query R
 SELECT date_part('minute', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 32
 
-query I
+query R
 SELECT extract(minute from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 32
 
-query I
+query R
 SELECT date_part('second', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50
 
-query I
+query R
 select extract(second from '2024-08-09T12:13:14')
 ----
 14
 
-query I
+query R
 select extract(second from timestamp '2024-08-09T12:13:14')
 ----
 14
 
-query I
+query R
 select extract(seconds from '2024-08-09T12:13:14')
 ----
 14
 
-query I
+query R
 select extract(seconds from timestamp '2024-08-09T12:13:14')
 ----
 14
 
-query I
+query R
 SELECT extract(second from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50
 
-query I
+query R
 SELECT date_part('millisecond', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50123
 
-query I
+query R
 SELECT extract(millisecond from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50123
 
 # just some floating point stuff happening in the result here
-query I
+query R
 SELECT date_part('microsecond', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50123456
 
-query I
+query R
 SELECT extract(microsecond from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50123456
 
-query I
+query R
 SELECT extract(us from arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50123456
 
-query I
+query R
 SELECT date_part('nanosecond', arrow_cast('23:32:50.123456789'::time, 'Time64(Nanosecond)'))
 ----
 50123456789
@@ -933,32 +933,32 @@ SELECT extract(epoch from arrow_cast('1969-12-31', 'Date64'))
 
 # test_extract_interval
 
-query I
+query R
 SELECT extract(year from arrow_cast('10 years', 'Interval(YearMonth)'))
 ----
 10
 
-query I
+query R
 SELECT extract(month from arrow_cast('10 years', 'Interval(YearMonth)'))
 ----
 0
 
-query I
+query R
 SELECT extract(year from arrow_cast('10 months', 'Interval(YearMonth)'))
 ----
 0
 
-query I
+query R
 SELECT extract(month from arrow_cast('10 months', 'Interval(YearMonth)'))
 ----
 10
 
-query I
+query R
 SELECT extract(year from arrow_cast('20 months', 'Interval(YearMonth)'))
 ----
 1
 
-query I
+query R
 SELECT extract(month from arrow_cast('20 months', 'Interval(YearMonth)'))
 ----
 8
@@ -975,47 +975,47 @@ SELECT extract(isoyear from arrow_cast('10 days', 'Interval(DayTime)'))
 query error DataFusion error: Arrow error: Compute error: Month does not support: Interval\(DayTime\)
 SELECT extract(month from arrow_cast('10 days', 'Interval(DayTime)'))
 
-query I
+query R
 SELECT extract(day from arrow_cast('10 days', 'Interval(DayTime)'))
 ----
 10
 
-query I
+query R
 SELECT extract(day from arrow_cast('14400 minutes', 'Interval(DayTime)'))
 ----
 0
 
-query I
+query R
 SELECT extract(minute from arrow_cast('14400 minutes', 'Interval(DayTime)'))
 ----
 0
 
-query I
+query R
 SELECT extract(second from arrow_cast('5.1 seconds', 'Interval(DayTime)'))
 ----
 5
 
-query I
+query R
 SELECT extract(second from arrow_cast('14400 minutes', 'Interval(DayTime)'))
 ----
 0
 
-query I
+query R
 SELECT extract(second from arrow_cast('2 months', 'Interval(MonthDayNano)'))
 ----
 0
 
-query I
+query R
 SELECT extract(second from arrow_cast('2 days', 'Interval(MonthDayNano)'))
 ----
 0
 
-query I
+query R
 SELECT extract(second from arrow_cast('2 seconds', 'Interval(MonthDayNano)'))
 ----
 2
 
-query I
+query R
 SELECT extract(seconds from arrow_cast('2 seconds', 'Interval(MonthDayNano)'))
 ----
 2
@@ -1025,17 +1025,17 @@ SELECT extract(epoch from arrow_cast('2 seconds', 'Interval(MonthDayNano)'))
 ----
 2
 
-query I
+query R
 SELECT extract(milliseconds from arrow_cast('2 seconds', 'Interval(MonthDayNano)'))
 ----
 2000
 
-query I
+query R
 SELECT extract(second from arrow_cast('2030 milliseconds', 'Interval(MonthDayNano)'))
 ----
 2
 
-query I
+query R
 SELECT extract(second from arrow_cast(NULL, 'Interval(MonthDayNano)'))
 ----
 NULL
@@ -1100,7 +1100,7 @@ create table t (id int, i interval) as values
   (4, interval '8 months'),
   (5, NULL);
 
-query III
+query IRR
 select
   id,
   extract(second from i),
@@ -1120,12 +1120,12 @@ drop table t;
 
 # test_extract_duration
 
-query I
+query R
 SELECT extract(second from arrow_cast(2, 'Duration(Second)'))
 ----
 2
 
-query I
+query R
 SELECT extract(seconds from arrow_cast(2, 'Duration(Second)'))
 ----
 2
@@ -1135,27 +1135,27 @@ SELECT extract(epoch from arrow_cast(2, 'Duration(Second)'))
 ----
 2
 
-query I
+query R
 SELECT extract(millisecond from arrow_cast(2, 'Duration(Second)'))
 ----
 2000
 
-query I
+query R
 SELECT extract(second from arrow_cast(2, 'Duration(Millisecond)'))
 ----
 0
 
-query I
+query R
 SELECT extract(second from arrow_cast(2002, 'Duration(Millisecond)'))
 ----
 2
 
-query I
+query R
 SELECT extract(millisecond from arrow_cast(2002, 'Duration(Millisecond)'))
 ----
 2002
 
-query I
+query R
 SELECT extract(day from arrow_cast(864000, 'Duration(Second)'))
 ----
 10
@@ -1169,7 +1169,7 @@ SELECT extract(year from arrow_cast(864000, 'Duration(Second)'))
 query error DataFusion error: Arrow error: Compute error: YearISO does not support: Duration\(s\)
 SELECT extract(isoyear from arrow_cast(864000, 'Duration(Second)'))
 
-query I
+query R
 SELECT extract(day from arrow_cast(NULL, 'Duration(Second)'))
 ----
 NULL
@@ -1237,22 +1237,22 @@ SELECT (date_part('nanosecond', now()) = EXTRACT(nanosecond FROM now()))
 true
 
 
-query I
+query R
 SELECT date_part('ISODOW', CAST('2000-01-01' AS DATE))
 ----
 6
 
-query I
+query R
 SELECT EXTRACT(isodow FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 2
 
-query I
+query R
 SELECT EXTRACT("isodow" FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 2
 
-query I
+query R
 SELECT EXTRACT('isodow' FROM to_timestamp('2020-09-08T12:00:00+00:00'))
 ----
 2
@@ -1467,7 +1467,7 @@ query TT
 explain select c from t1 where extract (quarter from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("QUARTER"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("QUARTER"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(QUARTER, c@0) = 2024
@@ -1477,7 +1477,7 @@ query TT
 explain select c from t1 where extract (month from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("MONTH"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("MONTH"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(MONTH, c@0) = 2024
@@ -1487,7 +1487,7 @@ query TT
 explain select c from t1 where extract (week from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("WEEK"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("WEEK"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(WEEK, c@0) = 2024
@@ -1497,7 +1497,7 @@ query TT
 explain select c from t1 where extract (day from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("DAY"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("DAY"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(DAY, c@0) = 2024
@@ -1507,7 +1507,7 @@ query TT
 explain select c from t1 where extract (hour from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("HOUR"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("HOUR"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(HOUR, c@0) = 2024
@@ -1517,7 +1517,7 @@ query TT
 explain select c from t1 where extract (minute from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("MINUTE"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("MINUTE"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(MINUTE, c@0) = 2024
@@ -1527,7 +1527,7 @@ query TT
 explain select c from t1 where extract (second from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("SECOND"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("SECOND"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(SECOND, c@0) = 2024
@@ -1537,7 +1537,7 @@ query TT
 explain select c from t1 where extract (millisecond from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("MILLISECOND"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("MILLISECOND"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(MILLISECOND, c@0) = 2024
@@ -1547,7 +1547,7 @@ query TT
 explain select c from t1 where extract (microsecond from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("MICROSECOND"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("MICROSECOND"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(MICROSECOND, c@0) = 2024
@@ -1557,7 +1557,7 @@ query TT
 explain select c from t1 where extract (nanosecond from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("NANOSECOND"), t1.c) = Int64(2024)
+01)Filter: date_part(Utf8("NANOSECOND"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(NANOSECOND, c@0) = 2024
@@ -1567,7 +1567,7 @@ query TT
 explain select c from t1 where extract (dow from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("DOW"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("DOW"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(DOW, c@0) = 2024
@@ -1577,7 +1577,7 @@ query TT
 explain select c from t1 where extract (doy from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("DOY"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("DOY"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(DOY, c@0) = 2024
@@ -1597,7 +1597,7 @@ query TT
 explain select c from t1 where extract (isodow from c) = 2024
 ----
 logical_plan
-01)Filter: date_part(Utf8("ISODOW"), t1.c) = Int32(2024)
+01)Filter: date_part(Utf8("ISODOW"), t1.c) = Float64(2024)
 02)--TableScan: t1 projection=[c]
 physical_plan
 01)FilterExec: date_part(ISODOW, c@0) = 2024

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -2023,13 +2023,13 @@ SELECT date_bin('1 day', TIMESTAMPTZ '2022-01-01 20:10:00Z', TIMESTAMP '2020-01-
 2022-01-01T07:00:00+07:00
 
 # postgresql: 1
-query I
+query R
 SELECT date_part('hour', TIMESTAMPTZ '2000-01-01T01:01:01') as part
 ----
 1
 
 # postgresql: 8
-query I
+query R
 SELECT date_part('hour', TIMESTAMPTZ '2000-01-01T01:01:01Z') as part
 ----
 8
@@ -2106,13 +2106,13 @@ SELECT date_bin('2 hour', TIMESTAMPTZ '2022-01-01 01:10:00+07', '2020-01-01T00:0
 2021-12-31T18:00:00Z
 
 # postgresql: 1
-query I
+query R
 SELECT date_part('hour', TIMESTAMPTZ '2000-01-01T01:01:01') as part
 ----
 1
 
 # postgresql: 18
-query I
+query R
 SELECT date_part('hour', TIMESTAMPTZ '2000-01-01T01:01:01+07') as part
 ----
 18

--- a/datafusion/sqllogictest/test_files/group_by.slt
+++ b/datafusion/sqllogictest/test_files/group_by.slt
@@ -4335,7 +4335,7 @@ physical_plan
 07)------------RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1, maintains_sort_order=true
 08)--------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/timestamps.csv]]}, projection=[ts], output_ordering=[ts@0 DESC], file_type=csv, has_header=false
 
-query I
+query R
 SELECT extract(month from ts) as months
   FROM csv_with_timestamps
   GROUP BY extract(month from ts)
@@ -4385,7 +4385,7 @@ create table t1(state string, city string, min_temp float, area int, time timest
     ('MA', 'Boston', 70.4, 1, 50),
     ('MA', 'Bedford', 71.59, 2, 150);
 
-query II
+query RI
 select date_part('year', time) as bla, count(distinct state) as count from t1 group by bla;
 ----
 1970 1

--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -261,7 +261,7 @@ select log(-1), log(0), sqrt(-1);
 
 | Syntax               | Description                                            |
 | -------------------- | ------------------------------------------------------ |
-| date_part            | Extracts a subfield from the date.                     |
+| date_part            | Extracts a subfield from the date as a double.         |
 | date_trunc           | Truncates the date to a specified level of precision.  |
 | from_unixtime        | Returns the unix time in format.                       |
 | to_timestamp         | Converts a string to a `Timestamp(_, _)`               |

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2557,7 +2557,7 @@ _Alias of [to_char](#to_char)._
 
 ### `date_part`
 
-Returns the specified part of the date as an integer.
+Returns the specified part of the date as a double precision floating-point value. Matches PostgreSQL's `date_part` return type (https://www.postgresql.org/docs/current/functions-datetime.html).
 
 ```sql
 date_part(part, expression)
@@ -2593,13 +2593,13 @@ date_part(part, expression)
 +-----------------------------------------------------+
 | date_part(Utf8("year"),Utf8("2024-05-01T00:00:00")) |
 +-----------------------------------------------------+
-| 2024                                                |
+| 2024.0                                              |
 +-----------------------------------------------------+
 > SELECT extract(day FROM timestamp '2024-05-01T00:00:00');
 +----------------------------------------------------+
 | date_part(Utf8("DAY"),Utf8("2024-05-01T00:00:00")) |
 +----------------------------------------------------+
-| 1                                                  |
+| 1.0                                                |
 +----------------------------------------------------+
 ```
 


### PR DESCRIPTION
## Which issue does this PR close ?


## Rationale for this change ?

In DataFusion today, `date_part`'s return type depends on the part being
extracted: most parts (`year`, `month`, `day`, `hour`, `minute`,
`second`, ...) return `Int32`, `nanosecond` returns `Int64`, and `epoch`
returns `Float64`. That is internally inconsistent and disagrees with
PostgreSQL, which defines `date_part` to always return `double
precision` regardless of the field:

> The `date_part` function is modeled on the traditional Ingres
> equivalent to the SQL-standard function `extract` ... It returns
> values of type `double precision`.
>
> — https://www.postgresql.org/docs/current/functions-datetime.html

## What changes are included in this PR?

`date_part` (and its `datepart` alias) now always returns `Float64`.
`Extract(field FROM source)`, which parses to `date_part`, is affected
the same way.

User-visible effects:

- Query result types for `date_part`/`extract` are now `Float64` rather
  than `Int32`/`Int64` (except for `epoch`, which was already `Float64`).
- Plans, schemas, and `arrow_typeof(...)` outputs reflect this.
- Downstream Spark dialect behavior is unchanged — the Spark
  `date_part` wrapper casts back to `Int32`.

- `DatePartFunc::return_field_from_args` always advertises `Float64`.
- `DatePartFunc::invoke_with_args` casts the arrow kernel result to
  `Float64` at the end (no-op for `epoch`, which already returns
  `Float64`; `cast` for the `Int32`/`Int64` cases).
- `DatePartFunc::preimage` learns to accept a `Float64` literal so that
  the existing `date_part('year', col) = 2024` → date-range pushdown
  keeps working after the binary op coerces `2024` to `Float64`.
- The dead `is_epoch` / `is_nanosecond` helpers from the old return-type
  switch are removed.
- The Spark `date_part` wrapper (`datafusion-spark`) now wraps the
  simplified DataFusion call in a `Cast(..., Int32)`. Spark's own
  `SparkDatePart::return_field_from_args` already declares `Int32`, so
  this keeps Spark semantics and the Spark sqllogictests untouched.

## Are these changes tested ? 

- `datafusion/sqllogictest/test_files/datetime/date_part.slt`,
  `datetime/timestamps.slt`, `clickbench.slt`, and `group_by.slt`
  updated (`query I[I...]` → `query R[R...]`; `arrow_typeof` strings go
  from `Int32`/`Int64` to `Float64`). Numeric expected values are
  unchanged because integer-valued doubles render the same way (`2020`
  not `2020.0`) in the sqllogictest `R` format.
- Spark `datafusion/sqllogictest/test_files/spark/datetime/date_part.slt`
  is unchanged and still passes thanks to the cast in the wrapper.
- `docs/source/user-guide/sql/scalar_functions.md` regenerated via
  `./dev/update_function_docs.sh`, and the prose entry in
  `docs/source/user-guide/expressions.md` updated.
- `cargo fmt --all`, `cargo clippy -p datafusion-functions -p
  datafusion-spark --all-features -- -D warnings`, and the full
  `cargo test --test sqllogictests -p datafusion-sqllogictest` (483
  files) pass locally.