### PR TITLE
chore(datasource): remove deprecated `create_writer` free function (Closes #23080 — partial)

### DIFF
--- a/datafusion/datasource/src/write/mod.rs
+++ b/datafusion/datasource/src/write/mod.rs
@@ -75,22 +75,6 @@ pub trait BatchSerializer: Sync + Send {
     fn serialize(&self, batch: RecordBatch, initial: bool) -> Result<Bytes>;
 }
 
-/// Returns an [`AsyncWrite`] which writes to the given object store location
-/// with the specified compression.
-///
-/// The writer will have a default buffer size as chosen by [`BufWriter::new`].
-///
-/// We drop the `AbortableWrite` struct and the writer will not try to cleanup on failure.
-/// Users can configure automatic cleanup with their cloud provider.
-#[deprecated(since = "48.0.0", note = "Use ObjectWriterBuilder::new(...) instead")]
-pub async fn create_writer(
-    file_compression_type: FileCompressionType,
-    location: &Path,
-    object_store: Arc<dyn ObjectStore>,
-) -> Result<Box<dyn AsyncWrite + Send + Unpin>> {
-    ObjectWriterBuilder::new(file_compression_type, location, object_store).build()
-}
-
 /// Converts table schema to writer schema, which may differ in the case
 /// of hive style partitioning where some columns are removed from the
 /// underlying files.


### PR DESCRIPTION
## Summary

Removes the free function `datafusion_datasource::write::create_writer`, which was deprecated in 48.0.0 with the suggestion to use `ObjectWriterBuilder::new(...)` instead. Per the [API health deprecation guidelines](https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines), APIs deprecated in 48.0.0 or earlier are now eligible for removal.

A grep across the workspace confirms `create_writer` has **zero callers** anywhere in the repo (the other matches are differently-named methods `create_writer_physical_plan` and `create_writer_props`, which we are not touching) and is not re-exported from `datafusion_datasource::lib`. This is the smallest possible pure-removal cleanup — 16 lines deleted from a single file.

Part of  #23080 (partial — one of the listed eligible items).

## Test plan

```
git diff upstream/main..chore/remove-deprecated-create-writer
 datafusion/datasource/src/write/mod.rs | 16 ----------------
 1 file changed, 16 deletions(-)
```

Since all callers are gone, no test updates are needed; the standard CI matrix (`./dev/rust_lint.sh`, `cargo check -p datafusion-datasource`, downstream consumer builds) will catch any indirect breakage.

## AI assistance

Used an AI coding assistant to identify and minimally remove the unused deprecated function. I read the file end-to-end before and after the diff, verified zero callers via a workspace grep, and the change is a 16-line pure deletion.