### PR TITLE
FFI: forward ScalarUDF preserves_lex_ordering

### DIFF
--- a/datafusion/ffi/src/tests/mod.rs
+++ b/datafusion/ffi/src/tests/mod.rs
@@ -91,6 +91,8 @@ pub struct ForeignLibraryModule {
 
     pub create_placement_udf: extern "C" fn() -> FFI_ScalarUDF,
 
+    pub create_lex_ordering_udf: extern "C" fn() -> FFI_ScalarUDF,
+
     pub create_table_function:
         extern "C" fn(FFI_LogicalExtensionCodec) -> FFI_TableFunction,
 
@@ -253,6 +255,7 @@ pub extern "C" fn datafusion_ffi_get_module() -> ForeignLibraryModule {
         create_nullary_udf: create_ffi_random_func,
         create_timezone_udf: udf_udaf_udwf::create_timezone_func,
         create_placement_udf: udf_udaf_udwf::create_placement_func,
+        create_lex_ordering_udf: udf_udaf_udwf::create_lex_ordering_func,
         create_table_function: create_ffi_table_func,
         create_sum_udaf: create_ffi_sum_func,
         create_stddev_udaf: create_ffi_stddev_func,

--- a/datafusion/ffi/src/tests/mod.rs
+++ b/datafusion/ffi/src/tests/mod.rs
@@ -91,8 +91,6 @@ pub struct ForeignLibraryModule {
 
     pub create_placement_udf: extern "C" fn() -> FFI_ScalarUDF,
 
-    pub create_lex_ordering_udf: extern "C" fn() -> FFI_ScalarUDF,
-
     pub create_table_function:
         extern "C" fn(FFI_LogicalExtensionCodec) -> FFI_TableFunction,
 
@@ -255,7 +253,6 @@ pub extern "C" fn datafusion_ffi_get_module() -> ForeignLibraryModule {
         create_nullary_udf: create_ffi_random_func,
         create_timezone_udf: udf_udaf_udwf::create_timezone_func,
         create_placement_udf: udf_udaf_udwf::create_placement_func,
-        create_lex_ordering_udf: udf_udaf_udwf::create_lex_ordering_func,
         create_table_function: create_ffi_table_func,
         create_sum_udaf: create_ffi_sum_func,
         create_stddev_udaf: create_ffi_stddev_func,

--- a/datafusion/ffi/src/tests/udf_udaf_udwf.rs
+++ b/datafusion/ffi/src/tests/udf_udaf_udwf.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use arrow_schema::DataType;
 use datafusion_catalog::TableFunctionImpl;
 use datafusion_common::ScalarValue;
+use datafusion_expr::sort_properties::ExprProperties;
 use datafusion_expr::{
     AggregateUDF, ColumnarValue, ExpressionPlacement, ScalarFunctionArgs, ScalarUDF,
     ScalarUDFImpl, Signature, Volatility, WindowUDF,
@@ -156,6 +157,50 @@ impl ScalarUDFImpl for PlacementUDF {
 
 pub(crate) extern "C" fn create_placement_func() -> FFI_ScalarUDF {
     let udf: Arc<ScalarUDF> = Arc::new(ScalarUDF::from(PlacementUDF {
+        signature: Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable),
+    }));
+
+    udf.into()
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct LexOrderingUDF {
+    signature: Signature,
+}
+
+impl ScalarUDFImpl for LexOrderingUDF {
+    fn name(&self) -> &str {
+        "lex_ordering_udf"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(
+        &self,
+        _arg_types: &[DataType],
+    ) -> datafusion_common::Result<DataType> {
+        Ok(DataType::Int64)
+    }
+
+    fn invoke_with_args(
+        &self,
+        _args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        datafusion_common::internal_err!("lex_ordering_udf is not meant to be invoked")
+    }
+
+    fn preserves_lex_ordering(
+        &self,
+        inputs: &[ExprProperties],
+    ) -> datafusion_common::Result<bool> {
+        Ok(inputs.iter().all(|input| input.preserves_lex_ordering))
+    }
+}
+
+pub(crate) extern "C" fn create_lex_ordering_func() -> FFI_ScalarUDF {
+    let udf: Arc<ScalarUDF> = Arc::new(ScalarUDF::from(LexOrderingUDF {
         signature: Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable),
     }));
 

--- a/datafusion/ffi/src/tests/udf_udaf_udwf.rs
+++ b/datafusion/ffi/src/tests/udf_udaf_udwf.rs
@@ -153,43 +153,6 @@ impl ScalarUDFImpl for PlacementUDF {
             ExpressionPlacement::KeepInPlace
         }
     }
-}
-
-pub(crate) extern "C" fn create_placement_func() -> FFI_ScalarUDF {
-    let udf: Arc<ScalarUDF> = Arc::new(ScalarUDF::from(PlacementUDF {
-        signature: Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable),
-    }));
-
-    udf.into()
-}
-
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct LexOrderingUDF {
-    signature: Signature,
-}
-
-impl ScalarUDFImpl for LexOrderingUDF {
-    fn name(&self) -> &str {
-        "lex_ordering_udf"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(
-        &self,
-        _arg_types: &[DataType],
-    ) -> datafusion_common::Result<DataType> {
-        Ok(DataType::Int64)
-    }
-
-    fn invoke_with_args(
-        &self,
-        _args: ScalarFunctionArgs,
-    ) -> datafusion_common::Result<ColumnarValue> {
-        datafusion_common::internal_err!("lex_ordering_udf is not meant to be invoked")
-    }
 
     fn preserves_lex_ordering(
         &self,
@@ -199,8 +162,8 @@ impl ScalarUDFImpl for LexOrderingUDF {
     }
 }
 
-pub(crate) extern "C" fn create_lex_ordering_func() -> FFI_ScalarUDF {
-    let udf: Arc<ScalarUDF> = Arc::new(ScalarUDF::from(LexOrderingUDF {
+pub(crate) extern "C" fn create_placement_func() -> FFI_ScalarUDF {
+    let udf: Arc<ScalarUDF> = Arc::new(ScalarUDF::from(PlacementUDF {
         signature: Signature::uniform(1, vec![DataType::Int64], Volatility::Immutable),
     }));
 

--- a/datafusion/ffi/src/udf/mod.rs
+++ b/datafusion/ffi/src/udf/mod.rs
@@ -26,6 +26,7 @@ use arrow::ffi::{FFI_ArrowSchema, from_ffi, to_ffi};
 use arrow_schema::FieldRef;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::{DataFusionError, Result, internal_err};
+use datafusion_expr::sort_properties::ExprProperties;
 use datafusion_expr::type_coercion::functions::fields_with_udf;
 use datafusion_expr::{
     ColumnarValue, ExpressionPlacement, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF,
@@ -41,6 +42,7 @@ use stabby::vec::Vec as SVec;
 use crate::arrow_wrappers::{WrappedArray, WrappedSchema};
 use crate::config::FFI_ConfigOptions;
 use crate::expr::columnar_value::FFI_ColumnarValue;
+use crate::expr::expr_properties::FFI_ExprProperties;
 use crate::placement::FFI_ExpressionPlacement;
 use crate::util::{
     FFI_Result, rvec_wrapped_to_vec_datatype, vec_datatype_to_rvec_wrapped,
@@ -99,6 +101,12 @@ pub struct FFI_ScalarUDF {
         udf: &Self,
         args: SVec<FFI_ExpressionPlacement>,
     ) -> FFI_ExpressionPlacement,
+
+    /// FFI equivalent to [`ScalarUDFImpl::preserves_lex_ordering`].
+    pub preserves_lex_ordering: unsafe extern "C" fn(
+        udf: &Self,
+        inputs: SVec<FFI_ExprProperties>,
+    ) -> FFI_Result<bool>,
 
     /// Used to create a clone on the provider of the udf. This should
     /// only need to be called by the receiver of the udf.
@@ -176,6 +184,20 @@ unsafe extern "C" fn placement_fn_wrapper(
         .collect::<Vec<_>>();
 
     udf.inner().placement(&args).into()
+}
+
+unsafe extern "C" fn preserves_lex_ordering_fn_wrapper(
+    udf: &FFI_ScalarUDF,
+    inputs: SVec<FFI_ExprProperties>,
+) -> FFI_Result<bool> {
+    let inputs = sresult_return!(
+        inputs
+            .into_iter()
+            .map(ExprProperties::try_from)
+            .collect::<Result<Vec<_>>>()
+    );
+
+    sresult!(udf.inner().preserves_lex_ordering(&inputs))
 }
 
 unsafe extern "C" fn invoke_with_args_fn_wrapper(
@@ -272,6 +294,7 @@ impl From<Arc<ScalarUDF>> for FFI_ScalarUDF {
             return_field_from_args: return_field_from_args_fn_wrapper,
             coerce_types: coerce_types_fn_wrapper,
             placement: placement_fn_wrapper,
+            preserves_lex_ordering: preserves_lex_ordering_fn_wrapper,
             clone: clone_fn_wrapper,
             release: release_fn_wrapper,
             private_data: Box::into_raw(private_data) as *mut c_void,
@@ -460,6 +483,17 @@ impl ScalarUDFImpl for ForeignScalarUDF {
 
         result.into()
     }
+
+    fn preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
+        let inputs = inputs
+            .iter()
+            .map(FFI_ExprProperties::try_from)
+            .collect::<Result<SVec<_>>>()?;
+
+        let result = unsafe { (self.udf.preserves_lex_ordering)(&self.udf, inputs) };
+
+        df_result!(result)
+    }
 }
 
 #[cfg(test)]
@@ -499,6 +533,33 @@ mod tests {
             } else {
                 ExpressionPlacement::KeepInPlace
             }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct LexOrderingUDF {
+        signature: Signature,
+    }
+
+    impl ScalarUDFImpl for LexOrderingUDF {
+        fn name(&self) -> &str {
+            "lex_ordering_udf"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Int64)
+        }
+
+        fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+            internal_err!("LexOrderingUDF is not meant to be invoked")
+        }
+
+        fn preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
+            Ok(inputs.iter().all(|input| input.preserves_lex_ordering))
         }
     }
 
@@ -571,6 +632,33 @@ mod tests {
             ExpressionPlacement::KeepInPlace
         );
         assert_eq!(foreign_udf.placement(&[]), ExpressionPlacement::KeepInPlace);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ffi_udf_preserves_lex_ordering_round_trip() -> Result<()> {
+        use datafusion_expr::Volatility;
+
+        let original_udf = Arc::new(ScalarUDF::from(LexOrderingUDF {
+            signature: Signature::uniform(
+                1,
+                vec![DataType::Int64],
+                Volatility::Immutable,
+            ),
+        }));
+
+        let mut ffi_udf = FFI_ScalarUDF::from(original_udf);
+        ffi_udf.library_marker_id = crate::mock_foreign_marker_id;
+
+        let foreign_udf: Arc<dyn ScalarUDFImpl> = (&ffi_udf).into();
+        assert!(foreign_udf.is::<ForeignScalarUDF>());
+
+        let preserves = ExprProperties::new_unknown().with_preserves_lex_ordering(true);
+        let does_not_preserve = ExprProperties::new_unknown();
+
+        assert!(foreign_udf.preserves_lex_ordering(std::slice::from_ref(&preserves))?);
+        assert!(!foreign_udf.preserves_lex_ordering(&[preserves, does_not_preserve])?);
 
         Ok(())
     }

--- a/datafusion/ffi/src/udf/mod.rs
+++ b/datafusion/ffi/src/udf/mod.rs
@@ -190,14 +190,13 @@ unsafe extern "C" fn preserves_lex_ordering_fn_wrapper(
     udf: &FFI_ScalarUDF,
     inputs: SVec<FFI_ExprProperties>,
 ) -> FFI_Result<bool> {
-    let inputs = sresult_return!(
-        inputs
-            .into_iter()
-            .map(ExprProperties::try_from)
-            .collect::<Result<Vec<_>>>()
-    );
+    let result = inputs
+        .into_iter()
+        .map(ExprProperties::try_from)
+        .collect::<Result<Vec<_>>>()
+        .and_then(|inputs| udf.inner().preserves_lex_ordering(&inputs));
 
-    sresult!(udf.inner().preserves_lex_ordering(&inputs))
+    sresult!(result)
 }
 
 unsafe extern "C" fn invoke_with_args_fn_wrapper(
@@ -485,14 +484,15 @@ impl ScalarUDFImpl for ForeignScalarUDF {
     }
 
     fn preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
-        let inputs = inputs
+        inputs
             .iter()
             .map(FFI_ExprProperties::try_from)
-            .collect::<Result<SVec<_>>>()?;
-
-        let result = unsafe { (self.udf.preserves_lex_ordering)(&self.udf, inputs) };
-
-        df_result!(result)
+            .collect::<Result<SVec<_>>>()
+            .and_then(|inputs| {
+                let result =
+                    unsafe { (self.udf.preserves_lex_ordering)(&self.udf, inputs) };
+                df_result!(result)
+            })
     }
 }
 
@@ -536,6 +536,10 @@ mod tests {
         }
 
         fn preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
+            if inputs.is_empty() {
+                return internal_err!("preserves_lex_ordering requires an input");
+            }
+
             Ok(inputs.iter().all(|input| input.preserves_lex_ordering))
         }
     }
@@ -613,8 +617,17 @@ mod tests {
         let preserves = ExprProperties::new_unknown().with_preserves_lex_ordering(true);
         let does_not_preserve = ExprProperties::new_unknown();
 
-        assert!(foreign_udf.preserves_lex_ordering(std::slice::from_ref(&preserves))?);
-        assert!(!foreign_udf.preserves_lex_ordering(&[preserves, does_not_preserve])?);
+        assert!(
+            foreign_udf
+                .preserves_lex_ordering(std::slice::from_ref(&preserves))
+                .unwrap()
+        );
+        assert!(
+            !foreign_udf
+                .preserves_lex_ordering(&[preserves, does_not_preserve])
+                .unwrap()
+        );
+        assert!(foreign_udf.preserves_lex_ordering(&[]).is_err());
 
         Ok(())
     }

--- a/datafusion/ffi/src/udf/mod.rs
+++ b/datafusion/ffi/src/udf/mod.rs
@@ -102,12 +102,6 @@ pub struct FFI_ScalarUDF {
         args: SVec<FFI_ExpressionPlacement>,
     ) -> FFI_ExpressionPlacement,
 
-    /// FFI equivalent to [`ScalarUDFImpl::preserves_lex_ordering`].
-    pub preserves_lex_ordering: unsafe extern "C" fn(
-        udf: &Self,
-        inputs: SVec<FFI_ExprProperties>,
-    ) -> FFI_Result<bool>,
-
     /// Used to create a clone on the provider of the udf. This should
     /// only need to be called by the receiver of the udf.
     pub clone: unsafe extern "C" fn(udf: &Self) -> Self,
@@ -123,6 +117,12 @@ pub struct FFI_ScalarUDF {
     /// the foreign interface. See [`crate::get_library_marker_id`] and
     /// the crate's `README.md` for more information.
     pub library_marker_id: extern "C" fn() -> usize,
+
+    /// FFI equivalent to [`ScalarUDFImpl::preserves_lex_ordering`].
+    pub preserves_lex_ordering: unsafe extern "C" fn(
+        udf: &Self,
+        inputs: SVec<FFI_ExprProperties>,
+    ) -> FFI_Result<bool>,
 }
 
 unsafe impl Send for FFI_ScalarUDF {}
@@ -294,11 +294,11 @@ impl From<Arc<ScalarUDF>> for FFI_ScalarUDF {
             return_field_from_args: return_field_from_args_fn_wrapper,
             coerce_types: coerce_types_fn_wrapper,
             placement: placement_fn_wrapper,
-            preserves_lex_ordering: preserves_lex_ordering_fn_wrapper,
             clone: clone_fn_wrapper,
             release: release_fn_wrapper,
             private_data: Box::into_raw(private_data) as *mut c_void,
             library_marker_id: crate::get_library_marker_id,
+            preserves_lex_ordering: preserves_lex_ordering_fn_wrapper,
         }
     }
 }
@@ -534,29 +534,6 @@ mod tests {
                 ExpressionPlacement::KeepInPlace
             }
         }
-    }
-
-    #[derive(Debug, PartialEq, Eq, Hash)]
-    struct LexOrderingUDF {
-        signature: Signature,
-    }
-
-    impl ScalarUDFImpl for LexOrderingUDF {
-        fn name(&self) -> &str {
-            "lex_ordering_udf"
-        }
-
-        fn signature(&self) -> &Signature {
-            &self.signature
-        }
-
-        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-            Ok(DataType::Int64)
-        }
-
-        fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-            internal_err!("LexOrderingUDF is not meant to be invoked")
-        }
 
         fn preserves_lex_ordering(&self, inputs: &[ExprProperties]) -> Result<bool> {
             Ok(inputs.iter().all(|input| input.preserves_lex_ordering))
@@ -632,27 +609,6 @@ mod tests {
             ExpressionPlacement::KeepInPlace
         );
         assert_eq!(foreign_udf.placement(&[]), ExpressionPlacement::KeepInPlace);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_ffi_udf_preserves_lex_ordering_round_trip() -> Result<()> {
-        use datafusion_expr::Volatility;
-
-        let original_udf = Arc::new(ScalarUDF::from(LexOrderingUDF {
-            signature: Signature::uniform(
-                1,
-                vec![DataType::Int64],
-                Volatility::Immutable,
-            ),
-        }));
-
-        let mut ffi_udf = FFI_ScalarUDF::from(original_udf);
-        ffi_udf.library_marker_id = crate::mock_foreign_marker_id;
-
-        let foreign_udf: Arc<dyn ScalarUDFImpl> = (&ffi_udf).into();
-        assert!(foreign_udf.is::<ForeignScalarUDF>());
 
         let preserves = ExprProperties::new_unknown().with_preserves_lex_ordering(true);
         let does_not_preserve = ExprProperties::new_unknown();

--- a/datafusion/ffi/tests/ffi_udf.rs
+++ b/datafusion/ffi/tests/ffi_udf.rs
@@ -26,6 +26,7 @@ mod tests {
     use datafusion::prelude::{SessionContext, col};
     use datafusion_execution::config::SessionConfig;
     use datafusion_expr::lit;
+    use datafusion_expr::sort_properties::ExprProperties;
     use datafusion_ffi::tests::create_record_batch;
     use datafusion_ffi::tests::utils::get_module;
     use std::sync::Arc;
@@ -111,6 +112,24 @@ mod tests {
                 .placement(&[ExpressionPlacement::Literal, ExpressionPlacement::Column]),
             ExpressionPlacement::KeepInPlace
         );
+
+        Ok(())
+    }
+
+    /// This test validates that a producer's `preserves_lex_ordering` override
+    /// survives the real dynamic-library FFI boundary.
+    #[tokio::test]
+    async fn test_scalar_udf_preserves_lex_ordering() -> Result<()> {
+        let module = get_module()?;
+
+        let ffi_lex_ordering_func = (module.create_lex_ordering_udf)();
+        let foreign_func: Arc<dyn ScalarUDFImpl> = (&ffi_lex_ordering_func).into();
+
+        let preserves = ExprProperties::new_unknown().with_preserves_lex_ordering(true);
+        let does_not_preserve = ExprProperties::new_unknown();
+
+        assert!(foreign_func.preserves_lex_ordering(std::slice::from_ref(&preserves))?);
+        assert!(!foreign_func.preserves_lex_ordering(&[preserves, does_not_preserve])?);
 
         Ok(())
     }

--- a/datafusion/ffi/tests/ffi_udf.rs
+++ b/datafusion/ffi/tests/ffi_udf.rs
@@ -91,8 +91,7 @@ mod tests {
         Ok(())
     }
 
-    /// This test validates that a producer's `placement` override survives the
-    /// FFI boundary instead of collapsing to the default `KeepInPlace`.
+    /// Checks planning-property overrides across the FFI boundary.
     #[tokio::test]
     async fn test_scalar_udf_placement() -> Result<()> {
         let module = get_module()?;
@@ -112,18 +111,6 @@ mod tests {
                 .placement(&[ExpressionPlacement::Literal, ExpressionPlacement::Column]),
             ExpressionPlacement::KeepInPlace
         );
-
-        Ok(())
-    }
-
-    /// This test validates that a producer's `preserves_lex_ordering` override
-    /// survives the real dynamic-library FFI boundary.
-    #[tokio::test]
-    async fn test_scalar_udf_preserves_lex_ordering() -> Result<()> {
-        let module = get_module()?;
-
-        let ffi_lex_ordering_func = (module.create_lex_ordering_udf)();
-        let foreign_func: Arc<dyn ScalarUDFImpl> = (&ffi_lex_ordering_func).into();
 
         let preserves = ExprProperties::new_unknown().with_preserves_lex_ordering(true);
         let does_not_preserve = ExprProperties::new_unknown();


### PR DESCRIPTION
## Which issue does this PR close?

Part of #22330.

## Rationale for this change

`ForeignScalarUDF` inherits the default `preserves_lex_ordering`, so producer overrides are lost across the FFI boundary.

## What changes are included in this PR?

- Forward `preserves_lex_ordering` through `FFI_ScalarUDF`.
- Reuse the existing placement UDF for unit and dynamic-library coverage.

## Are these changes tested?

- `cargo test -p datafusion-ffi --features integration-tests`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

The FFI ABI changes. Foreign libraries must rebuild against the new DataFusion version.