### PR TITLE
IN LIST: reinterpret small-width types for bitmap filters

### DIFF
--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -41,6 +41,7 @@ mod primitive_filter;
 mod result;
 mod static_filter;
 mod strategy;
+mod transform;
 
 use static_filter::StaticFilter;
 use strategy::instantiate_static_filter;

--- a/datafusion/physical-expr/src/expressions/in_list/primitive_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/primitive_filter.rs
@@ -142,6 +142,22 @@ where
     fn check(&self, needle: T::Native) -> bool {
         self.bits.get_bit(needle.as_usize())
     }
+
+    /// Check membership using a raw values slice (zero-copy path for type reinterpretation).
+    #[inline]
+    pub(super) fn contains_slice(
+        &self,
+        values: &[T::Native],
+        nulls: Option<&NullBuffer>,
+        negated: bool,
+    ) -> BooleanArray {
+        build_in_list_result(values.len(), nulls, self.null_count > 0, negated, |i| {
+            // SAFETY: `build_in_list_result` invokes this closure for
+            // indices in `0..values.len()`.
+            let needle = unsafe { *values.get_unchecked(i) };
+            self.check(needle)
+        })
+    }
 }
 
 impl<T> StaticFilter for BitmapFilter<T>
@@ -359,9 +375,6 @@ macro_rules! primitive_static_filter {
     };
 }
 
-// Generate specialized filters for all integer primitive types
-primitive_static_filter!(Int8StaticFilter, Int8Type);
-primitive_static_filter!(Int16StaticFilter, Int16Type);
 primitive_static_filter!(Int32StaticFilter, Int32Type);
 primitive_static_filter!(Int64StaticFilter, Int64Type);
 primitive_static_filter!(UInt32StaticFilter, UInt32Type);

--- a/datafusion/physical-expr/src/expressions/in_list/strategy.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/strategy.rs
@@ -25,6 +25,7 @@ use datafusion_common::Result;
 use super::array_static_filter::ArrayStaticFilter;
 use super::primitive_filter::*;
 use super::static_filter::StaticFilter;
