### PR TITLE
IN LIST: optimize Utf8View and BinaryView filters

### DIFF
--- a/datafusion/physical-expr/benches/in_list_strategy.rs
+++ b/datafusion/physical-expr/benches/in_list_strategy.rs
@@ -166,11 +166,11 @@ fn random_string(rng: &mut StdRng, len: usize) -> String {
 fn strings_with_shared_prefix(
     rng: &mut StdRng,
     count: usize,
-    prefix_len: usize,
+    prefix: &str,
+    discriminator: char,
 ) -> Vec<String> {
-    let prefix = random_string(rng, prefix_len);
     (0..count)
-        .map(|_| format!("{}{}", prefix, random_string(rng, 8))) // prefix + random 8-char suffix
+        .map(|_| format!("{prefix}{}{discriminator}", random_string(rng, 7)))
         .collect()
 }
 
@@ -275,12 +275,14 @@ fn bench_string_shared_prefix<A>(
         .wrapping_add(prefix_len as u64 * 0x4444);
     let mut rng = StdRng::seed_from_u64(seed);
 
-    // Generate IN list with a shared prefix.
-    let haystack = strings_with_shared_prefix(&mut rng, list_size, prefix_len);
+    // Use the same prefix and equal-length, disjoint suffixes for both pools so
+    // misses exercise length/prefix collisions rather than immediate rejection.
+    let prefix = random_string(&mut rng, prefix_len);
+    let haystack = strings_with_shared_prefix(&mut rng, list_size, &prefix, 'h');
 
     // Generate non-matching strings with the same prefix to keep misses close
     // to the matching set.
-    let non_match_pool = strings_with_shared_prefix(&mut rng, 100, prefix_len);
+    let non_match_pool = strings_with_shared_prefix(&mut rng, 100, &prefix, 'm');
 
     // Generate array with controlled match rate
     let values: A = (0..ARRAY_SIZE)
@@ -313,6 +315,7 @@ fn bench_string_mixed_lengths<A>(
     name: &str,
     list_size: usize,
     match_rate: f64,
+    inline_rate: f64,
     to_scalar: fn(String) -> ScalarValue,
 ) where
     A: Array + FromIterator<Option<String>> + 'static,
@@ -320,12 +323,21 @@ fn bench_string_mixed_lengths<A>(
     let seed = 0xABCD_EF01_u64.wrapping_add(list_size as u64 * 0x5555);
     let mut rng = StdRng::seed_from_u64(seed);
 
-    // Mixed lengths: some short (<= 12), some long (> 12)
-    let lengths = [4, 8, 12, 16, 20, 24];
+    let inline_lengths = [4, 8, 12];
+    let long_lengths = [16, 20, 24];
+    let inline_count = ((list_size as f64 * inline_rate).round() as usize)
+        .max(1)
+        .min(list_size - 1);
 
     // Generate IN list with mixed lengths
     let haystack: Vec<String> = (0..list_size)
-        .map(|_| {
+        .map(|idx| {
+            let inline = idx < inline_count;
+            let lengths = if inline {
+                &inline_lengths
+            } else {
+                &long_lengths
+            };
             let len = *lengths.choose(&mut rng).unwrap();
             random_string(&mut rng, len)
         })
@@ -337,6 +349,11 @@ fn bench_string_mixed_lengths<A>(
             Some(if !haystack.is_empty() && rng.random_bool(match_rate) {
                 haystack.choose(&mut rng).unwrap().clone()
             } else {
+                let lengths = if rng.random_bool(inline_rate) {
+                    &inline_lengths
+                } else {
+                    &long_lengths
+                };
                 let len = *lengths.choose(&mut rng).unwrap();
                 random_string(&mut rng, len)
             })
@@ -602,6 +619,7 @@ fn bench_utf8(c: &mut Criterion) {
                 &format!("mixed_len/list={list_size}/match={match_pct}%"),
                 list_size,
                 match_pct as f64 / 100.0,
+                0.5,
                 to_scalar,
             );
         }
@@ -694,6 +712,23 @@ fn bench_utf8view(c: &mut Criterion) {
                 &format!("mixed_len/list={list_size}/match={match_pct}%"),
                 list_size,
                 match_pct as f64 / 100.0,
+                0.5,
+                to_scalar,
+            );
+        }
+    }
+
+    // Strongly skewed mixed lists exercise routing near the all-inline and
+    // all-long boundaries while retaining both representations.
+    for inline_pct in [2, 98] {
+        for match_pct in MATCH_RATES {
+            bench_string_mixed_lengths::<StringViewArray>(
+                c,
+                "utf8view",
+                &format!("mixed_len/inline={inline_pct}%/list=64/match={match_pct}%"),
+                64,
+                match_pct as f64 / 100.0,
+                inline_pct as f64 / 100.0,
                 to_scalar,
             );
         }

--- a/datafusion/physical-expr/benches/in_list_strategy.rs
+++ b/datafusion/physical-expr/benches/in_list_strategy.rs
@@ -35,8 +35,8 @@
 //! |------|-------|-----------------|-------------------|
 //! | Narrow integer cases | UInt8 | small value domain | 4, 16 |
 //! | Narrow integer cases | Int16, Float16 | larger value domain | 4, 64, 256 |
-//! | 32-bit primitive cases | Int32, Float32 | small and large lists | 4, 32, 64, 256 |
-//! | 64-bit primitive cases | Int64, TimestampNs | small and large lists | 4, 16, 32, 128 |
+//! | 32-bit primitive cases | Int32, Float32 | small and large lists | 4, 32, 33, 64, 256, 1024, 10000 |
+//! | 64-bit primitive cases | Int64, TimestampNs | small and large lists | 4, 16, 17, 32, 128, 1024, 10000 |
 //! | 128-bit interval cases | IntervalMonthDayNano | small lists | 4 |
 //! | Utf8 short-string cases | Utf8 | 8-byte strings | 4, 64, 256 |
 //! | Utf8 long-string cases | Utf8 | 24-byte strings | 4, 64, 256 |
@@ -420,7 +420,7 @@ fn bench_narrow_integer(c: &mut Criterion) {
 
 fn bench_primitive(c: &mut Criterion) {
     // Int32: small and larger list sizes
-    for list_size in [4, 32, 64, 256] {
+    for list_size in [4, 32, 33, 64, 256, 1024, 10_000] {
         let list_case = if list_size <= 32 {
             "small_list"
         } else {
@@ -442,7 +442,7 @@ fn bench_primitive(c: &mut Criterion) {
     }
 
     // Int64: small and larger list sizes
-    for list_size in [4, 16, 32, 128] {
+    for list_size in [4, 16, 17, 32, 128, 1024, 10_000] {
         let list_case = if list_size <= 16 {
             "small_list"
         } else {

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -38,6 +38,7 @@ use datafusion_expr::{ColumnarValue, expr_vec_fmt};
 
 mod array_static_filter;
 mod branchless_filter;
+mod byte_view_filter;
 mod frozen_set;
 mod primitive_filter;
 mod result;
@@ -216,7 +217,7 @@ impl InListExpr {
             expr,
             list,
             negated,
-            Some(instantiate_static_filter(array)?),
+            Some(instantiate_static_filter(array, &expr_data_type)?),
         ))
     }
 
@@ -243,7 +244,7 @@ impl InListExpr {
 
         // Try to create a static filter if all list expressions are constants
         let static_filter = match try_evaluate_constant_list(&list, schema)? {
-            Some(in_array) => Some(instantiate_static_filter(in_array)?),
+            Some(in_array) => Some(instantiate_static_filter(in_array, &expr_data_type)?),
             None => None, // Non-constant expressions, fall back to dynamic evaluation
         };
 
@@ -3575,6 +3576,23 @@ mod tests {
                 wrap_in_dict(Arc::clone(&utf8_needle)),
                 wrap_in_dict(Arc::clone(&utf8_in)),
             )?
+        );
+
+        // Utf8View in_array, Utf8View and Dict(Utf8View) needles
+        let utf8view_in =
+            Arc::new(StringViewArray::from(vec!["a", "b", "c"])) as ArrayRef;
+        let utf8view_needle =
+            Arc::new(StringViewArray::from(vec!["a", "d", "b"])) as ArrayRef;
+        assert_eq!(
+            expected,
+            eval_in_list_from_array(
+                Arc::clone(&utf8view_needle),
+                Arc::clone(&utf8view_in),
+            )?
+        );
+        assert_eq!(
+            expected,
+            eval_in_list_from_array(wrap_in_dict(utf8view_needle), utf8view_in)?
         );
 
         // Struct in_array, Struct needle: multi-column join

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -38,6 +38,7 @@ use datafusion_expr::{ColumnarValue, expr_vec_fmt};
 
 mod array_static_filter;
 mod branchless_filter;
+mod frozen_set;
 mod primitive_filter;
 mod result;
 mod static_filter;
@@ -222,8 +223,8 @@ impl InListExpr {
     /// Create a new InList expression, using a static filter when possible.
     ///
     /// This validates data types and attempts to create a static filter for constant
-    /// list expressions. Uses specialized StaticFilter implementations for better
-    /// performance (e.g., Int32StaticFilter for Int32).
+    /// list expressions. Uses specialized `StaticFilter` implementations for better
+    /// performance (for example, primitive filters for fixed-width values).
     ///
     /// Returns an error if data types don't match. If the list contains non-constant
     /// expressions, falls back to dynamic evaluation at runtime.
@@ -2592,7 +2593,7 @@ mod tests {
         // Create IN list with Int32 literals: (100, 200, 300)
         let list = vec![lit(100i32), lit(200i32), lit(300i32)];
 
-        // Create InListExpr via in_list() - this uses Int32StaticFilter for Int32 lists
+        // Create InListExpr via in_list() - this uses a specialized primitive filter
         let expr = in_list(col_a, list, &false, &schema)?;
 
         // Create dictionary-encoded batch with values [100, 200, 500]

--- a/datafusion/physical-expr/src/expressions/in_list/branchless_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/branchless_filter.rs
@@ -58,8 +58,9 @@
 //! would be useful. Wider types have too many possible values for such a
 //! bitmap, so their limits are tuned separately.
 //!
-//! Larger lists use the standard filter strategy, including bitmap filters for
-//! one- and two-byte types.
+//! Larger lists use another filter strategy: bitmap filters for one- and
+//! two-byte types, frozen sets for supported four- and eight-byte types, and
+//! the standard fallback for the remaining types.
 //!
 //! # What about nulls?
 //!

--- a/datafusion/physical-expr/src/expressions/in_list/branchless_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/branchless_filter.rs
@@ -72,7 +72,7 @@
 use std::mem::size_of;
 
 use arrow::array::{Array, ArrayRef, AsArray, BooleanArray, PrimitiveArray};
-use arrow::buffer::{BooleanBuffer, ScalarBuffer};
+use arrow::buffer::{BooleanBuffer, NullBuffer, ScalarBuffer};
 use arrow::datatypes::*;
 use arrow::util::bit_iterator::BitIndexIterator;
 use datafusion_common::{Result, exec_datafusion_err, internal_datafusion_err};
@@ -245,6 +245,17 @@ where
             check_values,
         })
     }
+
+    #[inline]
+    pub(super) fn contains_slice(
+        &self,
+        input_values: &[BranchlessNative<T>],
+        nulls: Option<&NullBuffer>,
+        negated: bool,
+    ) -> BooleanArray {
+        let matches = (self.check_values)(self.in_list_values.as_ref(), input_values);
+        build_result_from_contains(nulls, self.null_count > 0, negated, matches)
+    }
 }
 
 impl<T> StaticFilter for BranchlessFilter<T>
@@ -273,14 +284,7 @@ where
             exec_datafusion_err!("BranchlessFilter: expected {} array", T::DATA_TYPE)
         })?;
         let input_values = branchless_values::<T>(v);
-        let matches =
-            (self.check_values)(self.in_list_values.as_ref(), input_values.as_ref());
-        Ok(build_result_from_contains(
-            v.nulls(),
-            self.null_count > 0,
-            negated,
-            matches,
-        ))
+        Ok(self.contains_slice(input_values.as_ref(), v.nulls(), negated))
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/in_list/byte_view_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/byte_view_filter.rs
@@ -1,0 +1,678 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Optimized filters for Utf8View and BinaryView IN lists.
+
+use std::hash::BuildHasher;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, AsArray, BooleanArray, GenericByteViewArray, MAX_INLINE_VIEW_LEN,
+    PrimitiveArray,
+};
+use arrow::buffer::ScalarBuffer;
+use arrow::datatypes::{
+    BinaryViewType, ByteViewType, DataType, Decimal128Type, StringViewType,
+};
+use arrow::util::bit_iterator::BitIndexIterator;
+use datafusion_common::hash_utils::RandomState;
+use datafusion_common::{Result, exec_datafusion_err};
+use hashbrown::{DefaultHashBuilder, HashTable};
+
+use super::branchless_filter::{BranchlessFilter, BranchlessFilterType};
+use super::frozen_set::{FrozenSet, FrozenSetHash};
+use super::result::{build_in_list_result, build_in_list_result_with_null_shortcircuit};
+use super::static_filter::{StaticFilter, handle_dictionary};
+
+#[inline(always)]
+fn view_len(view: u128) -> u32 {
+    view as u32
+}
+
+/// The low 64 bits of a long view contain its length and four-byte prefix.
+#[inline(always)]
+fn long_key(view: u128) -> u64 {
+    view as u64
+}
+
+#[inline(always)]
+fn view_key(view: u128) -> u128 {
+    if view_len(view) <= MAX_INLINE_VIEW_LEN {
+        view
+    } else {
+        long_key(view) as u128
+    }
+}
+
+fn downcast_byte_view<T: ByteViewType>(
+    array: &dyn Array,
+) -> Result<&GenericByteViewArray<T>> {
+    array
+        .as_byte_view_opt::<T>()
+        .ok_or_else(|| exec_datafusion_err!("Expected concrete {} array", T::DATA_TYPE))
+}
+
+/// Keyed folded-multiply hash specialized for Arrow's inline view encoding.
+struct InlineViewHash {
+    key: [u64; 2],
+}
+
+impl Default for InlineViewHash {
+    fn default() -> Self {
+        let state = DefaultHashBuilder::default();
+        Self {
+            key: [
+                BuildHasher::hash_one(&state, 0_u8),
+                BuildHasher::hash_one(&state, 1_u8),
+            ],
+        }
+    }
+}
+
+impl FrozenSetHash<u128> for InlineViewHash {
+    #[inline(always)]
+    fn hash_one(&self, value: u128) -> u64 {
+        let lo = value as u64 ^ self.key[0];
+        let hi = (value >> 64) as u64 ^ self.key[1];
+        let product = lo as u128 * hi as u128;
+        product as u64 ^ (product >> 64) as u64
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ViewComposition {
+    Inline,
+    Long,
+    Mixed {
+        inline_count: usize,
+        long_count: usize,
+    },
+}
+
+fn view_composition<T: ByteViewType>(array: &ArrayRef) -> Result<ViewComposition> {
+    let array = downcast_byte_view::<T>(array.as_ref())?;
+    let mut inline_count = 0;
+    let mut long_count = 0;
+    let mut visit = |idx: usize| {
+        if view_len(array.views()[idx]) <= MAX_INLINE_VIEW_LEN {
+            inline_count += 1;
+        } else {
+            long_count += 1;
+        }
+    };
+
+    match array.nulls() {
+        Some(nulls) => {
+            BitIndexIterator::new(nulls.validity(), nulls.offset(), nulls.len())
+                .for_each(&mut visit);
+        }
+        None => (0..array.len()).for_each(&mut visit),
+    }
+
+    Ok(match (inline_count, long_count) {
+        (inline_count, long_count) if inline_count > 0 && long_count > 0 => {
+            ViewComposition::Mixed {
+                inline_count,
+                long_count,
+            }
+        }
+        (0, long_count) if long_count > 0 => ViewComposition::Long,
+        _ => ViewComposition::Inline,
+    })
+}
+
+fn reinterpret_byte_view_as_decimal128<T: ByteViewType>(
+    array: &dyn Array,
+) -> Result<ArrayRef> {
+    let array = downcast_byte_view::<T>(array)?;
+    let views = array.views();
+    let values = ScalarBuffer::<i128>::new(views.inner().clone(), 0, views.len());
+    Ok(Arc::new(PrimitiveArray::<Decimal128Type>::new(
+        values,
+        array.nulls().cloned(),
+    )))
+}
+
+fn make_byte_view_branchless_filter<T: ByteViewType>(
+    in_array: &ArrayRef,
+) -> Result<Arc<dyn StaticFilter + Send + Sync>> {
+    let values = reinterpret_byte_view_as_decimal128::<T>(in_array.as_ref())?;
+
+    Ok(Arc::new(ByteViewBranchless::<T> {
+        inner: BranchlessFilter::<Decimal128Type>::try_new(&values)?,
+        _marker: PhantomData,
+    }))
+}
+
+struct ByteViewBranchless<T: ByteViewType> {
+    inner: BranchlessFilter<Decimal128Type>,
+    _marker: PhantomData<T>,
+}
+
+struct InlineByteViewFilter<T: ByteViewType> {
+    set: FrozenSet<u128, InlineViewHash>,
+    null_count: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T: ByteViewType> InlineByteViewFilter<T> {
+    fn try_new(in_array: &ArrayRef) -> Result<Self> {
+        if in_array.data_type() != &T::DATA_TYPE {
+            return Err(exec_datafusion_err!(
+                "InlineByteViewFilter: expected {} array, got {}",
+                T::DATA_TYPE,
+                in_array.data_type()
+            ));
+        }
+
+        let array = downcast_byte_view::<T>(in_array.as_ref())?;
+        let mut values = Vec::with_capacity(array.len() - array.null_count());
+        match array.nulls() {
+            Some(nulls) => {
+                BitIndexIterator::new(nulls.validity(), nulls.offset(), nulls.len())
+                    .for_each(|idx| values.push(array.views()[idx]));
+            }
+            None => values.extend_from_slice(array.views()),
+        }
+
+        Ok(Self {
+            set: FrozenSet::try_new_with_hasher(&values, InlineViewHash::default())?,
+            null_count: array.null_count(),
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T: ByteViewType> StaticFilter for InlineByteViewFilter<T> {
+    fn null_count(&self) -> usize {
+        self.null_count
+    }
+
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
+
+        if v.data_type() != &T::DATA_TYPE {
+            return Err(exec_datafusion_err!(
+                "InlineByteViewFilter: expected {} array, got {}",
+                T::DATA_TYPE,
+                v.data_type()
+            ));
+        }
+
+        let array = downcast_byte_view::<T>(v)?;
+        let views = array.views();
+        Ok(build_in_list_result(
+            array.len(),
+            array.nulls(),
+            self.null_count > 0,
+            negated,
+            |idx| {
+                // SAFETY: `build_in_list_result` visits indices in `0..array.len()`.
+                self.set.contains(unsafe { *views.get_unchecked(idx) })
+            },
+        ))
+    }
+}
+
+impl<T: ByteViewType> StaticFilter for ByteViewBranchless<T> {
+    fn null_count(&self) -> usize {
+        self.inner.null_count()
+    }
+
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
+
+        if v.data_type() != &T::DATA_TYPE {
+            return Err(exec_datafusion_err!(
+                "ByteViewBranchless: expected {} array, got {}",
+                T::DATA_TYPE,
+                v.data_type()
+            ));
+        }
+
+        let array = downcast_byte_view::<T>(v)?;
+        let values: &[i128] = array.views().inner().typed_data();
+        Ok(self.inner.contains_slice(values, array.nulls(), negated))
+    }
+}
+
+/// Two-stage filter for inline and mixed Utf8View and BinaryView arrays.
+///
+/// Inline values are represented completely by their 128-bit view. For long
+/// values, the length and prefix reject impossible matches before an exact
+/// full-byte lookup.
+struct ByteViewFilter<T: ByteViewType> {
+    in_array: ArrayRef,
+    view_keys: FrozenSet<u128, InlineViewHash>,
+    long_value_table: HashTable<usize>,
+    state: RandomState,
+    _marker: PhantomData<T>,
+}
+
+impl<T: ByteViewType> ByteViewFilter<T> {
+    fn try_new(in_array: ArrayRef) -> Result<Self> {
+        if in_array.data_type() != &T::DATA_TYPE {
+            return Err(exec_datafusion_err!(
+                "ByteViewFilter: expected {} array, got {}",
+                T::DATA_TYPE,
+                in_array.data_type()
+            ));
+        }
+
+        let array = downcast_byte_view::<T>(in_array.as_ref())?;
+        let mut view_keys = Vec::new();
+        let mut long_value_table = HashTable::new();
+        let state = RandomState::default();
+
+        let mut insert = |idx: usize| {
+            let view = array.views()[idx];
+            view_keys.push(view_key(view));
+            if view_len(view) <= MAX_INLINE_VIEW_LEN {
+                return;
+            }
+
+            // SAFETY: idx is produced from this array's bounds or validity bitmap.
+            let value: &[u8] = unsafe { array.value_unchecked(idx) }.as_ref();
+            let hash = state.hash_one(value);
+            if long_value_table
+                .find(hash, |&stored_idx| {
+                    // SAFETY: stored_idx was inserted from this array.
+                    let stored: &[u8] =
+                        unsafe { array.value_unchecked(stored_idx) }.as_ref();
+                    stored == value
+                })
+                .is_none()
+            {
+                long_value_table.insert_unique(hash, idx, |&stored_idx| {
+                    // SAFETY: stored_idx was inserted from this array.
+                    let stored: &[u8] =
+                        unsafe { array.value_unchecked(stored_idx) }.as_ref();
+                    state.hash_one(stored)
+                });
+            }
+        };
+
+        match array.nulls() {
+            Some(nulls) => {
+                BitIndexIterator::new(nulls.validity(), nulls.offset(), nulls.len())
+                    .for_each(&mut insert);
+            }
+            None => (0..array.len()).for_each(&mut insert),
+        }
+
+        view_keys.sort_unstable();
+        view_keys.dedup();
+
+        Ok(Self {
+            in_array,
+            view_keys: FrozenSet::try_new_with_hasher(
+                &view_keys,
+                InlineViewHash::default(),
+            )?,
+            long_value_table,
+            state,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T: ByteViewType> StaticFilter for ByteViewFilter<T> {
+    fn null_count(&self) -> usize {
+        self.in_array.null_count()
+    }
+
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
+
+        if v.data_type() != &T::DATA_TYPE {
+            return Err(exec_datafusion_err!(
+                "ByteViewFilter: expected {} array, got {}",
+                T::DATA_TYPE,
+                v.data_type()
+            ));
+        }
+
+        let needles = downcast_byte_view::<T>(v)?;
+        let haystack = downcast_byte_view::<T>(self.in_array.as_ref())?;
+        Ok(build_in_list_result_with_null_shortcircuit(
+            needles.len(),
+            needles.nulls(),
+            self.in_array.null_count() > 0,
+            negated,
+            |i| {
+                let view = needles.views()[i];
+                if !self.view_keys.contains(view_key(view)) {
+                    return false;
+                }
+                if view_len(view) <= MAX_INLINE_VIEW_LEN {
+                    return true;
+                }
+
+                // SAFETY: i is in bounds and null indices are skipped.
+                let needle: &[u8] = unsafe { needles.value_unchecked(i) }.as_ref();
+                let hash = self.state.hash_one(needle);
+                self.long_value_table
+                    .find(hash, |&idx| {
+                        // SAFETY: idx was inserted from self.in_array.
+                        let value: &[u8] =
+                            unsafe { haystack.value_unchecked(idx) }.as_ref();
+                        value == needle
+                    })
+                    .is_some()
+            },
+        ))
+    }
+}
+
+fn make_byte_view_filter<T: ByteViewType>(
+    in_array: &ArrayRef,
+) -> Result<Arc<dyn StaticFilter + Send + Sync>> {
+    Ok(Arc::new(ByteViewFilter::<T>::try_new(Arc::clone(
+        in_array,
+    ))?))
+}
+
+fn make_inline_byte_view_filter<T: ByteViewType>(
+    in_array: &ArrayRef,
+) -> Result<Arc<dyn StaticFilter + Send + Sync>> {
+    Ok(Arc::new(InlineByteViewFilter::<T>::try_new(in_array)?))
+}
+
+fn instantiate_typed_byte_view_filter<T: ByteViewType>(
+    in_array: &ArrayRef,
+) -> Result<Option<Arc<dyn StaticFilter + Send + Sync>>> {
+    let non_null_count = in_array.len() - in_array.null_count();
+    match view_composition::<T>(in_array)? {
+        ViewComposition::Inline
+            if non_null_count
+                <= <Decimal128Type as BranchlessFilterType>::MAX_LIST_LEN =>
+        {
+            make_byte_view_branchless_filter::<T>(in_array).map(Some)
+        }
+        ViewComposition::Inline => make_inline_byte_view_filter::<T>(in_array).map(Some),
+        ViewComposition::Mixed {
+            inline_count,
+            long_count,
+        } if inline_count <= long_count => make_byte_view_filter::<T>(in_array).map(Some),
+        ViewComposition::Mixed { .. } => Ok(None),
+        ViewComposition::Long => Ok(None),
+    }
+}
+
+/// Creates an optimized byte-view filter when its measured specialization wins.
+///
+/// Inline lists use direct view comparisons or a frozen set. Long-dominant mixed
+/// lists add length/prefix rejection and exact long-value verification. Other
+/// compositions stay on the generic filter when this extra stage does not win.
+pub(super) fn instantiate_byte_view_filter(
+    in_array: &ArrayRef,
+) -> Result<Option<Arc<dyn StaticFilter + Send + Sync>>> {
+    match in_array.data_type() {
+        DataType::Utf8View => {
+            instantiate_typed_byte_view_filter::<StringViewType>(in_array)
+        }
+        DataType::BinaryView => {
+            instantiate_typed_byte_view_filter::<BinaryViewType>(in_array)
+        }
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{BinaryViewArray, DictionaryArray, Int8Array, StringViewArray};
+    use arrow::datatypes::{BinaryViewType, StringViewType};
+
+    fn assert_contains(
+        filter: &dyn StaticFilter,
+        needles: &dyn Array,
+        expected: Vec<Option<bool>>,
+    ) -> Result<()> {
+        assert_eq!(
+            filter.contains(needles, false)?,
+            BooleanArray::from(expected)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn frozen_filter_handles_inline_slices() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(
+            StringViewArray::from(vec![
+                Some("outside"),
+                Some("a"),
+                Some("b"),
+                Some("c"),
+                Some("d"),
+                Some("e"),
+                Some("tail"),
+            ])
+            .slice(1, 5),
+        );
+        let filter = ByteViewFilter::<StringViewType>::try_new(haystack)?;
+        let needles =
+            StringViewArray::from(vec![Some("outside"), Some("b"), Some("z"), Some("e")])
+                .slice(1, 3);
+
+        assert_contains(&filter, &needles, vec![Some(true), Some(false), Some(true)])
+    }
+
+    #[test]
+    fn inline_filter_handles_slices_nulls_and_not_in() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(
+            StringViewArray::from(vec![
+                Some("outside"),
+                Some("a"),
+                Some("b"),
+                None,
+                Some("c"),
+                Some("d"),
+                Some("e"),
+                Some("tail"),
+            ])
+            .slice(1, 6),
+        );
+        let filter = InlineByteViewFilter::<StringViewType>::try_new(&haystack)?;
+        let needles =
+            StringViewArray::from(vec![Some("b"), Some("missing"), None, Some("e")]);
+
+        assert_contains(&filter, &needles, vec![Some(true), None, None, Some(true)])?;
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), None, None, Some(false)])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn frozen_filter_verifies_long_prefix_collisions_and_nulls() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(
+            StringViewArray::from(vec![
+                Some("outside-long-value"),
+                Some("abcdefghijklmn1"),
+                None,
+                Some("short"),
+                Some("tail-long-value"),
+            ])
+            .slice(1, 3),
+        );
+        let filter = ByteViewFilter::<StringViewType>::try_new(haystack)?;
+        let needles = StringViewArray::from(vec![
+            Some("abcdefghijklmn1"),
+            Some("abcdefghijklmn2"),
+            Some("short"),
+            None,
+        ]);
+
+        assert_contains(&filter, &needles, vec![Some(true), None, Some(true), None])?;
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), None, Some(false), None])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn frozen_filter_handles_binary_views() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(BinaryViewArray::from(vec![
+            Some([0xff, 0x00].as_slice()),
+            Some(b"abcdefghijklmn1".as_slice()),
+        ]));
+        let filter = ByteViewFilter::<BinaryViewType>::try_new(haystack)?;
+        let needles = BinaryViewArray::from(vec![
+            Some([0xff, 0x00].as_slice()),
+            Some(b"abcdefghijklmn1".as_slice()),
+            Some(b"abcdefghijklmn2".as_slice()),
+        ]);
+
+        assert_contains(&filter, &needles, vec![Some(true), Some(true), Some(false)])
+    }
+
+    #[test]
+    fn frozen_filter_handles_dictionary_needles() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("short"),
+            Some("abcdefghijklmn1"),
+            None,
+        ]));
+        let filter = ByteViewFilter::<StringViewType>::try_new(haystack)?;
+        let keys = Int8Array::from(vec![Some(0), Some(1), None, Some(2)]);
+        let values = Arc::new(StringViewArray::from(vec![
+            Some("short"),
+            Some("abcdefghijklmn1"),
+            Some("missing"),
+        ]));
+        let needles = DictionaryArray::try_new(keys, values)?;
+
+        assert_contains(&filter, &needles, vec![Some(true), Some(true), None, None])
+    }
+
+    #[test]
+    fn branchless_filter_handles_utf8_and_binary_views() -> Result<()> {
+        let utf8_haystack: ArrayRef =
+            Arc::new(StringViewArray::from(vec![Some("one"), None, Some("two")]));
+        let utf8_filter =
+            make_byte_view_branchless_filter::<StringViewType>(&utf8_haystack)?;
+        let utf8_needles = StringViewArray::from(vec![Some("two"), Some("three"), None]);
+        assert_contains(&*utf8_filter, &utf8_needles, vec![Some(true), None, None])?;
+
+        let binary_haystack: ArrayRef = Arc::new(BinaryViewArray::from(vec![
+            Some([0xff].as_slice()),
+            Some([0x00].as_slice()),
+        ]));
+        let binary_filter =
+            make_byte_view_branchless_filter::<BinaryViewType>(&binary_haystack)?;
+        let binary_needles =
+            BinaryViewArray::from(vec![Some([0x00].as_slice()), Some([0x01].as_slice())]);
+        assert_contains(
+            &*binary_filter,
+            &binary_needles,
+            vec![Some(true), Some(false)],
+        )
+    }
+
+    #[test]
+    fn byte_view_filters_reject_other_types() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("short"),
+            Some("abcdefghijklmn1"),
+        ]));
+        let frozen = ByteViewFilter::<StringViewType>::try_new(Arc::clone(&haystack))?;
+        let branchless_haystack: ArrayRef =
+            Arc::new(StringViewArray::from(vec![Some("short")]));
+        let branchless =
+            make_byte_view_branchless_filter::<StringViewType>(&branchless_haystack)?;
+        let needles = BinaryViewArray::from(vec![Some(b"short".as_slice())]);
+
+        assert!(frozen.contains(&needles, false).is_err());
+        assert!(branchless.contains(&needles, false).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn byte_view_routing_only_selects_measured_wins() -> Result<()> {
+        let inline_four: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("a"),
+            None,
+            Some("b"),
+            Some("c"),
+            Some("d"),
+        ]));
+        assert!(instantiate_byte_view_filter(&inline_four)?.is_some());
+
+        let inline_five: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("a"),
+            Some("b"),
+            Some("c"),
+            Some("d"),
+            Some("e"),
+        ]));
+        assert!(instantiate_byte_view_filter(&inline_five)?.is_some());
+
+        let all_null: ArrayRef =
+            Arc::new(StringViewArray::from(vec![None::<&str>, None::<&str>]));
+        assert!(instantiate_byte_view_filter(&all_null)?.is_some());
+
+        let all_long: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("abcdefghijklmn1"),
+            Some("abcdefghijklmn2"),
+        ]));
+        assert!(instantiate_byte_view_filter(&all_long)?.is_none());
+
+        let mixed: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("short"),
+            Some("abcdefghijklmn1"),
+        ]));
+        assert!(instantiate_byte_view_filter(&mixed)?.is_some());
+
+        let inline_dominant_mixed: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("a"),
+            Some("b"),
+            Some("c"),
+            Some("d"),
+            Some("e"),
+            Some("abcdefghijklmn1"),
+        ]));
+        assert!(instantiate_byte_view_filter(&inline_dominant_mixed)?.is_none());
+
+        let long_dominant_mixed: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("short"),
+            Some("abcdefghijklmn1"),
+            Some("abcdefghijklmn2"),
+        ]));
+        assert!(instantiate_byte_view_filter(&long_dominant_mixed)?.is_some());
+
+        let inline_binary: ArrayRef = Arc::new(BinaryViewArray::from(vec![
+            Some(b"a".as_slice()),
+            Some(b"b".as_slice()),
+            Some(b"c".as_slice()),
+            Some(b"d".as_slice()),
+            Some(b"e".as_slice()),
+        ]));
+        assert!(instantiate_byte_view_filter(&inline_binary)?.is_some());
+
+        let mixed_binary: ArrayRef = Arc::new(BinaryViewArray::from(vec![
+            Some([0xff].as_slice()),
+            Some(b"abcdefghijklmn1".as_slice()),
+        ]));
+        assert!(instantiate_byte_view_filter(&mixed_binary)?.is_some());
+
+        Ok(())
+    }
+}

