### PR TITLE
Upgrade minimal tokio-postgres version to address security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,9 +4698,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-derive"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1dad89d9ffdbf78502fde418eeede499b87772d88be780478f7f76dc8d471f"
+checksum = "4d9d9089bb0ce62f4b5d52a0be0f4acfb35738b979380670d3dea85fe38d6ddd"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4710,9 +4710,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -4728,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -4818,7 +4818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4837,7 +4837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6236,9 +6236,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/datafusion/sqllogictest/Cargo.toml
+++ b/datafusion/sqllogictest/Cargo.toml
@@ -65,7 +65,7 @@ tempfile = { workspace = true }
 testcontainers-modules = { workspace = true, features = ["postgres"], optional = true }
 thiserror = "2.0.18"
 tokio = { workspace = true }
-tokio-postgres = { version = "0.7.17", optional = true }
+tokio-postgres = { version = "0.7.18", optional = true }
 
 [features]
 avro = ["datafusion/avro"]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

`cargo audit` currently reports the following vulnerabilities:
```
Crate:     postgres-protocol
Version:   0.6.11
Title:     Unbounded SCRAM iteration count allows a malicious server to cause CPU-exhaustion denial of service
Date:      2026-06-12
ID:        RUSTSEC-2026-0179
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0179
Severity:  8.7 (high)
Solution:  Upgrade to >=0.6.12

Crate:     postgres-protocol
Version:   0.6.11
Title:     Panic decoding a malformed `hstore` value allows denial of service
Date:      2026-06-12
ID:        RUSTSEC-2026-0180
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0180
Severity:  6.9 (medium)
Solution:  Upgrade to >=0.6.12

Crate:     tokio-postgres
Version:   0.7.17
Title:     Panic on a `DataRow` with fewer fields than columns allows denial of service
Date:      2026-06-12
ID:        RUSTSEC-2026-0178
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0178
Severity:  6.9 (medium)
Solution:  Upgrade to >=0.7.18
```

## What changes are included in this PR?

Upgrade the minimal version of the `tokio-postgres` dependency

## Are these changes tested?

Existing tests

## Are there any user-facing changes?

None
