### PR TITLE
perf: preserve dictionary encoding for lower/upper to avoid materializing low-cardinality columns

### DIFF
--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -1066,29 +1066,29 @@ pub enum Coercion {
 
 /// Controls whether a [`Coercion`] preserves an argument's physical encoding
 /// (e.g. dictionary) instead of materializing it to the coerced value type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
-pub enum EncodingPreservation {
-    /// Do not request preservation of a physical encoding.
-    None,
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Hash)]
+pub struct EncodingPreservation {
+    preserve_dictionary: bool,
+}
+
+impl EncodingPreservation {
     /// Preserve dictionary encoding and coerce only the dictionary values.
-    Dictionary,
+    pub const fn with_dictionary(mut self) -> Self {
+        self.preserve_dictionary = true;
+        self
+    }
+
+    /// Returns whether dictionary encoding should be preserved.
+    pub const fn preserve_dictionary(self) -> bool {
+        self.preserve_dictionary
+    }
 }
 
 impl Coercion {
     pub fn new_exact(desired_type: TypeSignatureClass) -> Self {
         Self::Exact {
             desired_type,
-            encoding_preservation: EncodingPreservation::None,
-        }
-    }
-
-    pub fn new_exact_preserving_encoding(
-        desired_type: TypeSignatureClass,
-        encoding_preservation: EncodingPreservation,
-    ) -> Self {
-        Self::Exact {
-            desired_type,
-            encoding_preservation,
+            encoding_preservation: EncodingPreservation::default(),
         }
     }
 
@@ -1107,7 +1107,7 @@ impl Coercion {
                 allowed_source_types,
                 default_casted_type,
             },
-            encoding_preservation: EncodingPreservation::None,
+            encoding_preservation: EncodingPreservation::default(),
         }
     }
 
@@ -2240,10 +2240,14 @@ mod tests {
 
     #[test]
     fn test_coercion_encoding_preservation_affects_equality() {
+        assert!(!EncodingPreservation::default().preserve_dictionary());
+        let preserve_dictionary = EncodingPreservation::default().with_dictionary();
+        assert!(preserve_dictionary.preserve_dictionary());
+
         let default = Coercion::new_exact(TypeSignatureClass::Native(logical_string()));
         let preserving = default
             .clone()
-            .with_encoding_preservation(EncodingPreservation::Dictionary);
+            .with_encoding_preservation(preserve_dictionary);
 
         assert_ne!(default, preserving);
     }

--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -1043,14 +1043,6 @@ fn get_data_types(native_type: &NativeType) -> Vec<DataType> {
 ///
 /// * `Exact` - Only accepts arguments that exactly match the desired type
 /// * `Implicit` - Accepts the desired type and can coerce from specified source types
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
-pub enum EncodingPreservation {
-    /// Do not request preservation of a physical encoding.
-    None,
-    /// Preserve dictionary encoding and coerce only the dictionary values.
-    Dictionary,
-}
-
 #[derive(Debug, Clone, Eq, PartialOrd)]
 pub enum Coercion {
     /// Coercion that only accepts arguments exactly matching the desired type.
@@ -1070,6 +1062,16 @@ pub enum Coercion {
         /// Physical encoding preservation requested by the function.
         encoding_preservation: EncodingPreservation,
     },
+}
+
+/// Controls whether a [`Coercion`] preserves an argument's physical encoding
+/// (e.g. dictionary) instead of materializing it to the coerced value type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+pub enum EncodingPreservation {
+    /// Do not request preservation of a physical encoding.
+    None,
+    /// Preserve dictionary encoding and coerce only the dictionary values.
+    Dictionary,
 }
 
 impl Coercion {

--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -1043,12 +1043,22 @@ fn get_data_types(native_type: &NativeType) -> Vec<DataType> {
 ///
 /// * `Exact` - Only accepts arguments that exactly match the desired type
 /// * `Implicit` - Accepts the desired type and can coerce from specified source types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+pub enum EncodingPreservation {
+    /// Do not request preservation of a physical encoding.
+    None,
+    /// Preserve dictionary encoding and coerce only the dictionary values.
+    Dictionary,
+}
+
 #[derive(Debug, Clone, Eq, PartialOrd)]
 pub enum Coercion {
     /// Coercion that only accepts arguments exactly matching the desired type.
     Exact {
         /// The required type for the argument
         desired_type: TypeSignatureClass,
+        /// Physical encoding preservation requested by the function.
+        encoding_preservation: EncodingPreservation,
     },
 
     /// Coercion that accepts the desired type and can implicitly coerce from other types.
@@ -1057,12 +1067,27 @@ pub enum Coercion {
         desired_type: TypeSignatureClass,
         /// Rules for implicit coercion from other types
         implicit_coercion: ImplicitCoercion,
+        /// Physical encoding preservation requested by the function.
+        encoding_preservation: EncodingPreservation,
     },
 }
 
 impl Coercion {
     pub fn new_exact(desired_type: TypeSignatureClass) -> Self {
-        Self::Exact { desired_type }
+        Self::Exact {
+            desired_type,
+            encoding_preservation: EncodingPreservation::None,
+        }
+    }
+
+    pub fn new_exact_preserving_encoding(
+        desired_type: TypeSignatureClass,
+        encoding_preservation: EncodingPreservation,
+    ) -> Self {
+        Self::Exact {
+            desired_type,
+            encoding_preservation,
+        }
     }
 
     /// Create a new coercion with implicit coercion rules.
@@ -1080,6 +1105,37 @@ impl Coercion {
                 allowed_source_types,
                 default_casted_type,
             },
+            encoding_preservation: EncodingPreservation::None,
+        }
+    }
+
+    pub fn with_encoding_preservation(
+        mut self,
+        encoding_preservation: EncodingPreservation,
+    ) -> Self {
+        match &mut self {
+            Coercion::Exact {
+                encoding_preservation: current,
+                ..
+            }
+            | Coercion::Implicit {
+                encoding_preservation: current,
+                ..
+            } => *current = encoding_preservation,
+        }
+        self
+    }
+
+    pub fn encoding_preservation(&self) -> EncodingPreservation {
+        match self {
+            Coercion::Exact {
+                encoding_preservation,
+                ..
+            }
+            | Coercion::Implicit {
+                encoding_preservation,
+                ..
+            } => *encoding_preservation,
         }
     }
 
@@ -1103,7 +1159,7 @@ impl Coercion {
 
     pub fn desired_type(&self) -> &TypeSignatureClass {
         match self {
-            Coercion::Exact { desired_type } => desired_type,
+            Coercion::Exact { desired_type, .. } => desired_type,
             Coercion::Implicit { desired_type, .. } => desired_type,
         }
     }
@@ -1128,6 +1184,7 @@ impl PartialEq for Coercion {
     fn eq(&self, other: &Self) -> bool {
         self.desired_type() == other.desired_type()
             && self.implicit_coercion() == other.implicit_coercion()
+            && self.encoding_preservation() == other.encoding_preservation()
     }
 }
 
@@ -1135,6 +1192,7 @@ impl Hash for Coercion {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.desired_type().hash(state);
         self.implicit_coercion().hash(state);
+        self.encoding_preservation().hash(state);
     }
 }
 
@@ -2176,6 +2234,16 @@ mod tests {
             NativeType::Int64,
         );
         assert_snapshot!(implicit_with_multiple_sources, @"Int64");
+    }
+
+    #[test]
+    fn test_coercion_encoding_preservation_affects_equality() {
+        let default = Coercion::new_exact(TypeSignatureClass::Native(logical_string()));
+        let preserving = default
+            .clone()
+            .with_encoding_preservation(EncodingPreservation::Dictionary);
+
+        assert_ne!(default, preserving);
     }
 
     #[test]

