### PR TITLE
[sql]: remove deprecated TableReference re-exports

### DIFF
--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -2354,12 +2354,10 @@ mod tests {
     use crate::logical_expr::{AggregateUDF, ScalarUDF, TableSource, WindowUDF};
     use crate::physical_plan::ExecutionPlan;
     use crate::sql::planner::ContextProvider;
-    use crate::sql::{ResolvedTableReference, TableReference};
     use arrow::array::{ArrayRef, Int32Array, RecordBatch, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_catalog::MemoryCatalogProviderList;
-    use datafusion_common::DFSchema;
-    use datafusion_common::Result;
+    use datafusion_common::{DFSchema, Result, ResolvedTableReference, TableReference};
     use datafusion_common::config::Dialect;
     use datafusion_execution::config::SessionConfig;
     use datafusion_expr::Expr;

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -2357,8 +2357,8 @@ mod tests {
     use arrow::array::{ArrayRef, Int32Array, RecordBatch, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_catalog::MemoryCatalogProviderList;
-    use datafusion_common::{DFSchema, Result, ResolvedTableReference, TableReference};
     use datafusion_common::config::Dialect;
+    use datafusion_common::{DFSchema, ResolvedTableReference, Result, TableReference};
     use datafusion_execution::config::SessionConfig;
     use datafusion_expr::Expr;
     use datafusion_expr::HigherOrderUDF;

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1322,7 +1322,7 @@ mod test {
     use crate::assert_analyzed_plan_with_config_eq_snapshot;
     use datafusion_common::config::ConfigOptions;
     use datafusion_common::tree_node::{TransformedResult, TreeNode};
-    use datafusion_common::{DFSchema, DFSchemaRef, Result, ScalarValue, Spans};
+    use datafusion_common::{DFSchema, DFSchemaRef, Result, ScalarValue, Spans, TableReference};
     use datafusion_expr::expr::{self, InSubquery, Like, ScalarFunction};
     use datafusion_expr::logical_plan::{EmptyRelation, Projection, Sort};
     use datafusion_expr::test::function_stub::avg_udaf;
@@ -1333,7 +1333,6 @@ mod test {
         col, create_udaf, is_true, lit,
     };
     use datafusion_functions_aggregate::average::AvgAccumulator;
-    use datafusion_sql::TableReference;
 
     fn empty() -> Arc<LogicalPlan> {
         Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1322,7 +1322,9 @@ mod test {
     use crate::assert_analyzed_plan_with_config_eq_snapshot;
     use datafusion_common::config::ConfigOptions;
     use datafusion_common::tree_node::{TransformedResult, TreeNode};
-    use datafusion_common::{DFSchema, DFSchemaRef, Result, ScalarValue, Spans, TableReference};
+    use datafusion_common::{
+        DFSchema, DFSchemaRef, Result, ScalarValue, Spans, TableReference,
+    };
     use datafusion_expr::expr::{self, InSubquery, Like, ScalarFunction};
     use datafusion_expr::logical_plan::{EmptyRelation, Projection, Sort};
     use datafusion_expr::test::function_stub::avg_udaf;

--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -57,9 +57,4 @@ mod statement;
 pub mod unparser;
 pub mod utils;
 mod values;
-#[deprecated(
-    since = "46.0.0",
-    note = "use datafusion_common::{ResolvedTableReference, TableReference}"
-)]
-pub use datafusion_common::{ResolvedTableReference, TableReference};
 pub use sqlparser;

--- a/datafusion/sql/src/resolve.rs
+++ b/datafusion/sql/src/resolve.rs
@@ -20,7 +20,7 @@ use std::ops::ControlFlow;
 
 use datafusion_common::{DataFusionError, Result};
 
-use crate::TableReference;
+use datafusion_common::TableReference;
 use crate::parser::{CopyToSource, CopyToStatement, Statement as DFStatement};
 use crate::planner::object_name_to_table_reference;
 use sqlparser::ast::*;

--- a/datafusion/sql/src/resolve.rs
+++ b/datafusion/sql/src/resolve.rs
@@ -20,9 +20,9 @@ use std::ops::ControlFlow;
 
 use datafusion_common::{DataFusionError, Result};
 
-use datafusion_common::TableReference;
 use crate::parser::{CopyToSource, CopyToStatement, Statement as DFStatement};
 use crate::planner::object_name_to_table_reference;
+use datafusion_common::TableReference;
 use sqlparser::ast::*;
 
 // following constants are used in `resolve_table_references`

--- a/datafusion/substrait/src/logical_plan/consumer/utils.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/utils.rs
@@ -18,8 +18,8 @@
 use crate::logical_plan::consumer::SubstraitConsumer;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit, UnionFields};
 use datafusion::common::{
-    DFSchema, DFSchemaRef, exec_err, not_impl_err, substrait_datafusion_err,
-    substrait_err, TableReference
+    DFSchema, DFSchemaRef, TableReference, exec_err, not_impl_err,
+    substrait_datafusion_err, substrait_err,
 };
 use datafusion::logical_expr::expr::Sort;
 use datafusion::logical_expr::{Cast, Expr, ExprSchemable};

--- a/datafusion/substrait/src/logical_plan/consumer/utils.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/utils.rs
@@ -19,11 +19,10 @@ use crate::logical_plan::consumer::SubstraitConsumer;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit, UnionFields};
 use datafusion::common::{
     DFSchema, DFSchemaRef, exec_err, not_impl_err, substrait_datafusion_err,
-    substrait_err,
+    substrait_err, TableReference
 };
 use datafusion::logical_expr::expr::Sort;
 use datafusion::logical_expr::{Cast, Expr, ExprSchemable};
-use datafusion::sql::TableReference;
 use std::collections::HashSet;
 use std::sync::Arc;
 use substrait::proto::SortField;
@@ -570,12 +569,11 @@ pub(crate) mod tests {
     use crate::extensions::Extensions;
     use crate::logical_plan::consumer::DefaultSubstraitConsumer;
     use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema};
-    use datafusion::common::DFSchema;
+    use datafusion::common::{DFSchema, TableReference};
     use datafusion::error::Result;
     use datafusion::execution::SessionState;
     use datafusion::logical_expr::{Expr, col};
     use datafusion::prelude::SessionContext;
-    use datafusion::sql::TableReference;
     use std::collections::HashMap;
     use std::sync::{Arc, LazyLock};
 


### PR DESCRIPTION
## Which issue does this PR close?

- part of #23080

## Rationale for this change

`ResolvedTableReference` and `TableReference` re-exports were deprecated in 46.0.0 in `datafusion-sql` and should be imported from `datafusion_common` (or `datafusion::common`) instead.

## What changes are included in this PR?

- Removed deprecated `ResolvedTableReference` and `TableReference` re-exports from `datafusion-sql` (`lib.rs`).
- Updated internal downstream imports in `datafusion-sql`, `datafusion-core`, and `datafusion-substrait` to use correct paths.

## Are these changes tested?

Verified by running local compilation and tests.

## Are there any user-facing changes?

Yes. This removes deprecated public Rust API re-exports `ResolvedTableReference` and `TableReference` from `datafusion-sql`. Downstream users should migrate to importing them from `datafusion_common` (or `datafusion::common`).

This is an API change and should be labeled `api change`.
