### PR TITLE
refactor: factor distinct-from unparsing into a shared helper

### DIFF
--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -122,6 +122,39 @@ impl Unparser<'_> {
         Ok(root_expr)
     }
 
+    fn distinct_from_to_sql(
+        &self,
+        left: ast::Expr,
+        right: ast::Expr,
+        is_distinct: bool,
+    ) -> Result<ast::Expr> {
+        match self.dialect.distinct_from_style() {
+            DistinctFromStyle::FullText => {
+                let expr = if is_distinct {
+                    ast::Expr::IsDistinctFrom(Box::new(left), Box::new(right))
+                } else {
+                    ast::Expr::IsNotDistinctFrom(Box::new(left), Box::new(right))
+                };
+                Ok(ast::Expr::Nested(Box::new(expr)))
+            }
+            DistinctFromStyle::Spaceship => {
+                let expr = ast::Expr::Nested(Box::new(ast::Expr::BinaryOp {
+                    left: Box::new(left),
+                    right: Box::new(right),
+                    op: BinaryOperator::Spaceship,
+                }));
+                if is_distinct {
+                    Ok(ast::Expr::Nested(Box::new(ast::Expr::UnaryOp {
+                        op: UnaryOperator::Not,
+                        expr: Box::new(expr),
+                    })))
+                } else {
+                    Ok(expr)
+                }
+            }
+        }
+    }
+
     #[cfg_attr(feature = "recursive_protection", recursive::recursive)]
     fn expr_to_sql_inner(&self, expr: &Expr) -> Result<ast::Expr> {
         match expr {
@@ -176,24 +209,7 @@ impl Unparser<'_> {
             }) => {
                 let l = self.expr_to_sql_inner(left.as_ref())?;
                 let r = self.expr_to_sql_inner(right.as_ref())?;
-
-                match self.dialect.distinct_from_style() {
-                    DistinctFromStyle::FullText => Ok(ast::Expr::Nested(Box::new(
-                        ast::Expr::IsDistinctFrom(Box::new(l), Box::new(r)),
-                    ))),
-                    DistinctFromStyle::Spaceship => {
-                        Ok(ast::Expr::Nested(Box::new(ast::Expr::UnaryOp {
-                            op: UnaryOperator::Not,
-                            expr: Box::new(ast::Expr::Nested(Box::new(
-                                ast::Expr::BinaryOp {
-                                    left: Box::new(l),
-                                    right: Box::new(r),
-                                    op: BinaryOperator::Spaceship,
-                                },
-                            ))),
-                        })))
-                    }
-                }
+                self.distinct_from_to_sql(l, r, true)
             }
             Expr::BinaryExpr(BinaryExpr {
                 left,
@@ -202,19 +218,7 @@ impl Unparser<'_> {
             }) => {
                 let l = self.expr_to_sql_inner(left.as_ref())?;
                 let r = self.expr_to_sql_inner(right.as_ref())?;
-
-                match self.dialect.distinct_from_style() {
-                    DistinctFromStyle::FullText => Ok(ast::Expr::Nested(Box::new(
-                        ast::Expr::IsNotDistinctFrom(Box::new(l), Box::new(r)),
-                    ))),
-                    DistinctFromStyle::Spaceship => {
-                        Ok(ast::Expr::Nested(Box::new(ast::Expr::BinaryOp {
-                            left: Box::new(l),
-                            right: Box::new(r),
-                            op: BinaryOperator::Spaceship,
-                        })))
-                    }
-                }
+                self.distinct_from_to_sql(l, r, false)
             }
             Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
                 let l = self.expr_to_sql_inner(left.as_ref())?;


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23158

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The `IsDistinctFrom` and `IsNotDistinctFrom` arms of `expr_to_sql_inner`
each carried a near-identical `match self.dialect.distinct_from_style()`
block, dispatching over `DistinctFromStyle::{FullText, Spaceship}`. The two
copies differed only in whether the comparison is "distinct" or
"not distinct", so the dialect-handling logic was duplicated. #23158 tracks
factoring this out.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add a private helper `distinct_from_to_sql(&self, left, right, is_distinct)`
  that performs the `DistinctFromStyle` dispatch in a single place.
- Call it from both arms: `IsDistinctFrom` with `is_distinct = true` and
  `IsNotDistinctFrom` with `is_distinct = false`.

This is a pure refactor with no behavior change.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Covered by existing tests, since there is no behavior change:

- `cargo test -p datafusion-sql --lib unparser` (incl. `test_is_distinct_from`)
- `cargo test -p datafusion-sql --test sql_integration`
- `cargo clippy -p datafusion-sql -- -D warnings`
- `cargo fmt --all`

I also checked by hand that all four combinations
(`FullText`/`Spaceship` × distinct/not-distinct) produce the same `ast::Expr`
as before.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No. The helper is private and the generated SQL is unchanged for every
dialect. No public API changes.
