### PR TITLE
[sql]: remove old deprecated `DFParser::new` and `DFParser::new_with_dialect`

### DIFF
--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -504,19 +504,6 @@ fn token_starts_query(tok: &Token) -> bool {
 }
 
 impl<'a> DFParser<'a> {
-    #[deprecated(since = "46.0.0", note = "DFParserBuilder")]
-    pub fn new(sql: &'a str) -> Result<Self, DataFusionError> {
-        DFParserBuilder::new(sql).build()
-    }
-
-    #[deprecated(since = "46.0.0", note = "DFParserBuilder")]
-    pub fn new_with_dialect(
-        sql: &'a str,
-        dialect: &'a dyn Dialect,
-    ) -> Result<Self, DataFusionError> {
-        DFParserBuilder::new(sql).with_dialect(dialect).build()
-    }
-
     /// Parse a sql string into one or [`Statement`]s using the
     /// [`GenericDialect`].
     pub fn parse_sql(sql: &'a str) -> Result<VecDeque<Statement>, DataFusionError> {


### PR DESCRIPTION
## Which issue does this PR close?

- part of #23080

## Rationale for this change

`DFParser::new` and `DFParser::new_with_dialect` were deprecated in 46.0.0 and replaced by `DFParserBuilder`.

## What changes are included in this PR?

Removed the deprecated `DFParser::new` and `DFParser::new_with_dialect` constructors from `datafusion-sql`.

## Are these changes tested?

Verified by running local tests for `datafusion-sql` package.

## Are there any user-facing changes?

Yes. This removes public Rust APIs `DFParser::new` and `DFParser::new_with_dialect` that were deprecated in 46.0.0. Downstream users should migrate to `DFParserBuilder`.

This is an API change and should be labeled `api change`.