### PR TITLE
chore(catalog-listing): remove deprecated split_files free fn (Closes #23080)

### DIFF
--- a/datafusion/catalog-listing/src/helpers.rs
+++ b/datafusion/catalog-listing/src/helpers.rs
@@ -17,7 +17,6 @@
 
 //! Helper functions for the table implementation
 
-use std::mem;
 use std::sync::Arc;
 
 use datafusion_catalog::Session;
@@ -136,41 +135,6 @@ pub fn expr_applicable_for_cols(col_names: &[&str], expr: &Expr) -> bool {
 
 /// The maximum number of concurrent listing requests
 const CONCURRENCY_LIMIT: usize = 100;
-
-/// Partition the list of files into `n` groups
-#[deprecated(since = "47.0.0", note = "use `FileGroup::split_files` instead")]
-pub fn split_files(
-    mut partitioned_files: Vec<PartitionedFile>,
-    n: usize,
-) -> Vec<Vec<PartitionedFile>> {
-    if partitioned_files.is_empty() {
-        return vec![];
-    }
-
-    // ObjectStore::list does not guarantee any consistent order and for some
-    // implementations such as LocalFileSystem, it may be inconsistent. Thus
-    // Sort files by path to ensure consistent plans when run more than once.
-    partitioned_files.sort_by(|a, b| a.path().cmp(b.path()));
-
-    // effectively this is div with rounding up instead of truncating
-    let chunk_size = partitioned_files.len().div_ceil(n);
-    let mut chunks = Vec::with_capacity(n);
-    let mut current_chunk = Vec::with_capacity(chunk_size);
-    for file in partitioned_files.drain(..) {
-        current_chunk.push(file);
-        if current_chunk.len() == chunk_size {
-            let full_chunk =
-                mem::replace(&mut current_chunk, Vec::with_capacity(chunk_size));
-            chunks.push(full_chunk);
-        }
-    }
-
-    if !current_chunk.is_empty() {
-        chunks.push(current_chunk)
-    }
-
-    chunks
-}
 
 #[derive(Debug)]
 pub struct Partition {


### PR DESCRIPTION
Fixes #23080 (partial)

## Summary

Removes `datafusion_catalog_listing::helpers::split_files`, deprecated since 47.0.0 in favor of the `FileGroup::split_files` method on `datafusion-catalog/datasource::file_groups::FileGroup`.

Verified workspace-wide:
- 0 non-test call sites for the deprecated free function (`grep -rn "split_files" --include="*.rs"`)
- The 5 in-tree references in `datafusion/catalog-listing/src/helpers.rs::tests::test_split_files` are calls on `FileGroup` values (`files.clone().split_files(N)`), not the deprecated free function — they exercise `FileGroup::split_files` correctly.
- 3 other call sites in `datafusion/catalog-listing/src/table.rs` also call the `FileGroup` method.
- `cargo check -p datafusion-catalog-listing` is clean (no warnings after also dropping the now-unused `use std::mem;`).
- `cargo test -p datafusion-catalog-listing test_split_files` passes.

This is a 36-line pure deletion: 35 lines for the function body plus the `use std::mem;` import. Replaces only — the public method `FileGroup::split_files` already exists at `datafusion/datasource/src/file_groups.rs:454` and is what callers use.

## Test plan

- `cargo check -p datafusion-catalog-listing` ✓ (clean)
- `cargo test -p datafusion-catalog-listing test_split_files` ✓ 1 passed
- `grep -rn "helpers::split_files\|use.*helpers::{.*split_files" datafusion/` → 0 matches after this change

`(e of in-tree call sites verified before edit via workspace grep; revisited after edit.)`

## AI assistance

This patch was drafted with the help of an AI coding assistant. The diff was reviewed line by line before submission and the change was verified independently (cargo check + a focused cargo test run).

Signed-off-by: Dodothereal <129273127+Dodothereal@users.noreply.github.com>
