### PR TITLE
feat: string to numeric coercion

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -1481,6 +1481,37 @@ fn mathematics_numerical_coercion(
 ) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
 
+    // String coercion
+    if let Some(coerced) = match (lhs_type, rhs_type) {
+        (s, Float64)
+        | (Float64, s)
+        | (Decimal32(_, _), s)
+        | (s, Decimal32(_, _))
+        | (Decimal64(_, _), s)
+        | (s, Decimal64(_, _))
+        | (Decimal128(_, _), s)
+        | (s, Decimal128(_, _))
+        | (Decimal256(_, _), s)
+        | (s, Decimal256(_, _))
+            if s.is_string() =>
+        {
+            Some(Float64)
+        }
+        (s, Float32) | (Float32, s) if s.is_string() => Some(Float32),
+        (s, Float16) | (Float16, s) if s.is_string() => Some(Float16),
+        (s, Int64) | (Int64, s) if s.is_string() => Some(Int64),
+        (s, Int32) | (Int32, s) if s.is_string() => Some(Int32),
+        (s, Int16) | (Int16, s) if s.is_string() => Some(Int16),
+        (s, Int8) | (Int8, s) if s.is_string() => Some(Int8),
+        (s, UInt64) | (UInt64, s) if s.is_string() => Some(UInt64),
+        (s, UInt32) | (UInt32, s) if s.is_string() => Some(UInt32),
+        (s, UInt16) | (UInt16, s) if s.is_string() => Some(UInt16),
+        (s, UInt8) | (UInt8, s) if s.is_string() => Some(UInt8),
+        _ => None,
+    } {
+        return Some(coerced);
+    }
+
     // Error on any non-numeric type
     if !both_numeric_or_null_and_numeric(lhs_type, rhs_type) {
         return None;

--- a/datafusion/expr-common/src/type_coercion/binary/tests/arithmetic.rs
+++ b/datafusion/expr-common/src/type_coercion/binary/tests/arithmetic.rs
@@ -19,20 +19,6 @@ use super::*;
 use datafusion_common::assert_contains;
 
 #[test]
-fn test_coercion_error() -> Result<()> {
-    let coercer =
-        BinaryTypeCoercer::new(&DataType::Float32, &Operator::Plus, &DataType::Utf8);
-    let result_type = coercer.get_input_types();
-
-    let e = result_type.unwrap_err();
-    assert_eq!(
-        e.strip_backtrace(),
-        "Error during planning: Cannot coerce arithmetic expression Float32 + Utf8 to valid types"
-    );
-    Ok(())
-}
-
-#[test]
 fn test_date_timestamp_arithmetic_error() -> Result<()> {
     let (lhs, rhs) = BinaryTypeCoercer::new(
         &DataType::Timestamp(Nanosecond, None),

--- a/datafusion/expr-common/src/type_coercion/binary/tests/arithmetic.rs
+++ b/datafusion/expr-common/src/type_coercion/binary/tests/arithmetic.rs
@@ -225,6 +225,39 @@ fn test_type_coercion_arithmetic() -> Result<()> {
     // (Int8, _) | (_, Int8) => Some(Int8)
     test_coercion_binary_rule!(Int8, Int8, Operator::Plus, Int8);
 
+    test_coercion_binary_rule_multiple!(
+        Utf8,
+        [
+            Float64,
+            Decimal32(10, 2),
+            Decimal64(10, 2),
+            Decimal128(10, 2),
+            Decimal256(10, 2),
+        ],
+        Operator::Plus,
+        Float64
+    );
+    test_coercion_binary_rule!(Utf8, Float32, Operator::Plus, Float32);
+    test_coercion_binary_rule!(Utf8, Float16, Operator::Plus, Float16);
+    test_coercion_binary_rule!(Utf8, Int64, Operator::Plus, Int64);
+    test_coercion_binary_rule!(Utf8, Int32, Operator::Plus, Int32);
+    test_coercion_binary_rule!(Utf8, Int16, Operator::Plus, Int16);
+    test_coercion_binary_rule!(Utf8, Int8, Operator::Plus, Int8);
+    test_coercion_binary_rule!(Utf8, UInt64, Operator::Plus, UInt64);
+    test_coercion_binary_rule!(Utf8, UInt32, Operator::Plus, UInt32);
+    test_coercion_binary_rule!(Utf8, UInt16, Operator::Plus, UInt16);
+    test_coercion_binary_rule!(Utf8, UInt8, Operator::Plus, UInt8);
+    test_coercion_binary_rule!(Float32, Utf8, Operator::Plus, Float32);
+    test_coercion_binary_rule!(Float16, Utf8, Operator::Plus, Float16);
+    test_coercion_binary_rule!(Int64, Utf8, Operator::Plus, Int64);
+    test_coercion_binary_rule!(Int32, Utf8, Operator::Plus, Int32);
+    test_coercion_binary_rule!(Int16, Utf8, Operator::Plus, Int16);
+    test_coercion_binary_rule!(Int8, Utf8, Operator::Plus, Int8);
+    test_coercion_binary_rule!(UInt64, Utf8, Operator::Plus, UInt64);
+    test_coercion_binary_rule!(UInt32, Utf8, Operator::Plus, UInt32);
+    test_coercion_binary_rule!(UInt16, Utf8, Operator::Plus, UInt16);
+    test_coercion_binary_rule!(UInt8, Utf8, Operator::Plus, UInt8);
+
     Ok(())
 }
 

--- a/datafusion/sql/tests/cases/diagnostic.rs
+++ b/datafusion/sql/tests/cases/diagnostic.rs
@@ -243,20 +243,6 @@ fn test_ambiguous_reference() -> Result<()> {
 }
 
 #[test]
-fn test_incompatible_types_binary_arithmetic() -> Result<()> {
-    let query = "SELECT /*whole+left*/id/*left*/ + /*right*/first_name/*right+whole*/ FROM person";
-    let spans = get_spans(query);
-    let diag = do_query(query);
-    assert_snapshot!(diag.message, @"expressions have incompatible types");
-    assert_eq!(diag.span, Some(spans["whole"]));
-    assert_snapshot!(diag.notes[0].message, @"has type UInt32");
-    assert_eq!(diag.notes[0].span, Some(spans["left"]));
-    assert_snapshot!(diag.notes[1].message, @"has type Utf8");
-    assert_eq!(diag.notes[1].span, Some(spans["right"]));
-    Ok(())
-}
-
-#[test]
 fn test_field_not_found_suggestion() -> Result<()> {
     let query = "SELECT /*whole*/first_na/*whole*/ FROM person";
     let spans = get_spans(query);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23041.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Coerces string values to the other operand type for binary mathematical operations.

Exception for Decimal values which are coerced to Float64.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
