### PR TITLE
refactor: centralize join-input table-scan filter extraction before u…

### DIFF
--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -584,6 +584,19 @@ impl Unparser<'_> {
         self.project_window_output(&window_expr, select, None)
     }
 
+    fn extract_join_input_table_scan_filters(
+        plan: &Arc<LogicalPlan>,
+        table_scan_filters: &mut Vec<Expr>,
+    ) -> Result<Arc<LogicalPlan>> {
+        match try_transform_to_simple_table_scan_with_filters(plan)? {
+            Some((plan, filters)) => {
+                table_scan_filters.extend(filters);
+                Ok(Arc::new(plan))
+            }
+            None => Ok(Arc::clone(plan)),
+        }
+    }
+
     #[cfg_attr(feature = "recursive_protection", recursive::recursive)]
     fn select_to_sql_recursively(
         &self,
@@ -1153,14 +1166,10 @@ impl Unparser<'_> {
                 // The outer projection plan will handle projecting the correct columns.
                 let already_projected = select.already_projected();
 
-                let left_plan =
-                    match try_transform_to_simple_table_scan_with_filters(left_plan)? {
-                        Some((plan, filters)) => {
-                            table_scan_filters.extend(filters);
-                            Arc::new(plan)
-                        }
-                        None => Arc::clone(left_plan),
-                    };
+                let left_plan = Self::extract_join_input_table_scan_filters(
+                    left_plan,
+                    &mut table_scan_filters,
+                )?;
                 let left_plan = if already_projected {
                     Self::unwrap_qualified_passthrough_join_projection(left_plan)
                 } else {
@@ -1181,14 +1190,10 @@ impl Unparser<'_> {
                     None
                 };
 
-                let right_plan =
-                    match try_transform_to_simple_table_scan_with_filters(right_plan)? {
-                        Some((plan, filters)) => {
-                            table_scan_filters.extend(filters);
-                            Arc::new(plan)
-                        }
-                        None => Arc::clone(right_plan),
-                    };
+                let right_plan = Self::extract_join_input_table_scan_filters(
+                    right_plan,
+                    &mut table_scan_filters,
+                )?;
 
                 let mut right_relation = RelationBuilder::default();
                 if already_projected

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2736,9 +2736,9 @@ fn test_unparse_inner_join_with_table_scan_projection() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_unparse_projected_join_unwraps_right_nested_passthrough_projection() -> Result<()>
-{
+/// Build the three base table scans (`left_table`, `mid_table`, `right_table`)
+/// shared by the nested passthrough-projection join unparsing tests.
+fn nested_passthrough_join_tables() -> Result<(LogicalPlan, LogicalPlan, LogicalPlan)> {
     let left_schema = Schema::new(vec![
         Field::new("left_id", DataType::Int32, false),
         Field::new("mid_id", DataType::Int32, false),
@@ -2755,6 +2755,13 @@ fn test_unparse_projected_join_unwraps_right_nested_passthrough_projection() -> 
     let left = table_scan(Some("left_table"), &left_schema, None)?.build()?;
     let mid = table_scan(Some("mid_table"), &mid_schema, None)?.build()?;
     let right = table_scan(Some("right_table"), &right_schema, None)?.build()?;
+    Ok((left, mid, right))
+}
+
+#[test]
+fn test_unparse_projected_join_unwraps_right_nested_passthrough_projection() -> Result<()>
+{
+    let (left, mid, right) = nested_passthrough_join_tables()?;
 
     let nested_right = LogicalPlanBuilder::from(mid)
         .join(
@@ -2788,6 +2795,52 @@ fn test_unparse_projected_join_unwraps_right_nested_passthrough_projection() -> 
     assert_snapshot!(
         sql,
         @r#"SELECT left_table.left_id, mid_table.mid_id, right_table."value" FROM left_table INNER JOIN (mid_table INNER JOIN right_table ON mid_table.right_id = right_table.right_id) ON left_table.mid_id = mid_table.mid_id"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_unparse_projected_join_unwraps_left_nested_passthrough_projection() -> Result<()>
+{
+    let (left, mid, right) = nested_passthrough_join_tables()?;
+
+    // Left join input is a qualified passthrough `Projection(Join)`, and the
+    // outer join condition (`mid_table.right_id`) references an alias from
+    // inside it. The unparser must not wrap this in a derived table that would
+    // hide `mid_table.right_id` from the outer condition.
+    let nested_left = LogicalPlanBuilder::from(left)
+        .join(
+            mid,
+            datafusion_expr::JoinType::Inner,
+            (vec!["left_table.mid_id"], vec!["mid_table.mid_id"]),
+            None,
+        )?
+        .project(vec![
+            col("left_table.left_id"),
+            col("mid_table.mid_id"),
+            col("mid_table.right_id"),
+        ])?
+        .build()?;
+
+    let plan = LogicalPlanBuilder::from(nested_left)
+        .join(
+            right,
+            datafusion_expr::JoinType::Inner,
+            (vec!["mid_table.right_id"], vec!["right_table.right_id"]),
+            None,
+        )?
+        .project(vec![
+            col("left_table.left_id"),
+            col("mid_table.mid_id"),
+            col("right_table.value"),
+        ])?
+        .build()?;
+
+    let sql = plan_to_sql(&plan)?;
+    assert_snapshot!(
+        sql,
+        @r#"SELECT left_table.left_id, mid_table.mid_id, right_table."value" FROM left_table INNER JOIN mid_table ON left_table.mid_id = mid_table.mid_id INNER JOIN right_table ON mid_table.right_id = right_table.right_id"#
     );
 
     Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23159 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Join unparsing handles the left and right inputs inline in
`select_to_sql_recursively` (`datafusion/sql/src/unparser/plan.rs`). Both sides
repeated the same table-scan filter extraction
(`try_transform_to_simple_table_scan_with_filters`: extend the collected
filters, then return the simplified or original plan), while the
passthrough-`Projection(Join)` handling intentionally diverges per side (the
left input can be unwrapped; the right input may need a nested-join relation so
SQL preserves the required join grouping).

Centralizing only the duplicated common setup — and keeping the side-specific
behavior explicit — makes the two paths easier to read and keeps the
alias-scope invariant in one obvious place. #23159 tracks this.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Extract the duplicated filter-extraction dispatch into a small helper
  `extract_join_input_table_scan_filters(plan, &mut table_scan_filters)`, and
  call it from both the left and right join-input paths.
- Keep the side-specific passthrough-projection handling inline and explicit
  (left: `unwrap_qualified_passthrough_join_projection`; right:
  `qualified_passthrough_join_projection_to_nested_relation`).
- Tests: factor the shared three-table setup into a
  `nested_passthrough_join_tables()` helper, and add
  `test_unparse_projected_join_unwraps_left_nested_passthrough_projection` to
  mirror the existing right-input test (this also fills a left-side coverage
  gap).

This is a pure refactor with no behavior change.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Covered by existing tests plus the new left-input test, all passing:

- `cargo test -p datafusion-sql --test sql_integration`
  (includes both `..._left_..._passthrough_projection` and
  `..._right_..._passthrough_projection`)
- `cargo clippy -p datafusion-sql --tests -- -D warnings`
- `cargo fmt --all`

Existing inline snapshots are unchanged (no behavior change); the new test locks
in the left-input behavior the refactor touches.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No. This is an internal refactor of the SQL unparser; the generated SQL is
unchanged and there are no public API changes.
