### PR TITLE
fix: Fix peak memory display in `EXPLAIN ANALYZE` for multiple operators

### DIFF
--- a/datafusion/ffi/src/physical_expr/metrics.rs
+++ b/datafusion/ffi/src/physical_expr/metrics.rs
@@ -128,6 +128,9 @@ pub struct FFI_RatioMetrics {
 }
 
 /// FFI-stable mirror of [`MetricValue`].
+///
+/// This is part of the stable ABI and must not be reordered. New variants must be
+/// appended at the end.
 #[repr(C, u8)]
 #[derive(Debug, Clone)]
 pub enum FFI_MetricValue {
@@ -144,10 +147,6 @@ pub enum FFI_MetricValue {
         count: u64,
     },
     Gauge {
-        name: SString,
-        gauge: u64,
-    },
-    PeakMemoryUsage {
         name: SString,
         gauge: u64,
     },
@@ -173,6 +172,10 @@ pub enum FFI_MetricValue {
         name: SString,
         display: SString,
         as_usize_value: u64,
+    },
+    PeakMemoryUsage {
+        name: SString,
+        gauge: u64,
     },
 }
 

--- a/datafusion/ffi/src/physical_expr/metrics.rs
+++ b/datafusion/ffi/src/physical_expr/metrics.rs
@@ -147,6 +147,10 @@ pub enum FFI_MetricValue {
         name: SString,
         gauge: u64,
     },
