### PR TITLE
Optimize Parquet row-filter struct schema pruning

### DIFF
--- a/datafusion/datasource-parquet/src/row_filter.rs
+++ b/datafusion/datasource-parquet/src/row_filter.rs
@@ -65,7 +65,7 @@
 //! - `WHERE s['value'] > 5` — pushed down (accesses a primitive leaf)
 //! - `WHERE s IS NOT NULL`  — not pushed down (references the whole struct)
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use arrow::array::BooleanArray;
@@ -796,15 +796,22 @@ fn build_filter_schema(
     struct_field_accesses: &[StructFieldAccess],
 ) -> SchemaRef {
     let regular_set: BTreeSet<usize> = regular_indices.iter().copied().collect();
+    let mut paths_by_root: BTreeMap<usize, Vec<&[String]>> = BTreeMap::new();
+    for StructFieldAccess {
+        root_index,
+        field_path,
+    } in struct_field_accesses
+    {
+        paths_by_root
+            .entry(*root_index)
+            .or_default()
+            .push(field_path.as_slice());
+    }
 
     let all_indices = regular_indices
         .iter()
         .copied()
-        .chain(
-            struct_field_accesses
-                .iter()
-                .map(|&StructFieldAccess { root_index, .. }| root_index),
-        )
+        .chain(paths_by_root.keys().copied())
         .collect::<BTreeSet<_>>();
 
     let fields = all_indices
@@ -821,24 +828,11 @@ fn build_filter_schema(
                 return Arc::new(field.clone());
             }
 
-            // collect all field paths that access this root struct column
-            let field_paths = struct_field_accesses
-                .iter()
-                .filter_map(
-                    |&StructFieldAccess {
-                         root_index,
-                         ref field_path,
-                     }| {
-                        (root_index == idx).then_some(field_path.as_slice())
-                    },
-                )
-                .collect::<Vec<_>>();
-
-            if field_paths.is_empty() {
+            let Some(field_paths) = paths_by_root.get(&idx) else {
                 return Arc::new(field.clone());
-            }
+            };
 
-            let pruned_data_type = prune_struct_type(field.data_type(), &field_paths);
+            let pruned_data_type = prune_struct_type(field.data_type(), field_paths);
             Arc::new(Field::new(
                 field.name(),
                 pruned_data_type,
@@ -858,36 +852,25 @@ fn prune_struct_type(dt: &DataType, paths: &[&[String]]) -> DataType {
         return dt.clone();
     };
 
-    let needed = paths
-        .iter()
-        .filter_map(|p| p.first().map(|s| s.as_str()))
-        .collect::<BTreeSet<_>>();
+    let paths_by_field = paths.iter().filter_map(|path| path.split_first()).fold(
+        BTreeMap::<&str, Vec<&[String]>>::new(),
+        |mut acc, (field, sub_path)| {
+            acc.entry(field.as_str()).or_default().push(sub_path);
+            acc
+        },
+    );
 
     let pruned_fields = fields
         .iter()
         .filter_map(|f| {
-            if !needed.contains(f.name().as_str()) {
-                return None;
-            }
+            let sub_paths = paths_by_field.get(f.name().as_str())?;
 
-            let sub_paths = paths
-                .iter()
-                .filter_map(|path| {
-                    if path.first().map(|s| s.as_str()) == Some(f.name()) {
-                        Some(&path[1..])
-                    } else {
-                        None
-                    }
-                })
-                .filter(|sub| !sub.is_empty())
-                .collect::<Vec<_>>();
-
-            let out = if sub_paths.is_empty() {
+            let out = if sub_paths.iter().any(|sub| sub.is_empty()) {
                 // Leaf of access path — keep the field as-is.
                 Arc::clone(f)
             } else {
                 // Recurse into nested struct.
-                let pruned = prune_struct_type(f.data_type(), &sub_paths);
+                let pruned = prune_struct_type(f.data_type(), sub_paths);
                 Arc::new(Field::new(f.name(), pruned, f.is_nullable()))
             };
 

--- a/datafusion/datasource-parquet/src/row_filter.rs
+++ b/datafusion/datasource-parquet/src/row_filter.rs
@@ -796,17 +796,7 @@ fn build_filter_schema(
     struct_field_accesses: &[StructFieldAccess],
 ) -> SchemaRef {
     let regular_set: BTreeSet<usize> = regular_indices.iter().copied().collect();
-    let mut paths_by_root: BTreeMap<usize, Vec<&[String]>> = BTreeMap::new();
-    for StructFieldAccess {
-        root_index,
-        field_path,
-    } in struct_field_accesses
-    {
-        paths_by_root
-            .entry(*root_index)
-            .or_default()
-            .push(field_path.as_slice());
-    }
+    let paths_by_root = group_access_paths_by_root(struct_field_accesses);
 
     let all_indices = regular_indices
         .iter()
@@ -847,18 +837,56 @@ fn build_filter_schema(
     ))
 }
 
+/// Groups struct field access paths once for the root schema level.
+///
+/// Each map entry contains the complete field paths accessed below a root
+/// column. Recursive pruning groups these paths by their next component at each
+/// nested struct level.
+fn group_access_paths_by_root(
+    struct_field_accesses: &[StructFieldAccess],
+) -> BTreeMap<usize, Vec<&[String]>> {
+    let mut paths_by_root: BTreeMap<usize, Vec<&[String]>> = BTreeMap::new();
+    for StructFieldAccess {
+        root_index,
+        field_path,
+    } in struct_field_accesses
+    {
+        paths_by_root
+            .entry(*root_index)
+            .or_default()
+            .push(field_path.as_slice());
+    }
+
+    paths_by_root
+}
+
+/// Groups access paths once for the current struct level.
+///
+/// The map key is the field name at this level. The map value is the list of
+/// remaining path suffixes below that field. An empty suffix means the access
+/// path terminates at that field, so the full field must be preserved.
+fn group_paths_by_next_field<'a>(
+    paths: &'a [&'a [String]],
+) -> BTreeMap<&'a str, Vec<&'a [String]>> {
+    let mut paths_by_field: BTreeMap<&str, Vec<&[String]>> = BTreeMap::new();
+    for path in paths {
+        if let Some((field, sub_path)) = path.split_first() {
+            paths_by_field
+                .entry(field.as_str())
+                .or_default()
+                .push(sub_path);
+        }
+    }
+
+    paths_by_field
+}
+
 fn prune_struct_type(dt: &DataType, paths: &[&[String]]) -> DataType {
     let DataType::Struct(fields) = dt else {
         return dt.clone();
     };
 
-    let paths_by_field = paths.iter().filter_map(|path| path.split_first()).fold(
-        BTreeMap::<&str, Vec<&[String]>>::new(),
-        |mut acc, (field, sub_path)| {
-            acc.entry(field.as_str()).or_default().push(sub_path);
-            acc
-        },
-    );
+    let paths_by_field = group_paths_by_next_field(paths);
 
     let pruned_fields = fields
         .iter()


### PR DESCRIPTION
## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
`build_filter_schema and `prune_struct_type` repeatedly scanned the same struct-field access paths while constructing Parquet row-filter projection schemas. That caused avoidable iterator work and temporary allocations when filters referenced multiple struct fields, especially across nested struct paths.

This change groups struct field access paths once per schema level, so schema pruning can reuse lookups instead of repeatedly filtering the full access-path list.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
* Group struct field access paths by root column in build_filter_schema.
* Reuse the grouped root-path lookup when deciding whether to keep a full field or prune a struct field.
* Group recursive struct pruning paths by field name in prune_struct_type.
* Avoid rebuilding per-field temporary vectors while walking struct fields.
* Preserve whole-field output when an access path terminates at that field.

## Benchmark Results

These results compare each benchmark’s with_pushdown case against its matching no_pushdown case in the current code.


Benchmark | No pushdown median | With pushdown median | Runtime improvement | Speedup
-- | -- | -- | -- | --
parquet_struct_filter_pushdown/select_star | 5.0117 s | 483.70 ms | 90.35% faster | 10.36×
parquet_struct_filter_pushdown/select_star_cross_col | 5.0457 s | 4.8399 s | 4.08% faster | 1.04×
parquet_struct_filter_pushdown/select_id | 4.7709 s | 369.30 µs | 99.99% faster | 12,919×
parquet_nested_filter_pushdown | 35.332 ms | 5.8611 ms | 83.41% faster | 6.03×

Throughput comparison

Benchmark | No pushdown median throughput | With pushdown median throughput | Throughput improvement
-- | -- | -- | --
parquet_struct_filter_pushdown/select_star | 19.953 Kelem/s | 206.74 Kelem/s | 936.16% higher
parquet_struct_filter_pushdown/select_star_cross_col | 19.819 Kelem/s | 20.662 Kelem/s | 4.25% higher
parquet_struct_filter_pushdown/select_id | 20.960 Kelem/s | 270.78 Melem/s | ~1,291,885% higher
parquet_nested_filter_pushdown | 2.8303 Melem/s | 17.062 Melem/s | 502.83% higher


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
* cargo fmt --all
* cargo clippy -p datafusion-datasource-parquet --all-targets --all-features -- -D warnings
* cargo test -p datafusion-datasource-parquet row_filter

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