--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -1073,6 +1073,13 @@ pub struct EncodingPreservation {
 
 impl EncodingPreservation {
     /// Preserve dictionary encoding and coerce only the dictionary values.
+    pub const fn dictionary() -> Self {
+        Self {
+            preserve_dictionary: true,
+        }
+    }
+
+    /// Preserve dictionary encoding and coerce only the dictionary values.
     pub const fn with_dictionary(mut self) -> Self {
         self.preserve_dictionary = true;
         self
@@ -2241,7 +2248,7 @@ mod tests {
     #[test]
     fn test_coercion_encoding_preservation_affects_equality() {
         assert!(!EncodingPreservation::default().preserve_dictionary());
-        let preserve_dictionary = EncodingPreservation::default().with_dictionary();
+        let preserve_dictionary = EncodingPreservation::dictionary();
         assert!(preserve_dictionary.preserve_dictionary());
 
         let default = Coercion::new_exact(TypeSignatureClass::Native(logical_string()));

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -101,8 +101,8 @@ pub use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
 pub use datafusion_expr_common::operator::Operator;
 pub use datafusion_expr_common::placement::ExpressionPlacement;
 pub use datafusion_expr_common::signature::{
-    ArrayFunctionArgument, ArrayFunctionSignature, Coercion, Signature,
-    TIMEZONE_WILDCARD, TypeSignature, TypeSignatureClass, Volatility,
+    ArrayFunctionArgument, ArrayFunctionSignature, Coercion, EncodingPreservation,
+    Signature, TIMEZONE_WILDCARD, TypeSignature, TypeSignatureClass, Volatility,
 };
 pub use datafusion_expr_common::type_coercion::binary;
 pub use expr::{

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -33,7 +33,7 @@ use datafusion_common::utils::{
 use datafusion_common::{
     Result, exec_err, internal_err, plan_err, types::NativeType, utils::list_ndims,
 };
-use datafusion_expr_common::signature::ArrayFunctionArgument;
+use datafusion_expr_common::signature::{ArrayFunctionArgument, EncodingPreservation};
 use datafusion_expr_common::type_coercion::binary::type_union_resolution;
 use datafusion_expr_common::{
     signature::{ArrayFunctionSignature, FIXED_SIZE_LIST_WILDCARD, TIMEZONE_WILDCARD},
@@ -873,9 +873,44 @@ fn get_valid_types(
         TypeSignature::Coercible(param_types) => {
             function_length_check(function_name, current_types.len(), param_types.len())?;
 
+            fn cast_origin(
+                current_type: &DataType,
+                encoding_preservation: EncodingPreservation,
+            ) -> &DataType {
+                match (encoding_preservation, current_type) {
+                    (
+                        EncodingPreservation::Dictionary,
+                        DataType::Dictionary(_, value_type),
+                    ) => value_type,
+                    _ => current_type,
+                }
+            }
+
+            fn preserve_encoding(
+                current_type: &DataType,
+                casted_type: DataType,
+                encoding_preservation: EncodingPreservation,
+            ) -> DataType {
+                match (encoding_preservation, current_type, &casted_type) {
+                    (
+                        EncodingPreservation::Dictionary,
+                        DataType::Dictionary(_, _),
+                        DataType::Dictionary(_, _),
+                    ) => casted_type,
+                    (
+                        EncodingPreservation::Dictionary,
+                        DataType::Dictionary(key_type, _),
+                        _,
+                    ) => DataType::Dictionary(key_type.clone(), Box::new(casted_type)),
+                    _ => casted_type,
+                }
+            }
+
             let mut new_types = Vec::with_capacity(current_types.len());
             for (current_type, param) in current_types.iter().zip(param_types.iter()) {
                 let current_native_type: NativeType = current_type.into();
+                let encoding_preservation = param.encoding_preservation();
+                let cast_origin = cast_origin(current_type, encoding_preservation);
 
                 if param
                     .desired_type()
@@ -883,9 +918,13 @@ fn get_valid_types(
                 {
                     let casted_type = param
                         .desired_type()
-                        .default_casted_type(&current_native_type, current_type)?;
+                        .default_casted_type(&current_native_type, cast_origin)?;
 
-                    new_types.push(casted_type);
+                    new_types.push(preserve_encoding(
+                        current_type,
+                        casted_type,
+                        encoding_preservation,
+                    ));
                 } else if param
                     .allowed_source_types()
                     .iter()
@@ -894,8 +933,12 @@ fn get_valid_types(
                     // If the condition is met which means `implicit coercion`` is provided so we can safely unwrap
                     let default_casted_type = param.default_casted_type().unwrap();
                     let casted_type =
-                        default_casted_type.default_cast_for(current_type)?;
-                    new_types.push(casted_type);
+                        default_casted_type.default_cast_for(cast_origin)?;
+                    new_types.push(preserve_encoding(
+                        current_type,
+                        casted_type,
+                        encoding_preservation,
+                    ));
                 } else {
                     let hint = if matches!(current_native_type, NativeType::Binary) {
                         "\n\nHint: Binary types are not automatically coerced to String. Use CAST(column AS VARCHAR) to convert Binary data to String."
@@ -1214,11 +1257,11 @@ mod tests {
     use arrow::datatypes::IntervalUnit;
     use datafusion_common::{
         assert_contains,
-        types::{logical_binary, logical_int64},
+        types::{logical_binary, logical_int64, logical_string},
     };
     use datafusion_expr_common::{
         columnar_value::ColumnarValue,
-        signature::{Coercion, TypeSignatureClass},
+        signature::{Coercion, EncodingPreservation, TypeSignatureClass},
     };
 
     #[test]
@@ -1827,6 +1870,53 @@ mod tests {
             NativeType::Int64,
         ))?;
         assert_eq!(vec![dictionary.clone()], output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_coercible_dictionary_preserves_encoding() -> Result<()> {
+        fn dictionary_input(
+            value_type: DataType,
+            coercion: Coercion,
+        ) -> Result<Vec<DataType>> {
+            fields_with_udf(
+                &[Field::new(
+                    "field",
+                    DataType::Dictionary(Box::new(DataType::Int8), Box::new(value_type)),
+                    true,
+                )
+                .into()],
+                &MockUdf(Signature::coercible(vec![coercion], Volatility::Immutable)),
+            )
+            .map(|v| v.into_iter().map(|f| f.data_type().clone()).collect())
+        }
+
+        let coercion = Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+            .with_encoding_preservation(EncodingPreservation::Dictionary);
+
+        assert_eq!(
+            dictionary_input(DataType::LargeUtf8, coercion.clone())?,
+            vec![DataType::Dictionary(
+                Box::new(DataType::Int8),
+                Box::new(DataType::LargeUtf8),
+            )]
+        );
+        assert_eq!(
+            dictionary_input(
+                DataType::BinaryView,
+                Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_string()),
+                    vec![TypeSignatureClass::Native(logical_binary())],
+                    NativeType::String,
+                )
+                .with_encoding_preservation(EncodingPreservation::Dictionary),
+            )?,
+            vec![DataType::Dictionary(
+                Box::new(DataType::Int8),
+                Box::new(DataType::Utf8View),
+            )]
+        );
 
         Ok(())
     }

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -1888,9 +1888,7 @@ mod tests {
         }
 
         let coercion = Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
-            .with_encoding_preservation(
-                EncodingPreservation::default().with_dictionary(),
-            );
+            .with_encoding_preservation(EncodingPreservation::dictionary());
 
         assert_eq!(
             dictionary_input(DataType::LargeUtf8, coercion.clone())?,
@@ -1907,13 +1905,41 @@ mod tests {
                     vec![TypeSignatureClass::Native(logical_binary())],
                     NativeType::String,
                 )
-                .with_encoding_preservation(
-                    EncodingPreservation::default().with_dictionary(),
-                ),
+                .with_encoding_preservation(EncodingPreservation::dictionary()),
             )?,
             vec![DataType::Dictionary(
                 Box::new(DataType::Int8),
                 Box::new(DataType::Utf8View),
+            )]
+        );
+        assert_eq!(
+            dictionary_input(
+                DataType::Int32,
+                Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_int64()),
+                    vec![TypeSignatureClass::Integer],
+                    NativeType::Int64,
+                )
+                .with_encoding_preservation(EncodingPreservation::dictionary()),
+            )?,
+            vec![DataType::Dictionary(
+                Box::new(DataType::Int8),
+                Box::new(DataType::Int64),
+            )]
+        );
+        assert_eq!(
+            dictionary_input(
+                DataType::Int32,
+                Coercion::new_implicit(
+                    TypeSignatureClass::Integer,
+                    vec![],
+                    NativeType::Int64,
+                )
+                .with_encoding_preservation(EncodingPreservation::dictionary()),
+            )?,
+            vec![DataType::Dictionary(
+                Box::new(DataType::Int8),
+                Box::new(DataType::Int32),
             )]
         );
 

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -1912,6 +1912,19 @@ mod tests {
                 Box::new(DataType::Utf8View),
             )]
         );
+        // Contrast: without encoding_preservation, Native strips dictionary entirely
+        assert_eq!(
+            dictionary_input(
+                DataType::Int32,
+                Coercion::new_implicit(
+                    TypeSignatureClass::Native(logical_int64()),
+                    vec![TypeSignatureClass::Integer],
+                    NativeType::Int64,
+                ),
+            )?,
+            vec![DataType::Int64]
+        );
+        // With encoding_preservation, dictionary wrapper is preserved, value coerced
         assert_eq!(
             dictionary_input(
                 DataType::Int32,
@@ -1927,6 +1940,22 @@ mod tests {
                 Box::new(DataType::Int64),
             )]
         );
+        // Contrast: without encoding_preservation, non-Native already passes through
+        assert_eq!(
+            dictionary_input(
+                DataType::Int32,
+                Coercion::new_implicit(
+                    TypeSignatureClass::Integer,
+                    vec![],
+                    NativeType::Int64,
+                ),
+            )?,
+            vec![DataType::Dictionary(
+                Box::new(DataType::Int8),
+                Box::new(DataType::Int32),
+            )]
+        );
+        // With encoding_preservation, same result — no difference for non-Native
         assert_eq!(
             dictionary_input(
                 DataType::Int32,

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -877,12 +877,12 @@ fn get_valid_types(
                 current_type: &DataType,
                 encoding_preservation: EncodingPreservation,
             ) -> &DataType {
-                match (encoding_preservation, current_type) {
-                    (
-                        EncodingPreservation::Dictionary,
-                        DataType::Dictionary(_, value_type),
-                    ) => value_type,
-                    _ => current_type,
+                if encoding_preservation.preserve_dictionary()
+                    && let DataType::Dictionary(_, value_type) = current_type
+                {
+                    value_type
+                } else {
+                    current_type
                 }
             }
 
@@ -891,18 +891,13 @@ fn get_valid_types(
                 casted_type: DataType,
                 encoding_preservation: EncodingPreservation,
             ) -> DataType {
-                match (encoding_preservation, current_type, &casted_type) {
-                    (
-                        EncodingPreservation::Dictionary,
-                        DataType::Dictionary(_, _),
-                        DataType::Dictionary(_, _),
-                    ) => casted_type,
-                    (
-                        EncodingPreservation::Dictionary,
-                        DataType::Dictionary(key_type, _),
-                        _,
-                    ) => DataType::Dictionary(key_type.clone(), Box::new(casted_type)),
-                    _ => casted_type,
+                if encoding_preservation.preserve_dictionary()
+                    && let DataType::Dictionary(key_type, _) = current_type
+                    && !matches!(casted_type, DataType::Dictionary(_, _))
+                {
+                    DataType::Dictionary(key_type.clone(), Box::new(casted_type))
+                } else {
+                    casted_type
                 }
             }
 
@@ -1893,7 +1888,9 @@ mod tests {
         }
 
         let coercion = Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
-            .with_encoding_preservation(EncodingPreservation::Dictionary);
+            .with_encoding_preservation(
+                EncodingPreservation::default().with_dictionary(),
+            );
 
         assert_eq!(
             dictionary_input(DataType::LargeUtf8, coercion.clone())?,
@@ -1910,7 +1907,9 @@ mod tests {
                     vec![TypeSignatureClass::Native(logical_binary())],
                     NativeType::String,
                 )
-                .with_encoding_preservation(EncodingPreservation::Dictionary),
+                .with_encoding_preservation(
+                    EncodingPreservation::default().with_dictionary(),
+                ),
             )?,
             vec![DataType::Dictionary(
                 Box::new(DataType::Int8),

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -24,7 +24,7 @@ use crate::strings::{
     StringViewArrayBuilder, append_view,
 };
 use arrow::array::{
-    Array, ArrayRef, GenericStringArray, NullBufferBuilder, OffsetSizeTrait,
+    Array, ArrayRef, AsArray, GenericStringArray, NullBufferBuilder, OffsetSizeTrait,
     StringViewArray, new_null_array,
 };
 use arrow::buffer::{Buffer, OffsetBuffer, ScalarBuffer};
@@ -387,6 +387,9 @@ fn case_conversion(
 
                 Ok(ColumnarValue::Array(Arc::new(builder.finish(nulls)?)))
             }
+            DataType::Dictionary(_, _) => Ok(ColumnarValue::Array(
+                case_conversion_dictionary(array, lower, name)?,
+            )),
             other => exec_err!("Unsupported data type {other:?} for function {name}"),
         },
         ColumnarValue::Scalar(scalar) => match scalar {
@@ -402,8 +405,42 @@ fn case_conversion(
                 let result = a.as_ref().map(|x| unicode_case(x, lower));
                 Ok(ColumnarValue::Scalar(ScalarValue::Utf8View(result)))
             }
+            ScalarValue::Dictionary(key_type, value) => {
+                let converted = case_conversion(
+                    &[ColumnarValue::Scalar((**value).clone())],
+                    lower,
+                    name,
+                )?;
+                match converted {
+                    ColumnarValue::Scalar(value) => Ok(ColumnarValue::Scalar(
+                        ScalarValue::Dictionary(key_type.clone(), Box::new(value)),
+                    )),
+                    ColumnarValue::Array(_) => {
+                        unreachable!("scalar case conversion returned an array")
+                    }
+                }
+            }
             other => exec_err!("Unsupported data type {other:?} for function {name}"),
         },
+    }
+}
+
+fn case_conversion_dictionary(
+    array: &ArrayRef,
+    lower: bool,
+    name: &str,
+) -> Result<ArrayRef> {
+    let dictionary = array.as_any_dictionary();
+    let converted = case_conversion(
+        &[ColumnarValue::Array(Arc::clone(dictionary.values()))],
+        lower,
+        name,
+    )?;
+    match converted {
+        ColumnarValue::Array(values) => Ok(dictionary.with_values(values)),
+        ColumnarValue::Scalar(_) => {
+            unreachable!("array case conversion returned a scalar")
+        }
     }
 }
 

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -348,81 +348,90 @@ fn case_conversion(
     name: &str,
 ) -> Result<ColumnarValue> {
     match &args[0] {
-        ColumnarValue::Array(array) => match array.data_type() {
-            DataType::Utf8 => Ok(ColumnarValue::Array(case_conversion_array::<i32>(
-                array, lower,
-            )?)),
-            DataType::LargeUtf8 => Ok(ColumnarValue::Array(
-                case_conversion_array::<i64>(array, lower)?,
-            )),
-            DataType::Utf8View => {
-                let string_array = as_string_view_array(array)?;
-                if string_array.is_ascii() {
-                    return Ok(ColumnarValue::Array(Arc::new(
-                        case_conversion_utf8view_ascii(string_array, lower),
-                    )));
-                }
-                let item_len = string_array.len();
-                // Null-preserving: reuse the input null buffer as the output null buffer.
-                let nulls = string_array.nulls().cloned();
-                let mut builder = StringViewArrayBuilder::with_capacity(item_len);
-
-                if let Some(ref n) = nulls {
-                    for i in 0..item_len {
-                        if n.is_null(i) {
-                            builder.try_append_placeholder()?;
-                        } else {
-                            // SAFETY: `n.is_null(i)` was false in the branch above.
-                            let s = unsafe { string_array.value_unchecked(i) };
-                            builder.try_append_value(&unicode_case(s, lower))?;
-                        }
-                    }
-                } else {
-                    for i in 0..item_len {
-                        // SAFETY: no null buffer means every index is valid.
-                        let s = unsafe { string_array.value_unchecked(i) };
-                        builder.try_append_value(&unicode_case(s, lower))?;
-                    }
-                }
-
-                Ok(ColumnarValue::Array(Arc::new(builder.finish(nulls)?)))
-            }
-            DataType::Dictionary(_, _) => Ok(ColumnarValue::Array(
-                case_conversion_dictionary(array, lower, name)?,
-            )),
-            other => exec_err!("Unsupported data type {other:?} for function {name}"),
-        },
-        ColumnarValue::Scalar(scalar) => match scalar {
-            ScalarValue::Utf8(a) => {
-                let result = a.as_ref().map(|x| unicode_case(x, lower));
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(result)))
-            }
-            ScalarValue::LargeUtf8(a) => {
-                let result = a.as_ref().map(|x| unicode_case(x, lower));
-                Ok(ColumnarValue::Scalar(ScalarValue::LargeUtf8(result)))
-            }
-            ScalarValue::Utf8View(a) => {
-                let result = a.as_ref().map(|x| unicode_case(x, lower));
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8View(result)))
-            }
-            ScalarValue::Dictionary(key_type, value) => {
-                let converted = case_conversion(
-                    &[ColumnarValue::Scalar((**value).clone())],
-                    lower,
-                    name,
-                )?;
-                match converted {
-                    ColumnarValue::Scalar(value) => Ok(ColumnarValue::Scalar(
-                        ScalarValue::Dictionary(key_type.clone(), Box::new(value)),
-                    )),
-                    ColumnarValue::Array(_) => {
-                        unreachable!("scalar case conversion returned an array")
-                    }
-                }
-            }
-            other => exec_err!("Unsupported data type {other:?} for function {name}"),
-        },
+        ColumnarValue::Array(array) => Ok(ColumnarValue::Array(
+            case_conversion_columnar_array(array, lower, name)?,
+        )),
+        ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(
+            case_conversion_scalar(scalar, lower, name)?,
+        )),
     }
+}
+
+fn case_conversion_scalar(
+    scalar: &ScalarValue,
+    lower: bool,
+    name: &str,
+) -> Result<ScalarValue> {
+    match scalar {
+        ScalarValue::Utf8(a) => {
+            let result = a.as_ref().map(|x| unicode_case(x, lower));
+            Ok(ScalarValue::Utf8(result))
+        }
+        ScalarValue::LargeUtf8(a) => {
+            let result = a.as_ref().map(|x| unicode_case(x, lower));
+            Ok(ScalarValue::LargeUtf8(result))
+        }
+        ScalarValue::Utf8View(a) => {
+            let result = a.as_ref().map(|x| unicode_case(x, lower));
+            Ok(ScalarValue::Utf8View(result))
+        }
+        ScalarValue::Dictionary(key_type, value) => {
+            let converted = case_conversion_scalar(value.as_ref(), lower, name)?;
+            Ok(ScalarValue::Dictionary(
+                key_type.clone(),
+                Box::new(converted),
+            ))
+        }
+        other => exec_err!("Unsupported data type {other:?} for function {name}"),
+    }
+}
+
+fn case_conversion_columnar_array(
+    array: &ArrayRef,
+    lower: bool,
+    name: &str,
+) -> Result<ArrayRef> {
+    match array.data_type() {
+        DataType::Utf8 => case_conversion_array::<i32>(array, lower),
+        DataType::LargeUtf8 => case_conversion_array::<i64>(array, lower),
+        DataType::Utf8View => case_conversion_utf8view(array, lower),
+        DataType::Dictionary(_, _) => case_conversion_dictionary(array, lower, name),
+        other => exec_err!("Unsupported data type {other:?} for function {name}"),
+    }
+}
+
+fn case_conversion_utf8view(array: &ArrayRef, lower: bool) -> Result<ArrayRef> {
+    let string_array = as_string_view_array(array)?;
+    if string_array.is_ascii() {
+        return Ok(Arc::new(case_conversion_utf8view_ascii(
+            string_array,
+            lower,
+        )));
+    }
+    let item_len = string_array.len();
+    // Null-preserving: reuse the input null buffer as the output null buffer.
+    let nulls = string_array.nulls().cloned();
+    let mut builder = StringViewArrayBuilder::with_capacity(item_len);
+
+    if let Some(ref n) = nulls {
+        for i in 0..item_len {
+            if n.is_null(i) {
+                builder.try_append_placeholder()?;
+            } else {
+                // SAFETY: `n.is_null(i)` was false in the branch above.
+                let s = unsafe { string_array.value_unchecked(i) };
+                builder.try_append_value(&unicode_case(s, lower))?;
+            }
+        }
+    } else {
+        for i in 0..item_len {
+            // SAFETY: no null buffer means every index is valid.
+            let s = unsafe { string_array.value_unchecked(i) };
+            builder.try_append_value(&unicode_case(s, lower))?;
+        }
+    }
+
+    Ok(Arc::new(builder.finish(nulls)?))
 }
 
 fn case_conversion_dictionary(
@@ -431,17 +440,8 @@ fn case_conversion_dictionary(
     name: &str,
 ) -> Result<ArrayRef> {
     let dictionary = array.as_any_dictionary();
-    let converted = case_conversion(
-        &[ColumnarValue::Array(Arc::clone(dictionary.values()))],
-        lower,
-        name,
-    )?;
-    match converted {
-        ColumnarValue::Array(values) => Ok(dictionary.with_values(values)),
-        ColumnarValue::Scalar(_) => {
-            unreachable!("array case conversion returned a scalar")
-        }
-    }
+    let converted = case_conversion_columnar_array(dictionary.values(), lower, name)?;
+    Ok(dictionary.with_values(converted))
 }
 
 fn case_conversion_array<O: OffsetSizeTrait>(

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -21,8 +21,8 @@ use crate::string::common::to_lower;
 use datafusion_common::Result;
 use datafusion_common::types::logical_string;
 use datafusion_expr::{
-    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
-    TypeSignatureClass, Volatility,
+    Coercion, ColumnarValue, Documentation, EncodingPreservation, ScalarFunctionArgs,
+    ScalarUDFImpl, Signature, TypeSignatureClass, Volatility,
 };
 use datafusion_macros::user_doc;
 
@@ -57,9 +57,10 @@ impl LowerFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Native(
-                    logical_string(),
-                ))],
+                vec![Coercion::new_exact_preserving_encoding(
+                    TypeSignatureClass::Native(logical_string()),
+                    EncodingPreservation::Dictionary,
+                )],
                 Volatility::Immutable,
             ),
         }
@@ -91,9 +92,11 @@ impl ScalarUDFImpl for LowerFunc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Array, ArrayRef, StringArray, StringViewArray};
-    use arrow::datatypes::Field;
-    use datafusion_common::config::ConfigOptions;
+    use arrow::array::{
+        Array, ArrayRef, DictionaryArray, Int8Array, StringArray, StringViewArray,
+    };
+    use arrow::datatypes::{Field, Int8Type};
+    use datafusion_common::{ScalarValue, config::ConfigOptions};
     use std::sync::Arc;
 
     fn invoke_lower(input: ArrayRef) -> Result<ArrayRef> {
@@ -115,6 +118,52 @@ mod tests {
     fn to_lower(input: ArrayRef, expected: ArrayRef) -> Result<()> {
         let result = invoke_lower(input)?;
         assert_eq!(&expected, &result);
+        Ok(())
+    }
+
+    fn invoke_lower_scalar(input: ScalarValue) -> Result<ScalarValue> {
+        let func = LowerFunc::new();
+        let data_type = input.data_type();
+        let args = ScalarFunctionArgs {
+            number_rows: 1,
+            args: vec![ColumnarValue::Scalar(input)],
+            arg_fields: vec![Field::new("a", data_type.clone(), true).into()],
+            return_field: Field::new("f", data_type, true).into(),
+            config_options: Arc::new(ConfigOptions::default()),
+        };
+        match func.invoke_with_args(args)? {
+            ColumnarValue::Scalar(result) => Ok(result),
+            _ => unreachable!("lower"),
+        }
+    }
+
+    #[test]
+    fn lower_dictionary() -> Result<()> {
+        let keys = Int8Array::from(vec![Some(0), Some(1), None, Some(0)]);
+        let input = Arc::new(DictionaryArray::<Int8Type>::try_new(
+            keys.clone(),
+            Arc::new(StringArray::from(vec![Some("FOO"), Some("Bar")])),
+        )?) as ArrayRef;
+        let expected = Arc::new(DictionaryArray::<Int8Type>::try_new(
+            keys,
+            Arc::new(StringArray::from(vec![Some("foo"), Some("bar")])),
+        )?) as ArrayRef;
+
+        to_lower(input, expected)
+    }
+
+    #[test]
+    fn lower_dictionary_scalar() -> Result<()> {
+        let input = ScalarValue::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(ScalarValue::Utf8(Some("FOO".to_string()))),
+        );
+        let expected = ScalarValue::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(ScalarValue::Utf8(Some("foo".to_string()))),
+        );
+
+        assert_eq!(invoke_lower_scalar(input)?, expected);
         Ok(())
     }
 

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -59,9 +59,7 @@ impl LowerFunc {
             signature: Signature::coercible(
                 vec![
                     Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
-                        .with_encoding_preservation(
-                            EncodingPreservation::default().with_dictionary(),
-                        ),
+                        .with_encoding_preservation(EncodingPreservation::dictionary()),
                 ],
                 Volatility::Immutable,
             ),
@@ -94,11 +92,9 @@ impl ScalarUDFImpl for LowerFunc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{
-        Array, ArrayRef, DictionaryArray, Int8Array, StringArray, StringViewArray,
-    };
-    use arrow::datatypes::{Field, Int8Type};
-    use datafusion_common::{ScalarValue, config::ConfigOptions};
+    use arrow::array::{Array, ArrayRef, StringArray, StringViewArray};
+    use arrow::datatypes::Field;
+    use datafusion_common::config::ConfigOptions;
     use std::sync::Arc;
 
     fn invoke_lower(input: ArrayRef) -> Result<ArrayRef> {
@@ -120,52 +116,6 @@ mod tests {
     fn to_lower(input: ArrayRef, expected: ArrayRef) -> Result<()> {
         let result = invoke_lower(input)?;
         assert_eq!(&expected, &result);
-        Ok(())
-    }
-
-    fn invoke_lower_scalar(input: ScalarValue) -> Result<ScalarValue> {
-        let func = LowerFunc::new();
-        let data_type = input.data_type();
-        let args = ScalarFunctionArgs {
-            number_rows: 1,
-            args: vec![ColumnarValue::Scalar(input)],
-            arg_fields: vec![Field::new("a", data_type.clone(), true).into()],
-            return_field: Field::new("f", data_type, true).into(),
-            config_options: Arc::new(ConfigOptions::default()),
-        };
-        match func.invoke_with_args(args)? {
-            ColumnarValue::Scalar(result) => Ok(result),
-            _ => unreachable!("lower"),
-        }
-    }
-
-    #[test]
-    fn lower_dictionary() -> Result<()> {
-        let keys = Int8Array::from(vec![Some(0), Some(1), None, Some(0)]);
-        let input = Arc::new(DictionaryArray::<Int8Type>::try_new(
-            keys.clone(),
-            Arc::new(StringArray::from(vec![Some("FOO"), Some("Bar")])),
-        )?) as ArrayRef;
-        let expected = Arc::new(DictionaryArray::<Int8Type>::try_new(
-            keys,
-            Arc::new(StringArray::from(vec![Some("foo"), Some("bar")])),
-        )?) as ArrayRef;
-
-        to_lower(input, expected)
-    }
-
-    #[test]
-    fn lower_dictionary_scalar() -> Result<()> {
-        let input = ScalarValue::Dictionary(
-            Box::new(DataType::Int8),
-            Box::new(ScalarValue::Utf8(Some("FOO".to_string()))),
-        );
-        let expected = ScalarValue::Dictionary(
-            Box::new(DataType::Int8),
-            Box::new(ScalarValue::Utf8(Some("foo".to_string()))),
-        );
-
-        assert_eq!(invoke_lower_scalar(input)?, expected);
         Ok(())
     }
 

--- a/datafusion/functions/src/string/lower.rs
+++ b/datafusion/functions/src/string/lower.rs
@@ -57,10 +57,12 @@ impl LowerFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact_preserving_encoding(
-                    TypeSignatureClass::Native(logical_string()),
-                    EncodingPreservation::Dictionary,
-                )],
+                vec![
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                        .with_encoding_preservation(
+                            EncodingPreservation::default().with_dictionary(),
+                        ),
+                ],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -56,10 +56,12 @@ impl UpperFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact_preserving_encoding(
-                    TypeSignatureClass::Native(logical_string()),
-                    EncodingPreservation::Dictionary,
-                )],
+                vec![
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                        .with_encoding_preservation(
+                            EncodingPreservation::default().with_dictionary(),
+                        ),
+                ],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -20,8 +20,8 @@ use arrow::datatypes::DataType;
 use datafusion_common::Result;
 use datafusion_common::types::logical_string;
 use datafusion_expr::{
-    Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
-    TypeSignatureClass, Volatility,
+    Coercion, ColumnarValue, Documentation, EncodingPreservation, ScalarFunctionArgs,
+    ScalarUDFImpl, Signature, TypeSignatureClass, Volatility,
 };
 use datafusion_macros::user_doc;
 
@@ -56,9 +56,10 @@ impl UpperFunc {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Native(
-                    logical_string(),
-                ))],
+                vec![Coercion::new_exact_preserving_encoding(
+                    TypeSignatureClass::Native(logical_string()),
+                    EncodingPreservation::Dictionary,
+                )],
                 Volatility::Immutable,
             ),
         }
@@ -90,9 +91,11 @@ impl ScalarUDFImpl for UpperFunc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Array, ArrayRef, StringArray, StringViewArray};
-    use arrow::datatypes::Field;
-    use datafusion_common::config::ConfigOptions;
+    use arrow::array::{
+        Array, ArrayRef, DictionaryArray, Int8Array, StringArray, StringViewArray,
+    };
+    use arrow::datatypes::{Field, Int8Type};
+    use datafusion_common::{ScalarValue, config::ConfigOptions};
     use std::sync::Arc;
 
     fn invoke_upper(input: ArrayRef) -> Result<ArrayRef> {
@@ -114,6 +117,52 @@ mod tests {
     fn to_upper(input: ArrayRef, expected: ArrayRef) -> Result<()> {
         let result = invoke_upper(input)?;
         assert_eq!(&expected, &result);
+        Ok(())
+    }
+
+    fn invoke_upper_scalar(input: ScalarValue) -> Result<ScalarValue> {
+        let func = UpperFunc::new();
+        let data_type = input.data_type();
+        let args = ScalarFunctionArgs {
+            number_rows: 1,
+            args: vec![ColumnarValue::Scalar(input)],
+            arg_fields: vec![Field::new("a", data_type.clone(), true).into()],
+            return_field: Field::new("f", data_type, true).into(),
+            config_options: Arc::new(ConfigOptions::default()),
+        };
+        match func.invoke_with_args(args)? {
+            ColumnarValue::Scalar(result) => Ok(result),
+            _ => unreachable!("upper"),
+        }
+    }
+
+    #[test]
+    fn upper_dictionary() -> Result<()> {
+        let keys = Int8Array::from(vec![Some(0), Some(1), None, Some(0)]);
+        let input = Arc::new(DictionaryArray::<Int8Type>::try_new(
+            keys.clone(),
+            Arc::new(StringArray::from(vec![Some("foo"), Some("Bar")])),
+        )?) as ArrayRef;
+        let expected = Arc::new(DictionaryArray::<Int8Type>::try_new(
+            keys,
+            Arc::new(StringArray::from(vec![Some("FOO"), Some("BAR")])),
+        )?) as ArrayRef;
+
+        to_upper(input, expected)
+    }
+
+    #[test]
+    fn upper_dictionary_scalar() -> Result<()> {
+        let input = ScalarValue::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(ScalarValue::Utf8(Some("foo".to_string()))),
+        );
+        let expected = ScalarValue::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(ScalarValue::Utf8(Some("FOO".to_string()))),
+        );
+
+        assert_eq!(invoke_upper_scalar(input)?, expected);
         Ok(())
     }
 

