### PR TITLE
Add regression coverage for quoted dotted column aliases

### DIFF
--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -591,7 +591,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 idents.len()
             )
         } else {
-            let columns = plan.schema().columns().clone();
+            let columns = plan.schema().columns();
             LogicalPlanBuilder::from(plan)
                 .project(columns.into_iter().zip(idents).map(|(col, ident)| {
                     Expr::Column(col).alias(self.ident_normalizer.normalize(ident))

--- a/datafusion/sqllogictest/test_files/alias.slt
+++ b/datafusion/sqllogictest/test_files/alias.slt
@@ -104,3 +104,33 @@ physical_plan
 
 statement ok
 drop table t;
+
+# Test quoted dotted column names with subquery column-list aliasing
+# (https://github.com/apache/datafusion/issues/22916)
+
+statement ok
+create table dotted_alias_source ("A.B" int, "C" int);
+
+statement ok
+insert into dotted_alias_source values (1, 2);
+
+query II
+select t_.x, t_.y
+from (select "A.B", "C" from dotted_alias_source) as t_(x, y);
+----
+1 2
+
+query I
+select "x.y"
+from (select "A.B" from dotted_alias_source) as t_("x.y");
+----
+1
+
+query I
+select t_."x.y"
+from (select "A.B" from dotted_alias_source) as t_("x.y");
+----
+1
+
+statement ok
+drop table dotted_alias_source;

--- a/datafusion/sqllogictest/test_files/alias.slt
+++ b/datafusion/sqllogictest/test_files/alias.slt
@@ -103,34 +103,25 @@ physical_plan
 02)--DataSourceExec: partitions=1, partition_sizes=[0]
 
 statement ok
-drop table t;
-
-# Test quoted dotted column names with subquery column-list aliasing
-# (https://github.com/apache/datafusion/issues/22916)
-
-statement ok
-create table dotted_alias_source ("A.B" int, "C" int);
-
-statement ok
-insert into dotted_alias_source values (1, 2);
+insert into t values (1, 2);
 
 query II
 select t_.x, t_.y
-from (select "A.B", "C" from dotted_alias_source) as t_(x, y);
+from (select "B.C", "A" from t) as t_(x, y);
 ----
-1 2
+2 1
 
 query I
 select "x.y"
-from (select "A.B" from dotted_alias_source) as t_("x.y");
+from (select "B.C" from t) as t_("x.y");
 ----
-1
+2
 
 query I
 select t_."x.y"
-from (select "A.B" from dotted_alias_source) as t_("x.y");
+from (select "B.C" from t) as t_("x.y");
 ----
-1
+2
 
 statement ok
-drop table dotted_alias_source;
+drop table t;


### PR DESCRIPTION
## Which issue does this PR close?

Follow up to #22917, I overlooked these:
- Add SLT regression coverage for quoted dotted names / column-list aliasing.
- remove redundant .clone() after columns() since it already returns Vec<Column>.


## What changes are included in this PR?

This PR adds SLT regression coverage for quoted dotted column names used with table column-list aliasing, including qualified and unqualified references.

It also removes a redundant `.clone()` call after `plan.schema().columns()`.

## Are these changes tested?

Yes. Tests are added in:

`datafusion/sqllogictest/test_files/alias.slt`

## Are there any user-facing changes?

No user-facing changes.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed.