+    PeakMemoryUsage {
+        name: SString,
+        gauge: u64,
+    },
     Time {
         name: SString,
         time_ns: u64,
@@ -425,6 +429,10 @@ impl From<&MetricValue> for FFI_MetricValue {
                 name: SString::from(name.as_ref()),
                 gauge: gauge.value() as u64,
             },
+            MetricValue::PeakMemoryUsage { name, gauge } => Self::PeakMemoryUsage {
+                name: SString::from(name.as_ref()),
+                gauge: gauge.value() as u64,
+            },
             MetricValue::Time { name, time } => Self::Time {
                 name: SString::from(name.as_ref()),
                 time_ns: time.value() as u64,
@@ -478,6 +486,10 @@ impl From<FFI_MetricValue> for MetricValue {
                 count: count_from_value(count),
             },
             FFI_MetricValue::Gauge { name, gauge } => Self::Gauge {
+                name: Cow::Owned(name.into()),
+                gauge: gauge_from_value(gauge),
+            },
+            FFI_MetricValue::PeakMemoryUsage { name, gauge } => Self::PeakMemoryUsage {
                 name: Cow::Owned(name.into()),
                 gauge: gauge_from_value(gauge),
             },
@@ -622,6 +634,13 @@ mod tests {
         assert_value_roundtrip(MetricValue::Gauge {
             name: Cow::Borrowed("custom_gauge"),
             gauge,
+        });
+
+        let peak_memory = Gauge::new();
+        peak_memory.add(44);
+        assert_value_roundtrip(MetricValue::PeakMemoryUsage {
+            name: Cow::Borrowed("peak_mem_used"),
+            gauge: peak_memory,
         });
 
         let time = Time::new();

--- a/datafusion/physical-expr-common/src/metrics/builder.rs
+++ b/datafusion/physical-expr-common/src/metrics/builder.rs
@@ -249,6 +249,23 @@ impl<'a> MetricBuilder<'a> {
         gauge
     }
 
+    /// Consumes self and creates a new [`Gauge`] for recording peak memory
+    /// usage in bytes.
+    pub fn peak_memory_usage(
+        self,
+        gauge_name: impl Into<Cow<'static, str>>,
+        partition: usize,
+    ) -> Gauge {
+        let gauge = Gauge::new();
+        self.with_category(MetricCategory::Bytes)
+            .with_partition(partition)
+            .build(MetricValue::PeakMemoryUsage {
+                name: gauge_name.into(),
+                gauge: gauge.clone(),
+            });
+        gauge
+    }
+
     /// Consume self and create a new Timer for recording the elapsed
     /// CPU time spent by an operator
     pub fn elapsed_compute(self, partition: usize) -> Time {

--- a/datafusion/physical-expr-common/src/metrics/mod.rs
+++ b/datafusion/physical-expr-common/src/metrics/mod.rs
@@ -309,6 +309,7 @@ impl MetricsSet {
             MetricValue::SpilledRows(_) => false,
             MetricValue::CurrentMemoryUsage(_) => false,
             MetricValue::Gauge { name, .. } => name == metric_name,
+            MetricValue::PeakMemoryUsage { name, .. } => name == metric_name,
             MetricValue::StartTimestamp(_) => false,
             MetricValue::EndTimestamp(_) => false,
             MetricValue::PruningMetrics { name, .. } => name == metric_name,

--- a/datafusion/physical-expr-common/src/metrics/value.rs
+++ b/datafusion/physical-expr-common/src/metrics/value.rs
@@ -672,6 +672,13 @@ pub enum MetricValue {
         /// The value of the metric
         gauge: Gauge,
     },
+    /// Operator defined peak memory usage in bytes.
+    PeakMemoryUsage {
+        /// The provided name of this metric
+        name: Cow<'static, str>,
+        /// The value of the metric
+        gauge: Gauge,
+    },
     /// Operator defined time
     Time {
         /// The provided name of this metric
@@ -744,6 +751,13 @@ impl PartialEq for MetricValue {
                     name: other_name,
                     gauge: other_gauge,
                 },
+            )
+            | (
+                MetricValue::PeakMemoryUsage { name, gauge },
+                MetricValue::PeakMemoryUsage {
+                    name: other_name,
+                    gauge: other_gauge,
+                },
             ) => name == other_name && gauge == other_gauge,
             (
                 MetricValue::Time { name, time },
@@ -810,7 +824,9 @@ impl MetricValue {
             Self::CurrentMemoryUsage(_) => "mem_used",
             Self::ElapsedCompute(_) => "elapsed_compute",
             Self::Count { name, .. } => name.borrow(),
-            Self::Gauge { name, .. } => name.borrow(),
+            Self::Gauge { name, .. } | Self::PeakMemoryUsage { name, .. } => {
+                name.borrow()
+            }
             Self::Time { name, .. } => name.borrow(),
             Self::StartTimestamp(_) => "start_timestamp",
             Self::EndTimestamp(_) => "end_timestamp",
@@ -833,7 +849,9 @@ impl MetricValue {
             Self::CurrentMemoryUsage(used) => used.value(),
             Self::ElapsedCompute(time) => time.value(),
             Self::Count { count, .. } => count.value(),
-            Self::Gauge { gauge, .. } => gauge.value(),
+            Self::Gauge { gauge, .. } | Self::PeakMemoryUsage { gauge, .. } => {
+                gauge.value()
+            }
             Self::Time { time, .. } => time.value(),
             Self::StartTimestamp(timestamp) => timestamp
                 .value()
@@ -872,6 +890,10 @@ impl MetricValue {
                 count: Count::new(),
             },
             Self::Gauge { name, .. } => Self::Gauge {
+                name: name.clone(),
+                gauge: Gauge::new(),
+            },
+            Self::PeakMemoryUsage { name, .. } => Self::PeakMemoryUsage {
                 name: name.clone(),
                 gauge: Gauge::new(),
             },
@@ -931,6 +953,12 @@ impl MetricValue {
             | (
                 Self::Gauge { gauge, .. },
                 Self::Gauge {
+                    gauge: other_gauge, ..
+                },
+            )
+            | (
+                Self::PeakMemoryUsage { gauge, .. },
+                Self::PeakMemoryUsage {
                     gauge: other_gauge, ..
                 },
             ) => gauge.add(other_gauge.value()),
@@ -1029,6 +1057,7 @@ impl MetricValue {
                 "page_index_pages_skipped_by_fully_matched" => 8,
                 _ => 14,
             },
+            Self::PeakMemoryUsage { .. } => 13,
             Self::Gauge { .. } => 15,
             Self::Time { .. } => 16,
             Self::Ratio { .. } => 17,
@@ -1061,6 +1090,10 @@ impl Display for MetricValue {
             }
             Self::CurrentMemoryUsage(gauge) => {
                 // CurrentMemoryUsage is in bytes, format like SpilledBytes
+                let readable_size = human_readable_size(gauge.value());
+                write!(f, "{readable_size}")
+            }
+            Self::PeakMemoryUsage { gauge, .. } => {
                 let readable_size = human_readable_size(gauge.value());
                 write!(f, "{readable_size}")
             }
@@ -1522,6 +1555,18 @@ mod tests {
         mem_gauge.add(100 * MB as usize);
         assert_eq!(
             MetricValue::CurrentMemoryUsage(mem_gauge.clone()).to_string(),
+            "100.0 MB"
+        );
+
+        // Test PeakMemoryUsage formatting (should use size, not count)
+        let peak_mem_gauge = Gauge::new();
+        peak_mem_gauge.add(100 * MB as usize);
+        assert_eq!(
+            MetricValue::PeakMemoryUsage {
+                name: "peak_mem_used".into(),
+                gauge: peak_mem_gauge.clone()
+            }
+            .to_string(),
             "100.0 MB"
         );
 

--- a/datafusion/physical-plan/src/aggregates/row_hash.rs
+++ b/datafusion/physical-plan/src/aggregates/row_hash.rs
@@ -527,8 +527,7 @@ impl GroupedHashAggregateStream {
             merging_aggregate_arguments,
             merging_group_by: PhysicalGroupBy::new_single(merging_group_by_expr),
             peak_mem_used: MetricBuilder::new(&agg.metrics)
-                .with_category(MetricCategory::Bytes)
-                .gauge("peak_mem_used", partition),
+                .peak_memory_usage("peak_mem_used", partition),
             spill_manager,
         };
 

--- a/datafusion/physical-plan/src/buffer.rs
+++ b/datafusion/physical-plan/src/buffer.rs
@@ -194,8 +194,7 @@ impl ExecutionPlan for BufferExec {
         let curr_mem_out = Arc::clone(&curr_mem_in);
         let mut max_mem_in = 0;
         let max_mem = MetricBuilder::new(&self.metrics)
-            .with_category(MetricCategory::Bytes)
-            .gauge("max_mem_used", partition);
+            .peak_memory_usage("max_mem_used", partition);
 
         let curr_queued_in = Arc::new(AtomicUsize::new(0));
         let curr_queued_out = Arc::clone(&curr_queued_in);

--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -775,6 +775,9 @@ impl PgJsonExecutionPlanVisitor<'_> {
             }
             MetricValue::Count { count, .. } => serde_json::Value::from(count.value()),
             MetricValue::Gauge { gauge, .. } => serde_json::Value::from(gauge.value()),
+            MetricValue::PeakMemoryUsage { gauge, .. } => {
+                serde_json::Value::from(gauge.value())
+            }
             MetricValue::Time { time, .. } => {
                 let ms = (time.value() as f64) / 1_000_000.0;
                 serde_json::Value::from(ms)

--- a/datafusion/physical-plan/src/joins/sort_merge_join/bitwise_stream.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/bitwise_stream.rs
@@ -360,7 +360,8 @@ impl BitwiseSortMergeJoinStream {
             MetricBuilder::new(metrics).counter("input_batches", partition);
         let input_rows = MetricBuilder::new(metrics).counter("input_rows", partition);
         let baseline_metrics = BaselineMetrics::new(metrics, partition);
-        let peak_mem_used = MetricBuilder::new(metrics).gauge("peak_mem_used", partition);
+        let peak_mem_used =
+            MetricBuilder::new(metrics).peak_memory_usage("peak_mem_used", partition);
 
         Ok(Self {
             join_type,

--- a/datafusion/physical-plan/src/joins/sort_merge_join/metrics.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/metrics.rs
@@ -46,9 +46,8 @@ impl SortMergeJoinMetrics {
         let input_rows = MetricBuilder::new(metrics)
             .with_category(MetricCategory::Rows)
             .counter("input_rows", partition);
-        let peak_mem_used = MetricBuilder::new(metrics)
-            .with_category(MetricCategory::Bytes)
-            .gauge("peak_mem_used", partition);
+        let peak_mem_used =
+            MetricBuilder::new(metrics).peak_memory_usage("peak_mem_used", partition);
 
         let baseline_metrics = BaselineMetrics::new(metrics, partition);
 

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1798,9 +1798,8 @@ impl BuildProbeJoinMetrics {
             .with_category(MetricCategory::Rows)
             .counter("build_input_rows", partition);
 
-        let build_mem_used = MetricBuilder::new(metrics)
-            .with_category(MetricCategory::Bytes)
-            .gauge("build_mem_used", partition);
+        let build_mem_used =
+            MetricBuilder::new(metrics).peak_memory_usage("build_mem_used", partition);
 
         let input_batches = MetricBuilder::new(metrics)
             .with_category(MetricCategory::Rows)

--- a/datafusion/sqllogictest/test_files/explain_analyze.slt
+++ b/datafusion/sqllogictest/test_files/explain_analyze.slt
@@ -300,6 +300,237 @@ reset datafusion.explain.analyze_categories;
 statement ok
 reset datafusion.explain.analyze_level;
 
+# ------------------------------------------------
+# Test memory metrics display.
+# ------------------------------------------------
+
+statement ok
+set datafusion.explain.analyze_level = dev;
+
+statement ok
+set datafusion.explain.analyze_categories = 'bytes';
+
+statement ok
+set datafusion.execution.target_partitions = 1;
+
+statement ok
+set datafusion.optimizer.repartition_joins = false;
+
+statement ok
+set datafusion.optimizer.prefer_hash_join = true;
+
+statement ok
+set datafusion.optimizer.enable_piecewise_merge_join = false;
+
+statement ok
+set datafusion.optimizer.hash_join_inlist_pushdown_max_size = 0;
+
+statement ok
+set datafusion.optimizer.hash_join_inlist_pushdown_max_distinct_values = 0;
+
+query TT
+EXPLAIN ANALYZE
+WITH t1 (k) AS (
+    VALUES (1), (2), (3)
+), t2 (k) AS (
+    VALUES (1), (2), (3)
+)
+SELECT *
+FROM t1
+JOIN t2 ON t1.k = t2.k;
+----
+Plan with Metrics
+01)HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(k@0, k@0)], metrics=[output_bytes=128.0 KB, build_mem_used=44.0 B]
+02)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+03)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+04)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+05)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+statement ok
+set datafusion.execution.hash_join_buffering_capacity = 1024;
+
+query TT
+EXPLAIN ANALYZE
+WITH t1 (k) AS (
+    VALUES (1), (2), (3)
+), t2 (k) AS (
+    VALUES (1), (2), (3)
+)
+SELECT *
+FROM t1
+JOIN t2 ON t1.k = t2.k;
+----
+Plan with Metrics
+01)HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(k@0, k@0)], metrics=[output_bytes=128.0 KB, build_mem_used=44.0 B]
+02)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+03)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+04)--BufferExec: capacity=1024, metrics=[max_mem_used=128.0 B]
+05)----ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+06)------DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+statement ok
+reset datafusion.execution.hash_join_buffering_capacity;
+
+query TT
+EXPLAIN ANALYZE
+WITH t1 (k) AS (
+    VALUES (1), (2)
+), t2 (k) AS (
+    VALUES (10), (20)
+)
+SELECT *
+FROM t1
+CROSS JOIN t2;
+----
+Plan with Metrics
+01)CrossJoinExec, metrics=[output_bytes=96.0 B, build_mem_used=128.0 B]
+02)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+03)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+04)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+05)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+query TT
+EXPLAIN ANALYZE
+WITH t1 (k) AS (
+    VALUES (1), (2)
+), t2 (k) AS (
+    VALUES (2), (3)
+)
+SELECT *
+FROM t1
+JOIN t2 ON t1.k < t2.k;
+----
+Plan with Metrics
+01)NestedLoopJoinExec: join_type=Inner, filter=k@0 < k@1, metrics=[output_bytes=128.0 KB, spilled_bytes=0.0 B, build_mem_used=128.0 B]
+02)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+03)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+04)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+05)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+statement ok
+set datafusion.optimizer.enable_piecewise_merge_join = true;
+
+query TT
+EXPLAIN ANALYZE
+WITH t1 (k) AS (
+    VALUES (3), (4)
+), t2 (k) AS (
+    VALUES (1), (2)
+)
+SELECT *
+FROM t1
+JOIN t2 ON t1.k > t2.k;
+----
+Plan with Metrics
+01)PiecewiseMergeJoin: operator=Gt, join_type=Inner, on=(k > k), metrics=[output_bytes=0.0 B, build_mem_used=144.0 B]
+02)--SortExec: expr=[k@0 ASC], preserve_partitioning=[false], metrics=[output_bytes=0.0 B, spilled_bytes=0.0 B]
+03)----ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+04)------DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+05)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+06)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+statement ok
+set datafusion.optimizer.enable_piecewise_merge_join = false;
+
+statement ok
+set datafusion.execution.target_partitions = 2;
+
+statement ok
+set datafusion.optimizer.repartition_joins = true;
+
+statement ok
+set datafusion.optimizer.prefer_hash_join = false;
+
+statement ok
+CREATE TABLE ea_smj_t1(a text, b int) AS VALUES ('Alice', 50), ('Alice', 100), ('Bob', 1);
+
+statement ok
+CREATE TABLE ea_smj_t2(a text, b int) AS VALUES ('Alice', 2), ('Alice', 1);
+
+query TT
+EXPLAIN ANALYZE
+SELECT ea_smj_t1.a, ea_smj_t1.b, ea_smj_t2.a, ea_smj_t2.b
+FROM ea_smj_t1
+JOIN ea_smj_t2 ON ea_smj_t1.a = ea_smj_t2.a
+    AND ea_smj_t2.b * 50 <= ea_smj_t1.b;
+----
+Plan with Metrics
+01)SortMergeJoinExec: join_type=Inner, on=[(a@0, a@0)], filter=CAST(b@1 AS Int64) * 50 <= CAST(b@0 AS Int64), metrics=[output_bytes=320.0 KB, spilled_bytes=0.0 B, peak_mem_used=432.0 B]
+02)--SortExec: expr=[a@0 ASC], preserve_partitioning=[false], metrics=[output_bytes=0.0 B, spilled_bytes=0.0 B]
+03)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+04)--SortExec: expr=[a@0 ASC], preserve_partitioning=[false], metrics=[output_bytes=0.0 B, spilled_bytes=0.0 B]
+05)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+query TT
+EXPLAIN ANALYZE
+SELECT ea_smj_t1.a, ea_smj_t1.b
+FROM ea_smj_t1
+LEFT SEMI JOIN ea_smj_t2 ON ea_smj_t1.a = ea_smj_t2.a;
+----
+Plan with Metrics
+01)SortMergeJoinExec: join_type=LeftSemi, on=[(a@0, a@0)], metrics=[output_bytes=160.0 KB, spilled_bytes=0.0 B, peak_mem_used=0.0 B]
+02)--SortExec: expr=[a@0 ASC], preserve_partitioning=[false], metrics=[output_bytes=0.0 B, spilled_bytes=0.0 B]
+03)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+04)--SortExec: expr=[a@0 ASC], preserve_partitioning=[false], metrics=[output_bytes=0.0 B, spilled_bytes=0.0 B]
+05)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+statement ok
+DROP TABLE ea_smj_t1;
+
+statement ok
+DROP TABLE ea_smj_t2;
+
+statement ok
+set datafusion.execution.target_partitions = 1;
+
+statement ok
+set datafusion.optimizer.repartition_joins = false;
+
+statement ok
+set datafusion.execution.enable_migration_aggregate = false;
+
+query TT
+EXPLAIN ANALYZE
+WITH t (k) AS (
+    VALUES (1), (2), (1), (3)
+)
+SELECT k, count(*)
+FROM t
+GROUP BY k;
+----
+Plan with Metrics
+01)ProjectionExec: expr=[k@0 as k, count(Int64(1))@1 as count(*)], metrics=[output_bytes=1056.0 B]
+02)--AggregateExec: mode=Single, gby=[k@0 as k], aggr=[count(Int64(1))], metrics=[output_bytes=1056.0 B, spilled_bytes=0.0 B, peak_mem_used=9.2 KB]
+03)----ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
+04)------DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+statement ok
+reset datafusion.execution.enable_migration_aggregate;
+
+statement ok
+reset datafusion.optimizer.prefer_hash_join;
+
+statement ok
+reset datafusion.optimizer.hash_join_inlist_pushdown_max_size;
+
+statement ok
+reset datafusion.optimizer.hash_join_inlist_pushdown_max_distinct_values;
+
+statement ok
+reset datafusion.optimizer.repartition_joins;
+
+statement ok
+reset datafusion.optimizer.enable_piecewise_merge_join;
+
+statement ok
+set datafusion.execution.target_partitions = 4;
+
+statement ok
+reset datafusion.explain.analyze_categories;
+
+statement ok
+reset datafusion.explain.analyze_level;
+
 # ------------------------------------------------------------------
 # Same category/level filtering, but via the Postgres-style
 # `EXPLAIN (ANALYZE, METRICS ..., LEVEL ...)` statement option list.

