### PR TITLE
fix(spark): return error from ELT coerce_types when fewer than 2 args

### DIFF
--- a/datafusion/spark/src/function/string/elt.rs
+++ b/datafusion/spark/src/function/string/elt.rs
@@ -69,9 +69,9 @@ impl ScalarUDFImpl for SparkElt {
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         let length = arg_types.len();
         if length < 2 {
-            plan_datafusion_err!(
+            return Err(plan_datafusion_err!(
                 "ELT function expects at least 2 arguments: index, value1"
-            );
+            ));
         }
 
         let idx_dt: &DataType = &arg_types[0];


### PR DESCRIPTION
## Which issue does this PR close?

- Closes N/A

## Rationale for this change

`SparkElt::coerce_types` validates that ELT receives at least 2 arguments (index + value1), but the error was never returned: it was built with `plan_datafusion_err!(...)` as an expression statement whose value was discarded. Since `DataFusionError` is not `#[must_use]`, the compiler didn't warn, so the function fell through and continued with fewer arguments than required instead of failing with a clear plan-time error.

## What changes are included in this PR?

In datafusion/spark/src/function/string/elt.rs, the argument-count check is wrapped in return Err(plan_datafusion_err!(...)) so the validation actually short-circuits when fewer than 2 arguments are provided.

## Are these changes tested?

This change restores an error path that was previously dropped silently. ELT's normal behavior is already covered by the existing tests in elt.rs. The invalid-arity branch had no coverage because it was never actually exercised.

## Are there any user-facing changes?

ELT now returns a plan-time error when invoked with fewer than 2 arguments, instead of silently continuing. No public API changes.
