### PR TITLE
fix: RIGHT/FULL/NATURAL JOIN USING does not coalesce the join key (returns NULL for right-only rows)

### DIFF
--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -89,6 +89,18 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 return Ok(Expr::Column(column));
             }
 
+            // A `RIGHT`/`FULL` `USING`/`NATURAL` join exposes both per-side keys
+            // (`left.k` and `right.k`) in its schema, so a bare `k` is ambiguous and
+            // falls through to here. Per SQL:2016 §7.10 the merged key is
+            // `COALESCE(left.k, right.k)`; resolve the unqualified reference to that
+            // coalesced value (built in `plan_using_join`) rather than to an
+            // unqualified column that would later bind to the NULL-padded left key.
+            if let Some(replacement) = planner_context
+                .using_merged_key_replacement(normalize_ident.as_str(), schema)
+            {
+                return Ok(replacement.clone());
+            }
+
             // Check the outer query schema
             for outer in planner_context.outer_schemas_iter() {
                 if let Ok((qualifier, field)) =

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -27,7 +27,9 @@ use datafusion_common::TableReference;
 use datafusion_common::config::SqlParserOptions;
 use datafusion_common::datatype::{DataTypeExt, FieldExt};
 use datafusion_common::error::add_possible_columns_to_diag;
-use datafusion_common::{DFSchema, DataFusionError, Result, not_impl_err, plan_err};
+use datafusion_common::{
+    Column, DFSchema, DataFusionError, Result, not_impl_err, plan_err,
+};
 use datafusion_common::{
     DFSchemaRef, Diagnostic, SchemaError, field_not_found, internal_err,
     plan_datafusion_err,
@@ -276,6 +278,33 @@ pub struct PlannerContext {
     set_expr_left_schema: Option<DFSchemaRef>,
     /// The parameters of all lambdas seen so far
     lambda_parameters: HashMap<String, FieldRef>,
+    /// The merged join keys produced by `RIGHT`/`FULL` `USING`/`NATURAL` joins
+    /// planned so far. An unqualified reference to such a key must resolve to the
+    /// coalesced value `COALESCE(left.k, right.k)` rather than to the left key
+    /// alone (which is NULL-padded for unmatched rows). See [`UsingMergedKey`].
+    using_merged_keys: Vec<UsingMergedKey>,
+}
+
+/// A single `USING`/`NATURAL` join key whose unqualified reference must resolve to
+/// a merged (coalesced) value because the left side can be NULL-padded
+/// (`RIGHT`/`FULL` outer joins).
+///
+/// Per SQL:2016 §7.10 a `USING`/`NATURAL` join column is
+/// `COALESCE(left.k, right.k)`. DataFusion keeps both per-side keys (`left.k` and
+/// `right.k`) in the join output schema so they remain individually addressable;
+/// an *unqualified* reference to the key is rewritten to [`Self::replacement`]
+/// during column resolution.
+#[derive(Debug, Clone)]
+pub(crate) struct UsingMergedKey {
+    /// Unqualified key name (e.g. `k`).
+    pub(crate) name: String,
+    /// The left-side key column (`left.k`).
+    pub(crate) left: Column,
+    /// The right-side key column (`right.k`).
+    pub(crate) right: Column,
+    /// The expression a bare reference to `name` resolves to:
+    /// `COALESCE(left, right) AS name` for `FULL`, or `right` for `RIGHT`.
+    pub(crate) replacement: Expr,
 }
 
 impl Default for PlannerContext {
@@ -295,6 +324,7 @@ impl PlannerContext {
             create_table_schema: None,
             set_expr_left_schema: None,
             lambda_parameters: HashMap::new(),
+            using_merged_keys: vec![],
         }
     }
 
@@ -378,6 +408,59 @@ impl PlannerContext {
             None => self.outer_from_schema = Some(Arc::clone(schema)),
         };
         Ok(())
+    }
+
+    /// Register the merged keys of a `RIGHT`/`FULL` `USING`/`NATURAL` join so that
+    /// later unqualified references to those keys resolve to the coalesced value.
+    pub(crate) fn register_using_merged_keys(
+        &mut self,
+        keys: impl IntoIterator<Item = UsingMergedKey>,
+    ) {
+        self.using_merged_keys.extend(keys);
+    }
+
+    /// Snapshot the number of registered merged keys, so a nested scope (e.g. a
+    /// subquery in the FROM clause) can be truncated back via
+    /// [`Self::truncate_using_merged_keys`] once it has been planned.
+    pub(crate) fn using_merged_keys_len(&self) -> usize {
+        self.using_merged_keys.len()
+    }
+
+    /// Drop merged keys registered after `len` (see [`Self::using_merged_keys_len`]).
+    pub(crate) fn truncate_using_merged_keys(&mut self, len: usize) {
+        self.using_merged_keys.truncate(len);
+    }
+
+    /// Find the merged-key replacement expression for an unqualified column `name`,
+    /// if such a key was registered and both of its per-side columns are present in
+    /// `schema` (so we only rewrite where the merged column is actually in scope).
+    pub(crate) fn using_merged_key_replacement(
+        &self,
+        name: &str,
+        schema: &DFSchema,
+    ) -> Option<&Expr> {
+        self.using_merged_keys.iter().rev().find_map(|k| {
+            (k.name == name && schema.has_column(&k.left) && schema.has_column(&k.right))
+                .then_some(&k.replacement)
+        })
+    }
+
+    /// Return the `(name, replacement)` of every distinct merged key in scope for
+    /// `schema` (both per-side columns present). The most recently registered key
+    /// wins for a given name. Used to rewrite unqualified `SELECT *` so the merged
+    /// key is shown once with its coalesced value.
+    pub(crate) fn using_merged_keys_in_scope(
+        &self,
+        schema: &DFSchema,
+    ) -> Vec<(String, Expr)> {
+        let mut seen = std::collections::HashSet::new();
+        self.using_merged_keys
+            .iter()
+            .rev()
+            .filter(|k| schema.has_column(&k.left) && schema.has_column(&k.right))
+            .filter(|k| seen.insert(k.name.clone()))
+            .map(|k| (k.name.clone(), k.replacement.clone()))
+            .collect()
     }
 
     /// Return the types of parameters (`$1`, `$2`, etc) if known

--- a/datafusion/sql/src/relation/join.rs
+++ b/datafusion/sql/src/relation/join.rs
@@ -15,13 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
-use datafusion_common::{Column, Result, not_impl_err, plan_datafusion_err};
-use datafusion_expr::{JoinType, LogicalPlan, LogicalPlanBuilder};
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel, UsingMergedKey};
+use datafusion_common::{
+    Column, Result, internal_datafusion_err, not_impl_err, plan_datafusion_err,
+};
+use datafusion_expr::expr::ScalarFunction;
+use datafusion_expr::{Expr, JoinType, LogicalPlan, LogicalPlanBuilder};
 use sqlparser::ast::{
     Join, JoinConstraint, JoinOperator, ObjectName, TableFactor, TableWithJoins,
 };
 use std::collections::HashSet;
