### PR TITLE
feat(functions-aggregate): support sum(interval)

### DIFF
--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -398,11 +398,6 @@ impl AggregateUDFImpl for Sum {
         if lit_type == DataType::Null {
             return Ok(None);
         }
-        // Skip the rewrite for interval: it requires `lit * COUNT(arg)`, but
-        // there is no generic Interval×Int64 multiplication kernel.
-        if matches!(lit_type, DataType::Interval(_)) {
-            return Ok(None);
-        }
 
         // Build up SUM(arg)
         let mut sum_agg = agg_function.clone();

--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -24,7 +24,8 @@ use arrow::datatypes::{
     DECIMAL128_MAX_PRECISION, DECIMAL256_MAX_PRECISION, DataType, Decimal32Type,
     Decimal64Type, Decimal128Type, Decimal256Type, DurationMicrosecondType,
     DurationMillisecondType, DurationNanosecondType, DurationSecondType, FieldRef,
-    Float64Type, Int64Type, TimeUnit, UInt64Type,
+    Float64Type, Int64Type, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit,
+    IntervalYearMonthType, TimeUnit, UInt64Type,
 };
 use datafusion_common::hash_utils::RandomState;
 use datafusion_common::internal_err;
@@ -117,6 +118,21 @@ macro_rules! downcast_sum {
                     $args.return_field.data_type().clone()
                 )
             }
+            DataType::Interval(IntervalUnit::YearMonth) => {
+                $helper!(
+                    IntervalYearMonthType,
+                    $args.return_field.data_type().clone()
+                )
+            }
+            DataType::Interval(IntervalUnit::DayTime) => {
+                $helper!(IntervalDayTimeType, $args.return_field.data_type().clone())
+            }
+            DataType::Interval(IntervalUnit::MonthDayNano) => {
+                $helper!(
+                    IntervalMonthDayNanoType,
+                    $args.return_field.data_type().clone()
+                )
+            }
             _ => {
                 not_impl_err!(
                     "Sum not supported for {}: {}",
@@ -186,6 +202,9 @@ impl Sum {
                     TypeSignature::Coercible(vec![Coercion::new_exact(
                         TypeSignatureClass::Duration,
                     )]),
+                    TypeSignature::Coercible(vec![Coercion::new_exact(
+                        TypeSignatureClass::Interval,
+                    )]),
                 ],
                 Volatility::Immutable,
             ),
@@ -232,6 +251,7 @@ impl AggregateUDFImpl for Sum {
                 Ok(DataType::Decimal256(new_precision, *scale))
             }
             DataType::Duration(time_unit) => Ok(DataType::Duration(*time_unit)),
+            DataType::Interval(interval_unit) => Ok(DataType::Interval(*interval_unit)),
             other => {
                 exec_err!("[return_type] SUM not supported for {}", other)
             }
@@ -376,6 +396,11 @@ impl AggregateUDFImpl for Sum {
             }
         };
         if lit_type == DataType::Null {
+            return Ok(None);
+        }
+        // Skip the rewrite for interval: it requires `lit * COUNT(arg)`, but
+        // there is no generic Interval×Int64 multiplication kernel.
+        if matches!(lit_type, DataType::Interval(_)) {
             return Ok(None);
         }
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -6551,6 +6551,101 @@ c NULL 2
 statement ok
 drop table dn;
 