--- a/datafusion/sqllogictest/test_files/joins.slt
+++ b/datafusion/sqllogictest/test_files/joins.slt
@@ -5185,7 +5185,7 @@ LEFT ANTI JOIN (
 ) t2 ON t1.k = t2.k;
 ----
 Plan with Metrics
-01)HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(k@0, k@0)], metrics=[output_rows=2, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=1, array_map_created_count=0, build_input_batches=0, build_input_rows=0, input_batches=1, input_rows=2, build_mem_used=<slt:ignore>, build_time=<slt:ignore>, join_time=<slt:ignore>, avg_fanout=N/A (0/0), probe_hit_rate=0% (0/2)]     
+01)HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(k@0, k@0)], metrics=[output_rows=2, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=1, build_mem_used=<slt:ignore>, array_map_created_count=0, build_input_batches=0, build_input_rows=0, input_batches=1, input_rows=2, build_time=<slt:ignore>, join_time=<slt:ignore>, avg_fanout=N/A (0/0), probe_hit_rate=0% (0/2)]
 02)--ProjectionExec: expr=[column1@0 as k], metrics=[output_rows=0, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=0, expr_0_eval_time=<slt:ignore>]
 03)----FilterExec: column1@0 != 1, metrics=[output_rows=0, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=0, selectivity=0% (0/1)]
 04)------DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
