### PR TITLE
chore(expr-common): remove deprecated Signature get_possible_types (Closes #23080 - partial)

### DIFF
--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -880,11 +880,6 @@ impl TypeSignature {
         }
     }
 
-    #[deprecated(since = "46.0.0", note = "See get_example_types instead")]
-    pub fn get_possible_types(&self) -> Vec<Vec<DataType>> {
-        self.get_example_types()
-    }
-
     /// Return example acceptable types for this `TypeSignature`'
     ///
     /// Returns a `Vec<DataType>` for each argument to the function


### PR DESCRIPTION
Removes Signature::get_possible_types (deprecated since 46.0.0 with replacement get_example_types). Pure 5-line deletion; the in-tree unit test already calls get_example_types directly, so no test updates needed. Closes #23080 (partial - fifth in housekeeping series after #23129, #23131, #23132, #23134). AI assistance: used an AI coding assistant; verified via repo-wide grep that the function is unused outside tests.