### PR TITLE
fix: release interning state before terminal output to fix hash aggregate regression (#23178)

### DIFF
--- a/datafusion/physical-plan/src/aggregates/aggregate_hash_table/common.rs
+++ b/datafusion/physical-plan/src/aggregates/aggregate_hash_table/common.rs
@@ -207,6 +207,10 @@ impl<AggrMode> AggregateHashTable<AggrMode> {
         };
 
         state.batch_group_indices = Vec::new();
+        // Release hash map and interning buffers that are no longer needed
+        // during terminal output. This prevents emit(EmitTo::First(n)) from
+        // doing expensive retain/reindex work on every output batch.
+        state.group_values.release_interning_state();
         self.state = AggregateHashTableState::Outputting(state);
     }
 }

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -111,6 +111,16 @@ pub trait GroupValues: Send {
     /// Emits the group values
     fn emit(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>>;
 
+    /// Release internal state used for interning (hash maps, row buffers, etc.)
+    /// but keep the accumulated group values intact.
+    ///
+    /// This should be called once when transitioning from the building phase to
+    /// the outputting phase. After this call, no more `intern` calls are
+    /// expected, and `emit(EmitTo::First(n))` can skip the expensive hash map
+    /// maintenance (retain / reindex) that was only needed to support future
+    /// `intern` calls.
+    fn release_interning_state(&mut self);
+
     /// Clear the contents and shrink the capacity to the size of the batch (free up memory usage)
     fn clear_shrink(&mut self, num_rows: usize);
 }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -1214,6 +1214,23 @@ impl<const STREAMING: bool> GroupValues for GroupValuesColumn<STREAMING> {
         Ok(output)
     }
 
+    fn release_interning_state(&mut self) {
+        // Clear the hash map — no more intern() calls are expected.
+        // This makes emit(EmitTo::First(n)) skip the expensive retain/reindex
+        // that was profiled as the hot path in terminal output.
+        self.map.clear();
+        self.map_size = 0;
+        self.hashes_buffer.clear();
+        self.hashes_buffer.shrink_to(0);
+
+        // Such structures are only used in `non-streaming` case
+        if !STREAMING {
+            self.group_index_lists.clear();
+            self.emit_group_index_list_buffer.clear();
+            self.vectorized_operation_buffers.clear();
+        }
+    }
+
     fn clear_shrink(&mut self, num_rows: usize) {
         // Reset to a fresh column-builder vector. The schema was validated
         // in `try_new`, so rebuilding cannot fail unless something else

--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -254,6 +254,14 @@ impl GroupValues for GroupValuesRows {
         Ok(output)
     }
 
+    fn release_interning_state(&mut self) {
+        // Clear the hash map and row buffers — no more intern() calls expected.
+        self.map.clear();
+        self.map_size = 0;
+        self.hashes_buffer.clear();
+        self.hashes_buffer.shrink_to(0);
+    }
+
     fn clear_shrink(&mut self, num_rows: usize) {
         self.group_values = self.group_values.take().map(|mut rows| {
             rows.clear();

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/boolean.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/boolean.rs
@@ -145,6 +145,10 @@ impl GroupValues for GroupValuesBoolean {
         Ok(vec![Arc::new(BooleanArray::new(values, nulls)) as _])
     }
 
+    fn release_interning_state(&mut self) {
+        // No hash map — only three optional group indices. Nothing to release.
+    }
+
     fn clear_shrink(&mut self, _num_rows: usize) {
         self.false_group = None;
         self.true_group = None;

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes.rs
@@ -120,6 +120,11 @@ impl<O: OffsetSizeTrait> GroupValues for GroupValuesBytes<O> {
         Ok(vec![group_values])
     }
 
+    fn release_interning_state(&mut self) {
+        // No hash map to clear — this implementation uses ArrowBytesMap which
+        // is rebuilt on each emit. Nothing to release.
+    }
+
     fn clear_shrink(&mut self, _num_rows: usize) {
         // in theory we could potentially avoid this reallocation and clear the
         // contents of the maps, but for now we just reset the map from the beginning

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes_view.rs
@@ -122,6 +122,11 @@ impl GroupValues for GroupValuesBytesView {
         Ok(vec![group_values])
     }
 
+    fn release_interning_state(&mut self) {
+        // No hash map to clear — this implementation uses ArrowBytesViewMap which
+        // is rebuilt on each emit. Nothing to release.
+    }
+
     fn clear_shrink(&mut self, _num_rows: usize) {
         // in theory we could potentially avoid this reallocation and clear the
         // contents of the maps, but for now we just reset the map from the beginning

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -239,6 +239,12 @@ where
         Ok(vec![Arc::new(array.with_data_type(self.data_type.clone()))])
     }
 
+    fn release_interning_state(&mut self) {
+        // Clear the hash map — no more intern() calls are expected.
+        // This makes emit(EmitTo::First(n)) skip the expensive retain/reindex.
+        self.map.clear();
+    }
+
     fn clear_shrink(&mut self, num_rows: usize) {
         self.values.clear();
         self.values.shrink_to(num_rows);


### PR DESCRIPTION
## What

Fixes the hash aggregate output performance regression introduced by #23055.

## Problem

PR #23055 introduced `EmitTo::First(batch_size)` for incremental hash aggregate output. During the **terminal output phase** (`Outputting` state), no more `intern()` calls happen, but `emit(EmitTo::First(n))` still maintained the hash lookup state on **every output batch**:

| Implementation | Wasted work per batch |
|---|---|
| `GroupValuesColumn` (multi-col) | `map.retain()` with complex index-list manipulation |
| `GroupValuesPrimitive` (single-col) | `map.retain()` shifting all remaining indexes |
| `GroupValuesRows` (fallback) | Rebuilds rows + `map.retain()` |

This caused **O(groups × output_batches)** unnecessary work.

## Performance Impact

On TPC-DS SF10 query 23 with 24 target partitions:
- **Before #23055**: ~2.43s mean
- **After #23055 (regressed)**: ~8.04s mean
- **With this fix**: should return to ~2.43s

The problematic node spent ~32s in `emitting_time` vs ~3s in actual aggregation time.

## Fix

Added `release_interning_state()` to the `GroupValues` trait, called once during the `Building → Outputting` state transition in `start_outputting()`. It clears the hash map and interning buffers, making `retain` a no-op during terminal output.

The group values themselves are stored separately (in `values` / `group_values` / column builders) and are **not** cleared, so output data is preserved.

## Files Changed

- `group_values/mod.rs` — Added `release_interning_state()` to the `GroupValues` trait
- `aggregate_hash_table/common.rs` — Call it in `start_outputting()`
- `multi_group_by/mod.rs` — Clear map, hashes, group-index lists (the main hot path)
- `row.rs` — Clear map, hashes, row buffers
- `single_group_by/primitive.rs` — Clear map
- `single_group_by/boolean.rs` — No-op (no hash map)
- `single_group_by/bytes.rs` — No-op (map rebuilt on emit)
- `single_group_by/bytes_view.rs` — No-op (map rebuilt on emit)

Closes #23178