### PR TITLE
chore(catalog): remove deprecated ViewTable try_new (Closes #23080 - partial)

### DIFF
--- a/datafusion/catalog/src/view.rs
+++ b/datafusion/catalog/src/view.rs
@@ -59,17 +59,6 @@ impl ViewTable {
         }
     }
 
-    #[deprecated(
-        since = "47.0.0",
-        note = "Use `ViewTable::new` instead and apply TypeCoercion to the logical plan if needed"
-    )]
-    pub fn try_new(
-        logical_plan: LogicalPlan,
-        definition: Option<String>,
-    ) -> Result<Self> {
-        Ok(Self::new(logical_plan, definition))
-    }
-
     /// Get definition ref
     pub fn definition(&self) -> Option<&String> {
         self.definition.as_ref()


### PR DESCRIPTION
Removes the deprecated ViewTable::try_new constructor (deprecated since 47.0.0). A repo-wide grep confirms zero callers; the only inline references are the function definition itself plus the deprecated attribute lines. Pure 11-line deletion. Part of #23080 (partial - second removal in this housekeeping series after #23129). AI assistance: used an AI coding assistant to identify and minimally remove the unused deprecated constructor; verified via repo-wide grep that the symbol has no callers.