+use super::transform::make_bitmap_filter;
 
 pub(super) fn instantiate_static_filter(
     in_array: ArrayRef,
@@ -37,13 +38,10 @@ pub(super) fn instantiate_static_filter(
         _ => in_array,
     };
     match in_array.data_type() {
-        // Integer primitive types
-        DataType::Int8 => Ok(Arc::new(Int8StaticFilter::try_new(&in_array)?)),
-        DataType::Int16 => Ok(Arc::new(Int16StaticFilter::try_new(&in_array)?)),
+        DataType::Int8 | DataType::UInt8 => make_bitmap_filter::<UInt8Type>(&in_array),
+        DataType::Int16 | DataType::UInt16 => make_bitmap_filter::<UInt16Type>(&in_array),
         DataType::Int32 => Ok(Arc::new(Int32StaticFilter::try_new(&in_array)?)),
         DataType::Int64 => Ok(Arc::new(Int64StaticFilter::try_new(&in_array)?)),
-        DataType::UInt8 => Ok(Arc::new(BitmapFilter::<UInt8Type>::try_new(&in_array)?)),
-        DataType::UInt16 => Ok(Arc::new(BitmapFilter::<UInt16Type>::try_new(&in_array)?)),
         DataType::UInt32 => Ok(Arc::new(UInt32StaticFilter::try_new(&in_array)?)),
         DataType::UInt64 => Ok(Arc::new(UInt64StaticFilter::try_new(&in_array)?)),
         // Float primitive types (use ordered wrappers for Hash/Eq)

--- a/datafusion/physical-expr/src/expressions/in_list/transform.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/transform.rs
@@ -118,7 +118,9 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    use arrow::array::{ArrayRef, BooleanArray, Int8Array, Int16Array};
+    use arrow::array::{
+        ArrayRef, BooleanArray, Int8Array, Int16Array, UInt8Array, UInt16Array,
+    };
     use arrow::datatypes::{UInt8Type, UInt16Type};
 
     #[test]
@@ -163,6 +165,23 @@ mod tests {
             filter.contains(&needles, true)?,
             BooleanArray::from(vec![Some(false), None, Some(false)])
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn reinterpreted_bitmap_rejects_same_width_unsigned_needles() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(Int8Array::from(vec![Some(-1)]));
+        let filter = make_bitmap_filter::<UInt8Type>(&haystack)?;
+        let needles = UInt8Array::from(vec![Some(u8::MAX)]);
+        let err = filter.contains(&needles, false).unwrap_err().to_string();
+        assert!(err.contains("expected Int8 array, got UInt8"), "{err}");
+
+        let haystack: ArrayRef = Arc::new(Int16Array::from(vec![Some(-1)]));
+        let filter = make_bitmap_filter::<UInt16Type>(&haystack)?;
+        let needles = UInt16Array::from(vec![Some(u16::MAX)]);
+        let err = filter.contains(&needles, false).unwrap_err().to_string();
+        assert!(err.contains("expected Int16 array, got UInt16"), "{err}");
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/expressions/in_list/transform.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/transform.rs
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Type transformation utilities for InList filters.
+//!
+//! Some filters only depend on fixed-width value bit patterns. For those cases,
+//! compatible primitive arrays can be reinterpreted to the filter's unsigned
+//! storage type without copying values.
+
+use std::mem::size_of;
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, BooleanArray, PrimitiveArray};
+use arrow::buffer::ScalarBuffer;
+use arrow::datatypes::{ArrowPrimitiveType, DataType};
+use datafusion_common::{Result, exec_datafusion_err};
+
+use super::primitive_filter::{BitmapFilter, BitmapFilterType};
+use super::static_filter::{StaticFilter, handle_dictionary};
+
+/// Bitmap filter for signed 1-byte and 2-byte primitive arrays.
+///
+/// The bitmap implementation is keyed by an unsigned primitive type (`UInt8` or
+/// `UInt16`). This wrapper keeps the original array type, such as `Int8`, and
+/// only reinterprets values as the unsigned type when probing the bitmap.
+struct ReinterpretedBitmap<T: BitmapFilterType> {
+    expected_data_type: DataType,
+    inner: BitmapFilter<T>,
+}
+
+impl<T: BitmapFilterType> StaticFilter for ReinterpretedBitmap<T> {
+    fn null_count(&self) -> usize {
+        self.inner.null_count()
+    }
+
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
+
+        if v.data_type() != &self.expected_data_type {
+            return Err(exec_datafusion_err!(
+                "BitmapFilter: expected {} array, got {}",
+                self.expected_data_type,
+                v.data_type()
+            ));
+        }
+
+        let data = v.to_data();
+        let values: &[T::Native] = &data.buffer::<T::Native>(0)[..v.len()];
+
+        Ok(self.inner.contains_slice(values, data.nulls(), negated))
+    }
+}
+
+/// Views a primitive array as another primitive type with the same byte width.
+///
+/// This does not convert values. It reuses the existing values buffer and
+/// interprets each value's bytes as `T::Native`, preserving the null buffer.
+/// The caller must check that the source and target primitive types have the
+/// same width.
+#[inline]
+pub(crate) fn reinterpret_any_primitive_to<T: ArrowPrimitiveType>(
+    array: &dyn Array,
+) -> ArrayRef {
+    let data = array.to_data();
+    let values = data.buffers()[0].clone();
+    let buffer = ScalarBuffer::<T::Native>::new(values, data.offset(), data.len());
+    Arc::new(PrimitiveArray::<T>::new(buffer, array.nulls().cloned()))
+}
+
+/// Creates a bitmap filter for 1-byte or 2-byte primitive arrays.
+///
+/// Unsigned inputs use the bitmap filter directly. Signed inputs of the same
+/// width are reinterpreted as the unsigned bitmap type, without copying.
+pub(crate) fn make_bitmap_filter<T>(
+    in_array: &ArrayRef,
+) -> Result<Arc<dyn StaticFilter + Send + Sync>>
+where
+    T: BitmapFilterType,
+{
+    if in_array.data_type() == &T::DATA_TYPE {
+        return Ok(Arc::new(BitmapFilter::<T>::try_new(in_array)?));
+    }
+
+    let width = size_of::<T::Native>();
+    if in_array.data_type().primitive_width() != Some(width) {
+        return Err(exec_datafusion_err!(
+            "BitmapFilter: expected {}-byte primitive array for {} bitmap, got {}",
+            width,
+            T::DATA_TYPE,
+            in_array.data_type()
+        ));
+    }
+
+    let reinterpreted = reinterpret_any_primitive_to::<T>(in_array.as_ref());
+    let inner = BitmapFilter::<T>::try_new(&reinterpreted)?;
+    Ok(Arc::new(ReinterpretedBitmap {
+        expected_data_type: in_array.data_type().clone(),
+        inner,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use arrow::array::{ArrayRef, BooleanArray, Int8Array, Int16Array};
+    use arrow::datatypes::{UInt8Type, UInt16Type};
+
+    #[test]
+    fn reinterpreted_bitmap_handles_signed_boundaries_and_slices() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(
+            Int8Array::from(vec![Some(99), Some(i8::MIN), None, Some(-1), Some(42)])
+                .slice(1, 3),
+        );
+        let filter = make_bitmap_filter::<UInt8Type>(&haystack)?;
+        let needles =
+            Int8Array::from(vec![Some(7), Some(i8::MIN), Some(-1), None]).slice(1, 3);
+
+        assert_eq!(
+            filter.contains(&needles, false)?,
+            BooleanArray::from(vec![Some(true), Some(true), None])
+        );
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), Some(false), None])
+        );
+
+        let haystack: ArrayRef = Arc::new(
+            Int16Array::from(vec![
+                Some(123),
+                Some(i16::MIN),
+                None,
+                Some(-1),
+                Some(i16::MAX),
+            ])
+            .slice(1, 4),
+        );
+        let filter = make_bitmap_filter::<UInt16Type>(&haystack)?;
+        let needles =
+            Int16Array::from(vec![Some(0), Some(i16::MIN), Some(7), Some(i16::MAX)])
+                .slice(1, 3);
+
+        assert_eq!(
+            filter.contains(&needles, false)?,
+            BooleanArray::from(vec![Some(true), None, Some(true)])
+        );
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), None, Some(false)])
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #19241.
- Based on `main` after #23035.
- Next in stack: #23014.
- Extracted from #19390.

