### PR TITLE
refactor: name build-row and matchable-map presence checks in hash join

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -242,8 +242,6 @@ impl JoinLeftData {
     /// Under [`NullEquality::NullEqualsNothing`] build rows whose join key is
     /// NULL are omitted from the map, so this can be `false` even when
     /// [`Self::has_build_rows`] is `true`.
-    ///
-    /// [`NullEquality::NullEqualsNothing`]: datafusion_common::NullEquality::NullEqualsNothing
     pub(super) fn has_matchable_build_rows(&self) -> bool {
         !self.map().is_empty()
     }

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -229,6 +229,25 @@ impl JoinLeftData {
         &self.batch
     }
 
+    /// Returns `true` if the build side physically contains rows.
+    ///
+    /// This is distinct from [`Self::has_matchable_build_rows`]: a build side
+    /// can hold rows while its hash map is empty (see that method).
+    pub(super) fn has_build_rows(&self) -> bool {
+        self.batch().num_rows() > 0
+    }
+
+    /// Returns `true` if the build-side hash map has any matchable entries.
+    ///
+    /// Under [`NullEquality::NullEqualsNothing`] build rows whose join key is
+    /// NULL are omitted from the map, so this can be `false` even when
+    /// [`Self::has_build_rows`] is `true`.
+    ///
+    /// [`NullEquality::NullEqualsNothing`]: datafusion_common::NullEquality::NullEqualsNothing
+    pub(super) fn has_matchable_build_rows(&self) -> bool {
+        !self.map().is_empty()
+    }
+
     /// returns a reference to the build side expressions values
     pub(super) fn values(&self) -> &[ArrayRef] {
         &self.values

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -523,12 +523,12 @@ impl HashJoinStream {
         join_type: JoinType,
         left_data: &JoinLeftData,
     ) -> HashJoinStreamState {
-        let build_empty = left_data.batch().num_rows() == 0;
+        let build_empty = !left_data.has_build_rows();
         // The map can be empty even when the build side has rows: under
         // `NullEqualsNothing`, build rows with a NULL join key are omitted. For
         // join types whose every output row requires a build match, that still
         // guarantees an empty result, so we can skip scanning the probe side.
-        let map_empty = left_data.map().is_empty();
+        let map_empty = !left_data.has_matchable_build_rows();
 
         if (build_empty && join_type.empty_build_side_produces_empty_result())
             || (map_empty && join_type.empty_map_produces_empty_result())

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -779,7 +779,7 @@ impl HashJoinStream {
             }
         }
 
-        let is_empty = build_side.left_data.map().is_empty();
+        let is_empty = !build_side.left_data.has_matchable_build_rows();
 
         if is_empty {
             let result = build_batch_empty_build_side(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23008.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`HashJoinStream::state_after_build_ready` relies on two *different* facts about the collected build side:

- whether the build side physically has rows (`batch().num_rows()`)
- whether the hash map has any matchable entries (`map().is_empty()`)

These diverge under `NullEquality::NullEqualsNothing`: build rows whose join key is NULL are omitted from the map, so the map can be empty while the build side still has rows. Conflating the two was the source of the bug fixed in #22893.

Today both checks are written inline as raw `batch().num_rows() == 0` / `map().is_empty()`. Giving each a name on `JoinLeftData` makes the distinction explicit at the API surface, so future call sites are harder to get wrong.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add two helpers on `JoinLeftData`:
  - `has_build_rows()` — build-side row presence
  - `has_matchable_build_rows()` — matchable hash-map entry presence
- Update `state_after_build_ready` to use them instead of the raw checks.

Pure readability refactor — no behavior change.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Covered by the existing hash join tests; `cargo test -p datafusion-physical-plan hash_join` passes (804 tests). Since this is a readability-only refactor with no behavior change, no new tests are added.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No.