+use std::sync::Arc;
 
 impl<S: ContextProvider> SqlToRel<'_, S> {
     pub(crate) fn plan_table_with_joins(
@@ -149,9 +153,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                LogicalPlanBuilder::from(left)
-                    .join_using(right, join_type, keys)?
-                    .build()
+                self.plan_using_join(left, right, join_type, keys, planner_context)
             }
             JoinConstraint::Natural => {
                 let left_cols: HashSet<&String> =
@@ -167,15 +169,108 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 if keys.is_empty() {
                     self.parse_cross_join(left, right)
                 } else {
-                    LogicalPlanBuilder::from(left)
-                        .join_using(right, join_type, keys)?
-                        .build()
+                    self.plan_using_join(left, right, join_type, keys, planner_context)
                 }
             }
             JoinConstraint::None => LogicalPlanBuilder::from(left)
                 .join_on(right, join_type, [])?
                 .build(),
         }
+    }
+
+    /// Plan a `USING` / `NATURAL` join, registering merged keys when the left side
+    /// can be NULL-padded.
+    ///
+    /// Per SQL:2016 §7.10 a `USING`/`NATURAL` join column is
+    /// `COALESCE(left.k, right.k)`. For `RIGHT`/`FULL` outer joins the left key is
+    /// NULL-padded for unmatched rows, so resolving an unqualified reference to the
+    /// left key alone yields the wrong (NULL) value. We keep both per-side keys in
+    /// the join's output schema (so `left.k` / `right.k` remain individually
+    /// addressable) and register a [`UsingMergedKey`] so that a later *unqualified*
+    /// reference to the key resolves to the coalesced value instead. See
+    /// [`SqlToRel::sql_identifier_to_expr`].
+    ///
+    /// `INNER`/`LEFT` joins need no rewrite: their left key is never NULL-padded, so
+    /// the existing resolution to the left column is already correct.
+    fn plan_using_join(
+        &self,
+        left: LogicalPlan,
+        right: LogicalPlan,
+        join_type: JoinType,
+        keys: Vec<Column>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        let join = LogicalPlanBuilder::from(left)
+            .join_using(right, join_type, keys)?
+            .build()?;
+
+        // Only RIGHT/FULL outer joins can NULL-pad the left key.
+        if !matches!(join_type, JoinType::Right | JoinType::Full) {
+            return Ok(join);
+        }
+
+        // `join_using` degrades to a cross join + filter when the keys are not
+        // hashable; there is no USING merge to register in that case.
+        let LogicalPlan::Join(inner) = &join else {
+            return Ok(join);
+        };
+        if inner.join_constraint != datafusion_expr::JoinConstraint::Using {
+            return Ok(join);
+        }
+
+        let coalesce = if matches!(join_type, JoinType::Full) {
+            Some(
+                self.context_provider
+                    .get_function_meta("coalesce")
+                    .ok_or_else(|| {
+                        internal_datafusion_err!(
+                            "Unable to find expected 'coalesce' function"
+                        )
+                    })?,
+            )
+        } else {
+            None
+        };
+
+        let mut merged_keys = Vec::with_capacity(inner.on.len());
+        for (a, b) in &inner.on {
+            // `join_using` may order the equi-join pair as (right, left) depending on
+            // which side is hashable, so identify the sides by schema membership.
+            let (Expr::Column(ca), Expr::Column(cb)) = (a, b) else {
+                continue;
+            };
+            let (left_col, right_col) = if inner.left.schema().has_column(ca) {
+                (ca.clone(), cb.clone())
+            } else {
+                (cb.clone(), ca.clone())
+            };
+            let name = left_col.name.clone();
+            // The replacement is left *unaliased* so that it stays clean when
+            // substituted into arbitrary expression contexts (e.g. `WHERE k = 4`).
+            // SELECT-list output naming (`... AS k`) and `SELECT *` expansion are
+            // handled where the key name is known (see `sql_select_to_rex`).
+            let replacement = match &coalesce {
+                // FULL: either side may be NULL-padded -> COALESCE(left, right).
+                Some(coalesce) => Expr::ScalarFunction(ScalarFunction::new_udf(
+                    Arc::clone(coalesce),
+                    vec![
+                        Expr::Column(left_col.clone()),
+                        Expr::Column(right_col.clone()),
+                    ],
+                )),
+                // RIGHT: the right side is always present.
+                None => Expr::Column(right_col.clone()),
+            };
+            merged_keys.push(UsingMergedKey {
+                name,
+                left: left_col,
+                right: right_col,
+                replacement,
+            });
+        }
+        planner_context.register_using_merged_keys(merged_keys);
+
+        Ok(join)
     }
 }
 