+# sum_interval
+# Component-wise sum across all three Interval variants (matches PostgreSQL).
+
+# Basic Interval(MonthDayNano): the issue's repro.
+# (0 mons, 0 days, 1s) + (12 mons, 0, 0) + (1 mon, 0, 0) = (13 mons, 0, 1s)
+query T?
+SELECT arrow_typeof(sum(v)), sum(v) FROM (VALUES
+  (interval '1 second'),
+  (interval '1 year'),
+  (interval '1 month')) t(v);
+----
+Interval(MonthDayNano) 13 mons 1.000000000 secs
+
+# NULLs are skipped.
+query ?
+SELECT sum(v) FROM (VALUES
+  (interval '1 day'),
+  (NULL),
+  (interval '2 days')) t(v);
+----
+3 days
+
+# Empty input → NULL.
+query ?
+SELECT sum(v) FROM (VALUES (interval '1 day')) t(v) WHERE 1 = 0;
+----
+NULL
+
+# GROUP BY exercises the PrimitiveGroupsAccumulator path.
+query I? rowsort
+SELECT k, sum(v) FROM (VALUES
+  (1, interval '1 day'),
+  (1, interval '2 days'),
+  (2, interval '1 month')) t(k, v)
+GROUP BY k;
+----
+1 3 days
+2 1 mons
+
+# Interval(YearMonth) via cast.
+query T?
+SELECT arrow_typeof(sum(v)), sum(v) FROM (VALUES
+  (arrow_cast('1 year', 'Interval(YearMonth)')),
+  (arrow_cast('6 months', 'Interval(YearMonth)'))) t(v);
+----
+Interval(YearMonth) 1 years 6 mons
+
+# Interval(DayTime) via cast.
+query T?
+SELECT arrow_typeof(sum(v)), sum(v) FROM (VALUES
+  (arrow_cast('1 day', 'Interval(DayTime)')),
+  (arrow_cast('1 day', 'Interval(DayTime)'))) t(v);
+----
+Interval(DayTime) 2 days
+
+# Sliding window sum on intervals.
+query ??
+SELECT v, sum(v) OVER (ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM (VALUES
+  (interval '1 day'),
+  (interval '2 days'),
+  (interval '3 days')) t(v);
+----
+1 days 1 days
+2 days 3 days
+3 days 5 days
+
+# DISTINCT sum drops duplicates (DistinctSumAccumulator path).
+query ?
+SELECT sum(DISTINCT v) FROM (VALUES
+  (interval '1 day'),
+  (interval '1 day'),
+  (interval '2 days')) t(v);
+----
+3 days
+
+# Regression: SUM(col + interval_lit) must NOT be rewritten to
+# SUM(col) + lit * COUNT(col) by simplify_expr_op_literal — there is no
+# Interval×Int64 multiplication kernel. Without the guard, this query fails.
+query ?
+SELECT sum(v + interval '1 day') FROM (VALUES
+  (interval '1 day'),
+  (interval '2 days'),
+  (interval '3 days')) t(v);
+----
+9 days
+
+# Negative intervals: component-wise wrapping_add over signed i32/i64.
+query ?
+SELECT sum(v) FROM (VALUES
+  (interval '1 day'),
+  (interval '-3 days')) t(v);
+----
+-2 days
+
 # Prepare the table with dictionary values for testing
 statement ok
 CREATE TABLE value(x bigint) AS VALUES (1), (2), (3), (1), (3), (4), (5), (2);

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -6627,9 +6627,7 @@ SELECT sum(DISTINCT v) FROM (VALUES
 ----
 3 days
 
-# Regression: SUM(col + interval_lit) must NOT be rewritten to
-# SUM(col) + lit * COUNT(col) by simplify_expr_op_literal — there is no
-# Interval×Int64 multiplication kernel. Without the guard, this query fails.
+# SUM(col + interval_lit) — exercises the simplify_expr_op_literal path.
 query ?
 SELECT sum(v + interval '1 day') FROM (VALUES
   (interval '1 day'),


### PR DESCRIPTION
## Which issue does this PR close?

  - Part of #23085.

  ## Rationale for this change

  PostgreSQL supports `sum()` over `interval` values via component-wise addition; DataFusion currently
  only supports `sum()` on `Duration`, so a query like

  ```sql
  SELECT sum(value) FROM (VALUES
    (interval '1 second'), (interval '1 year'), (interval '1 month')) t(value);
  ```

  errors with No function matches the given name and argument types 'sum(Interval(MonthDayNano))'. The
  most useful real-world case is summing time-series gaps / durations expressed as intervals, which the
  issue filer calls out.

  ## What changes are included in this PR?

  ## Are these changes tested?

  Yes.

  ## Are there any user-facing changes?

  Yes — SUM(<Interval(YearMonth | DayTime | MonthDayNano)>) and SUM(DISTINCT <interval>) are now valid;
  previously they errored at planning time with No function matches. No change to existing behavior on
  any other type. No public API changes.

  A note for reviewers: the rendered output for (months=13, days=0, nanos=1e9) is 13 mons 1.000000000 
  secs rather than PostgreSQL's 1 years 1 mons 0 days 0 hours 0 mins 1.0 secs. The stored value is
  identical; the difference is a display-formatter choice in DataFusion (it doesn't normalize 13 mons to
  1 year 1 month). Keeping that out of scope here.