--- a/datafusion/physical-expr/src/expressions/in_list/frozen_set.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/frozen_set.rs
@@ -1,0 +1,213 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Immutable set for fixed-width values.
+
+use std::hash::{BuildHasher, Hash};
+
+use datafusion_common::{Result, exec_datafusion_err};
+use hashbrown::{DefaultHashBuilder, HashTable};
+
+/// Immutable set optimized for repeated membership tests.
+///
+/// Each hash bucket holds two values directly. Values that collide beyond those
+/// two slots use a `HashTable`, which keeps the common lookup path to one hash
+/// and two bucket comparisons without sacrificing collision handling.
+///
+/// The first member is used as the empty-slot sentinel and handled before
+/// lookup, so primary slots store `V` directly without an `Option<V>` wrapper.
+pub(super) struct FrozenSet<V> {
+    hash_builder: DefaultHashBuilder,
+    sentinel: Option<V>,
+    buckets: Box<[[V; 2]]>,
+    overflowed: Box<[bool]>,
+    overflow: HashTable<V>,
+}
+
+impl<V> FrozenSet<V>
+where
+    V: Copy + Eq + Hash,
+{
+    pub(super) fn try_new(values: &[V]) -> Result<Self> {
+        let Some((&sentinel, values)) = values.split_first() else {
+            return Ok(Self {
+                hash_builder: DefaultHashBuilder::default(),
+                sentinel: None,
+                buckets: Box::default(),
+                overflowed: Box::default(),
+                overflow: HashTable::new(),
+            });
+        };
+
+        if values.is_empty() {
+            return Ok(Self {
+                hash_builder: DefaultHashBuilder::default(),
+                sentinel: Some(sentinel),
+                buckets: Box::default(),
+                overflowed: Box::default(),
+                overflow: HashTable::new(),
+            });
+        }
+
+        let bucket_count = values
+            .len()
+            .checked_add(1)
+            .ok_or_else(|| exec_datafusion_err!("FrozenSet capacity overflow"))?;
+        bucket_count
+            .checked_mul(2)
+            .ok_or_else(|| exec_datafusion_err!("FrozenSet capacity overflow"))?;
+        let mut set = Self {
+            hash_builder: DefaultHashBuilder::default(),
+            sentinel: Some(sentinel),
+            buckets: vec![[sentinel; 2]; bucket_count].into_boxed_slice(),
+            overflowed: vec![false; bucket_count].into_boxed_slice(),
+            overflow: HashTable::with_capacity(bucket_count / 8),
+        };
+        values.iter().copied().for_each(|value| set.insert(value));
+        Ok(set)
+    }
+
+    fn insert(&mut self, value: V) {
+        let sentinel = self.sentinel.expect("non-empty frozen set");
+        if value == sentinel {
+            return;
+        }
+
+        let hash = self.hash_builder.hash_one(value);
+        let bucket = reduce_hash(hash, self.buckets.len());
+        let slots = &mut self.buckets[bucket];
+        if slots[0] == sentinel {
+            slots[0] = value;
+            return;
+        }
+        if slots[0] == value {
+            return;
+        }
+        if slots[1] == sentinel {
+            slots[1] = value;
+            return;
+        }
+        if slots[1] == value {
+            return;
+        }
+
+        let hash_builder = &self.hash_builder;
+        self.overflow
+            .entry(
+                hash,
+                |stored| *stored == value,
+                |stored| hash_builder.hash_one(stored),
+            )
+            .or_insert(value);
+        self.overflowed[bucket] = true;
+    }
+
+    #[inline(always)]
+    pub(super) fn contains(&self, value: V) -> bool {
+        let Some(sentinel) = self.sentinel else {
+            return false;
+        };
+        if value == sentinel {
+            return true;
+        }
+        if self.buckets.is_empty() {
+            return false;
+        }
+
+        let hash = self.hash_builder.hash_one(value);
+        let bucket = reduce_hash(hash, self.buckets.len());
+        // SAFETY: `reduce_hash` returns an index in `0..buckets.len()`.
+        let slots = unsafe { self.buckets.get_unchecked(bucket) };
+        if (slots[0] == value) | (slots[1] == value) {
+            return true;
+        }
+
+        // SAFETY: `overflowed` has exactly one entry per bucket.
+        (unsafe { *self.overflowed.get_unchecked(bucket) })
+            && self
+                .overflow
+                .find(hash, |stored| *stored == value)
+                .is_some()
+    }
+}
+
+#[inline(always)]
+fn reduce_hash(hash: u64, len: usize) -> usize {
+    #[cfg(target_pointer_width = "64")]
+    return ((hash as u128 * len as u128) >> 64) as usize;
+
+    #[cfg(target_pointer_width = "32")]
+    return (((hash as u32) as u64 * len as u64) >> 32) as usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::hash::{Hash, Hasher};
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct Colliding(u64);
+
+    impl Hash for Colliding {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            0_u8.hash(state);
+        }
+    }
+
+    #[test]
+    fn handles_empty_duplicates_and_sentinel_member() {
+        let empty = FrozenSet::<u64>::try_new(&[]).unwrap();
+        assert!(!empty.contains(0));
+
+        let singleton = FrozenSet::try_new(&[42]).unwrap();
+        assert!(singleton.contains(42));
+        assert!(!singleton.contains(7));
+
+        let values = [42, 7, 42, 9, 11, 7];
+        let set = FrozenSet::try_new(&values).unwrap();
+        for value in [42, 7, 9, 11] {
+            assert!(set.contains(value));
+        }
+        for value in [0, 8, 10, 12] {
+            assert!(!set.contains(value));
+        }
+    }
+
+    #[test]
+    fn handles_many_values() {
+        let values = (0_u64..10_000).collect::<Vec<_>>();
+        let set = FrozenSet::try_new(&values).unwrap();
+        assert!(values.iter().all(|&value| set.contains(value)));
+        assert!((10_000..20_000).all(|value| !set.contains(value)));
+    }
+
+    #[test]
+    fn handles_u128_values() {
+        let values = [1_u128, (1_u128 << 64) | 1, (2_u128 << 96) | 7, u128::MAX];
+        let set = FrozenSet::try_new(&values).unwrap();
+        assert!(values.iter().all(|&value| set.contains(value)));
+        assert!(!set.contains(1_u128 << 96));
+    }
+
+    #[test]
+    fn handles_collisions() {
+        let values = (0..128).map(Colliding).collect::<Vec<_>>();
+        let set = FrozenSet::try_new(&values).unwrap();
+        assert!(values.iter().all(|&value| set.contains(value)));
+        assert!((128..256).all(|value| !set.contains(Colliding(value))));
+    }
+}

