### PR TITLE
Perf: avoid redundant comparison in SortPreservingMerge round-robin tie-breaker; optimize inner loop

### DIFF
--- a/datafusion/physical-plan/src/sorts/merge.rs
+++ b/datafusion/physical-plan/src/sorts/merge.rs
@@ -512,22 +512,33 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
         let mut cmp_node = self.lt_leaf_node_index(winner);
 
         // Traverse up the tree to adjust comparisons until reaching the root.
-        while cmp_node != 0 {
+        while cmp_node > 1 {
             let challenger = self.loser_tree[cmp_node];
+            if self.is_gt(winner, challenger) {
+                self.update_winner(cmp_node, &mut winner, challenger);
+            }
+            cmp_node = self.lt_parent_node_index(cmp_node);
+        }
+
+        if cmp_node == 1 {
+            let challenger = self.loser_tree[1];
             // If round-robin tie-breaker is enabled and we're at the final comparison (cmp_node == 1)
-            if self.enable_round_robin_tie_breaker && cmp_node == 1 {
+            if self.enable_round_robin_tie_breaker {
                 match (&self.cursors[winner], &self.cursors[challenger]) {
-                    (Some(ac), Some(bc)) => {
-                        if ac == bc {
+                    (Some(ac), Some(bc)) => match ac.cmp(bc) {
+                        std::cmp::Ordering::Equal => {
                             self.handle_tie(cmp_node, &mut winner, challenger);
-                        } else {
+                        }
+                        std::cmp::Ordering::Greater => {
                             // Ends of tie breaker
                             self.round_robin_tie_breaker_mode = false;
-                            if ac > bc {
-                                self.update_winner(cmp_node, &mut winner, challenger);
-                            }
+                            self.update_winner(cmp_node, &mut winner, challenger);
                         }
-                    }
+                        std::cmp::Ordering::Less => {
+                            // Ends of tie breaker
+                            self.round_robin_tie_breaker_mode = false;
+                        }
+                    },
                     (None, _) => {
                         // Challenger wins, update winner
                         // Ends of tie breaker
@@ -543,8 +554,8 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
             } else if self.is_gt(winner, challenger) {
                 self.update_winner(cmp_node, &mut winner, challenger);
             }
-            cmp_node = self.lt_parent_node_index(cmp_node);
         }
+
         self.loser_tree[0] = winner;
         self.loser_tree_adjusted = true;
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes: #23108

## Rationale for this change

`SortPreservingMergeStream` (the loser-tree k-way merge behind `SortPreservingMergeExec`, and `SortExec`'s spill/streaming merge) uses a round-robin tie-breaker — enabled by default — applied at the root comparison.

Two small inefficiencies on the hot `update_loser_tree` path:

1. At the root it compared the two finalists with `==` and then, when not equal, again with `>` — up to **two** comparisons per output row where the non-tie-breaker path does one. For byte-wise row comparisons (multi-column keys) and string keys the extra comparison per row is measurable.
2. The round-robin handling only applies at the root (`cmp_node == 1`), yet the per-node loop tested `cmp_node == 1` (and carried the tie-breaker branch) on every node.

On sort_tpch it shows some nice gains:
```
│ Q4    │  213.82 / 216.41 ±2.86 / 221.41 ms │   196.81 / 200.38 ±3.91 / 206.99 ms │ +1.08x faster │
│ Q5    │  300.12 / 300.95 ±0.45 / 301.43 ms │   280.25 / 281.01 ±1.13 / 283.25 ms │ +1.07x faster │
│ Q6    │  313.95 / 318.37 ±7.24 / 332.81 ms │   293.26 / 294.82 ±1.24 / 296.98 ms │ +1.08x faster │
```

## What changes are included in this PR?

- Collapse the root `==` + `>` into a single `Ord::cmp` and match on the `Ordering`.
- Lift the root comparison out of the per-node loop, leaving a tight `is_gt` inner loop (`while cmp_node > 1`) that no longer checks `cmp_node == 1` per node.


## Are these changes tested?

Covered by the existing tests in `sorts/merge.rs` and `sorts/sort_preserving_merge.rs` (including `test_round_robin_tie_breaker_success` / `test_round_robin_tie_breaker_fail` and the merge ordering tests). Behavior-preserving, so no new tests are added.

## Are there any user-facing changes?

No.
