### PR TITLE
chore(expr-common): remove deprecated Signature::get_possible_types (Closes #23080 - partial)

### DIFF
--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -880,11 +880,6 @@ impl TypeSignature {
         }
     }
 
-    #[deprecated(since = "46.0.0", note = "See get_example_types instead")]
-    pub fn get_possible_types(&self) -> Vec<Vec<DataType>> {
-        self.get_example_types()
-    }
-
     /// Return example acceptable types for this `TypeSignature`'
     ///
     /// Returns a `Vec<DataType>` for each argument to the function


### PR DESCRIPTION
Fixes #23080

## Summary

Removes `Signature::get_possible_types`, deprecated since 46.0.0 ("See get_example_types instead"). A grep across the workspace confirms zero remaining callers and zero public re-exports — the function is definition-only. (The lone in-tree test, `test_get_possible_types`, retained its name for stability but already exercises the new `get_example_types` path.) The 6-major-version grace period cited by the API-health policy is past due (we are now on 55.x).

## Test plan

- `git grep -nE '\bget_possible_types\b'` returns no matches in source code (only the removed definition site). The 44.0.0 changelog entry is historical and is left intact.
- `test_get_possible_types` continues to compile and pass since it never called the deprecated function.

AI assistance: drafted with the help of an Anthropic coding assistant. Diff was reviewed line by line before submission, and the change was verified independently.

Signed-off-by: Dodothereal <129273127+Dodothereal@users.noreply.github.com>
