### PR TITLE
Move Parquet `input_file_name()` tests to `input_file_name.slt`

### DIFF
--- a/datafusion/sqllogictest/test_files/input_file_name.slt
+++ b/datafusion/sqllogictest/test_files/input_file_name.slt
@@ -79,3 +79,50 @@ SELECT input_file_name() FROM (VALUES (1)) v(x);
 
 statement ok
 DROP TABLE csv_table;
+
+# Parquet tests as it has its own implementation
+
+statement ok
+COPY  (VALUES (10), (20), (30))
+TO 'test_files/scratch/input_file_name/parquet/first.parquet'
+STORED AS PARQUET;
+
+statement ok
+COPY  (VALUES (40), (50), (60))
+TO 'test_files/scratch/input_file_name/parquet/second.parquet'
+STORED AS PARQUET;
+
+statement ok
+CREATE EXTERNAL TABLE pq_table(column1 int)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/input_file_name/parquet/';
+
+query I
+SELECT column1 FROM pq_table
+WHERE input_file_name() LIKE '%first.parquet'
+ORDER BY column1
+----
+10
+20
+30
+
+query TT
+EXPLAIN SELECT column1 FROM pq_table
+WHERE input_file_name() LIKE '%first.parquet'
+ORDER BY column1
+----
+logical_plan
+01)Sort: pq_table.column1 ASC NULLS LAST
+02)--Projection: pq_table.column1
+03)----Filter: __datafusion_extracted_1 LIKE Utf8("%first.parquet")
+04)------Projection: input_file_name() AS __datafusion_extracted_1, pq_table.column1
+05)--------TableScan: pq_table projection=[column1]
+physical_plan
+01)SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
+02)--SortExec: expr=[column1@0 ASC NULLS LAST], preserve_partitioning=[true]
+03)----FilterExec: __datafusion_extracted_1@0 LIKE %first.parquet, projection=[column1@1]
+04)------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=2
+05)--------DataSourceExec: file_groups={2 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/input_file_name/parquet/first.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/input_file_name/parquet/second.parquet]]}, projection=[input_file_name() as __datafusion_extracted_1, column1], file_type=parquet, predicate=input_file_name() LIKE %first.parquet
+
+statement ok
+DROP TABLE pq_table;

--- a/datafusion/sqllogictest/test_files/parquet_metadata_functions.slt
+++ b/datafusion/sqllogictest/test_files/parquet_metadata_functions.slt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Test for Parquet scans with metadata function
+# Test for Parquet scans with a mix of metadata functions
 
 statement ok
 COPY  (VALUES (10), (20), (30))
@@ -51,34 +51,6 @@ logical_plan
 01)Projection: input_file_name(), file_row_index(), test_table.column1
 02)--TableScan: test_table projection=[column1]
 physical_plan DataSourceExec: file_groups={2 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_metadata_functions/first.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_metadata_functions/second.parquet]]}, projection=[input_file_name() as input_file_name(), CAST(__datafusion_file_row_index@1 AS Int64) as file_row_index(), column1], file_type=parquet
-
-# input_file_name() in a WHERE predicate: only rows from the matching file are returned
-query I
-SELECT column1 FROM test_table
-WHERE input_file_name() LIKE '%first.parquet'
-ORDER BY column1
-----
-10
-20
-30
-
-# input_file_name() as a GROUP BY key: per-file aggregation
-query TII
-SELECT input_file_name(), count(*), sum(column1)
-FROM test_table
-GROUP BY input_file_name()
-ORDER BY input_file_name()
-----
-WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_metadata_functions/first.parquet 3 60
-WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_metadata_functions/second.parquet 3 150
-
-# input_file_name() inside a projection expression
-query B rowsort
-SELECT DISTINCT input_file_name() LIKE '%second.parquet'
-FROM test_table
-----
-false
-true
 
 statement ok
 DROP TABLE test_table;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

This was part of #22978 which I had locally and apparently didn't push

## What changes are included in this PR?

Move parquet-only tests that only test `input_file_name()` from `parquet_metadata_functions.slt` (which tests how the metadata functions interact) to the canonical test file for the UDF.

## Are these changes tested?

They are tests. Verified locally.

## Are there any user-facing changes?

No