See reproducer in `datafusion-cli`:
```sh
yongting@Yongtings-MacBook-Pro-2 ~/C/d/datafusion (hj-mem-fix *)> datafusion-cli
DataFusion CLI v54.0.0
> set datafusion.explain.analyze_categories = 'bytes';
0 row(s) fetched.
Elapsed 0.001 seconds.

> explain analyze
select *
from generate_series(100000000) as t1(v1)
join generate_series(100000000) as t2(v1)
on t1.v1=t2.v1;
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type         | plan                                                                                                                                                  |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics | HashJoinExec: mode=Partitioned, join_type=Inner, on=[(v1@0, v1@0)], metrics=[output_bytes=1526.7 MB, build_mem_used=2.80 B]                           |
|                   |   RepartitionExec: partitioning=Hash([v1@0], 14), input_partitions=1, maintains_sort_order=true, metrics=[output_bytes=763.4 MB, spilled_bytes=0.0 B] |
|                   |     ProjectionExec: expr=[value@0 as v1], metrics=[output_bytes=763.0 MB]                                                                             |
|                   |       LazyMemoryExec: partitions=1, batch_generators=[generate_series: start=0, end=100000000, batch_size=8192], metrics=[output_bytes=763.0 MB]      |
|                   |   RepartitionExec: partitioning=Hash([v1@0], 14), input_partitions=1, maintains_sort_order=true, metrics=[output_bytes=763.4 MB, spilled_bytes=0.0 B] |
|                   |     ProjectionExec: expr=[value@0 as v1], metrics=[output_bytes=763.0 MB]                                                                             |
|                   |       LazyMemoryExec: partitions=1, batch_generators=[generate_series: start=0, end=100000000, batch_size=8192], metrics=[output_bytes=763.0 MB]      |
|                   |                                                                                                                                                       |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 1.040 seconds.
```

See `HashJoinExec: ... build_mem_used=2.80 B`, it actually means 2.8 billion bytes, but it looks quite misleading. This PR fixes it:

```sh
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type         | plan                                                                                                                                                  |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| Plan with Metrics | HashJoinExec: mode=Partitioned, join_type=Inner, on=[(v1@0, v1@0)], metrics=[output_bytes=1526.7 MB, build_mem_used=2.6 GB]  
```

The reason is those metrics are tracking peak memory usage for a operator in the query lifecycle, so it's using `Gauge` metrics type, but how to choose display format become tricky (bytes or count?)

This PR adds a new `Metric` type, that wraps the existing `Gauge`, and use it to represent 'gauge for memory bytes', this fixes the bytes display issue.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Introduce `MetricValue::PeakMemoryUsage` to address the above issue
2. Use this metric type for applicable metrics
3. Add slts for testing.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
