### PR TITLE
fix: round large UInt64 values without narrowing

### DIFF
--- a/datafusion/spark/src/function/math/round.rs
+++ b/datafusion/spark/src/function/math/round.rs
@@ -275,6 +275,34 @@ fn round_integer(value: i64, scale: i32, enable_ansi_mode: bool) -> Result<i64> 
     Ok(result)
 }
 
+fn round_unsigned_integer(value: u64, scale: i32, enable_ansi_mode: bool) -> Result<u64> {
+    if scale >= 0 {
+        return Ok(value);
+    }
+    let abs_scale = (-scale) as u32;
+    let Some(factor) = 10_u64.checked_pow(abs_scale) else {
+        return Ok(0);
+    };
+    let remainder = value % factor;
+    let result = if remainder >= factor / 2 {
+        if enable_ansi_mode {
+            value
+                .checked_sub(remainder)
+                .and_then(|v| v.checked_add(factor))
+                .ok_or_else(|| {
+                    (exec_err!("UInt64 overflow on round({value}, {scale})")
+                        as Result<(), _>)
+                        .unwrap_err()
+                })?
+        } else {
+            value.wrapping_sub(remainder).wrapping_add(factor)
+        }
+    } else {
+        value - remainder
+    };
+    Ok(result)
+}
+
 // ---------------------------------------------------------------------------
 // Decimal rounding using ArrowNativeTypeOp (HALF_UP)
 // ---------------------------------------------------------------------------
@@ -463,16 +491,8 @@ fn spark_round(args: &[ColumnarValue], enable_ansi_mode: bool) -> Result<Columna
             }
             DataType::UInt64 => {
                 let array = array.as_primitive::<UInt64Type>();
-                let result: PrimitiveArray<UInt64Type> = array.try_unary(|x| {
-                    let v_i64 = i64::try_from(x).map_err(|_| {
-                        (exec_err!(
-                            "round: UInt64 value {x} exceeds i64::MAX and cannot be rounded"
-                        ) as Result<(), _>)
-                            .unwrap_err()
-                    })?;
-                    round_integer(v_i64, scale, enable_ansi_mode)
-                        .map(|v| v as u64)
-                })?;
+                let result: PrimitiveArray<UInt64Type> = array
+                    .try_unary(|x| round_unsigned_integer(x, scale, enable_ansi_mode))?;
                 Ok(ColumnarValue::Array(Arc::new(result)))
             }
 
@@ -588,16 +608,8 @@ fn spark_round(args: &[ColumnarValue], enable_ansi_mode: bool) -> Result<Columna
                 Ok(ColumnarValue::Scalar(ScalarValue::UInt32(Some(result))))
             }
             ScalarValue::UInt64(Some(v)) => {
-                let v_i64 = i64::try_from(*v).map_err(|_| {
-                    (exec_err!(
-                        "round: UInt64 value {v} exceeds i64::MAX and cannot be rounded"
-                    ) as Result<(), _>)
-                        .unwrap_err()
-                })?;
-                let result = round_integer(v_i64, scale, enable_ansi_mode)?;
-                Ok(ColumnarValue::Scalar(ScalarValue::UInt64(Some(
-                    result as u64,
-                ))))
+                let result = round_unsigned_integer(*v, scale, enable_ansi_mode)?;
+                Ok(ColumnarValue::Scalar(ScalarValue::UInt64(Some(result))))
             }
 
             // Float scalars
@@ -650,5 +662,28 @@ fn spark_round(args: &[ColumnarValue], enable_ansi_mode: bool) -> Result<Columna
 
             dt => not_impl_err!("Unsupported data type for Spark round(): {dt}"),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::round_unsigned_integer;
+
+    #[test]
+    fn round_large_unsigned_integer() {
+        assert_eq!(
+            round_unsigned_integer(u64::MAX, 0, false).unwrap(),
+            u64::MAX
+        );
+        assert_eq!(
+            round_unsigned_integer(10_000_000_000_000_000_001, -1, false).unwrap(),
+            10_000_000_000_000_000_000
+        );
+    }
+
+    #[test]
+    fn round_unsigned_integer_overflow() {
+        assert!(round_unsigned_integer(u64::MAX, -1, true).is_err());
+        assert_eq!(round_unsigned_integer(u64::MAX, -1, false).unwrap(), 4);
     }
 }

--- a/datafusion/sqllogictest/test_files/spark/math/round.slt
+++ b/datafusion/sqllogictest/test_files/spark/math/round.slt
@@ -274,6 +274,23 @@ SELECT round(arrow_cast(42, 'UInt32'), 2::int);
 ----
 42
 
+# round(uint64, non-negative scale) preserves values above i64::MAX
+query I
+SELECT round(arrow_cast(18446744073709551615, 'UInt64'));
+----
+18446744073709551615
+
+query I
+SELECT round(arrow_cast(18446744073709551615, 'UInt64'), 2::int);
+----
+18446744073709551615
+
+# round(uint64, negative scale) operates without narrowing through i64
+query I
+SELECT round(arrow_cast(10000000000000000001, 'UInt64'), -1::int);
+----
+10000000000000000000
+
 # -------------------------------------------------------------------
 # Decimal tests (HALF_UP rounding)
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22696.

## Rationale for this change

Spark `round` currently narrows `UInt64` inputs through `i64`. Values above `i64::MAX` therefore fail even when a non-negative scale makes rounding a no-op. The narrowing also prevents correct negative-scale rounding for the upper half of the `UInt64` domain.

## What changes are included in this PR?

- Add a native `u64` HALF_UP rounding path with the same ANSI overflow and non-ANSI wrapping behavior as the signed implementation.
- Use it for both scalar and array `UInt64` inputs.
- Add helper-level coverage for large values and overflow behavior.
- Add SQL regression coverage for `u64::MAX` with default/positive scales and a large negative-scale case.

## Are these changes tested?

Yes:

- `cargo test -p datafusion-spark function::math::round::tests --lib`
- `cargo test -p datafusion-sqllogictest --test sqllogictests -- spark/math/round --test-threads 1`
- `cargo clippy -p datafusion-spark --features core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Are there any user-facing changes?

Yes. Spark `round` now accepts `UInt64` values above `i64::MAX` and returns correct results instead of reporting a narrowing error. There are no public API changes.
