### PR TITLE
test: correct feature gating of two datafusion-common tests

### DIFF
--- a/datafusion/common/src/hash_utils.rs
+++ b/datafusion/common/src/hash_utils.rs
@@ -1853,6 +1853,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "force_hash_collisions"))]
     fn test_create_hashes_with_quality_hash_state() {
         let int_array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3, 4]));
         let str_array: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c", "d"]));

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -1486,6 +1486,7 @@ mod tests {
         buffer::NullBuffer,
         datatypes::Int32Type,
     };
+    #[cfg(feature = "sql")]
     use sqlparser::ast::Ident;
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- N/A — two small, unrelated-to-features test-gating fixes in `datafusion-common` found while building the crate's tests under non-default feature sets.

## Rationale for this change

Two `#[cfg]` feature-gating issues in `datafusion-common` test code:

1. **`test_create_hashes_with_quality_hash_state`** asserts that `create_hashes`
   reproduces a specific high-quality hash distribution. Under the
   `force_hash_collisions` feature, `create_hashes` is replaced by a stub that
   writes all-zero hashes, so the exact-value assertion fails — this breaks the
   `cargo test hash collisions` CI job. Every other exact-hash-value test in
   that module is already gated with `#[cfg(not(feature = "force_hash_collisions"))]`;
   this one was missing the gate.

2. The test-only `use sqlparser::ast::Ident;` in `utils::tests` is used solely by
   `test_quote_identifier`, which is `#[cfg(feature = "sql")]`. Building the tests
   without the `sql` feature leaves the import unused and emits an
   `unused_imports` warning.

## What changes are included in this PR?

- Gate `test_create_hashes_with_quality_hash_state` with
  `#[cfg(not(feature = "force_hash_collisions"))]`.
- Gate the test-only `Ident` import with `#[cfg(feature = "sql")]` to match its
  sole user.

Both are test-only changes; no production code is touched.

## Are these changes tested?

Verified via the existing tests:

- With `--features force_hash_collisions`, `test_create_hashes_with_quality_hash_state`
  is now excluded (no longer fails the forced-collision build); without the
  feature it still compiles and passes.
- Building `datafusion-common` tests without the `sql` feature no longer emits
  the `unused_imports` warning; with `sql` the import and `test_quote_identifier`
  are both present.

## Are there any user-facing changes?

No.