--- a/datafusion/functions/src/string/upper.rs
+++ b/datafusion/functions/src/string/upper.rs
@@ -58,9 +58,7 @@ impl UpperFunc {
             signature: Signature::coercible(
                 vec![
                     Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
-                        .with_encoding_preservation(
-                            EncodingPreservation::default().with_dictionary(),
-                        ),
+                        .with_encoding_preservation(EncodingPreservation::dictionary()),
                 ],
                 Volatility::Immutable,
             ),
@@ -93,11 +91,9 @@ impl ScalarUDFImpl for UpperFunc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{
-        Array, ArrayRef, DictionaryArray, Int8Array, StringArray, StringViewArray,
-    };
-    use arrow::datatypes::{Field, Int8Type};
-    use datafusion_common::{ScalarValue, config::ConfigOptions};
+    use arrow::array::{Array, ArrayRef, StringArray, StringViewArray};
+    use arrow::datatypes::Field;
+    use datafusion_common::config::ConfigOptions;
     use std::sync::Arc;
 
     fn invoke_upper(input: ArrayRef) -> Result<ArrayRef> {
@@ -119,52 +115,6 @@ mod tests {
     fn to_upper(input: ArrayRef, expected: ArrayRef) -> Result<()> {
         let result = invoke_upper(input)?;
         assert_eq!(&expected, &result);
-        Ok(())
-    }
-
-    fn invoke_upper_scalar(input: ScalarValue) -> Result<ScalarValue> {
-        let func = UpperFunc::new();
-        let data_type = input.data_type();
-        let args = ScalarFunctionArgs {
-            number_rows: 1,
-            args: vec![ColumnarValue::Scalar(input)],
-            arg_fields: vec![Field::new("a", data_type.clone(), true).into()],
-            return_field: Field::new("f", data_type, true).into(),
-            config_options: Arc::new(ConfigOptions::default()),
-        };
-        match func.invoke_with_args(args)? {
-            ColumnarValue::Scalar(result) => Ok(result),
-            _ => unreachable!("upper"),
-        }
-    }
-
-    #[test]
-    fn upper_dictionary() -> Result<()> {
-        let keys = Int8Array::from(vec![Some(0), Some(1), None, Some(0)]);
-        let input = Arc::new(DictionaryArray::<Int8Type>::try_new(
-            keys.clone(),
-            Arc::new(StringArray::from(vec![Some("foo"), Some("Bar")])),
-        )?) as ArrayRef;
-        let expected = Arc::new(DictionaryArray::<Int8Type>::try_new(
-            keys,
-            Arc::new(StringArray::from(vec![Some("FOO"), Some("BAR")])),
-        )?) as ArrayRef;
-
-        to_upper(input, expected)
-    }
-
-    #[test]
-    fn upper_dictionary_scalar() -> Result<()> {
-        let input = ScalarValue::Dictionary(
-            Box::new(DataType::Int8),
-            Box::new(ScalarValue::Utf8(Some("foo".to_string()))),
-        );
-        let expected = ScalarValue::Dictionary(
-            Box::new(DataType::Int8),
-            Box::new(ScalarValue::Utf8(Some("FOO".to_string()))),
-        );
-
-        assert_eq!(invoke_upper_scalar(input)?, expected);
         Ok(())
     }
 

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -470,6 +470,23 @@ SELECT arrow_typeof(upper(arrow_cast(arrow_cast('foo', 'Dictionary(Int32, Utf8)'
 ----
 Dictionary(Int32, Utf8View)
 
+statement ok
+CREATE TABLE upper_dictionary_test AS
+SELECT arrow_cast(column1, 'Dictionary(Int32, Utf8)') AS c1 FROM (VALUES
+('foo'),
+(NULL),
+('Bar'));
+
+query TT
+SELECT upper(c1), arrow_typeof(upper(c1)) FROM upper_dictionary_test
+----
+FOO Dictionary(Int32, Utf8)
+NULL Dictionary(Int32, Utf8)
+BAR Dictionary(Int32, Utf8)
+
+statement ok
+DROP TABLE upper_dictionary_test
+
 query T
 SELECT btrim('   foo  ')
 ----
@@ -549,6 +566,23 @@ query T
 SELECT arrow_typeof(lower(arrow_cast(arrow_cast('FOObar', 'Dictionary(Int32, Utf8)'), 'Dictionary(Int32, Utf8View)')))
 ----
 Dictionary(Int32, Utf8View)
+
+statement ok
+CREATE TABLE lower_dictionary_test AS
+SELECT arrow_cast(column1, 'Dictionary(Int32, Utf8)') AS c1 FROM (VALUES
+('FOO'),
+(NULL),
+('Bar'));
+
+query TT
+SELECT lower(c1), arrow_typeof(lower(c1)) FROM lower_dictionary_test
+----
+foo Dictionary(Int32, Utf8)
+NULL Dictionary(Int32, Utf8)
+bar Dictionary(Int32, Utf8)
+
+statement ok
+DROP TABLE lower_dictionary_test
 
 query T
 SELECT ltrim('   foo')

--- a/datafusion/sqllogictest/test_files/functions.slt
+++ b/datafusion/sqllogictest/test_files/functions.slt
@@ -468,7 +468,7 @@ Utf8View
 query T
 SELECT arrow_typeof(upper(arrow_cast(arrow_cast('foo', 'Dictionary(Int32, Utf8)'), 'Dictionary(Int32, Utf8View)')))
 ----
-Utf8View
+Dictionary(Int32, Utf8View)
 
 query T
 SELECT btrim('   foo  ')
@@ -548,7 +548,7 @@ Utf8View
 query T
 SELECT arrow_typeof(lower(arrow_cast(arrow_cast('FOObar', 'Dictionary(Int32, Utf8)'), 'Dictionary(Int32, Utf8View)')))
 ----
-Utf8View
+Dictionary(Int32, Utf8View)
 
 query T
 SELECT ltrim('   foo')

--- a/docs/source/library-user-guide/functions/adding-udfs.md
+++ b/docs/source/library-user-guide/functions/adding-udfs.md
@@ -397,9 +397,9 @@ impl AsyncUpper {
     pub fn new() -> Self {
         Self {
             signature: Signature::new(
-                TypeSignature::Coercible(vec![Coercion::Exact {
-                    desired_type: TypeSignatureClass::Native(logical_string()),
-                }]),
+                TypeSignature::Coercible(vec![Coercion::new_exact(
+                    TypeSignatureClass::Native(logical_string()),
+                )]),
                 Volatility::Volatile,
             ),
         }
@@ -497,9 +497,9 @@ We can now transfer the async UDF into the normal scalar using `into_scalar_udf`
 #     pub fn new() -> Self {
 #         Self {
 #             signature: Signature::new(
-#                 TypeSignature::Coercible(vec![Coercion::Exact {
-#                     desired_type: TypeSignatureClass::Native(logical_string()),
-#                 }]),
+#                 TypeSignature::Coercible(vec![Coercion::new_exact(
+#                     TypeSignatureClass::Native(logical_string()),
+#                 )]),
 #                 Volatility::Volatile,
 #             ),
 #         }

--- a/docs/source/library-user-guide/upgrading/55.0.0.md
+++ b/docs/source/library-user-guide/upgrading/55.0.0.md
@@ -82,6 +82,27 @@ will now appear as `Decimal128(NULL,10,2)`.
 Query result values already used human-readable decimal formatting and are
 unchanged.
 
+### `Coercion` supports dictionary encoding preservation
+
+`datafusion_expr_common::signature::Coercion` now supports optional dictionary
+encoding preservation. When enabled for `TypeSignatureClass::Native(...)`
+coercions, DataFusion coerces dictionary inputs to
+`Dictionary(original_key_type, coerced_value_type)` instead of materializing them
+to the coerced value type.
+
+User-defined functions can opt in by setting dictionary encoding preservation on
+the relevant coercion:
+
+```rust
+Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+    .with_encoding_preservation(EncodingPreservation::dictionary())
+```
+
+This changes the coerced argument type passed to the function. If a function
+derives its return type from that coerced argument type, code that checks exact
+result types may need to update its expectations or add an explicit cast to
+materialize the result.
+
 ### `GroupsAccumulator::merge_batch` no longer takes `opt_filter`
 
 The `opt_filter` argument has been removed from


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to #19458
- Related to #20935

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When a `Dictionary(K, Utf8)` column is passed to a string scalar function, the type-coercion layer currently materializes it to flat Utf8/Utf8View before the function runs, so the operation is applied to every row instead of just the unique dictionary values, and the dictionary encoding is lost on the output. See #19458 for the underlying coercion behavior and #20935 for the string-function-specific impact.

This is wasteful for low-cardinality columns and inflates Arrow IPC/Flight message sizes downstream.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add `EncodingPreservation { None, Dictionary }` and opt-in constructors on `Coercion` (`new_exact_preserving_encoding`, `with_encoding_preservation`).
- In `get_valid_types`, when a `Coercible` arg requests `Dictionary` preservation, run coercion against the dictionary's value type and re-wrap the result as `Dictionary(K, V')`, so the function receives a `DictionaryArray`.
- Make `lower/upper` opt in and handle dictionary inputs (array + scalar) by converting only the dictionary values and re-wrapping with the original keys.

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

Yes. upper/lower now return Dictionary(...) for dictionary inputs instead of the previously materialized Utf8View. New public API (EncodingPreservation, new Coercion constructors) is added — please add the api change label.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