## Rationale for this change

#23011 and #23012 add bitmap lookups for unsigned 1-byte and 2-byte integers, and #23035 unifies those concrete filters behind one shared bitmap implementation. This PR lets signed primitive types with the same byte width reuse those bitmaps without copying values.

For `Int8` and `Int16`, the IN-list values and input values still have the same logical type. The optimization only changes the internal representation used by the lookup filter: `Int8` is viewed through the `UInt8` bitmap representation, and `Int16` is viewed through the `UInt16` bitmap representation.

This is a zero-copy view of the same bytes, not a numeric cast. For example, an `Int8` value such as `-1` is inserted and probed through the same one-byte bit pattern. The wrapper also keeps the original array type, so a filter built from `Int8` is probed with `Int8` values, not arbitrary same-width arrays.

## What changes are included in this PR?

- Adds a helper that views a primitive Arrow array as another primitive type with the same width.
- Makes the helper slice-aware, so sliced Arrow arrays still start at the correct logical offset.
- Wraps bitmap filters so signed 1-byte and 2-byte primitive arrays can reuse the unsigned bitmap storage.
- Validates source width before constructing a reinterpreted bitmap filter.
- Preserves the original array type on the wrapper and validates it again before probing.
- Adds focused coverage for signed boundary values, sliced arrays, `NOT IN`, and same-width unsigned probe rejection.

## Are these changes tested?

Yes.

- `cargo fmt --all -- --check`
- `cargo test -p datafusion-physical-expr expressions::in_list --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

No. This is an internal performance optimization only.

<!-- codex-benchmark-start -->
## Local benchmark snapshot

Benchmark command:

```bash
cargo bench -p datafusion-physical-expr --profile release-nonlto --bench in_list_strategy -- --save-baseline <name>
```

Method: compare adjacent saved baselines using raw Criterion sample minima (`min(time / iters)`). Lower is better; changes within +/-5% are treated as noise. These numbers were not rerun after splitting the behavior-preserving bitmap unification into #23035.

Compared baselines: [#23035](https://github.com/apache/datafusion/pull/23035) -> [#23013](https://github.com/apache/datafusion/pull/23013)

Relevant scope: signed 16-bit reinterpretation rows.

Summary: 6 relevant rows, 6 faster, 0 slower, 0 within +/-5%.

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `narrow_integer/i16/list=256/match=0%` | 19.15 us | 4.00 us | -79.1% (4.79x faster) |
| `narrow_integer/i16/list=256/match=50%` | 31.32 us | 4.00 us | -87.2% (7.82x faster) |
| `narrow_integer/i16/list=4/match=0%` | 16.79 us | 4.01 us | -76.1% (4.18x faster) |
| `narrow_integer/i16/list=4/match=50%` | 34.80 us | 4.01 us | -88.5% (8.69x faster) |
| `narrow_integer/i16/list=64/match=0%` | 19.21 us | 4.11 us | -78.6% (4.68x faster) |
| `narrow_integer/i16/list=64/match=50%` | 34.72 us | 4.01 us | -88.5% (8.66x faster) |
<!-- codex-benchmark-end -->

