### PR TITLE
fix: restrict Substrait physical local file imports

### DIFF
--- a/datafusion/substrait/src/physical_plan/consumer.rs
+++ b/datafusion/substrait/src/physical_plan/consumer.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
@@ -37,19 +38,55 @@ use async_recursion::async_recursion;
 use chrono::DateTime;
 use datafusion::datasource::memory::DataSourceExec;
 use object_store::ObjectMeta;
+use object_store::path::Path as ObjectStorePath;
 use substrait::proto::Type;
 use substrait::proto::read_rel::local_files::file_or_files::PathType;
 use substrait::proto::r#type::{Kind, Nullability};
 use substrait::proto::{
     Rel, expression::MaskExpression, read_rel::ReadType, rel::RelType,
 };
+use url::Url;
+
+/// Options controlling Substrait physical plan import.
+#[derive(Debug, Clone, Default)]
+pub struct PhysicalPlanConsumerOptions {
+    allowed_local_file_roots: Vec<PathBuf>,
+}
+
+impl PhysicalPlanConsumerOptions {
+    /// Create import options that deny access to local files.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allow imported local file paths under `root`.
+    ///
+    /// The root and imported file path are canonicalized before comparison, so
+    /// relative paths and symlinks cannot escape the configured root.
+    pub fn with_allowed_local_file_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.allowed_local_file_roots.push(root.into());
+        self
+    }
+}
 
 /// Convert Substrait Rel to DataFusion ExecutionPlan
 #[async_recursion]
 pub async fn from_substrait_rel(
+    ctx: &SessionContext,
+    rel: &Rel,
+    extensions: &HashMap<u32, &String>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let options = PhysicalPlanConsumerOptions::default();
+    from_substrait_rel_with_options(ctx, rel, extensions, &options).await
+}
+
+/// Convert Substrait Rel to DataFusion ExecutionPlan using explicit import options.
+#[async_recursion]
+pub async fn from_substrait_rel_with_options(
     _ctx: &SessionContext,
     rel: &Rel,
     _extensions: &HashMap<u32, &String>,
+    options: &PhysicalPlanConsumerOptions,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut base_config_builder;
 
@@ -96,10 +133,15 @@ pub async fn from_substrait_rel(
                     for file in &files.items {
                         let path = if let Some(path_type) = &file.path_type {
                             match path_type {
-                                PathType::UriPath(path) => Ok(path.clone()),
-                                PathType::UriPathGlob(path) => Ok(path.clone()),
-                                PathType::UriFile(path) => Ok(path.clone()),
-                                PathType::UriFolder(path) => Ok(path.clone()),
+                                PathType::UriPath(path) | PathType::UriFile(path) => {
+                                    local_file_path(path, options)
+                                }
+                                PathType::UriPathGlob(_) => not_impl_err!(
+                                    "Substrait physical plan import with local file globs is not supported"
+                                ),
+                                PathType::UriFolder(_) => not_impl_err!(
+                                    "Substrait physical plan import with local folders is not supported"
+                                ),
                             }
                         } else {
                             Err(DataFusionError::Substrait(
@@ -122,7 +164,7 @@ pub async fn from_substrait_rel(
                         let partitioned_file =
                             PartitionedFile::new_from_meta(ObjectMeta {
                                 last_modified: last_modified.into(),
-                                location: path.into(),
+                                location: path,
                                 size,
                                 e_tag: None,
                                 version: None,
@@ -162,6 +204,65 @@ pub async fn from_substrait_rel(
         }
         _ => not_impl_err!("Unsupported Reltype: {:?}", rel.rel_type),
     }
+}
+
+fn local_file_path(
+    path: &str,
+    options: &PhysicalPlanConsumerOptions,
+) -> Result<ObjectStorePath> {
+    if options.allowed_local_file_roots.is_empty() {
+        return substrait_err!(
+            "Importing Substrait physical plans with local file paths requires an allowed local file root"
+        );
+    }
+
+    let path = parse_local_file_path(path)?;
+    let path = canonicalize_path(&path)?;
+
+    let is_allowed = options
+        .allowed_local_file_roots
+        .iter()
+        .map(|root| canonicalize_path(root))
+        .collect::<Result<Vec<_>>>()?
+        .iter()
+        .any(|root| path.starts_with(root));
+
+    if !is_allowed {
+        return substrait_err!(
+            "Substrait physical plan local file path {} is outside the allowed local file roots",
+            path.display()
+        );
+    }
+
+    ObjectStorePath::from_filesystem_path(path).map_err(|e| {
+        DataFusionError::Substrait(format!(
+            "Invalid local file path in Substrait physical plan: {e}"
+        ))
+    })
+}
+
+fn parse_local_file_path(path: &str) -> Result<PathBuf> {
+    match Url::parse(path) {
+        Ok(url) if url.scheme() == "file" => url.to_file_path().map_err(|_| {
+            DataFusionError::Substrait(format!(
+                "Invalid local file URL in Substrait physical plan: {path}"
+            ))
+        }),
+        Ok(url) => substrait_err!(
+            "Unsupported Substrait physical plan file URL scheme: {}",
+            url.scheme()
+        ),
+        Err(_) => Ok(Path::new("/").join(path)),
+    }
+}
+
+fn canonicalize_path(path: &Path) -> Result<PathBuf> {
+    path.canonicalize().map_err(|e| {
+        DataFusionError::Substrait(format!(
+            "Unable to canonicalize Substrait physical plan local file path {}: {e}",
+            path.display()
+        ))
+    })
 }
 
 fn to_field(name: &String, r#type: &Type) -> Result<Field> {

--- a/datafusion/substrait/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_physical_plan.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::Schema;
@@ -25,13 +26,19 @@ use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::datasource::physical_plan::{
     FileGroup, FileScanConfigBuilder, ParquetSource,
 };
-use datafusion::error::Result;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_plan::{ExecutionPlan, displayable};
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
+use datafusion_substrait::physical_plan::consumer::PhysicalPlanConsumerOptions;
 use datafusion_substrait::physical_plan::{consumer, producer};
 
 use datafusion::datasource::memory::DataSourceExec;
+use object_store::path::Path as ObjectStorePath;
+use substrait::proto::Rel;
 use substrait::proto::extensions;
+use substrait::proto::read_rel::ReadType;
+use substrait::proto::read_rel::local_files::file_or_files::PathType;
+use substrait::proto::rel::RelType;
 
 #[tokio::test]
 async fn parquet_exec() -> Result<()> {
@@ -42,11 +49,11 @@ async fn parquet_exec() -> Result<()> {
         FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), source)
             .with_file_groups(vec![
                 FileGroup::new(vec![PartitionedFile::new(
-                    "file://foo/part-0.parquet".to_string(),
+                    testdata_object_path("data.parquet"),
                     123,
                 )]),
                 FileGroup::new(vec![PartitionedFile::new(
-                    "file://foo/part-1.parquet".to_string(),
+                    testdata_object_path("empty.parquet"),
                     123,
                 )]),
             ])
@@ -64,9 +71,13 @@ async fn parquet_exec() -> Result<()> {
 
     let ctx = SessionContext::new();
 
-    let parquet_exec_roundtrip =
-        consumer::from_substrait_rel(&ctx, substrait_rel.as_ref(), &HashMap::new())
-            .await?;
+    let parquet_exec_roundtrip = consumer::from_substrait_rel_with_options(
+        &ctx,
+        substrait_rel.as_ref(),
+        &HashMap::new(),
+        &testdata_physical_plan_options(),
+    )
+    .await?;
 
     let expected = format!("{}", displayable(parquet_exec.as_ref()).indent(true));
     let actual = format!(
@@ -74,6 +85,47 @@ async fn parquet_exec() -> Result<()> {
         displayable(parquet_exec_roundtrip.as_ref()).indent(true)
     );
     assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn local_files_require_allowed_root() -> Result<()> {
+    let rel = local_file_rel(testdata_object_path("data.parquet"))?;
+    let ctx = SessionContext::new();
+
+    let err = consumer::from_substrait_rel(&ctx, rel.as_ref(), &HashMap::new())
+        .await
+        .expect_err("local file imports should require an explicit allowed root");
+
+    assert_contains(
+        &err,
+        "requires an allowed local file root",
+        "unexpected error for missing local file root",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn local_files_must_stay_under_allowed_root() -> Result<()> {
+    let rel = local_file_rel(workspace_path("Cargo.toml").display().to_string())?;
+    let ctx = SessionContext::new();
+
+    let err = consumer::from_substrait_rel_with_options(
+        &ctx,
+        rel.as_ref(),
+        &HashMap::new(),
+        &testdata_physical_plan_options(),
+    )
+    .await
+    .expect_err("local file imports outside the allowed root should fail");
+
+    assert_contains(
+        &err,
+        "outside the allowed local file roots",
+        "unexpected error for local file root escape",
+    );
 
     Ok(())
 }
@@ -104,7 +156,7 @@ async fn roundtrip(sql: &str) -> Result<()> {
     let ctx = create_parquet_context().await?;
     let df = ctx.sql(sql).await?;
 
-    roundtrip_parquet(df).await?;
+    roundtrip_parquet(df, testdata_physical_plan_options()).await?;
 
     Ok(())
 }
@@ -112,13 +164,21 @@ async fn roundtrip(sql: &str) -> Result<()> {
 async fn roundtrip_alltypes(sql: &str) -> Result<()> {
     let ctx = create_all_types_context().await?;
     let df = ctx.sql(sql).await?;
+    let testdata = datafusion::test_util::parquet_test_data();
 
-    roundtrip_parquet(df).await?;
+    roundtrip_parquet(
+        df,
+        PhysicalPlanConsumerOptions::new().with_allowed_local_file_root(testdata),
+    )
+    .await?;
 
     Ok(())
 }
 
-async fn roundtrip_parquet(df: DataFrame) -> Result<()> {
+async fn roundtrip_parquet(
+    df: DataFrame,
+    options: PhysicalPlanConsumerOptions,
+) -> Result<()> {
     let physical_plan = df.create_physical_plan().await?;
 
     // Convert the plan into a substrait (protobuf) Rel
@@ -128,9 +188,13 @@ async fn roundtrip_parquet(df: DataFrame) -> Result<()> {
 
     // Convert the substrait Rel back into a physical plan
     let ctx = create_parquet_context().await?;
-    let physical_plan_roundtrip =
-        consumer::from_substrait_rel(&ctx, substrait_plan.as_ref(), &HashMap::new())
-            .await?;
+    let physical_plan_roundtrip = consumer::from_substrait_rel_with_options(
+        &ctx,
+        substrait_plan.as_ref(),
+        &HashMap::new(),
+        &options,
+    )
+    .await?;
 
     // Compare the original and roundtrip physical plans
     let expected = format!("{}", displayable(physical_plan.as_ref()).indent(true));
@@ -147,10 +211,79 @@ async fn create_parquet_context() -> Result<SessionContext> {
     let ctx = SessionContext::new();
     let explicit_options = ParquetReadOptions::default();
 
-    ctx.register_parquet("data", "tests/testdata/data.parquet", explicit_options)
-        .await?;
+    ctx.register_parquet(
+        "data",
+        testdata_path("data.parquet").to_string_lossy().as_ref(),
+        explicit_options,
+    )
+    .await?;
 
     Ok(ctx)
+}
+
+fn testdata_physical_plan_options() -> PhysicalPlanConsumerOptions {
+    PhysicalPlanConsumerOptions::new().with_allowed_local_file_root(testdata_path(""))
+}
+
+fn testdata_path(file_name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("testdata")
+        .join(file_name)
+}
+
+fn workspace_path(path: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(path)
+}
+
+fn testdata_object_path(file_name: &str) -> String {
+    ObjectStorePath::from_filesystem_path(testdata_path(file_name))
+        .unwrap()
+        .to_string()
+}
+
+fn local_file_rel(path: String) -> Result<Box<Rel>> {
+    let schema = Arc::new(Schema::empty());
+    let source = Arc::new(ParquetSource::new(schema.clone()));
+    let scan_config =
+        FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), source)
+            .with_file_groups(vec![FileGroup::new(vec![PartitionedFile::new(
+                testdata_object_path("data.parquet"),
+                123,
+            )])])
+            .build();
+    let parquet_exec: Arc<dyn ExecutionPlan> =
+        DataSourceExec::from_data_source(scan_config);
+
+    let mut extension_info: (
+        Vec<extensions::SimpleExtensionDeclaration>,
+        HashMap<String, u32>,
+    ) = (vec![], HashMap::new());
+
+    let mut rel = producer::to_substrait_rel(parquet_exec.as_ref(), &mut extension_info)?;
+    set_first_local_file_path(&mut rel, path);
+    Ok(rel)
+}
+
+fn set_first_local_file_path(rel: &mut Rel, path: String) {
+    let Some(RelType::Read(read)) = &mut rel.rel_type else {
+        panic!("expected read rel");
+    };
+    let Some(ReadType::LocalFiles(files)) = &mut read.read_type else {
+        panic!("expected local files read");
+    };
+    files.items[0].path_type = Some(PathType::UriPath(path));
+}
+
+fn assert_contains(err: &DataFusionError, expected: &str, context: &str) {
+    let actual = err.to_string();
+    assert!(
+        actual.contains(expected),
+        "{context}: expected error to contain {expected:?}, got {actual:?}"
+    );
 }
 
 async fn create_all_types_context() -> Result<SessionContext> {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23171.

## Rationale for this change

Imported Substrait physical plans currently turn `ReadRel.LocalFiles` entries into a local filesystem-backed Parquet `DataSourceExec` without requiring the embedding host to approve the referenced local paths. In hosts that accept physical Substrait plans from lower-trust callers, that can let serialized plan input select process-local Parquet files outside intended dataset roots.

This change makes local file access during physical plan import explicit instead of ambient.

## What changes are included in this PR?

- Adds `PhysicalPlanConsumerOptions` for Substrait physical plan import.
- Keeps `from_substrait_rel` as a default-deny wrapper for local file imports.
- Adds `from_substrait_rel_with_options` so callers can opt in with allowed local file roots.
- Canonicalizes imported local file paths and configured roots before comparing them.
- Rejects local file globs and folders in physical plan import rather than accepting them without a policy.
- Updates physical roundtrip tests to pass explicit allowed roots.
- Adds regression coverage for missing allowed roots and paths outside the allowed root.

## Are these changes tested?

Yes.

- `cargo fmt --all --check`
- `cargo test -p datafusion-substrait`
- `cargo clippy -p datafusion-substrait --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

Yes. Substrait physical plan consumers that import `ReadRel.LocalFiles` now need to call `from_substrait_rel_with_options` and explicitly configure allowed local file roots. The existing `from_substrait_rel` API no longer imports local files by default.

This is an intentional security hardening change. It may require the `api change` label because it changes behavior for the existing public API and adds a new opt-in API.
