### PR TITLE
perf: avoid possibly expensive string formatting if no error is encountered

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -373,13 +373,13 @@ impl DefaultPhysicalPlanner {
         &self,
         logical_schema: &DFSchemaRef,
         physical_plan: &Arc<dyn ExecutionPlan>,
-        context: &str,
+        context_factory: impl FnOnce() -> String,
     ) -> Result<()> {
         if !logical_schema.matches_arrow_schema(&physical_plan.schema()) {
             return plan_err!(
                 "{} created an ExecutionPlan with mismatched schema. \
                     LogicalPlan schema: {:?}, ExecutionPlan schema: {:?}",
-                context,
+                context_factory(),
                 logical_schema,
                 physical_plan.schema()
             );
@@ -700,9 +700,11 @@ impl DefaultPhysicalPlanner {
                             );
                         }
                     };
-                    let context =
-                        format!("Extension planner for table scan {}", scan.table_name);
-                    self.ensure_schema_matches(projected_schema, &plan, &context)?;
+
+                    self.ensure_schema_matches(projected_schema, &plan, || {
+                        format!("Extension planner for table scan {}", scan.table_name)
+                    })?;
+
                     plan
                 }
             }
@@ -1830,8 +1832,10 @@ impl DefaultPhysicalPlanner {
                     ),
                 }?;
 
-                let context = format!("Extension planner for {node:?}");
-                self.ensure_schema_matches(node.schema(), &plan, &context)?;
+                self.ensure_schema_matches(node.schema(), &plan, || {
+                    format!("Extension planner for {node:?}")
+                })?;
+
                 plan
             }
 


### PR DESCRIPTION
## Which issue does this PR close?

We had a `LogicalPlan` extension for which it was expensive to print the debugging information and which occurred multiple times in each query.  Because the old code always created a string with the debugging information even in the success path, this overhead accumulated. I think this was exaggerated by our huge debug info but I thought we could avoid this.

Are there any existing benchmarks with respect to extension planning? At least `sql_planner` and `sql_planner_extended` don't seem to have one on first sight.

## Rationale for this change

Avoid printing debug info if it's not needed

## What changes are included in this PR?

- Swap an `&str` to a closure that computes the string on-demand. 

## Are these changes tested?

Existing tests

## Are there any user-facing changes?

No