### PR TITLE
chore(expr): remove deprecated Filter::try_new_with_having (Closes #23080 - partial)

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -2655,13 +2655,6 @@ impl Filter {
         Self::try_new_internal(predicate, input)
     }
 
-    /// Create a new filter operator for a having clause.
-    /// This is similar to a filter, but its having flag is set to true.
-    #[deprecated(since = "48.0.0", note = "Use `try_new` instead")]
-    pub fn try_new_with_having(predicate: Expr, input: Arc<LogicalPlan>) -> Result<Self> {
-        Self::try_new_internal(predicate, input)
-    }
-
     fn is_allowed_filter_type(data_type: &DataType) -> bool {
         match data_type {
             // Interpret NULL as a missing boolean value.


### PR DESCRIPTION
Fixes part of  #23080

## Summary

Removes `Filter::try_new_with_having`, deprecated since 48.0.0 ("Use `try_new` instead"). A grep across the workspace confirms zero remaining callers and zero public re-exports — the method is definition-only. The 6-major-version grace period cited by the API-health policy is past due (we are now on 55.x).

## Test plan

- `git grep -nE 'try_new_with_having'` returns no matches in source or docs (only the removed definition site).

AI assistance: drafted with the help of an Anthropic coding assistant. Diff was reviewed line by line before submission, and the change was verified independently.

Signed-off-by: Dodothereal <129273127+Dodothereal@users.noreply.github.com>