--- a/datafusion/physical-expr/src/expressions/in_list/frozen_set.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/frozen_set.rs
@@ -22,6 +22,18 @@ use std::hash::{BuildHasher, Hash};
 use datafusion_common::{Result, exec_datafusion_err};
 use hashbrown::{DefaultHashBuilder, HashTable};
 
+/// Computes the keyed hash used to place values in a [`FrozenSet`].
+pub(super) trait FrozenSetHash<V> {
+    fn hash_one(&self, value: V) -> u64;
+}
+
+impl<V: Hash> FrozenSetHash<V> for DefaultHashBuilder {
+    #[inline(always)]
+    fn hash_one(&self, value: V) -> u64 {
+        BuildHasher::hash_one(self, value)
+    }
+}
+
 /// Immutable set optimized for repeated membership tests.
 ///
 /// Each hash bucket holds two values directly. Values that collide beyond those
@@ -30,8 +42,8 @@ use hashbrown::{DefaultHashBuilder, HashTable};
 ///
 /// The first member is used as the empty-slot sentinel and handled before
 /// lookup, so primary slots store `V` directly without an `Option<V>` wrapper.
-pub(super) struct FrozenSet<V> {
-    hash_builder: DefaultHashBuilder,
+pub(super) struct FrozenSet<V, H = DefaultHashBuilder> {
+    hash_builder: H,
     sentinel: Option<V>,
     buckets: Box<[[V; 2]]>,
     overflowed: Box<[bool]>,
@@ -43,9 +55,19 @@ where
     V: Copy + Eq + Hash,
 {
     pub(super) fn try_new(values: &[V]) -> Result<Self> {
+        Self::try_new_with_hasher(values, DefaultHashBuilder::default())
+    }
+}
+
+impl<V, H> FrozenSet<V, H>
+where
+    V: Copy + Eq,
+    H: FrozenSetHash<V>,
+{
+    pub(super) fn try_new_with_hasher(values: &[V], hash_builder: H) -> Result<Self> {
         let Some((&sentinel, values)) = values.split_first() else {
             return Ok(Self {
-                hash_builder: DefaultHashBuilder::default(),
+                hash_builder,
                 sentinel: None,
                 buckets: Box::default(),
                 overflowed: Box::default(),
@@ -55,7 +77,7 @@ where
 
         if values.is_empty() {
             return Ok(Self {
-                hash_builder: DefaultHashBuilder::default(),
+                hash_builder,
                 sentinel: Some(sentinel),
                 buckets: Box::default(),
                 overflowed: Box::default(),
@@ -71,7 +93,7 @@ where
             .checked_mul(2)
             .ok_or_else(|| exec_datafusion_err!("FrozenSet capacity overflow"))?;
         let mut set = Self {
-            hash_builder: DefaultHashBuilder::default(),
+            hash_builder,
             sentinel: Some(sentinel),
             buckets: vec![[sentinel; 2]; bucket_count].into_boxed_slice(),
             overflowed: vec![false; bucket_count].into_boxed_slice(),
@@ -110,7 +132,7 @@ where
             .entry(
                 hash,
                 |stored| *stored == value,
-                |stored| hash_builder.hash_one(stored),
+                |stored| hash_builder.hash_one(*stored),
             )
             .or_insert(value);
         self.overflowed[bucket] = true;
@@ -162,6 +184,14 @@ mod tests {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     struct Colliding(u64);
 
+    struct ConstantHash;
+
+    impl FrozenSetHash<u64> for ConstantHash {
+        fn hash_one(&self, _value: u64) -> u64 {
+            0
+        }
+    }
+
     impl Hash for Colliding {
         fn hash<H: Hasher>(&self, state: &mut H) {
             0_u8.hash(state);
@@ -209,5 +239,13 @@ mod tests {
         let set = FrozenSet::try_new(&values).unwrap();
         assert!(values.iter().all(|&value| set.contains(value)));
         assert!((128..256).all(|value| !set.contains(Colliding(value))));
+    }
+
+    #[test]
+    fn handles_custom_hash_collisions() {
+        let values = (0_u64..128).collect::<Vec<_>>();
+        let set = FrozenSet::try_new_with_hasher(&values, ConstantHash).unwrap();
+        assert!(values.iter().all(|&value| set.contains(value)));
+        assert!((128..256).all(|value| !set.contains(value)));
     }
 }

--- a/datafusion/physical-expr/src/expressions/in_list/primitive_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/primitive_filter.rs
@@ -19,13 +19,15 @@
 //!
 //! This module provides membership tests for Arrow primitive types.
 
-use arrow::array::{Array, ArrayRef, AsArray, BooleanArray};
-use arrow::buffer::{BooleanBuffer, NullBuffer};
+use arrow::array::{Array, ArrayRef, AsArray, BooleanArray, PrimitiveArray};
+use arrow::buffer::{NullBuffer, ScalarBuffer};
 use arrow::datatypes::*;
 use arrow::util::bit_iterator::BitIndexIterator;
-use datafusion_common::{HashSet, Result, exec_datafusion_err};
-use std::hash::{Hash, Hasher};
+use datafusion_common::{Result, exec_datafusion_err};
+use std::hash::Hash;
 
+use super::branchless_filter::{BranchlessFilterType, BranchlessNative};
+use super::frozen_set::FrozenSet;
 use super::result::build_in_list_result;
 use super::static_filter::{StaticFilter, handle_dictionary};
 
@@ -222,207 +224,100 @@ where
     }
 }
 
-/// Wrapper for f32 that implements Hash and Eq using bit comparison.
-/// This treats NaN values as equal to each other when they have the same bit pattern.
-#[derive(Clone, Copy)]
-struct OrderedFloat32(f32);
+fn primitive_values<T>(array: &PrimitiveArray<T>) -> ScalarBuffer<BranchlessNative<T>>
+where
+    T: BranchlessFilterType,
+{
+    let data = array.to_data();
+    ScalarBuffer::<BranchlessNative<T>>::new(
+        data.buffers()[0].clone(),
+        data.offset(),
+        data.len(),
+    )
+}
 
-impl Hash for OrderedFloat32 {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_ne_bytes().hash(state);
+/// Frozen-set filter for larger fixed-width primitive `IN` lists.
+pub(super) struct PrimitiveFrozenFilter<T: BranchlessFilterType>
+where
+    BranchlessNative<T>: Copy + Eq + Hash,
+{
+    expected_data_type: DataType,
+    null_count: usize,
+    values: FrozenSet<BranchlessNative<T>>,
+}
+
+impl<T> PrimitiveFrozenFilter<T>
+where
+    T: BranchlessFilterType,
+    BranchlessNative<T>: Copy + Eq + Hash,
+{
+    pub(super) fn try_new(in_array: &ArrayRef) -> Result<Self> {
+        let in_array = in_array.as_primitive_opt::<T>().ok_or_else(|| {
+            exec_datafusion_err!("PrimitiveFrozenFilter: expected {} array", T::DATA_TYPE)
+        })?;
+
+        let null_count = in_array.null_count();
+        let values = primitive_values::<T>(in_array);
+        let values = match in_array.nulls() {
+            None => FrozenSet::try_new(values.as_ref())?,
+            Some(nulls) => {
+                let values =
+                    BitIndexIterator::new(nulls.validity(), nulls.offset(), nulls.len())
+                        .map(|i| values[i])
+                        .collect::<Vec<_>>();
+                FrozenSet::try_new(&values)?
+            }
+        };
+        Ok(Self {
+            expected_data_type: in_array.data_type().clone(),
+            null_count,
+            values,
+        })
+    }
+
+    #[inline]
+    fn contains_slice(
+        &self,
+        values: &[BranchlessNative<T>],
+        nulls: Option<&NullBuffer>,
+        negated: bool,
+    ) -> BooleanArray {
+        build_in_list_result(values.len(), nulls, self.null_count > 0, negated, |i| {
+            // SAFETY: `build_in_list_result` invokes this closure for
+            // indices in `0..values.len()`.
+            let needle = unsafe { *values.get_unchecked(i) };
+            self.values.contains(needle)
+        })
     }
 }
 
-impl PartialEq for OrderedFloat32 {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.to_bits() == other.0.to_bits()
+impl<T> StaticFilter for PrimitiveFrozenFilter<T>
+where
+    T: BranchlessFilterType,
+    BranchlessNative<T>: Copy + Eq + Hash + Send + Sync,
+{
+    fn null_count(&self) -> usize {
+        self.null_count
     }
-}
 
-impl Eq for OrderedFloat32 {}
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
 
-impl From<f32> for OrderedFloat32 {
-    fn from(v: f32) -> Self {
-        Self(v)
-    }
-}
-
-/// Wrapper for f64 that implements Hash and Eq using bit comparison.
-/// This treats NaN values as equal to each other when they have the same bit pattern.
-#[derive(Clone, Copy)]
-struct OrderedFloat64(f64);
-
-impl Hash for OrderedFloat64 {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_ne_bytes().hash(state);
-    }
-}
-
-impl PartialEq for OrderedFloat64 {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.to_bits() == other.0.to_bits()
-    }
-}
-
-impl Eq for OrderedFloat64 {}
-
-impl From<f64> for OrderedFloat64 {
-    fn from(v: f64) -> Self {
-        Self(v)
-    }
-}
-
-// Macro to generate specialized StaticFilter implementations for primitive types
-macro_rules! primitive_static_filter {
-    ($Name:ident, $ArrowType:ty) => {
-        primitive_static_filter!(
-            $Name,
-            $ArrowType,
-            <$ArrowType as ArrowPrimitiveType>::Native,
-            |v| v
-        );
-    };
-    ($Name:ident, $ArrowType:ty, $SetValueType:ty, $to_set_value:expr) => {
-        pub(super) struct $Name {
-            null_count: usize,
-            values: HashSet<$SetValueType>,
+        if !PrimitiveArray::<T>::is_compatible(v.data_type()) {
+            return Err(exec_datafusion_err!(
+                "PrimitiveFrozenFilter: expected {} array, got {}",
+                self.expected_data_type,
+                v.data_type()
+            ));
         }
 
-        impl $Name {
-            pub(super) fn try_new(in_array: &ArrayRef) -> Result<Self> {
-                let in_array =
-                    in_array.as_primitive_opt::<$ArrowType>().ok_or_else(|| {
-                        exec_datafusion_err!(
-                            "Failed to downcast an array to a '{}' array",
-                            stringify!($ArrowType)
-                        )
-                    })?;
-
-                let mut values = HashSet::with_capacity(in_array.len());
-                let null_count = in_array.null_count();
-
-                for v in in_array.iter().flatten() {
-                    values.insert(($to_set_value)(v));
-                }
-
-                Ok(Self { null_count, values })
-            }
-        }
-
-        impl StaticFilter for $Name {
-            fn null_count(&self) -> usize {
-                self.null_count
-            }
-
-            fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
-                handle_dictionary!(self, v, negated);
-
-                let v = v.as_primitive_opt::<$ArrowType>().ok_or_else(|| {
-                    exec_datafusion_err!(
-                        "Failed to downcast an array to a '{}' array",
-                        stringify!($ArrowType)
-                    )
-                })?;
-
-                let haystack_has_nulls = self.null_count > 0;
-                let needle_values = v.values();
-                let needle_nulls = v.nulls();
-                let needle_has_nulls = v.null_count() > 0;
-
-                // Truth table for `value [NOT] IN (set)` with SQL three-valued logic:
-                // ("-" means the value doesn't affect the result)
-                //
-                // | needle_null | haystack_null | negated | in set? | result |
-                // |-------------|---------------|---------|---------|--------|
-                // | true        | -             | false   | -       | null   |
-                // | true        | -             | true    | -       | null   |
-                // | false       | true          | false   | yes     | true   |
-                // | false       | true          | false   | no      | null   |
-                // | false       | true          | true    | yes     | false  |
-                // | false       | true          | true    | no      | null   |
-                // | false       | false         | false   | yes     | true   |
-                // | false       | false         | false   | no      | false  |
-                // | false       | false         | true    | yes     | false  |
-                // | false       | false         | true    | no      | true   |
-
-                // Compute the "contains" result using collect_bool (fast batched approach)
-                // This ignores nulls - we handle them separately
-                let contains_buffer = if negated {
-                    BooleanBuffer::collect_bool(needle_values.len(), |i| {
-                        !self.values.contains(&($to_set_value)(needle_values[i]))
-                    })
-                } else {
-                    BooleanBuffer::collect_bool(needle_values.len(), |i| {
-                        self.values.contains(&($to_set_value)(needle_values[i]))
-                    })
-                };
-
-                // Compute the null mask
-                // Output is null when:
-                // 1. needle value is null, OR
-                // 2. needle value is not in set AND haystack has nulls
-                let result_nulls = match (needle_has_nulls, haystack_has_nulls) {
-                    (false, false) => {
-                        // No nulls anywhere
-                        None
-                    }
-                    (true, false) => {
-                        // Only needle has nulls - just use needle's null mask
-                        needle_nulls.cloned()
-                    }
-                    (false, true) => {
-                        // Only haystack has nulls - result is null when value not in set
-                        // Valid (not null) when original "in set" is true
-                        // For NOT IN: contains_buffer = !original, so validity = !contains_buffer
-                        let validity = if negated {
-                            !&contains_buffer
-                        } else {
-                            contains_buffer.clone()
-                        };
-                        Some(NullBuffer::new(validity))
-                    }
-                    (true, true) => {
-                        // Both have nulls - combine needle nulls with haystack-induced nulls
-                        let needle_validity =
-                            needle_nulls.map(|n| n.inner().clone()).unwrap_or_else(
-                                || BooleanBuffer::new_set(needle_values.len()),
-                            );
-
-                        // Valid when original "in set" is true (see above)
-                        let haystack_validity = if negated {
-                            !&contains_buffer
-                        } else {
-                            contains_buffer.clone()
-                        };
-
-                        // Combined validity: valid only where both are valid
-                        let combined_validity = &needle_validity & &haystack_validity;
-                        Some(NullBuffer::new(combined_validity))
-                    }
-                };
-
-                Ok(BooleanArray::new(contains_buffer, result_nulls))
-            }
-        }
-    };
+        let v = v.as_primitive_opt::<T>().ok_or_else(|| {
+            exec_datafusion_err!("PrimitiveFrozenFilter: expected {} array", T::DATA_TYPE)
+        })?;
+        let values = primitive_values::<T>(v);
+        Ok(self.contains_slice(values.as_ref(), v.nulls(), negated))
+    }
 }
-
-primitive_static_filter!(Int32StaticFilter, Int32Type);
-primitive_static_filter!(Int64StaticFilter, Int64Type);
-primitive_static_filter!(UInt32StaticFilter, UInt32Type);
-primitive_static_filter!(UInt64StaticFilter, UInt64Type);
-
-// Macro to generate specialized StaticFilter implementations for float types
-// Floats require a wrapper type (OrderedFloat*) to implement Hash/Eq due to NaN semantics
-macro_rules! float_static_filter {
-    ($Name:ident, $ArrowType:ty, $OrderedType:ty) => {
-        primitive_static_filter!($Name, $ArrowType, $OrderedType, <$OrderedType>::from);
-    };
-}
-
-// Generate specialized filters for float types using ordered wrappers
-float_static_filter!(Float32StaticFilter, Float32Type, OrderedFloat32);
-float_static_filter!(Float64StaticFilter, Float64Type, OrderedFloat64);
 
 #[cfg(test)]
 mod tests {
@@ -430,7 +325,9 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::{
-        DictionaryArray, Float16Array, Int8Array, Int16Array, UInt8Array, UInt16Array,
+        DictionaryArray, Float16Array, Float32Array, Int8Array, Int16Array,
+        TimestampMillisecondArray, TimestampNanosecondArray, UInt8Array, UInt16Array,
+        UInt32Array,
     };
     use half::f16;
 
@@ -581,6 +478,74 @@ mod tests {
             filter.contains(&needles, true)?,
             BooleanArray::from(vec![Some(false), Some(false), None, None])
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_frozen_filter_handles_slices_and_nulls() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(
+            UInt32Array::from(vec![
+                Some(999),
+                Some(10),
+                None,
+                Some(20),
+                Some(10),
+                Some(30),
+            ])
+            .slice(1, 5),
+        );
+        let filter = PrimitiveFrozenFilter::<UInt32Type>::try_new(&haystack)?;
+        let needles =
+            UInt32Array::from(vec![Some(0), Some(10), Some(11), Some(30), None])
+                .slice(1, 4);
+
+        assert_contains(&filter, &needles, vec![Some(true), None, Some(true), None])?;
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), None, Some(false), None])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_frozen_filter_floats_use_bit_equality() -> Result<()> {
+        let nan_a = f32::from_bits(0x7fc0_0001);
+        let nan_b = f32::from_bits(0x7fc0_0002);
+        let haystack: ArrayRef =
+            Arc::new(Float32Array::from(vec![Some(-0.0), Some(nan_a)]));
+        let filter = PrimitiveFrozenFilter::<Float32Type>::try_new(&haystack)?;
+        let needles =
+            Float32Array::from(vec![Some(0.0), Some(-0.0), Some(nan_a), Some(nan_b)]);
+
+        assert_eq!(
+            filter.contains(&needles, false)?,
+            BooleanArray::from(vec![Some(false), Some(true), Some(true), Some(false)])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_frozen_filter_timestamp_uses_physical_compatibility() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(
+            TimestampNanosecondArray::from(vec![Some(1), Some(3)]).with_timezone("UTC"),
+        );
+        let filter =
+            PrimitiveFrozenFilter::<TimestampNanosecondType>::try_new(&haystack)?;
+
+        let different_timezone = TimestampNanosecondArray::from(vec![Some(1), Some(2)])
+            .with_timezone("Europe/Paris");
+        assert_contains(&filter, &different_timezone, vec![Some(true), Some(false)])?;
+
+        let different_unit = TimestampMillisecondArray::from(vec![Some(1)]);
+        let err = filter
+            .contains(&different_unit, false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Timestamp(ns"), "{err}");
+        assert!(err.contains("Timestamp(ms"), "{err}");
 
         Ok(())
     }

--- a/datafusion/physical-expr/src/expressions/in_list/result.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/result.rs
@@ -58,6 +58,34 @@ where
     build_result_from_contains(needle_nulls, haystack_has_nulls, negated, contains_buf)
 }
 
+/// Builds an IN-list result without evaluating null needle values.
+#[inline]
+pub(crate) fn build_in_list_result_with_null_shortcircuit<C>(
+    len: usize,
+    needle_nulls: Option<&NullBuffer>,
+    haystack_has_nulls: bool,
+    negated: bool,
+    mut contains: C,
+) -> BooleanArray
+where
+    C: FnMut(usize) -> bool,
+{
+    if needle_nulls.is_none_or(|nulls| nulls.null_count() == 0) {
+        return build_in_list_result(
+            len,
+            needle_nulls,
+            haystack_has_nulls,
+            negated,
+            contains,
+        );
+    }
+
+    let needle_nulls = needle_nulls.expect("null count was checked above");
+    build_in_list_result(len, Some(needle_nulls), haystack_has_nulls, negated, |i| {
+        needle_nulls.is_valid(i) && contains(i)
+    })
+}
+
 /// Builds a BooleanArray result from a pre-computed contains buffer.
 ///
 /// This version does not assume contains_buf is pre-masked at null positions.

--- a/datafusion/physical-expr/src/expressions/in_list/strategy.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/strategy.rs
@@ -34,19 +34,37 @@ use super::array_static_filter::ArrayStaticFilter;
 use super::branchless_filter::{
     BranchlessFilter, BranchlessFilterType, BranchlessNative,
 };
+use super::byte_view_filter::instantiate_byte_view_filter;
 use super::primitive_filter::*;
 use super::static_filter::StaticFilter;
 
 type StaticFilterRef = Arc<dyn StaticFilter + Send + Sync>;
 
-pub(super) fn instantiate_static_filter(in_array: ArrayRef) -> Result<StaticFilterRef> {
+pub(super) fn instantiate_static_filter(
+    in_array: ArrayRef,
+    expr_data_type: &DataType,
+) -> Result<StaticFilterRef> {
     let in_array = flatten_dictionary_haystack(in_array)?;
+
+    // Byte-view filters inspect the physical view representation directly.
+    if dictionary_value_type(expr_data_type) == in_array.data_type()
+        && let Some(filter) = instantiate_byte_view_filter(&in_array)?
+    {
+        return Ok(filter);
+    }
 
     if let Some(filter) = instantiate_primitive_filter(&in_array)? {
         return Ok(filter);
     }
 
     Ok(Arc::new(ArrayStaticFilter::try_new(in_array)?))
+}
+
+fn dictionary_value_type(mut data_type: &DataType) -> &DataType {
+    while let DataType::Dictionary(_, value_type) = data_type {
+        data_type = value_type;
+    }
+    data_type
 }
 
 fn flatten_dictionary_haystack(in_array: ArrayRef) -> Result<ArrayRef> {

--- a/datafusion/physical-expr/src/expressions/in_list/strategy.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/strategy.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
+use std::{hash::Hash, sync::Arc};
 
 use arrow::array::ArrayRef;
 use arrow::compute::cast;
@@ -42,103 +42,147 @@ type StaticFilterRef = Arc<dyn StaticFilter + Send + Sync>;
 pub(super) fn instantiate_static_filter(in_array: ArrayRef) -> Result<StaticFilterRef> {
     let in_array = flatten_dictionary_haystack(in_array)?;
 
-    if let Some(filter) = instantiate_branchless_filter(&in_array)? {
+    if let Some(filter) = instantiate_primitive_filter(&in_array)? {
         return Ok(filter);
     }
 
-    instantiate_standard_filter(in_array)
+    Ok(Arc::new(ArrayStaticFilter::try_new(in_array)?))
 }
 
 fn flatten_dictionary_haystack(in_array: ArrayRef) -> Result<ArrayRef> {
     // Flatten dictionary-encoded haystacks to their value type so that
-    // specialized filters (e.g. Int32StaticFilter) are used instead of
-    // falling through to the generic ArrayStaticFilter.
+    // specialized primitive filters are used instead of falling through to
+    // the generic ArrayStaticFilter.
     match in_array.data_type() {
         DataType::Dictionary(_, value_type) => Ok(cast(&in_array, value_type.as_ref())?),
         _ => Ok(in_array),
     }
 }
 
-fn instantiate_branchless_filter(in_array: &ArrayRef) -> Result<Option<StaticFilterRef>> {
+fn instantiate_primitive_filter(in_array: &ArrayRef) -> Result<Option<StaticFilterRef>> {
     let non_null_count = in_array.len() - in_array.null_count();
 
     macro_rules! filter {
-        ($arrow_type:ty) => {
-            branchless_filter::<$arrow_type>(in_array, non_null_count)
+        ($arrow_type:ty, $strategy:ident) => {
+            $strategy::<$arrow_type>(in_array, non_null_count)
         };
     }
 
     match in_array.data_type() {
-        DataType::Int8 => filter!(Int8Type),
-        DataType::UInt8 => filter!(UInt8Type),
-        DataType::Int16 => filter!(Int16Type),
-        DataType::UInt16 => filter!(UInt16Type),
-        DataType::Float16 => filter!(Float16Type),
-        DataType::Int32 => filter!(Int32Type),
-        DataType::UInt32 => filter!(UInt32Type),
-        DataType::Float32 => filter!(Float32Type),
-        DataType::Date32 => filter!(Date32Type),
+        DataType::Int8 => filter!(Int8Type, branchless_or_bitmap_filter),
+        DataType::UInt8 => filter!(UInt8Type, branchless_or_bitmap_filter),
+        DataType::Int16 => filter!(Int16Type, branchless_or_bitmap_filter),
+        DataType::UInt16 => filter!(UInt16Type, branchless_or_bitmap_filter),
+        DataType::Float16 => filter!(Float16Type, branchless_or_bitmap_filter),
+        DataType::Int32 => filter!(Int32Type, branchless_or_frozen_filter),
+        DataType::UInt32 => filter!(UInt32Type, branchless_or_frozen_filter),
+        DataType::Float32 => filter!(Float32Type, branchless_or_frozen_filter),
+        DataType::Date32 => filter!(Date32Type, branchless_or_frozen_filter),
         DataType::Time32(unit) => match unit {
-            TimeUnit::Second => filter!(Time32SecondType),
-            TimeUnit::Millisecond => filter!(Time32MillisecondType),
+            TimeUnit::Second => {
+                filter!(Time32SecondType, branchless_or_frozen_filter)
+            }
+            TimeUnit::Millisecond => {
+                filter!(Time32MillisecondType, branchless_or_frozen_filter)
+            }
             _ => Ok(None),
         },
-        DataType::Int64 => filter!(Int64Type),
-        DataType::UInt64 => filter!(UInt64Type),
-        DataType::Float64 => filter!(Float64Type),
-        DataType::Date64 => filter!(Date64Type),
+        DataType::Int64 => filter!(Int64Type, branchless_or_frozen_filter),
+        DataType::UInt64 => filter!(UInt64Type, branchless_or_frozen_filter),
+        DataType::Float64 => filter!(Float64Type, branchless_or_frozen_filter),
+        DataType::Date64 => filter!(Date64Type, branchless_or_frozen_filter),
         DataType::Time64(unit) => match unit {
-            TimeUnit::Microsecond => filter!(Time64MicrosecondType),
-            TimeUnit::Nanosecond => filter!(Time64NanosecondType),
+            TimeUnit::Microsecond => {
+                filter!(Time64MicrosecondType, branchless_or_frozen_filter)
+            }
+            TimeUnit::Nanosecond => {
+                filter!(Time64NanosecondType, branchless_or_frozen_filter)
+            }
             _ => Ok(None),
         },
         DataType::Timestamp(unit, _) => match unit {
-            TimeUnit::Second => filter!(TimestampSecondType),
-            TimeUnit::Millisecond => filter!(TimestampMillisecondType),
-            TimeUnit::Microsecond => filter!(TimestampMicrosecondType),
-            TimeUnit::Nanosecond => filter!(TimestampNanosecondType),
+            TimeUnit::Second => {
+                filter!(TimestampSecondType, branchless_or_frozen_filter)
+            }
+            TimeUnit::Millisecond => {
+                filter!(TimestampMillisecondType, branchless_or_frozen_filter)
+            }
+            TimeUnit::Microsecond => {
+                filter!(TimestampMicrosecondType, branchless_or_frozen_filter)
+            }
+            TimeUnit::Nanosecond => {
+                filter!(TimestampNanosecondType, branchless_or_frozen_filter)
+            }
         },
         DataType::Duration(unit) => match unit {
-            TimeUnit::Second => filter!(DurationSecondType),
-            TimeUnit::Millisecond => filter!(DurationMillisecondType),
-            TimeUnit::Microsecond => filter!(DurationMicrosecondType),
-            TimeUnit::Nanosecond => filter!(DurationNanosecondType),
+            TimeUnit::Second => {
+                filter!(DurationSecondType, branchless_or_frozen_filter)
+            }
+            TimeUnit::Millisecond => {
+                filter!(DurationMillisecondType, branchless_or_frozen_filter)
+            }
+            TimeUnit::Microsecond => {
+                filter!(DurationMicrosecondType, branchless_or_frozen_filter)
+            }
+            TimeUnit::Nanosecond => {
+                filter!(DurationNanosecondType, branchless_or_frozen_filter)
+            }
         },
-        DataType::Decimal128(_, _) => filter!(Decimal128Type),
+        DataType::Decimal128(_, _) => {
+            filter!(Decimal128Type, branchless_filter)
+        }
         DataType::Interval(IntervalUnit::MonthDayNano) => {
-            filter!(IntervalMonthDayNanoType)
+            filter!(IntervalMonthDayNanoType, branchless_filter)
         }
         _ => Ok(None),
     }
 }
 
-fn instantiate_standard_filter(in_array: ArrayRef) -> Result<StaticFilterRef> {
-    match in_array.data_type() {
-        DataType::Int8 => bitmap_filter::<Int8Type>(&in_array),
-        DataType::UInt8 => bitmap_filter::<UInt8Type>(&in_array),
-        DataType::Int16 => bitmap_filter::<Int16Type>(&in_array),
-        DataType::UInt16 => bitmap_filter::<UInt16Type>(&in_array),
-        DataType::Float16 => bitmap_filter::<Float16Type>(&in_array),
-        DataType::Int32 => Ok(Arc::new(Int32StaticFilter::try_new(&in_array)?)),
-        DataType::Int64 => Ok(Arc::new(Int64StaticFilter::try_new(&in_array)?)),
-        DataType::UInt32 => Ok(Arc::new(UInt32StaticFilter::try_new(&in_array)?)),
-        DataType::UInt64 => Ok(Arc::new(UInt64StaticFilter::try_new(&in_array)?)),
-        // Float primitive types (use ordered wrappers for Hash/Eq)
-        DataType::Float32 => Ok(Arc::new(Float32StaticFilter::try_new(&in_array)?)),
-        DataType::Float64 => Ok(Arc::new(Float64StaticFilter::try_new(&in_array)?)),
-        _ => {
-            // Fall through to generic implementation for unsupported types
-            // (Struct, etc.).
-            Ok(Arc::new(ArrayStaticFilter::try_new(in_array)?))
-        }
+fn branchless_or_bitmap_filter<T>(
+    in_array: &ArrayRef,
+    non_null_count: usize,
+) -> Result<Option<StaticFilterRef>>
+where
+    T: BranchlessFilterType + BitmapFilterType,
+    BranchlessNative<T>: Copy + PartialEq + Send + Sync,
+{
+    if let Some(filter) = branchless_filter::<T>(in_array, non_null_count)? {
+        return Ok(Some(filter));
     }
+
+    Ok(Some(Arc::new(BitmapFilter::<T>::try_new(in_array)?)))
 }
 
-fn bitmap_filter<T>(in_array: &ArrayRef) -> Result<StaticFilterRef>
+fn branchless_or_frozen_filter<T>(
+    in_array: &ArrayRef,
+    non_null_count: usize,
+) -> Result<Option<StaticFilterRef>>
 where
-    T: BitmapFilterType,
+    T: BranchlessFilterType,
+    BranchlessNative<T>: Copy + Eq + Hash + Send + Sync,
 {
-    Ok(Arc::new(BitmapFilter::<T>::try_new(in_array)?))
+    if let Some(filter) = branchless_filter::<T>(in_array, non_null_count)? {
+        return Ok(Some(filter));
+    }
+
+    primitive_frozen_filter::<T>(in_array, non_null_count)
+}
+
+fn primitive_frozen_filter<T>(
+    in_array: &ArrayRef,
+    non_null_count: usize,
+) -> Result<Option<StaticFilterRef>>
+where
+    T: BranchlessFilterType,
+    BranchlessNative<T>: Copy + Eq + Hash + Send + Sync,
+{
+    if non_null_count <= T::MAX_LIST_LEN {
+        return Ok(None);
+    }
+
+    Ok(Some(Arc::new(PrimitiveFrozenFilter::<T>::try_new(
+        in_array,
+    )?)))
 }
 
 fn branchless_filter<T>(
@@ -149,7 +193,7 @@ where
     T: BranchlessFilterType,
     BranchlessNative<T>: Copy + PartialEq + Send + Sync,
 {
-    // Larger lists use the standard filter. `try_new` checks the limit again.
+    // Larger lists use another filter strategy. `try_new` checks the limit again.
     if non_null_count > T::MAX_LIST_LEN {
         return Ok(None);
     }
@@ -159,7 +203,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use arrow::array::UInt32Array;
+    use arrow::array::{Decimal128Array, UInt32Array};
     use arrow::datatypes::UInt32Type;
 
     use super::super::branchless_filter::BranchlessFilterType;
@@ -176,13 +220,48 @@ mod tests {
         let values = (0..max_len)
             .map(|value| Some(value as u32))
             .collect::<Vec<_>>();
-        assert!(instantiate_branchless_filter(&uint32_array(values))?.is_some());
+        assert!(
+            branchless_filter::<UInt32Type>(&uint32_array(values), max_len)?.is_some()
+        );
 
         let values = (0..=max_len)
             .map(|value| Some(value as u32))
             .collect::<Vec<_>>();
-        assert!(instantiate_branchless_filter(&uint32_array(values))?.is_none());
+        assert!(
+            branchless_filter::<UInt32Type>(&uint32_array(values), max_len + 1)?
+                .is_none()
+        );
 
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_frozen_routing_starts_after_max_list_len() -> Result<()> {
+        let max_len = <UInt32Type as BranchlessFilterType>::MAX_LIST_LEN;
+
+        let values = (0..max_len)
+            .map(|value| Some(value as u32))
+            .collect::<Vec<_>>();
+        assert!(
+            primitive_frozen_filter::<UInt32Type>(&uint32_array(values), max_len)?
+                .is_none()
+        );
+
+        let values = (0..=max_len)
+            .map(|value| Some(value as u32))
+            .collect::<Vec<_>>();
+        assert!(
+            primitive_frozen_filter::<UInt32Type>(&uint32_array(values), max_len + 1)?
+                .is_some()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_frozen_routing_excludes_128_bit_values() -> Result<()> {
+        let array: ArrayRef = Arc::new(Decimal128Array::from(vec![1, 2, 3, 4, 5]));
+        assert!(instantiate_primitive_filter(&array)?.is_none());
         Ok(())
     }
 
@@ -190,7 +269,7 @@ mod tests {
     fn branchless_routing_handles_zero_non_null_values() -> Result<()> {
         let array = uint32_array(vec![None; 3]);
 
-        assert!(instantiate_branchless_filter(&array)?.is_some());
+        assert!(branchless_filter::<UInt32Type>(&array, 0)?.is_some());
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #19241.
- Stacked on [#23015](https://github.com/apache/datafusion/pull/23015).
- Next in stack: [#23018](https://github.com/apache/datafusion/pull/23018).
- Extracted from #19390.

## Rationale for this change

Arrow `Utf8View` and `BinaryView` arrays store each value in a 128-bit view. Values up to 12 bytes are fully inline. Longer values keep their length and four-byte prefix in the view and store the remaining bytes separately.

That representation allows cheap rejection without hashing or comparing complete strings. Inline values can be matched exactly from the view itself; long candidates are always confirmed against their full bytes before reporting a match.

## What changes are included in this PR?

- Adds branchless matching for all-inline lists up to four values.
- Adds a keyed `FrozenSet<u128>` for larger inline lists.
- Adds a mixed byte-view filter that uses view keys for rejection and a native `HashTable` for exact long-value confirmation.
- Specializes only measured winning shapes and keeps all-long or inline-dominant mixed lists on the generic fallback.
- Requires exact byte-view physical types after recursively unwrapping dictionary expression types.
- Skips membership work for null needles while preserving `IN` and `NOT IN` semantics.
- Covers slices, dictionaries, `Utf8View`, `BinaryView`, nulls, long-prefix collisions, and custom hash collisions.

## Are these changes tested?

Yes.

- `cargo fmt --all`
- `cargo test -p datafusion-physical-expr --lib expressions::in_list`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./dev/rust_lint.sh`
- `RUST_BACKTRACE=1 cargo test --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-cli --workspace --lib --tests --bins --features avro,json,backtrace,extended_tests,recursive_protection,parquet_encryption`

## Are there any user-facing changes?

No. This is an internal performance optimization only.

## Local benchmark snapshot

Built and run in separate target directories, using identical benchmark source and filtering to the relevant byte-view rows:

```bash
cargo bench --target-dir <target-dir> -p datafusion-physical-expr --bench in_list_strategy -- <filter>
```

Filters used: `utf8view/short_8b`, `utf8view/len_12b`, `utf8view/mixed_len`, and `nulls/utf8view/short_8b`.

Method: directly compared Criterion median point estimates. Filter construction remains outside the timed loop. Lower is better; changes within +/-5% are treated as noise.

Compared baselines: [#23015](https://github.com/apache/datafusion/pull/23015) -> [#23016](https://github.com/apache/datafusion/pull/23016)

Relevant scope: all-inline `Utf8View` rows, mixed inline/long shapes, the inline-dominant fallback, and nullable inline views. `BinaryView` uses the same physical view representation and filter implementation.

Summary: 23 relevant rows, 18 faster, 0 slower, 5 within +/-5%.

The inline-dominant mixed rows remain within noise, supporting the conservative fallback for that shape.

Largest relevant deltas:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=20%` | 61.57 us | 14.34 us | -76.7% (4.29x faster) |
| `utf8view/short_8b/list=4/match=50%` | 53.04 us | 12.40 us | -76.6% (4.28x faster) |
| `utf8view/short_8b/list=16/match=50%` | 52.90 us | 13.97 us | -73.6% (3.79x faster) |
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=20%/NOT_IN` | 58.28 us | 15.75 us | -73.0% (3.70x faster) |
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=50%` | 51.40 us | 14.52 us | -71.8% (3.54x faster) |
| `utf8view/short_8b/list=64/match=50%` | 55.34 us | 16.25 us | -70.6% (3.41x faster) |
| `utf8view/short_8b/list=256/match=50%` | 49.59 us | 15.51 us | -68.7% (3.20x faster) |
| `utf8view/len_12b/list=16/match=50%` | 52.23 us | 17.05 us | -67.4% (3.06x faster) |
| `utf8view/len_12b/list=64/match=50%` | 50.71 us | 17.00 us | -66.5% (2.98x faster) |
| `utf8view/mixed_len/list=16/match=50%` | 123.49 us | 72.83 us | -41.0% (1.70x faster) |

<details>
<summary>Full relevant table (23 rows)</summary>

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `utf8view/short_8b/list=4/match=0%` | 19.13 us | 12.45 us | -34.9% (1.54x faster) |
| `utf8view/short_8b/list=4/match=50%` | 53.04 us | 12.40 us | -76.6% (4.28x faster) |
| `utf8view/short_8b/list=16/match=0%` | 19.28 us | 17.23 us | -10.6% (1.12x faster) |
| `utf8view/short_8b/list=16/match=50%` | 52.90 us | 13.97 us | -73.6% (3.79x faster) |
| `utf8view/short_8b/list=64/match=0%` | 19.32 us | 17.77 us | -8.0% (1.09x faster) |
| `utf8view/short_8b/list=64/match=50%` | 55.34 us | 16.25 us | -70.6% (3.41x faster) |
| `utf8view/short_8b/list=256/match=0%` | 19.35 us | 17.36 us | -10.3% (1.11x faster) |
| `utf8view/short_8b/list=256/match=50%` | 49.59 us | 15.51 us | -68.7% (3.20x faster) |
| `utf8view/len_12b/list=16/match=0%` | 18.97 us | 18.05 us | -4.8% (within noise) |
| `utf8view/len_12b/list=16/match=50%` | 52.23 us | 17.05 us | -67.4% (3.06x faster) |
| `utf8view/len_12b/list=64/match=0%` | 18.87 us | 18.59 us | -1.5% (within noise) |
| `utf8view/len_12b/list=64/match=50%` | 50.71 us | 17.00 us | -66.5% (2.98x faster) |
| `utf8view/mixed_len/list=16/match=0%` | 44.87 us | 29.04 us | -35.3% (1.55x faster) |
| `utf8view/mixed_len/list=16/match=50%` | 123.49 us | 72.83 us | -41.0% (1.70x faster) |
| `utf8view/mixed_len/list=64/match=0%` | 44.92 us | 39.42 us | -12.2% (1.14x faster) |
| `utf8view/mixed_len/list=64/match=50%` | 124.43 us | 90.50 us | -27.3% (1.37x faster) |
| `utf8view/mixed_len/inline=2%/list=64/match=0%` | 43.98 us | 40.63 us | -7.6% (1.08x faster) |
| `utf8view/mixed_len/inline=2%/list=64/match=50%` | 107.15 us | 102.70 us | -4.2% (within noise) |
| `utf8view/mixed_len/inline=98%/list=64/match=0%` | 22.39 us | 22.64 us | +1.1% (within noise) |
| `utf8view/mixed_len/inline=98%/list=64/match=50%` | 58.15 us | 58.90 us | +1.3% (within noise) |
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=20%` | 61.57 us | 14.34 us | -76.7% (4.29x faster) |
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=20%/NOT_IN` | 58.28 us | 15.75 us | -73.0% (3.70x faster) |
| `nulls/utf8view/short_8b/list=16/match=50%/nulls=50%` | 51.40 us | 14.52 us | -71.8% (3.54x faster) |

</details>