### PR TITLE
fix: union coercion coerces to string instead of number

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -806,7 +806,7 @@ fn type_union_resolution_coercion(
             .or_else(|| temporal_coercion_nonstrict_timezone(lhs_type, rhs_type))
             .or_else(|| string_coercion(lhs_type, rhs_type))
             .or_else(|| null_coercion(lhs_type, rhs_type))
-            .or_else(|| string_numeric_coercion(lhs_type, rhs_type))
+            .or_else(|| string_numeric_union_coercion(lhs_type, rhs_type))
             .or_else(|| binary_coercion(lhs_type, rhs_type)),
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23045.

## Rationale for this change

Aligns the behavior of coercion with `type_union_coercion`.

In an union of types containing both Int and String, String is a better type as all Int can be cast to String, but not all String can be cast to Int.

## What changes are included in this PR?

When coercing an union that contains both strings and ints, coerce to string instead of int.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Covered by existing tests I assume

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
