### PR TITLE
chore(datasource): remove deprecated add_row_stats (Closes #23080 - partial)

### DIFF
--- a/datafusion/datasource/src/mod.rs
+++ b/datafusion/datasource/src/mod.rs
@@ -55,6 +55,7 @@ pub mod write;
 pub use self::file::as_file_source;
 pub use self::url::ListingTableUrl;
 use crate::file_groups::FileGroup;
+use arrow::datatypes::SchemaRef;
 use chrono::TimeZone;
 use datafusion_common::stats::Precision;
 use datafusion_common::{ColumnStatistics, Result, TableReference};
@@ -62,15 +63,11 @@ use datafusion_common::{ScalarValue, Statistics};
 use datafusion_physical_expr::LexOrdering;
 use futures::Stream;
 use object_store::{ObjectMeta, path::Path};
-pub use table_schema::{TableSchema, TableSchemaBuilder};
-// Remove when add_row_stats is remove
-use arrow::datatypes::SchemaRef;
-#[expect(deprecated)]
-pub use statistics::add_row_stats;
 pub use statistics::compute_all_files_statistics;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
+pub use table_schema::{TableSchema, TableSchemaBuilder};
 
 /// User-defined per-file extension data, keyed by concrete Rust type.
 ///

--- a/datafusion/datasource/src/statistics.rs
+++ b/datafusion/datasource/src/statistics.rs
@@ -541,14 +541,6 @@ pub fn compute_all_files_statistics(
     Ok((file_groups_with_stats, statistics))
 }
 
-#[deprecated(since = "47.0.0", note = "Use Statistics::add")]
-pub fn add_row_stats(
-    file_num_rows: Precision<usize>,
-    num_rows: Precision<usize>,
-) -> Precision<usize> {
-    file_num_rows.add(&num_rows)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Removes datafusion_datasource::add_row_stats (deprecated since 47.0.0 with replacement Statistics::add). Zero callers — the only references are the deprecated function definition and a single pub use re-export (carrying an explicit 'Remove when add_row_stats is remove' comment, indicating this was already acknowledged as future work). Pure 11-line deletion across 2 files. Closes #23080 (partial - fourth in housekeeping series after #23129, #23131, #23132). AI assistance: used an AI coding assistant; verified via repo-wide grep that the function has no callers.