### PR TITLE
refactor: name build-row and matchable-map presence checks in hash join

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -228,6 +228,25 @@ impl JoinLeftData {
         &self.batch
     }
 
+    /// Returns `true` if the build side physically contains rows.
+    ///
+    /// This is distinct from [`Self::has_matchable_build_rows`]: a build side
+    /// can hold rows while its hash map is empty (see that method).
+    pub(super) fn has_build_rows(&self) -> bool {
+        self.batch().num_rows() > 0
+    }
+
+    /// Returns `true` if the build-side hash map has any matchable entries.
+    ///
+    /// Under [`NullEquality::NullEqualsNothing`] build rows whose join key is
+    /// NULL are omitted from the map, so this can be `false` even when
+    /// [`Self::has_build_rows`] is `true`.
+    ///
+    /// [`NullEquality::NullEqualsNothing`]: datafusion_common::NullEquality::NullEqualsNothing
+    pub(super) fn has_matchable_build_rows(&self) -> bool {
+        !self.map().is_empty()
+    }
+
     /// returns a reference to the build side expressions values
     pub(super) fn values(&self) -> &[ArrayRef] {
         &self.values

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -523,12 +523,12 @@ impl HashJoinStream {
         join_type: JoinType,
         left_data: &JoinLeftData,
     ) -> HashJoinStreamState {
-        let build_empty = left_data.batch().num_rows() == 0;
+        let build_empty = !left_data.has_build_rows();
         // The map can be empty even when the build side has rows: under
         // `NullEqualsNothing`, build rows with a NULL join key are omitted. For
         // join types whose every output row requires a build match, that still
         // guarantees an empty result, so we can skip scanning the probe side.
-        let map_empty = left_data.map().is_empty();
+        let map_empty = !left_data.has_matchable_build_rows();
 
         if (build_empty && join_type.empty_build_side_produces_empty_result())
             || (map_empty && join_type.empty_map_produces_empty_result())


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23008.

## Rationale for this change

`HashJoinStream::state_after_build_ready` distinguishes two facts about the
collected build side: whether it physically has rows, and whether its hash map
has any matchable entries. These differ under `NullEquality::NullEqualsNothing`,
where build rows with a NULL join key are omitted from the map — the
distinction that was the source of the bug fixed in #22893.

Today that distinction is expressed inline as raw `batch().num_rows() == 0` /
`map().is_empty()` checks. Naming it at the API surface makes the invariant
explicit and harder to misuse at future call sites.

## What changes are included in this PR?

- Add two helper methods on `JoinLeftData`:
  - `has_build_rows()` — original build-side row presence
  - `has_matchable_build_rows()` — matchable hash-map row presence
- Update `state_after_build_ready` to use them instead of the raw
  `batch().num_rows()` / `map().is_empty()` checks.

No behavior change.

## Are these changes tested?

Covered by the existing hash join tests (`cargo test -p datafusion-physical-plan hash_join`,
804 passing). This is a readability-only refactor with no behavior change, so no
new tests are added.

## Are there any user-facing changes?

No.
