### PR TITLE
test: drive stdin store reuse through get_or_create

### DIFF
--- a/datafusion-cli/src/object_storage/stdin.rs
+++ b/datafusion-cli/src/object_storage/stdin.rs
@@ -268,15 +268,26 @@ mod tests {
         // stdin can only be read once, so a second `stdin://` table must reuse
         // the store buffered by the first instead of re-reading (now-empty)
         // stdin and overwriting it.
+        //
+        // The very first read happens inside `get_or_create` -> `object_store`,
+        // which consumes the real process stdin and so cannot be driven from a
+        // unit test. Seed the registry with the store that first read would have
+        // produced (as the first `CREATE EXTERNAL TABLE` does), then drive the
+        // lookup through `get_or_create` and assert it hands back that exact
+        // store rather than rebuilding it.
         let url = Url::parse("stdin:///stdin.csv").unwrap();
-        let store =
-            StdinUtils::in_memory_object_store(&url, b"a\n1\n2\n".to_vec()).await?;
+        let path = ObjectStorePath::from_url_path(url.path())?;
+        let buffered: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        buffered.put(&path, b"a\n1\n2\n".to_vec().into()).await?;
 
         let ctx = SessionContext::new();
-        ctx.register_object_store(&url, store);
+        ctx.register_object_store(&url, Arc::clone(&buffered));
 
         let reused = StdinUtils::get_or_create(&ctx.state(), &url).await?;
-        let path = ObjectStorePath::from_url_path(url.path())?;
+        assert!(
+            Arc::ptr_eq(&buffered, &reused),
+            "get_or_create must reuse the registered stdin store, not rebuild it"
+        );
         let bytes = reused.get(&path).await?.bytes().await?;
         assert_eq!(bytes.as_ref(), b"a\n1\n2\n");
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #22839 (stdin support in `datafusion-cli`), addressing post-merge review feedback from @alamb. No separate issue.

## Rationale for this change

In the review of #22839, @alamb noted the `reuses_buffered_stdin_store` test would be clearer if it used the same API to create and re-fetch the object store:

> this test would be clearer for me if it used the same API to create and recreate the object store -- aka `StdinUtils::get_or_create` rather than `StdinUtils::in_memory_object_store`

The test built the buffered store via `StdinUtils::in_memory_object_store` but re-fetched it via `StdinUtils::get_or_create`, which obscured what "reuse" actually guarantees.

## What changes are included in this PR?

Refactor `reuses_buffered_stdin_store` so the only `StdinUtils` API it exercises is `get_or_create`:

- Seed the registry with a plain `InMemory` store. The genuine first stdin read happens inside `get_or_create` → `object_store`, which consumes the real process stdin and so cannot be driven from a unit test; the comment now explains this.
- Assert via `Arc::ptr_eq` that `get_or_create` hands back that *exact* store rather than rebuilding it — a stronger and clearer statement of the reuse invariant than comparing bytes alone.

Test-only change; no production behavior change.

## Are these changes tested?

Yes — this is a test change. Verified locally:

```
cargo test -p datafusion-cli --lib object_storage::stdin
...
test object_storage::stdin::tests::reuses_buffered_stdin_store ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 62 filtered out
```

## Are there any user-facing changes?

No.
