### PR TITLE
fix: coerce SIMILAR TO operands to a common string type

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -613,6 +613,33 @@ impl TreeNodeRewriter for TypeCoercionRewriter<'_> {
                     case_insensitive,
                 ))))
             }
+            Expr::SimilarTo(Like {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+                case_insensitive,
+            }) => {
+                let left_type = expr.get_type(self.schema)?;
+                let right_type = pattern.get_type(self.schema)?;
+                let coerced_type = like_coercion(&left_type, &right_type).ok_or_else(|| {
+                    plan_datafusion_err!(
+                        "There isn't a common type to coerce {left_type} and {right_type} in SIMILAR TO expression"
+                    )
+                })?;
+                let expr = match left_type {
+                    DataType::Dictionary(_, inner) if *inner == DataType::Utf8 => expr,
+                    _ => Box::new(expr.cast_to(&coerced_type, self.schema)?),
+                };
+                let pattern = Box::new(pattern.cast_to(&coerced_type, self.schema)?);
+                Ok(Transformed::yes(Expr::SimilarTo(Like::new(
+                    negated,
+                    expr,
+                    pattern,
+                    escape_char,
+                    case_insensitive,
+                ))))
+            }
             Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
                 let (left, right) =
                     self.coerce_binary_op(*left, self.schema, op, *right, self.schema)?;
@@ -812,7 +839,6 @@ impl TreeNodeRewriter for TypeCoercionRewriter<'_> {
             | Expr::Column(_)
             | Expr::ScalarVariable(_, _)
             | Expr::Literal(_, _)
-            | Expr::SimilarTo(_)
             | Expr::IsNotNull(_)
             | Expr::IsNull(_)
             | Expr::Cast(_)
@@ -2234,6 +2260,58 @@ mod test {
         assert_type_coercion_error(
             plan,
             "There isn't a common type to coerce Int64 and Utf8 in ILIKE expression",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn similar_to_for_type_coercion() -> Result<()> {
+        // similar to : utf8 SIMILAR TO "abc"
+        let expr = Box::new(col("a"));
+        let pattern = Box::new(lit(ScalarValue::new_utf8("abc")));
+        let similar_to_expr =
+            Expr::SimilarTo(Like::new(false, expr, pattern, None, false));
+        let empty = empty_with_type(Utf8);
+        let plan =
+            LogicalPlan::Projection(Projection::try_new(vec![similar_to_expr], empty)?);
+
+        assert_analyzed_plan_eq!(
+            plan,
+            @r#"
+        Projection: a SIMILAR TO Utf8("abc")
+          EmptyRelation: rows=0
+        "#
+        )?;
+
+        // NULL pattern is coerced into the common type rather than panicking
+        // during constant folding (see issue #22886).
+        let expr = Box::new(col("a"));
+        let pattern = Box::new(lit(ScalarValue::Null));
+        let similar_to_expr =
+            Expr::SimilarTo(Like::new(false, expr, pattern, None, false));
+        let empty = empty_with_type(Utf8);
+        let plan =
+            LogicalPlan::Projection(Projection::try_new(vec![similar_to_expr], empty)?);
+
+        assert_analyzed_plan_eq!(
+            plan,
+            @r"
+        Projection: a SIMILAR TO CAST(NULL AS Utf8)
+          EmptyRelation: rows=0
+        "
+        )?;
+
+        let expr = Box::new(col("a"));
+        let pattern = Box::new(lit(ScalarValue::new_utf8("abc")));
+        let similar_to_expr =
+            Expr::SimilarTo(Like::new(false, expr, pattern, None, false));
+        let empty = empty_with_type(DataType::Int64);
+        let plan =
+            LogicalPlan::Projection(Projection::try_new(vec![similar_to_expr], empty)?);
+        assert_type_coercion_error(
+            plan,
+            "There isn't a common type to coerce Int64 and Utf8 in SIMILAR TO expression",
         )?;
 
         Ok(())

--- a/datafusion/sqllogictest/test_files/type_coercion.slt
+++ b/datafusion/sqllogictest/test_files/type_coercion.slt
@@ -302,3 +302,33 @@ SELECT * FROM (SELECT 1) WHERE CAST(STARTS_WITH() AS STRING) = 'x';
 
 query error does not support zero arguments
 SELECT * FROM (SELECT 1) WHERE TRY_CAST(STARTS_WITH() AS INT) = 1;
+
+################################################################
+## SIMILAR TO operand type coercion
+## https://github.com/apache/datafusion/issues/22886
+################################################################
+
+statement ok
+CREATE TABLE similar_to_t AS
+SELECT arrow_cast(s, 'Utf8View') AS v, p FROM (VALUES
+  ('abc', 'abc'),
+  ('xyz', 'abc')
+) AS t(s, p);
+
+# Utf8View column matched against a non-literal Utf8 pattern column used to panic
+# with "failed to downcast array"; both operands now coerce to a common type.
+query B
+SELECT v SIMILAR TO p FROM similar_to_t ORDER BY v;
+----
+true
+false
+
+# A NULL pattern used to panic during constant folding; it now evaluates to NULL.
+query B
+SELECT v SIMILAR TO NULL FROM similar_to_t ORDER BY v;
+----
+NULL
+NULL
+
+statement ok
+DROP TABLE similar_to_t;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22886.

## Rationale for this change

`SIMILAR TO` panics with `failed to downcast array` whenever its two operands resolve to arrays of different physical string types, for example a `Utf8View` column matched against a non-literal `Utf8` pattern, or a `NULL` pattern that produces a `NullArray`. A `NULL` pattern even panics at plan time during constant folding.

The cause is that, unlike `LIKE`/`ILIKE` and the regex operators, the `TypeCoercion` analyzer never coerces `Expr::SimilarTo` operands to a common type. `Expr::SimilarTo(_)` was listed in the "nothing to coerce" no-op arm of `TypeCoercionRewriter::f_up`, so both operands reached the executing kernel unchanged. That kernel picks the downcast type from the left array and `.expect()`s the right array to match, which panics when they differ. Literal patterns take the scalar fast path, which is why the common `col SIMILAR TO 'pattern'` form works and this went unnoticed.

## What changes are included in this PR?

- Removed `Expr::SimilarTo(_)` from the no-op coercion arm.
- Added a dedicated `Expr::SimilarTo` coercion arm in `datafusion/optimizer/src/analyzer/type_coercion.rs` that mirrors the existing `Expr::Like` arm: it computes the operand types, finds the common string type via `like_coercion`, and casts both operands to it (preserving the same `Dictionary(_, Utf8)` short-circuit the `Like` arm uses). This guarantees both operands reach the regex kernel as the same physical type and coerces `NULL` patterns into the common type, fixing both the execution-time and plan-time panics. The no-common-type error message uses the `SIMILAR TO` operator name.

## Are these changes tested?

Yes.

- A new unit test `similar_to_for_type_coercion` in `type_coercion.rs` (next to `like_for_type_coercion`) covers the literal-pattern, `NULL`-pattern, and no-common-type-error cases.
- New end-to-end coverage in `datafusion/sqllogictest/test_files/type_coercion.slt` exercises a `Utf8View` column matched against a non-literal `Utf8` pattern column and a `NULL` pattern, both of which previously panicked and now return correct results.

## Are there any user-facing changes?

`SIMILAR TO` queries that previously panicked now plan and execute correctly. There are no API changes.
