### PR TITLE
chore: `cargo update -p quinn` to resolve security audit issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4885,9 +4885,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4905,9 +4905,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
- closes https://github.com/apache/datafusion/issues/23133

security audit failing, bumping version via running `cargo update -p quinn`

```

Crate:     quinn-proto
Version:   0.11.14
Title:      Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
Date:      2026-06-22
ID:        RUSTSEC-2026-0185
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0185
Severity:  7.5 (high)
Solution:  Upgrade to >=0.11.15
```