### PR TITLE
chore: gate `internal_datafusion_err` import behind the `proto` feature

### DIFF
--- a/datafusion/physical-expr/src/expressions/dynamic_filters/mod.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters/mod.rs
@@ -22,10 +22,13 @@ use tokio::sync::watch;
 
 use crate::PhysicalExpr;
 use arrow::datatypes::{DataType, Schema};
+#[cfg(feature = "proto")]
+use datafusion_common::internal_datafusion_err;
 use datafusion_common::{
-    Result, internal_datafusion_err,
+    Result,
     tree_node::{Transformed, TransformedResult, TreeNode},
 };
+
 use datafusion_expr::ColumnarValue;
 use datafusion_physical_expr_common::physical_expr::DynHash;
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A — a trivial build-warning fix, no tracking issue.

## Rationale for this change

Building `datafusion-physical-expr` without the `proto` feature emits an
`unused import` warning:

```
warning: unused import: `internal_datafusion_err`
  --> datafusion/physical-expr/src/expressions/dynamic_filters/mod.rs:26
```

`internal_datafusion_err` is only referenced inside
`impl DynamicFilterPhysicalExpr { fn try_from_proto(..) }`, which is itself gated
behind `#[cfg(feature = "proto")]`. The import was unconditional, so it became
dead whenever `proto` is disabled.

## What changes are included in this PR?

Move the `internal_datafusion_err` import behind `#[cfg(feature = "proto")]` so it
is compiled only when its sole use site is, matching the existing gate on the
`try_from_proto` impl block.

## Are these changes tested?

No new tests — this is a compile-time-only change. It is exercised by existing CI,
which builds the crate both with and without the `proto` feature; the warning
(promoted to an error under `-D warnings`) no longer fires.

## Are there any user-facing changes?

No.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