--- a/datafusion/sql/src/select.rs
+++ b/datafusion/sql/src/select.rs
@@ -51,9 +51,9 @@ use datafusion_expr::{
 
 use indexmap::IndexMap;
 use sqlparser::ast::{
-    Distinct, Expr as SQLExpr, GroupByExpr, NamedWindowExpr, OrderBy,
-    SelectItemQualifiedWildcardKind, WildcardAdditionalOptions, WindowType,
-    visit_expressions_mut,
+    Distinct, Expr as SQLExpr, GroupByExpr, Ident, NamedWindowExpr, OrderBy,
+    ReplaceSelectElement, SelectItemQualifiedWildcardKind, WildcardAdditionalOptions,
+    WindowType, visit_expressions_mut,
 };
 use sqlparser::ast::{NamedWindowDefinition, Select, SelectItem, TableWithJoins};
 
@@ -94,7 +94,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     /// Generate a logic plan from an SQL select
     pub(super) fn select_to_plan(
         &self,
-        mut select: Select,
+        select: Select,
         query_order_by: Option<OrderBy>,
         planner_context: &mut PlannerContext,
     ) -> Result<LogicalPlan> {
@@ -117,6 +117,31 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         // into subqueries planned during FROM clause handling.
         let set_expr_left_schema = planner_context.set_set_expr_left_schema(None);
 
+        // `RIGHT`/`FULL` `USING`/`NATURAL` joins register merged keys (see
+        // `plan_using_join`) that are only in scope for this SELECT. Snapshot the
+        // registry so any keys added while planning this query (and its FROM
+        // subqueries) are dropped on the way out and do not leak to sibling queries
+        // (e.g. the other arms of a UNION).
+        let using_merged_keys_snapshot = planner_context.using_merged_keys_len();
+
+        let result = self.select_to_plan_inner(
+            select,
+            query_order_by,
+            set_expr_left_schema,
+            planner_context,
+        );
+
+        planner_context.truncate_using_merged_keys(using_merged_keys_snapshot);
+        result
+    }
+
+    fn select_to_plan_inner(
+        &self,
+        mut select: Select,
+        query_order_by: Option<OrderBy>,
+        set_expr_left_schema: Option<DFSchemaRef>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
         // Process `from` clause
         let plan = self.plan_from_tables(select.from, planner_context)?;
         let empty_from = matches!(plan, LogicalPlan::EmptyRelation(_));
@@ -960,6 +985,25 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         error_builder.error_or(prepared_select_exprs)
     }
 
+    /// If `expr` is a bare unqualified identifier that names a registered
+    /// `RIGHT`/`FULL` `USING`/`NATURAL` merged key in scope for `schema`, return its
+    /// normalized name. Used to preserve the key name as the SELECT output column
+    /// name when the merged key resolves to a `COALESCE(...)` expression.
+    fn bare_using_merged_key_name(
+        &self,
+        expr: &SQLExpr,
+        schema: &DFSchema,
+        planner_context: &PlannerContext,
+    ) -> Option<String> {
+        let SQLExpr::Identifier(ident) = expr else {
+            return None;
+        };
+        let name = self.ident_normalizer.normalize(ident.clone());
+        planner_context
+            .using_merged_key_replacement(&name, schema)
+            .map(|_| name)
+    }
+
     /// Generate a relational expression from a select SQL expression
     fn sql_select_to_rex(
         &self,
@@ -970,12 +1014,27 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     ) -> Result<SelectExpr> {
         match sql {
             SelectItem::UnnamedExpr(expr) => {
+                // A bare unqualified reference to a `RIGHT`/`FULL` `USING`/`NATURAL`
+                // merged key resolves to a `COALESCE(...)` / right-key expression
+                // (see `plan_using_join`). Preserve the key name as the output
+                // column name (e.g. `SELECT k` stays `k`, not `coalesce(a.k, b.k)`).
+                let merged_key_name = self.bare_using_merged_key_name(
+                    &expr,
+                    plan.schema(),
+                    planner_context,
+                );
                 let expr = self.sql_to_expr(expr, plan.schema(), planner_context)?;
                 let col = normalize_col_with_schemas_and_ambiguity_check(
                     expr,
                     &[&[plan.schema()]],
                     &plan.using_columns()?,
                 )?;
+                let col = match merged_key_name {
+                    Some(name) if !matches!(&col, Expr::Column(c) if c.name == name) => {
+                        col.alias(name)
+                    }
+                    _ => col,
+                };
 
                 Ok(SelectExpr::Expression(col))
             }
@@ -1004,11 +1063,18 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 if empty_from {
                     return plan_err!("SELECT * with no tables specified is not valid");
                 }
+                // For a `RIGHT`/`FULL` `USING`/`NATURAL` join, `expand_wildcard`
+                // keeps a single (left) key column; replace it with the coalesced
+                // merged value so `SELECT *` exposes the correct key (SQL:2016
+                // §7.10). Qualified wildcards (`a.*`) are left untouched.
+                let merged_keys =
+                    planner_context.using_merged_keys_in_scope(plan.schema());
                 let planned_options = self.plan_wildcard_options(
                     plan,
                     empty_from,
                     planner_context,
                     options,
+                    &merged_keys,
                 )?;
 
                 Ok(SelectExpr::Wildcard(planned_options))
@@ -1026,11 +1092,14 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     }
                 };
                 let qualifier = self.object_name_to_table_reference(object_name)?;
+                // A qualified wildcard (`a.*`) selects that table's own columns, so
+                // the per-side key (`a.k`) is kept as-is, matching PostgreSQL.
                 let planned_options = self.plan_wildcard_options(
                     plan,
                     empty_from,
                     planner_context,
                     options,
+                    &[],
                 )?;
 
                 Ok(SelectExpr::QualifiedWildcard(qualifier, planned_options))
@@ -1062,12 +1131,18 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     /// If there is a REPLACE statement in the projected expression in the form of
     /// "REPLACE (some_column_within_an_expr AS some_column)", we should plan the
     /// replace expressions first.
+    ///
+    /// `merged_keys` are synthetic `(name, replacement)` substitutions for
+    /// `RIGHT`/`FULL` `USING`/`NATURAL` merged keys (see `using_merged_keys_in_scope`):
+    /// the wildcard keeps a single (left) key column per name, which we replace with
+    /// the coalesced value. An explicit user `REPLACE` for the same name wins.
     fn plan_wildcard_options(
         &self,
         plan: &LogicalPlan,
         empty_from: bool,
         planner_context: &mut PlannerContext,
         options: WildcardAdditionalOptions,
+        merged_keys: &[(String, Expr)],
     ) -> Result<WildcardOptions> {
         let planned_option = WildcardOptions {
             ilike: options.opt_ilike,
@@ -1076,33 +1151,57 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             replace: None,
             rename: options.opt_rename,
         };
-        if let Some(replace) = options.opt_replace {
-            let replace_expr = replace
-                .items
-                .iter()
-                .map(|item| {
-                    self.sql_select_to_rex(
-                        SelectItem::UnnamedExpr(item.expr.clone()),
-                        plan,
-                        empty_from,
-                        planner_context,
-                    )
-                })
-                .collect::<Result<Vec<_>>>()?
-                .into_iter()
-                .filter_map(|expr| match expr {
-                    SelectExpr::Expression(expr) => Some(expr),
-                    _ => None,
-                })
-                .collect::<Vec<_>>();
 
-            let planned_replace = PlannedReplaceSelectItem {
-                items: replace.items.into_iter().map(|i| *i).collect(),
-                planned_expressions: replace_expr,
-            };
-            Ok(planned_option.with_replace(planned_replace))
-        } else {
+        // Plan any user-supplied REPLACE items.
+        let (mut items, mut planned_expressions) = match options.opt_replace {
+            Some(replace) => {
+                let planned = replace
+                    .items
+                    .iter()
+                    .map(|item| {
+                        self.sql_select_to_rex(
+                            SelectItem::UnnamedExpr(item.expr.clone()),
+                            plan,
+                            empty_from,
+                            planner_context,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?
+                    .into_iter()
+                    .filter_map(|expr| match expr {
+                        SelectExpr::Expression(expr) => Some(expr),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                let items: Vec<ReplaceSelectElement> =
+                    replace.items.into_iter().map(|i| *i).collect();
+                (items, planned)
+            }
+            None => (vec![], vec![]),
+        };
+
+        // Append synthetic replacements for merged keys not already replaced by the
+        // user. `replace_columns` matches on `column_name` and re-aliases to it, so
+        // the coalesced value keeps the key's name in the wildcard output.
+        for (name, replacement) in merged_keys {
+            if items.iter().any(|i| &i.column_name.value == name) {
+                continue;
+            }
+            items.push(ReplaceSelectElement {
+                expr: SQLExpr::Identifier(Ident::new(name.clone())),
+                column_name: Ident::new(name.clone()),
+                as_keyword: true,
+            });
+            planned_expressions.push(replacement.clone());
+        }
+
+        if items.is_empty() {
             Ok(planned_option)
+        } else {
+            Ok(planned_option.with_replace(PlannedReplaceSelectItem {
+                items,
+                planned_expressions,
+            }))
         }
     }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -1095,17 +1095,108 @@ fn natural_left_join() {
 
 #[test]
 fn natural_right_join() {
+    // The merged key of a NATURAL/USING RIGHT join resolves to the right key
+    // (always present) rather than the NULL-padded left key (SQL:2016 §7.10).
     let sql = "SELECT l_item_id FROM lineitem a NATURAL RIGHT JOIN lineitem b";
     let plan = logical_plan(sql).unwrap();
     assert_snapshot!(
         plan,
         @r"
-    Projection: a.l_item_id
+    Projection: b.l_item_id
       Right Join: Using a.l_orderkey = b.l_orderkey, a.l_item_id = b.l_item_id, a.l_description = b.l_description, a.l_extendedprice = b.l_extendedprice, a.price = b.price
         SubqueryAlias: a
           TableScan: lineitem
         SubqueryAlias: b
           TableScan: lineitem
+    "
+    );
+}
+
+#[test]
+fn using_join_full_coalesces_merged_key() {
+    // A FULL JOIN can NULL-pad either side, so the merged key resolves to
+    // COALESCE(left.id, right.id) (SQL:2016 §7.10), not the left key alone.
+    let sql = "SELECT id FROM person a FULL JOIN person b USING (id)";
+    let plan = logical_plan(sql).unwrap();
+    assert_snapshot!(
+        plan,
+        @r"
+    Projection: coalesce(a.id, b.id) AS id
+      Full Join: Using a.id = b.id
+        SubqueryAlias: a
+          TableScan: person
+        SubqueryAlias: b
+          TableScan: person
+    "
+    );
+}
+
+#[test]
+fn using_join_right_resolves_to_right_key() {
+    // A RIGHT JOIN NULL-pads the left key, so the merged key resolves to the
+    // right key (which is always present).
+    let sql = "SELECT id FROM person a RIGHT JOIN person b USING (id)";
+    let plan = logical_plan(sql).unwrap();
+    assert_snapshot!(
+        plan,
+        @r"
+    Projection: b.id
+      Right Join: Using a.id = b.id
+        SubqueryAlias: a
+          TableScan: person
+        SubqueryAlias: b
+          TableScan: person
+    "
+    );
+}
+
+#[test]
+fn using_join_full_preserves_qualified_keys() {
+    // The per-side keys remain individually addressable alongside the merged key.
+    let sql = "SELECT id AS merged, a.id AS a_id, b.id AS b_id \
+               FROM person a FULL JOIN person b USING (id)";
+    let plan = logical_plan(sql).unwrap();
+    assert_snapshot!(
+        plan,
+        @r"
+    Projection: coalesce(a.id, b.id) AS merged, a.id AS a_id, b.id AS b_id
+      Full Join: Using a.id = b.id
+        SubqueryAlias: a
+          TableScan: person
+        SubqueryAlias: b
+          TableScan: person
+    "
+    );
+}
+
+#[test]
+fn using_join_inner_left_unchanged() {
+    // INNER/LEFT never NULL-pad the left key, so the merged key stays the left
+    // column with no COALESCE wrapper (no behavior change).
+    let inner = logical_plan("SELECT id FROM person a JOIN person b USING (id)").unwrap();
+    assert_snapshot!(
+        inner,
+        @r"
+    Projection: a.id
+      Inner Join: Using a.id = b.id
+        SubqueryAlias: a
+          TableScan: person
+        SubqueryAlias: b
+          TableScan: person
+    "
+    );
+
+    let left =
+        logical_plan("SELECT id FROM person a LEFT JOIN person b USING (id)").unwrap();
+    assert_snapshot!(
+        left,
+        @r"
+    Projection: a.id
+      Left Join: Using a.id = b.id
+        SubqueryAlias: a
+          TableScan: person
+        SubqueryAlias: b
+          TableScan: person
     "
     );
 }
@@ -3551,6 +3642,8 @@ fn mock_session_state() -> MockSessionState {
     MockSessionState::default()
         .with_scalar_function(Arc::new(unicode::character_length().as_ref().clone()))
         .with_scalar_function(Arc::new(string::concat().as_ref().clone()))
+        // `RIGHT`/`FULL` USING/NATURAL joins build a `coalesce(...)` merged key.
+        .with_scalar_function(datafusion_functions::core::coalesce())
         .with_scalar_function(Arc::new(make_udf(
             "nullif",
             vec![DataType::Int32, DataType::Int32],
@@ -5182,7 +5275,9 @@ fn test_using_join_wildcard_schema() {
         ]
     );
 
-    // Multiple joins
+    // Multiple joins. The final `RIGHT JOIN ... USING (c)` can NULL-pad the left
+    // key `t2.c`, so `*` exposes the merged key `coalesce(t2.c, t3.c)` (named `c`,
+    // belonging to neither input) instead of the NULL-padded `t2.c` (SQL:2016 §7.10).
     let sql = "WITH t1 AS (SELECT 1 AS a, 1 AS b),
         t2 AS (SELECT 1 AS a, 2 AS c),
         t3 AS (SELECT 1 AS c, 2 AS d)
@@ -5193,7 +5288,7 @@ fn test_using_join_wildcard_schema() {
         [
             "t1.a".to_string(),
             "t1.b".to_string(),
-            "t2.c".to_string(),
+            "c".to_string(),
             "t3.d".to_string()
         ]
     );

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -5571,3 +5571,129 @@ set datafusion.execution.target_partitions = 4;
 
 statement ok
 reset datafusion.execution.batch_size;
+
+##########
+# RIGHT / FULL / NATURAL JOIN ... USING(k) must coalesce the merged join key
+# Per SQL:2016 §7.10 a USING/NATURAL join column is COALESCE(left.k, right.k),
+# so a right-only row of a RIGHT/FULL join must expose the RIGHT key value
+# (not the NULL-padded left key). See the GitHub issue this section covers.
+##########
+
+statement ok
+create table using_a(k int, x int) as values (1, 10);
+
+statement ok
+create table using_b(k int, y int) as values (4, 400);
+
+# FULL JOIN USING: the right-only row (k=4) must report k=4, not NULL
+query I
+select k from using_a full join using_b using (k) order by k nulls last;
+----
+1
+4
+
+# The unqualified key is COALESCE(a.k, b.k); the per-side keys remain addressable
+query III
+select k as unqual_k, using_a.k as a_k, using_b.k as b_k
+from using_a full join using_b using (k) order by unqual_k nulls last;
+----
+1 1 NULL
+4 NULL 4
+
+# RIGHT JOIN USING: right-only row exposes the right key
+query I
+select k from using_a right join using_b using (k);
+----
+4
+
+# NATURAL FULL JOIN: same coalescing behavior
+query I
+select k from using_a natural full join using_b order by k nulls last;
+----
+1
+4
+
+# NATURAL RIGHT JOIN
+query I
+select k from using_a natural right join using_b;
+----
+4
+
+# Must match the standard-equivalent explicit COALESCE ... ON form
+query I
+select coalesce(using_a.k, using_b.k) as k
+from using_a full join using_b on using_a.k = using_b.k order by k nulls last;
+----
+1
+4
+
+# Downstream WHERE on the merged key keeps the real right-only row
+query II
+select x, y from using_a full join using_b using (k) where k = 4;
+----
+NULL 400
+
+# Downstream GROUP BY buckets the right-only row under its real key, not NULL
+query II
+select k, count(*) from using_a full join using_b using (k) group by k order by k nulls last;
+----
+1 1
+4 1
+
+# SELECT * exposes a single, coalesced key column (Postgres semantics)
+query III
+select * from using_a full join using_b using (k) order by k nulls last;
+----
+1 10 NULL
+4 NULL 400
+
+# The merged key plan is COALESCE(left, right) for FULL ...
+query TT
+explain select k from using_a full join using_b using (k);
+----
+logical_plan
+01)Projection: CASE WHEN using_a.k IS NOT NULL THEN using_a.k ELSE using_b.k END AS k
+02)--Full Join: Using using_a.k = using_b.k
+03)----TableScan: using_a projection=[k]
+04)----TableScan: using_b projection=[k]
+physical_plan
+01)ProjectionExec: expr=[CASE WHEN k@0 IS NOT NULL THEN k@0 ELSE k@1 END as k]
+02)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----HashJoinExec: mode=CollectLeft, join_type=Full, on=[(k@0, k@0)]
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+05)------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# ... and the right key for RIGHT (the right side is always present)
+query TT
+explain select k from using_a right join using_b using (k);
+----
+logical_plan
+01)Projection: using_b.k
+02)--Right Join: Using using_a.k = using_b.k
+03)----TableScan: using_a projection=[k]
+04)----TableScan: using_b projection=[k]
+physical_plan
+01)HashJoinExec: mode=CollectLeft, join_type=Right, on=[(k@0, k@0)], projection=[k@1]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+03)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+# INNER / LEFT are unaffected: the left key is never NULL-padded, so the merged
+# key still resolves to the (unchanged) left column with no COALESCE wrapper.
+query TT
+explain select k from using_a inner join using_b using (k);
+----
+logical_plan
+01)Projection: using_a.k
+02)--Inner Join: using_a.k = using_b.k
+03)----TableScan: using_a projection=[k]
+04)----TableScan: using_b projection=[k]
+physical_plan
+01)HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(k@0, k@0)], projection=[k@0]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+03)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement ok
+DROP TABLE using_a;
+
+statement ok
+DROP TABLE using_b;


