### PR TITLE
chore(sql): remove deprecated DFParser constructors (Closes #23080 - partial)

### DIFF
--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -504,19 +504,6 @@ fn token_starts_query(tok: &Token) -> bool {
 }
 
 impl<'a> DFParser<'a> {
-    #[deprecated(since = "46.0.0", note = "DFParserBuilder")]
-    pub fn new(sql: &'a str) -> Result<Self, DataFusionError> {
-        DFParserBuilder::new(sql).build()
-    }
-
-    #[deprecated(since = "46.0.0", note = "DFParserBuilder")]
-    pub fn new_with_dialect(
-        sql: &'a str,
-        dialect: &'a dyn Dialect,
-    ) -> Result<Self, DataFusionError> {
-        DFParserBuilder::new(sql).with_dialect(dialect).build()
-    }
-
     /// Parse a sql string into one or [`Statement`]s using the
     /// [`GenericDialect`].
     pub fn parse_sql(sql: &'a str) -> Result<VecDeque<Statement>, DataFusionError> {


### PR DESCRIPTION
Fixes #23080

## Summary

Removes the deprecated `DFParser::new` and `DFParser::new_with_dialect` constructors from `datafusion-sql`. Both were deprecated since 46.0.0 in favor of the `DFParserBuilder` API, and a grep across the workspace confirms zero remaining callers (the only references are to `DFParser::parse_sql` and `DFParserBuilder::new`, which we keep). With DataFusion now on 55.x, this clears the 6-major-version grace period for trivial removal.

## Test plan

- `git grep -nE 'DFParser::new\b|DFParser::new_with_dialect\b'` returns no results in source or docs.
- The `datafusion-sql` package's `DFParserBuilder` API surfaces (`parse_sql`, `parse_sql_with_dialect`) are unchanged and provide drop-in replacement ergonomics.

AI assistance: drafted with the help of an Anthropic coding assistant. Diff was reviewed line by line before submission, and the change was verified independently.

Signed-off-by: Dodothereal <129273127+Dodothereal@users.noreply.github.com>
