### PR TITLE
Perf: cache primitive sort key in SortPreservingMerge to drop per-comparison bounds checks

### DIFF
--- a/datafusion/physical-plan/src/sorts/cursor.rs
+++ b/datafusion/physical-plan/src/sorts/cursor.rs
@@ -44,6 +44,21 @@ pub trait CursorValues {
 
     /// Returns comparison of `l[l_idx]` and `r[r_idx]`
     fn compare(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> Ordering;
+
+    /// Notifies the values that the owning [`Cursor`] has moved to `offset`,
+    /// which is guaranteed to be `< len()`.
+    ///
+    /// Implementations may use this to cache the value(s) at the current
+    /// position so that the (hot) loser-tree comparisons — which always compare
+    /// values at the cursors' *current* offsets — can avoid repeatedly indexing
+    /// (and bounds-checking) the underlying buffer. The default is a no-op for
+    /// implementations that do not benefit from caching (e.g. variable-length
+    /// byte / row cursors, whose comparison cost is dominated by the byte
+    /// comparison itself rather than the index).
+    #[inline]
+    fn set_offset(&mut self, offset: usize) {
+        let _ = offset;
+    }
 }
 
 /// A comparable cursor, used by sort operations
@@ -89,14 +104,23 @@ impl<T: CursorValues> Cursor<T> {
     }
 
     /// Returns true if there are no more rows in this cursor
+    #[inline]
     pub fn is_finished(&self) -> bool {
         self.offset == self.values.len()
     }
 
     /// Advance the cursor, returning the previous row index
+    #[inline]
     pub fn advance(&mut self) -> usize {
         let t = self.offset;
         self.offset += 1;
+        // Keep any cached current value in sync with the new position. Guard on
+        // `is_finished` so implementations never have to index out of bounds:
+        // when the cursor is exhausted the cache is left stale, but a finished
+        // cursor is taken (set to `None`) before it is compared again.
+        if self.offset < self.values.len() {
+            self.values.set_offset(self.offset);
+        }
         t
     }
 
@@ -112,6 +136,7 @@ impl<T: CursorValues> Cursor<T> {
 }
 
 impl<T: CursorValues> PartialEq for Cursor<T> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         T::eq(&self.values, self.offset, &other.values, other.offset)
     }
@@ -142,6 +167,7 @@ impl<T: CursorValues> PartialOrd for Cursor<T> {
 }
 
 impl<T: CursorValues> Ord for Cursor<T> {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         T::compare(&self.values, self.offset, &other.values, other.offset)
     }
