### PR TITLE
fix: pin action SHAs in dev.yml (backport to maint-16.x)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0ae58361cdfd39e2950bed97a1e26aa20c3d8955  # v4
         with:
           python-version: "3.10"
       - name: Audit licenses
@@ -36,8 +36,8 @@ jobs:
     name: Use prettier to check formatting of documents
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3
         with:
           node-version: "14"
       - name: Prettier check


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23037

## Rationale for this change

The default branch already hardened `.github/workflows/dev.yml` against unpinned-uses (commit SHAs instead of mutable tags), but the `maint-16.x` release branch still uses mutable tags. This backports the same fix.

## What changes are included in this PR?

Pin the following actions to their commit SHA (with the version tag as a comment):

| Action | Previous | Pinned SHA |
|--------|----------|------------|
| `actions/checkout` (rat job) | `@v3` | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/setup-python` (rat job) | `@v4` | `0ae58361cdfd39e2950bed97a1e26aa20c3d8955` |
| `actions/checkout` (prettier job) | `@v3` | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/setup-node` (prettier job) | `@v3` | `3235b876344d2a9aa001b8d1453c930bba69e610` |

## Are these changes tested?

Checked with `actionlint` — no new lint or security findings introduced. The fix matches the pattern already applied on the default branch.

## Are there any user-facing changes?

No — CI workflow only.