### PR TITLE
docs: link to 2026 Q3-Q4 roadmap discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,14 @@ It lets you start quickly from a fully working engine, and then customize those 
 
 Please see the [contributor guide] and [communication] pages for more information.
 
+We discuss our [roadmap] via GitHub issues and invite you
+to join the conversation. The current discussion is the
+[DataFusion 2026 Q3-Q4 Roadmap Discussion].
+
 [contributor guide]: https://datafusion.apache.org/contributor-guide
 [communication]: https://datafusion.apache.org/contributor-guide/communication.html
+[roadmap]: https://datafusion.apache.org/contributor-guide/roadmap.html
+[datafusion 2026 q3-q4 roadmap discussion]: https://github.com/apache/datafusion/issues/22882
 
 ## Crate features
 

--- a/docs/source/contributor-guide/roadmap.md
+++ b/docs/source/contributor-guide/roadmap.md
@@ -52,12 +52,16 @@ any single organization or coordinating committee. We typically discuss our
 roadmap using GitHub issues, approximately quarterly, and invite you to join the
 discussion.
 
+The current roadmap discussion is
+[DataFusion 2026 Q3-Q4 Roadmap Discussion](https://github.com/apache/datafusion/issues/22882).
+
 For more information:
 
 1. [Search for issues labeled `roadmap`](https://github.com/apache/datafusion/issues?q=is%3Aissue%20%20%20roadmap)
-2. [DataFusion Road Map: Q1 2026](https://github.com/apache/datafusion/issues/18494)
-3. [DataFusion Road Map: Q3-Q4 2025](https://github.com/apache/datafusion/issues/15878)
-4. [2024 Q4 / 2025 Q1 Roadmap](https://github.com/apache/datafusion/issues/13274)
+2. [DataFusion 2026 Q3-Q4 Roadmap Discussion](https://github.com/apache/datafusion/issues/22882)
+3. [DataFusion Road Map: Q1 2026](https://github.com/apache/datafusion/issues/18494)
+4. [DataFusion Road Map: Q3-Q4 2025](https://github.com/apache/datafusion/issues/15878)
+5. [2024 Q4 / 2025 Q1 Roadmap](https://github.com/apache/datafusion/issues/13274)
 
 ## Improvement Proposals
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to #22882.

## Rationale for this change

I opened a new roadmap discussion, [DataFusion 2026 Q3-Q4 Roadmap Discussion](https://github.com/apache/datafusion/issues/22882), and it would be nice if public-facing docs pointed readers at it so the community can find and join the current discussion.

## What changes are included in this PR?

- Add a roadmap pointer to the `README.md` "Contributing to DataFusion" section linking to the roadmap docs and the current discussion (#22882).
- Update the contributor-guide roadmap page (`docs/source/contributor-guide/roadmap.md`) to call out #22882 as the current discussion and list it at the top of the quarterly roadmap discussions.

## Are these changes tested?

No tests; documentation-only change.

## Are there any user-facing changes?

Documentation only — adds links to the current roadmap discussion.