### PR DESCRIPTION
## Problem

A `USING` / `NATURAL` join column is `COALESCE(left.k, right.k)`. For a right-only row of a `RIGHT` / `FULL` join the left key is NULL padded, so the merged key must take the right key. DataFusion instead binds the unqualified key to the left column only, so it comes out `NULL`:

```
> explain format indent select k from a full join b using (k);

Projection: a.k                       <-- bound to a.k, not coalesce(a.k, b.k)
  Full Join: Using a.k = b.k
```

It's silent (plans and runs fine) and corrupts downstream `WHERE` / `GROUP BY`. `INNER` / `LEFT` are unaffected (their left key is never NULL padded).

## Proof

```sql
create table a(k int, x int) as values (1, 10);
create table b(k int, y int) as values (4, 400);

-- right-only row reports k = NULL instead of 4
select k from a full join b using (k) order by k nulls last;   -- before: 1, NULL   after: 1, 4
select k from a right join b using (k);                        -- before: NULL      after: 4
select k from a natural full join b order by k nulls last;     -- before: 1, NULL   after: 1, 4

-- silently drops a real row; buckets right-only rows under NULL
select * from a full join b using (k) where k = 4;             -- before: 0 rows    after: 1 row
select k, count(*) from a full join b using (k) group by k;    -- before: k=NULL    after: k=4

-- explicit form was already correct, confirming the divergence
select coalesce(a.k, b.k) as k from a full join b on a.k = b.k order by k nulls last;  -- 1, 4
```

## Solution

`RIGHT` / `FULL` `USING` / `NATURAL` joins register each merged key in `PlannerContext` with its replacement — `COALESCE(left, right)` for `FULL`, `right` for `RIGHT` — and an unqualified reference to the key resolves to that replacement in `sql_identifier_to_expr` (one chokepoint covering `SELECT` / `WHERE` / `GROUP BY` / `HAVING` / `ORDER BY`), plus `SELECT *`. The join schema is left untouched, so `a.k` / `b.k` stay individually addressable. `INNER` / `LEFT` are unchanged.

```
> explain format indent select k from a full join b using (k);

Projection: coalesce(a.k, b.k) AS k
  Full Join: Using a.k = b.k
```

There was previously no test coverage for `RIGHT` / `FULL` `USING` / `NATURAL`; this adds it in `joins.slt` plus planner unit tests. The full sqllogictest suite and all `datafusion-sql` tests pass.

