### PR TITLE
fix: make table function arg coercion non-fatal, add raw_exprs accessor

### DIFF
--- a/datafusion/catalog/src/table.rs
+++ b/datafusion/catalog/src/table.rs
@@ -552,8 +552,10 @@ pub trait TableProviderFactory: Debug + Sync + Send {
 
 /// Describes arguments provided to the table function call.
 pub struct TableFunctionArgs<'e, 's> {
-    /// Call arguments.
+    /// Call arguments (potentially coerced/simplified).
     exprs: &'e [Expr],
+    /// Original raw arguments before any coercion/simplification.
+    raw_exprs: &'e [Expr],
     /// Session within which the function is called.
     session: &'s dyn Session,
 }
@@ -561,7 +563,11 @@ pub struct TableFunctionArgs<'e, 's> {
 impl<'e, 's> TableFunctionArgs<'e, 's> {
     /// Make a new [`TableFunctionArgs`].
     pub fn new(exprs: &'e [Expr], session: &'s dyn Session) -> Self {
-        Self { exprs, session }
+        Self {
+            exprs,
+            raw_exprs: exprs,
+            session,
+        }
     }
 
     /// Get expressions passed as the called function arguments.
@@ -569,9 +575,38 @@ impl<'e, 's> TableFunctionArgs<'e, 's> {
         self.exprs
     }
 
+    /// Get the original, unprocessed call arguments (before
+    /// type coercion and simplification).
+    ///
+    /// The arguments returned by [`Self::exprs`] may have been
+    /// type-coerced or simplified. Use this method to access the
+    /// arguments exactly as the user wrote them in the SQL query.
+    pub fn raw_exprs(&self) -> &'e [Expr] {
+        self.raw_exprs
+    }
+
     /// Get a session where the table function is called.
     pub fn session(&self) -> &'s dyn Session {
         self.session
+    }
+}
+
+impl<'e, 's> TableFunctionArgs<'e, 's> {
+    /// Make a new [`TableFunctionArgs`] with separate processed and raw expressions.
+    ///
+    /// This is useful when the table function implementation needs
+    /// access to both the (possibly coerced/simplified) expressions
+    /// and the original expressions as written.
+    pub fn new_with_raw(
+        exprs: &'e [Expr],
+        raw_exprs: &'e [Expr],
+        session: &'s dyn Session,
+    ) -> Self {
+        Self {
+            exprs,
+            raw_exprs,
+            session,
+        }
     }
 }
 

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -1984,16 +1984,20 @@ impl ContextProvider for SessionContextProvider<'_> {
             .build();
         let simplifier = ExprSimplifier::new(simplify_context);
         let schema = DFSchema::empty();
+        let raw_args = args.clone();
         let args = args
             .into_iter()
             .map(|arg| {
+                let backup = arg.clone();
                 simplifier
                     .coerce(arg, &schema)
                     .and_then(|e| simplifier.simplify(e))
+                    .unwrap_or(backup)
             })
-            .collect::<datafusion_common::Result<Vec<_>>>()?;
-        let provider = tbl_func
-            .create_table_provider_with_args(TableFunctionArgs::new(&args, self.state))?;
+            .collect::<Vec<_>>();
+        let provider = tbl_func.create_table_provider_with_args(
+            TableFunctionArgs::new_with_raw(&args, &raw_args, self.state),
+        )?;
 
         Ok(provider_as_source(provider))
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22952.

## Rationale for this change

The type coercion and simplification applied to table function arguments in `get_table_function_source` can fail for custom table function expressions (e.g., `tbf(a='x', b='x')`), breaking user-facing SQL. The error propagates before the table function implementation ever sees the arguments.

## What changes are included in this PR?

1. **Non-fatal coercion/simplification** (`session_state.rs`): If `coerce()` or `simplify()` fails for a particular argument, fall back to the original raw expression instead of propagating the error. Existing built-in functions continue to get successfully coerced/simplified arguments as before.

2. **`raw_exprs()` accessor** (`table.rs`): Added to `TableFunctionArgs` so that table function implementations can access the original, unprocessed arguments when needed. Added `new_with_raw()` constructor for this purpose.

## Are these changes tested?

Covered by existing tests:
- `test_udtf_type_coercion` - type coercion still works when it can succeed
- `test_simple_read_csv_udtf` - basic UDTF functionality intact
- `generate_series` tests - simplification path still works
- `type_coercion` sqllogictests pass

## Are there any user-facing changes?

Yes - custom table function implementations can now use `args.raw_exprs()` to access original expression arguments. No breaking changes to existing APIs.