### PR TITLE
fix: TRY_CAST returns NULL for timestamp/date overflow

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4292,12 +4292,13 @@ impl ScalarValue {
             .or_else(|| timestamp_to_timestamp_multiplier(&source_type, target_type))
             && let Some(value) = self.temporal_scalar_value_as_i64()
         {
-            if cast_options.safe {
-                if multiplier > 1 && value.checked_mul(multiplier).is_none() {
+            match ensure_timestamp_in_bounds(value, multiplier, &source_type, target_type)
+            {
+                Ok(()) => {}
+                Err(_) if cast_options.safe => {
                     return ScalarValue::try_new_null(target_type);
                 }
-            } else {
-                ensure_timestamp_in_bounds(value, multiplier, &source_type, target_type)?;
+                Err(e) => return Err(e),
             }
         }
 

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4292,7 +4292,13 @@ impl ScalarValue {
             .or_else(|| timestamp_to_timestamp_multiplier(&source_type, target_type))
             && let Some(value) = self.temporal_scalar_value_as_i64()
         {
-            ensure_timestamp_in_bounds(value, multiplier, &source_type, target_type)?;
+            if cast_options.safe {
+                if multiplier > 1 && value.checked_mul(multiplier).is_none() {
+                    return ScalarValue::try_new_null(target_type);
+                }
+            } else {
+                ensure_timestamp_in_bounds(value, multiplier, &source_type, target_type)?;
+            }
         }
 
         let scalar_array = self.to_array()?;
@@ -10191,6 +10197,24 @@ mod tests {
     }
 
     #[test]
+    fn safe_cast_date_to_timestamp_overflow_returns_null() {
+        let scalar = ScalarValue::Date32(Some(i32::MAX));
+        let safe_options = CastOptions {
+            safe: true,
+            ..DEFAULT_CAST_OPTIONS
+        };
+
+        let casted = scalar
+            .cast_to_with_options(
+                &DataType::Timestamp(TimeUnit::Nanosecond, None),
+                &safe_options,
+            )
+            .expect("expected safe cast to return null");
+
+        assert_eq!(casted, ScalarValue::TimestampNanosecond(None, None));
+    }
+
+    #[test]
     fn cast_timestamp_to_timestamp_overflow_returns_error() {
         let scalar = ScalarValue::TimestampSecond(Some(i64::MAX), None);
         let err = scalar
@@ -10201,6 +10225,24 @@ mod tests {
                 .contains("converted value exceeds the representable i64 range"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn safe_cast_timestamp_to_timestamp_overflow_returns_null() {
+        let scalar = ScalarValue::TimestampSecond(Some(i64::MAX), None);
+        let safe_options = CastOptions {
+            safe: true,
+            ..DEFAULT_CAST_OPTIONS
+        };
+
+        let casted = scalar
+            .cast_to_with_options(
+                &DataType::Timestamp(TimeUnit::Nanosecond, None),
+                &safe_options,
+            )
+            .expect("expected safe cast to return null");
+
+        assert_eq!(casted, ScalarValue::TimestampNanosecond(None, None));
     }
 
     #[test]

--- a/datafusion/expr-common/src/columnar_value.rs
+++ b/datafusion/expr-common/src/columnar_value.rs
@@ -325,7 +325,9 @@ fn cast_array_by_name(
     ) {
         datafusion_common::nested_struct::cast_column(array, cast_type, cast_options)
     } else {
-        ensure_temporal_array_timestamp_bounds(array, cast_type)?;
+        if !cast_options.safe {
+            ensure_temporal_array_timestamp_bounds(array, cast_type)?;
+        }
         Ok(kernels::cast::cast_with_options(
             array,
             cast_type,
@@ -765,5 +767,33 @@ mod tests {
                 .contains("converted value exceeds the representable i64 range"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn safe_cast_timestamp_array_to_timestamp_overflow_returns_null() {
+        let overflow_value = i64::MAX / 1_000_000_000 + 1;
+        let array: ArrayRef =
+            Arc::new(TimestampSecondArray::from(vec![Some(overflow_value)]));
+        let value = ColumnarValue::Array(array);
+        let safe_options = CastOptions {
+            safe: true,
+            ..DEFAULT_CAST_OPTIONS
+        };
+
+        let casted = value
+            .cast_to(
+                &DataType::Timestamp(TimeUnit::Nanosecond, None),
+                Some(&safe_options),
+            )
+            .expect("expected safe cast to return null");
+
+        let ColumnarValue::Array(array) = casted else {
+            panic!("expected array after cast");
+        };
+        let array = array
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .expect("expected TimestampNanosecondArray");
+        assert!(array.is_null(0));
     }
 }

--- a/datafusion/sqllogictest/src/engines/datafusion_engine/runner.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/runner.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::any::Any;
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 use std::{path::PathBuf, time::Duration};
 
@@ -28,6 +30,7 @@ use async_trait::async_trait;
 use datafusion::physical_plan::common::collect;
 use datafusion::physical_plan::execute_stream;
 use datafusion::prelude::SessionContext;
+use futures::FutureExt;
 use indicatif::ProgressBar;
 use log::Level::{Debug, Info};
 use log::{debug, log_enabled, warn};
@@ -154,7 +157,19 @@ impl sqllogictest::AsyncDB for DataFusion {
         let tracked_sql = self.currently_executing_sql_tracker.set_sql(sql);
 
         let start = Instant::now();
-        let result = run_query(&self.ctx, is_spark_path(&self.relative_path), sql).await;
+        let result = AssertUnwindSafe(run_query(
+            &self.ctx,
+            is_spark_path(&self.relative_path),
+            sql,
+        ))
+        .catch_unwind()
+        .await
+        .unwrap_or_else(|panic| {
+            Err(DFSqlLogicTestError::Other(format!(
+                "panic: {}",
+                panic_message(panic.as_ref())
+            )))
+        });
         let duration = start.elapsed();
 
         self.currently_executing_sql_tracker.remove_sql(tracked_sql);
@@ -196,6 +211,16 @@ impl sqllogictest::AsyncDB for DataFusion {
         {
             config_change_errors.lock().unwrap().push(error.to_string());
         }
+    }
+}
+
+fn panic_message(panic: &(dyn Any + Send)) -> &str {
+    if let Some(message) = panic.downcast_ref::<&str>() {
+        message
+    } else if let Some(message) = panic.downcast_ref::<String>() {
+        message
+    } else {
+        "unknown panic"
     }
 }
 

--- a/datafusion/sqllogictest/src/engines/datafusion_engine/runner.rs
+++ b/datafusion/sqllogictest/src/engines/datafusion_engine/runner.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::any::Any;
 use std::collections::HashMap;
-use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 use std::{path::PathBuf, time::Duration};
 
@@ -30,7 +28,6 @@ use async_trait::async_trait;
 use datafusion::physical_plan::common::collect;
 use datafusion::physical_plan::execute_stream;
 use datafusion::prelude::SessionContext;
-use futures::FutureExt;
 use indicatif::ProgressBar;
 use log::Level::{Debug, Info};
 use log::{debug, log_enabled, warn};
@@ -157,19 +154,7 @@ impl sqllogictest::AsyncDB for DataFusion {
         let tracked_sql = self.currently_executing_sql_tracker.set_sql(sql);
 
         let start = Instant::now();
-        let result = AssertUnwindSafe(run_query(
-            &self.ctx,
-            is_spark_path(&self.relative_path),
-            sql,
-        ))
-        .catch_unwind()
-        .await
-        .unwrap_or_else(|panic| {
-            Err(DFSqlLogicTestError::Other(format!(
-                "panic: {}",
-                panic_message(panic.as_ref())
-            )))
-        });
+        let result = run_query(&self.ctx, is_spark_path(&self.relative_path), sql).await;
         let duration = start.elapsed();
 
         self.currently_executing_sql_tracker.remove_sql(tracked_sql);
@@ -211,16 +196,6 @@ impl sqllogictest::AsyncDB for DataFusion {
         {
             config_change_errors.lock().unwrap().push(error.to_string());
         }
-    }
-}
-
-fn panic_message(panic: &(dyn Any + Send)) -> &str {
-    if let Some(message) = panic.downcast_ref::<&str>() {
-        message
-    } else if let Some(message) = panic.downcast_ref::<String>() {
-        message
-    } else {
-        "unknown panic"
     }
 }
 

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -5390,6 +5390,10 @@ SELECT TRY_CAST(DATE '3000-01-01' AS TIMESTAMP(9));
 ----
 NULL
 
+query error panic: attempt to multiply with overflow
+SELECT TRY_CAST(d AS TIMESTAMP(9))
+FROM (VALUES (DATE '3000-01-01')) t(d);
+
 query P
 SELECT TRY_CAST(ts AS TIMESTAMP(9)) AS ts
 FROM (

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -5390,10 +5390,6 @@ SELECT TRY_CAST(DATE '3000-01-01' AS TIMESTAMP(9));
 ----
 NULL
 
-query error panic: attempt to multiply with overflow
-SELECT TRY_CAST(d AS TIMESTAMP(9))
-FROM (VALUES (DATE '3000-01-01')) t(d);
-
 query P
 SELECT TRY_CAST(ts AS TIMESTAMP(9)) AS ts
 FROM (

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -5390,6 +5390,14 @@ SELECT TRY_CAST(DATE '3000-01-01' AS TIMESTAMP(9));
 ----
 NULL
 
+query P
+SELECT TRY_CAST(ts AS TIMESTAMP(9)) AS ts
+FROM (
+    VALUES (arrow_cast(9223372037, 'Timestamp(s)'))
+) t(ts);
+----
+NULL
+
 # Float truncation behavior
 query P
 SELECT to_timestamp_seconds(arrow_cast(-1.9, 'Float64'));

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -5379,6 +5379,17 @@ SELECT to_timestamp(arrow_cast(-9223372036, 'Int64'));
 query error converted value exceeds the representable i64 range
 SELECT to_timestamp(arrow_cast(9223372037, 'Int64'));
 
+# TRY_CAST returns NULL for timestamp/date casts that overflow
+query P
+SELECT TRY_CAST(arrow_cast(9223372037, 'Timestamp(s)') AS TIMESTAMP(9));
+----
+NULL
+
+query P
+SELECT TRY_CAST(DATE '3000-01-01' AS TIMESTAMP(9));
+----
+NULL
+
 # Float truncation behavior
 query P
 SELECT to_timestamp_seconds(arrow_cast(-1.9, 'Float64'));


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #22896.

## Rationale for this change

`TRY_CAST` should return NULL on cast failure, but overflowing date/timestamp casts returned errors.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
  
- Make scalar temporal overflow checks respect CastOptions.safe.
- Skip DataFusion’s array pre-check for safe casts so Arrow can return NULLs.
- Add regression tests.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes:

```bash
cargo test -p datafusion-common timestamp_overflow_returns
cargo test -p datafusion-expr-common timestamp_array_to_timestamp_overflow
cargo test --test sqllogictests -- datetime/timestamps.slt
```

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Yes. TRY_CAST for overflowing date/timestamp casts now returns NULL; regular CAST still errors.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

## Known Limitation

This PR does not add Date array-path coverage yet. For example:

```sql
SELECT TRY_CAST(d AS TIMESTAMP(9))
FROM (VALUES (DATE '3000-01-01')) t(d);
```

This depends on the upstream Arrow fix in apache/arrow-rs#9825. Once DataFusion updates to an Arrow version containing that fix, we can add this regression test.


