### PR TITLE
docs: clarify stdin store buffers on construction, not first use

### DIFF
--- a/datafusion-cli/src/object_storage/stdin.rs
+++ b/datafusion-cli/src/object_storage/stdin.rs
@@ -99,9 +99,9 @@ impl StdinUtils {
         format!("{}:///{object_name}", Self::SCHEME)
     }
 
-    /// Returns the object store backing the `stdin://` scheme, reading and
-    /// buffering standard input on first use and reusing that buffer for any
-    /// subsequent `stdin://` table created in the same session.
+    /// Returns the object store backing the `stdin://` scheme, buffering all of
+    /// standard input when the store is first constructed and reusing that
+    /// buffer for any subsequent `stdin://` table created in the same session.
     ///
     /// stdin is a one-shot stream: it can only be read once. The object store
     /// registry keys by scheme/authority, so every `stdin://` URL maps to the


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #22839 (stdin support in `datafusion-cli`), addressing post-merge review feedback from @alamb. No separate issue.

## Rationale for this change

In the review of #22839, @alamb noted that the `StdinUtils::get_or_create` doc comment was technically imprecise:

> technically I would say this buffers stdin on construction, not first use.

The `stdin://` store reads and buffers all of standard input eagerly when the store is constructed (`object_store` → `read_to_end` → `in_memory_object_store`), not lazily on first use of the store. The doc comment said "on first use", which suggests lazy buffering.

## What changes are included in this PR?

Reword the first sentence of the `get_or_create` doc comment to say the store buffers all of standard input "when the store is first constructed" instead of "on first use". Doc-comment only; no behavior change.

## Are these changes tested?

No code change — documentation only. Existing tests in `object_storage/stdin.rs` are unaffected.

## Are there any user-facing changes?

No.