@@ -180,10 +206,18 @@ impl RowValues {
 }
 
 impl CursorValues for RowValues {
+    #[inline]
     fn len(&self) -> usize {
         self.rows.num_rows()
     }
 
+    // NOTE: `eq`/`eq_to_previous`/`compare` are deliberately NOT `#[inline]`.
+    // The `Rows` byte-wise comparison is comparatively heavyweight (it
+    // materializes `Row` views and compares variable-length byte slices), and
+    // forcing it into the already-large `update_loser_tree`/`poll_next` hot loop
+    // regresses the multi-column merge path. Leaving it as an out-of-line call
+    // keeps that loop compact. (The lightweight primitive/byte cursors below DO
+    // benefit from inlining.)
     fn eq(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> bool {
         l.rows.row(l_idx) == r.rows.row(r_idx)
     }
@@ -209,29 +243,85 @@ impl<T: ArrowPrimitiveType> CursorArray for PrimitiveArray<T> {
     type Values = PrimitiveValues<T::Native>;
 
     fn values(&self) -> Self::Values {
-        PrimitiveValues(self.values().clone())
+        PrimitiveValues::new(self.values().clone())
     }
 }
 
+/// [`CursorValues`] for a primitive column.
+///
+/// The value at the cursor's current offset — and the one immediately before it
+/// — are cached in [`Self::set_offset`] (called once per [`Cursor::advance`]).
+/// The hot loser-tree comparisons (`compare`/`eq_to_previous`), which always
+/// operate at the cursor's *current* position, then read these cached fields
+/// instead of indexing (and bounds-checking) the buffer on every comparison.
 #[derive(Debug)]
-pub struct PrimitiveValues<T: ArrowNativeTypeOp>(ScalarBuffer<T>);
+pub struct PrimitiveValues<T: ArrowNativeTypeOp> {
+    values: ScalarBuffer<T>,
+    /// Cached value at the current offset (`values[offset]`).
+    current: T,
+    /// Cached value at the previous offset (`values[offset - 1]`); meaningful
+    /// once the cursor has advanced past offset 0 (the only case in which
+    /// `eq_to_previous` reads it).
+    previous: T,
+    /// The current offset. Kept solely to `debug_assert!` that the cache is read
+    /// at the position the caller claims, guarding the invariant the cache
+    /// relies on; it is not used to index the buffer.
+    offset: usize,
+}
+
+impl<T: ArrowNativeTypeOp> PrimitiveValues<T> {
+    fn new(values: ScalarBuffer<T>) -> Self {
+        // Cursors are only built over non-empty batches; the `unwrap_or_default`
+        // merely avoids a panic for the (unreachable) empty case.
+        let first = values.first().copied().unwrap_or_default();
+        Self {
+            values,
+            current: first,
+            previous: first,
+            offset: 0,
+        }
+    }
+}
 
 impl<T: ArrowNativeTypeOp> CursorValues for PrimitiveValues<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
-        self.0.len()
+        self.values.len()
     }
 
+    #[inline(always)]
     fn eq(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> bool {
-        l.0[l_idx].is_eq(r.0[r_idx])
+        // Arbitrary indices (used when comparing across batch boundaries), so
+        // this path indexes the buffer directly rather than using the cache.
+        l.values[l_idx].is_eq(r.values[r_idx])
     }
 
+    #[inline(always)]
     fn eq_to_previous(cursor: &Self, idx: usize) -> bool {
         assert!(idx > 0);
-        cursor.0[idx].is_eq(cursor.0[idx - 1])
+        debug_assert_eq!(idx, cursor.offset);
+        cursor.current.is_eq(cursor.previous)
     }
 
+    #[inline(always)]
     fn compare(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> Ordering {
-        l.0[l_idx].compare(r.0[r_idx])
+        debug_assert_eq!(l_idx, l.offset);
+        debug_assert_eq!(r_idx, r.offset);
+        l.current.compare(r.current)
+    }
+
+    #[inline(always)]
+    fn set_offset(&mut self, offset: usize) {
+        // `offset < len` is guaranteed by the caller (`Cursor::advance`), which
+        // performs that exact comparison immediately before calling this. With
+        // this method inlined, the bounds check on `self.values[offset]` is
+        // dominated by — and identical to — that comparison, so the optimizer
+        // elides it: the length is checked once per advanced row, not on every
+        // (per-comparison) buffer access. The old `current` holds
+        // `values[offset - 1]`, so it becomes `previous`.
+        self.previous = self.current;
+        self.current = self.values[offset];
+        self.offset = offset;
     }
 }
 
@@ -241,6 +331,7 @@ pub struct ByteArrayValues<T: OffsetSizeTrait> {
 }
 
 impl<T: OffsetSizeTrait> ByteArrayValues<T> {
+    #[inline]
     fn value(&self, idx: usize) -> &[u8] {
         assert!(idx < self.len());
         // Safety: offsets are valid and checked bounds above
@@ -253,19 +344,23 @@ impl<T: OffsetSizeTrait> ByteArrayValues<T> {
 }
 
 impl<T: OffsetSizeTrait> CursorValues for ByteArrayValues<T> {
+    #[inline]
     fn len(&self) -> usize {
         self.offsets.len() - 1
     }
 
+    #[inline]
     fn eq(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> bool {
         l.value(l_idx) == r.value(r_idx)
     }
 
+    #[inline]
     fn eq_to_previous(cursor: &Self, idx: usize) -> bool {
         assert!(idx > 0);
         cursor.value(idx) == cursor.value(idx - 1)
     }
 
+    #[inline]
     fn compare(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> Ordering {
         l.value(l_idx).cmp(r.value(r_idx))
     }
@@ -394,16 +489,19 @@ impl<T: CursorValues> ArrayValues<T> {
         }
     }
 
+    #[inline(always)]
     fn is_null(&self, idx: usize) -> bool {
         (idx < self.null_threshold) == self.options.nulls_first
     }
 }
 
 impl<T: CursorValues> CursorValues for ArrayValues<T> {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.values.len()
     }
 
+    #[inline(always)]
     fn eq(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> bool {
         match (l.is_null(l_idx), r.is_null(r_idx)) {
             (true, true) => true,
@@ -412,15 +510,20 @@ impl<T: CursorValues> CursorValues for ArrayValues<T> {
         }
     }
 
+    #[inline(always)]
     fn eq_to_previous(cursor: &Self, idx: usize) -> bool {
         assert!(idx > 0);
         match (cursor.is_null(idx), cursor.is_null(idx - 1)) {
             (true, true) => true,
-            (false, false) => T::eq(&cursor.values, idx, &cursor.values, idx - 1),
+            // Delegate to the inner `eq_to_previous` (rather than `eq` at
+            // `idx`/`idx - 1`) so cursors that cache their current/previous
+            // value can answer without indexing.
+            (false, false) => T::eq_to_previous(&cursor.values, idx),
             _ => false,
         }
     }
 
+    #[inline(always)]
     fn compare(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> Ordering {
         match (l.is_null(l_idx), r.is_null(r_idx)) {
             (true, true) => Ordering::Equal,
@@ -437,6 +540,13 @@ impl<T: CursorValues> CursorValues for ArrayValues<T> {
                 false => T::compare(&l.values, l_idx, &r.values, r_idx),
             },
         }
+    }
+
+    #[inline(always)]
+    fn set_offset(&mut self, offset: usize) {
+        // Forward to the wrapped values so a caching inner cursor (e.g.
+        // `PrimitiveValues`) can refresh its cached current/previous value.
+        self.values.set_offset(offset);
     }
 }
 
@@ -463,7 +573,7 @@ mod tests {
         let reservation = consumer.register(&memory_pool);
 
         let values = ArrayValues {
-            values: PrimitiveValues(values),
+            values: PrimitiveValues::new(values),
             null_threshold,
             options,
             _reservation: reservation,

--- a/datafusion/physical-plan/src/sorts/cursor.rs
+++ b/datafusion/physical-plan/src/sorts/cursor.rs
@@ -45,16 +45,9 @@ pub trait CursorValues {
     /// Returns comparison of `l[l_idx]` and `r[r_idx]`
     fn compare(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> Ordering;
 
-    /// Notifies the values that the owning [`Cursor`] has moved to `offset`,
-    /// which is guaranteed to be `< len()`.
-    ///
-    /// Implementations may use this to cache the value(s) at the current
-    /// position so that the (hot) loser-tree comparisons — which always compare
-    /// values at the cursors' *current* offsets — can avoid repeatedly indexing
-    /// (and bounds-checking) the underlying buffer. The default is a no-op for
-    /// implementations that do not benefit from caching (e.g. variable-length
-    /// byte / row cursors, whose comparison cost is dominated by the byte
-    /// comparison itself rather than the index).
+    /// Notifies the values that the owning [`Cursor`] moved to `offset` (always
+    /// `< len()`), so caching implementations can refresh the value(s) read by
+    /// the hot comparisons. Default no-op (e.g. byte/row cursors don't benefit).
     #[inline]
     fn set_offset(&mut self, offset: usize) {
         let _ = offset;
@@ -114,10 +107,9 @@ impl<T: CursorValues> Cursor<T> {
     pub fn advance(&mut self) -> usize {
         let t = self.offset;
         self.offset += 1;
-        // Keep any cached current value in sync with the new position. Guard on
-        // `is_finished` so implementations never have to index out of bounds:
-        // when the cursor is exhausted the cache is left stale, but a finished
-        // cursor is taken (set to `None`) before it is compared again.
+        // Refresh the cache for the new position. The guard keeps `set_offset`
+        // in bounds; a finished cursor's stale cache is never read (it is taken
+        // before the next comparison).
         if self.offset < self.values.len() {
             self.values.set_offset(self.offset);
         }
@@ -211,13 +203,9 @@ impl CursorValues for RowValues {
         self.rows.num_rows()
     }
 
-    // NOTE: `eq`/`eq_to_previous`/`compare` are deliberately NOT `#[inline]`.
-    // The `Rows` byte-wise comparison is comparatively heavyweight (it
-    // materializes `Row` views and compares variable-length byte slices), and
-    // forcing it into the already-large `update_loser_tree`/`poll_next` hot loop
-    // regresses the multi-column merge path. Leaving it as an out-of-line call
-    // keeps that loop compact. (The lightweight primitive/byte cursors below DO
-    // benefit from inlining.)
+    // No inline hint on purpose: for the heavyweight `Rows` byte comparison the
+    // compiler's own choice wins — both `#[inline]` and `#[inline(never)]`
+    // measurably regress the multi-column merge path.
     fn eq(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> bool {
         l.rows.row(l_idx) == r.rows.row(r_idx)
     }
@@ -249,30 +237,23 @@ impl<T: ArrowPrimitiveType> CursorArray for PrimitiveArray<T> {
 
 /// [`CursorValues`] for a primitive column.
 ///
-/// The value at the cursor's current offset — and the one immediately before it
-/// — are cached in [`Self::set_offset`] (called once per [`Cursor::advance`]).
-/// The hot loser-tree comparisons (`compare`/`eq_to_previous`), which always
-/// operate at the cursor's *current* position, then read these cached fields
-/// instead of indexing (and bounds-checking) the buffer on every comparison.
+/// Caches the value at the current (and previous) offset, refreshed once per
+/// [`Cursor::advance`] via [`CursorValues::set_offset`], so the hot loser-tree
+/// comparisons read a cached field instead of indexing the buffer each time.
 #[derive(Debug)]
 pub struct PrimitiveValues<T: ArrowNativeTypeOp> {
     values: ScalarBuffer<T>,
-    /// Cached value at the current offset (`values[offset]`).
+    /// Cached `values[offset]`.
     current: T,
-    /// Cached value at the previous offset (`values[offset - 1]`); meaningful
-    /// once the cursor has advanced past offset 0 (the only case in which
-    /// `eq_to_previous` reads it).
+    /// Cached `values[offset - 1]` (read by `eq_to_previous`, only past offset 0).
     previous: T,
-    /// The current offset. Kept solely to `debug_assert!` that the cache is read
-    /// at the position the caller claims, guarding the invariant the cache
-    /// relies on; it is not used to index the buffer.
+    /// Current offset; used only to `debug_assert!` the cache is read in sync.
     offset: usize,
 }
 
 impl<T: ArrowNativeTypeOp> PrimitiveValues<T> {
     fn new(values: ScalarBuffer<T>) -> Self {
-        // Cursors are only built over non-empty batches; the `unwrap_or_default`
-        // merely avoids a panic for the (unreachable) empty case.
+        // Non-empty in practice; `unwrap_or_default` just avoids a panic.
         let first = values.first().copied().unwrap_or_default();
         Self {
             values,
@@ -291,8 +272,7 @@ impl<T: ArrowNativeTypeOp> CursorValues for PrimitiveValues<T> {
 
     #[inline(always)]
     fn eq(l: &Self, l_idx: usize, r: &Self, r_idx: usize) -> bool {
-        // Arbitrary indices (used when comparing across batch boundaries), so
-        // this path indexes the buffer directly rather than using the cache.
+        // Arbitrary indices (cross-batch comparison), so index directly.
         l.values[l_idx].is_eq(r.values[r_idx])
     }
 
@@ -312,13 +292,10 @@ impl<T: ArrowNativeTypeOp> CursorValues for PrimitiveValues<T> {
 
     #[inline(always)]
     fn set_offset(&mut self, offset: usize) {
-        // `offset < len` is guaranteed by the caller (`Cursor::advance`), which
-        // performs that exact comparison immediately before calling this. With
-        // this method inlined, the bounds check on `self.values[offset]` is
-        // dominated by — and identical to — that comparison, so the optimizer
-        // elides it: the length is checked once per advanced row, not on every
-        // (per-comparison) buffer access. The old `current` holds
-        // `values[offset - 1]`, so it becomes `previous`.
+        // The caller (`Cursor::advance`) guarantees `offset < len`; inlined, that
+        // guard dominates the index below so its bounds check is elided — the
+        // length is checked once per row, not per comparison. The old `current`
+        // is `values[offset - 1]`, so it becomes `previous`.
         self.previous = self.current;
         self.current = self.values[offset];
         self.offset = offset;
@@ -515,9 +492,8 @@ impl<T: CursorValues> CursorValues for ArrayValues<T> {
         assert!(idx > 0);
         match (cursor.is_null(idx), cursor.is_null(idx - 1)) {
             (true, true) => true,
-            // Delegate to the inner `eq_to_previous` (rather than `eq` at
-            // `idx`/`idx - 1`) so cursors that cache their current/previous
-            // value can answer without indexing.
+            // Delegate to inner `eq_to_previous` so a caching cursor can answer
+            // without indexing.
             (false, false) => T::eq_to_previous(&cursor.values, idx),
             _ => false,
         }
@@ -544,8 +520,7 @@ impl<T: CursorValues> CursorValues for ArrayValues<T> {
 
     #[inline(always)]
     fn set_offset(&mut self, offset: usize) {
-        // Forward to the wrapped values so a caching inner cursor (e.g.
-        // `PrimitiveValues`) can refresh its cached current/previous value.
+        // Forward to the wrapped values (e.g. caching `PrimitiveValues`).
         self.values.set_offset(offset);
     }
 }

--- a/datafusion/physical-plan/src/sorts/merge.rs
+++ b/datafusion/physical-plan/src/sorts/merge.rs
@@ -294,10 +294,9 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
             // Adjust the loser tree if necessary, returning control if needed
             if !self.loser_tree_adjusted {
                 let winner = self.loser_tree[0];
-                // Fast path: the winner's cursor is still live for almost every
-                // row, so avoid the `maybe_poll_stream` call (and its `Poll`
-                // plumbing) unless the cursor is actually exhausted and needs a
-                // fresh `RecordBatch`.
+                // Fast path: skip the `maybe_poll_stream` call (and its `Poll`
+                // plumbing) unless the winner's cursor is exhausted and needs a
+                // fresh batch — it is live for almost every row.
                 if self.cursors[winner].is_none() {
                     match ready!(self.maybe_poll_stream(cx, winner)) {
                         Ok(()) => {}

--- a/datafusion/physical-plan/src/sorts/merge.rs
+++ b/datafusion/physical-plan/src/sorts/merge.rs
@@ -294,9 +294,18 @@ impl<C: CursorValues> SortPreservingMergeStream<C> {
             // Adjust the loser tree if necessary, returning control if needed
             if !self.loser_tree_adjusted {
                 let winner = self.loser_tree[0];
-                if let Err(e) = ready!(self.maybe_poll_stream(cx, winner)) {
-                    self.done = true;
-                    return Poll::Ready(Some(Err(e)));
+                // Fast path: the winner's cursor is still live for almost every
+                // row, so avoid the `maybe_poll_stream` call (and its `Poll`
+                // plumbing) unless the cursor is actually exhausted and needs a
+                // fresh `RecordBatch`.
+                if self.cursors[winner].is_none() {
+                    match ready!(self.maybe_poll_stream(cx, winner)) {
+                        Ok(()) => {}
+                        Err(e) => {
+                            self.done = true;
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    }
                 }
                 self.update_loser_tree();
             }


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No dedicated issue; this is a self-contained performance improvement to the
sort-preserving merge hot path. Happy to file a tracking issue if preferred. -->

- N/A (performance)

## Rationale for this change
Two inefficiencies in the hot path:

1. The single-column primitive/array cursor comparison was **not being inlined**
   (in profiles it appeared as a separate ~21% self-time symbol), and every comparison
   bounds-checked the underlying `ScalarBuffer` twice.
2. `maybe_poll_stream` was called on **every** output row, even though it is a
   no-op whenever the winner's cursor is still live (the common case).

```
 ┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query ┃                              HEAD ┃             perf_spm-compare-cache ┃        Change ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ Q1    │ 165.13 / 166.08 ±0.75 / 166.98 ms │  131.46 / 132.49 ±0.79 / 133.86 ms │ +1.25x faster │
│ Q2    │ 141.22 / 141.86 ±0.81 / 143.38 ms │  118.06 / 120.08 ±1.30 / 121.91 ms │ +1.18x faster │
│ Q3    │ 652.56 / 657.09 ±2.91 / 661.10 ms │  645.82 / 649.88 ±3.27 / 654.55 ms │     no change │
│ Q4    │ 195.87 / 199.80 ±6.83 / 213.43 ms │  180.22 / 183.86 ±5.04 / 193.43 ms │ +1.09x faster │
│ Q5    │ 279.14 / 279.91 ±0.50 / 280.71 ms │  260.15 / 260.70 ±0.48 / 261.54 ms │ +1.07x faster │
│ Q6    │ 292.50 / 293.43 ±0.71 / 294.56 ms │  273.28 / 274.77 ±1.66 / 277.81 ms │ +1.07x faster │
│ Q7    │ 465.87 / 467.23 ±2.01 / 471.21 ms │  445.83 / 449.21 ±3.47 / 455.33 ms │     no change │
│ Q8    │ 327.51 / 330.08 ±3.25 / 336.40 ms │  319.12 / 325.35 ±6.20 / 336.30 ms │     no change │
│ Q9    │ 342.17 / 346.17 ±2.68 / 348.71 ms │ 336.40 / 348.61 ±13.37 / 368.15 ms │     no change │
│ Q10   │ 484.08 / 486.50 ±2.53 / 490.75 ms │ 474.15 / 490.16 ±13.58 / 507.56 ms │     no change │
│ Q11   │ 244.24 / 250.98 ±8.70 / 267.17 ms │  229.07 / 237.38 ±8.10 / 249.40 ms │ +1.06x faster │
└───────┴───────────────────────────────────┴────────────────────────────────────┴───────────────┘
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Summary                     ┃           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Total Time (HEAD)                     │ 3619.13ms │
│ Total Time (perf_spm-compare-cache)   │ 3472.49ms │
│ Average Time (HEAD)                   │  329.01ms │
│ Average Time (perf_spm-compare-cache) │  315.68ms │
│ Queries Faster                        │         6 │
│ Queries Slower                        │         0 │
│ Queries with No Change                │         5 │
│ Queries with Failure                  │         0 │
└───────────────────────────────────────┴───────────┘

```

## What changes are included in this PR?

- Inline the lightweight primitive/array cursor comparisons. 
- Skip the per-row `maybe_poll_stream` call unless the winner's cursor is
  actually exhausted and needs a fresh `RecordBatch`.
- Cache the current (and previous) value of a primitive cursor, refreshed once
  per `advance()` via a new `CursorValues::set_offset` hook (default no-op;
  `ArrayValues` forwards to the inner cursor). 


## Are these changes tested?

Existing tests 
## Are there any user-facing changes?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
