### PR TITLE
chore(common): remove deprecated DFSchema type-check method (Closes #23080 - partial)

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -599,30 +599,6 @@ impl DFSchema {
             .all(|(dffield, arrowfield)| dffield.name() == arrowfield.name())
     }
 
-    /// Check to see if fields in 2 Arrow schemas are compatible
-    #[deprecated(since = "47.0.0", note = "This method is no longer used")]
-    pub fn check_arrow_schema_type_compatible(
-        &self,
-        arrow_schema: &Schema,
-    ) -> Result<()> {
-        let self_arrow_schema = self.as_arrow();
-        self_arrow_schema
-            .fields()
-            .iter()
-            .zip(arrow_schema.fields().iter())
-            .try_for_each(|(l_field, r_field)| {
-                if !can_cast_types(r_field.data_type(), l_field.data_type()) {
-                    _plan_err!("Column {} (type: {}) is not compatible with column {} (type: {})",
-                                r_field.name(),
-                                r_field.data_type(),
-                                l_field.name(),
-                                l_field.data_type())
-                } else {
-                    Ok(())
-                }
-            })
-    }
-
     /// Returns true if the two schemas have the same qualified named
     /// fields with logically equivalent data types. Returns false otherwise.
     ///


### PR DESCRIPTION
Fixes #23080

## Summary

Removes `DFSchema::check_arrow_schema_type_compatible`, deprecated since 47.0.0 ("This method is no longer used"). A grep across the workspace confirms zero remaining callers and zero public re-exports — the method is definition-only. The 6-major-version grace period cited by the API-health policy is past due (we are now on 55.x).

## Test plan

- `git grep -nE 'check_arrow_schema_type_compatible'` returns no matches in source or docs (only the removed definition site).
- `Schema` is still imported at the top of `dfschema.rs` because it remains in use elsewhere in the file (e.g., `qualified_schema_from_field_names`, etc.).

AI assistance: drafted with the help of an Anthropic coding assistant. Diff was reviewed line by line before submission, and the change was verified independently.

Signed-off-by: Dodothereal <129273127+Dodothereal@users.noreply.github.com>
