### PR TITLE
perf: coalesce single-column sort runs to cut merge fan-in

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -476,8 +476,7 @@ impl ExternalSorter {
         // reserved again for the next spill.
         self.merge_reservation.free();
 
-        // Do not coalesce on the spill path: it is already memory-constrained,
-        // and merging into fewer/larger runs raises per-run peak memory.
+        // No coalescing on the spill path: it raises per-run peak memory.
         let mut sorted_stream =
             self.in_mem_sort_stream(self.metrics.baseline.intermediate(), false)?;
         // After `in_mem_sort_stream()` is constructed, all `in_mem_batches` is taken
@@ -586,10 +585,8 @@ impl ExternalSorter {
     ///
     ///   in_mem_batches
     /// ```
-    /// `coalesce_runs` enables merging the buffered batches into a small number
-    /// of larger sorted runs to reduce merge fan-in (a throughput optimization).
-    /// It is disabled on the spill path, which already runs under memory
-    /// pressure and must keep per-run peak memory low.
+    /// `coalesce_runs` merges buffered batches into fewer, larger sorted runs to
+    /// reduce merge fan-in. Disabled on the spill path to keep peak memory low.
     fn in_mem_sort_stream(
         &mut self,
         metrics: BaselineMetrics,
@@ -630,22 +627,11 @@ impl ExternalSorter {
             return self.sort_batch_stream(batch, &metrics, reservation);
         }
 
-        // Take the buffered batches. For single-column sorts, coalesce them into
-        // a small number of larger runs (each bounded by
-        // `sort_in_place_threshold_bytes`) before sorting and merging. This
-        // drastically reduces the merge fan-in (e.g. from hundreds/thousands of
-        // tiny one-batch runs down to a handful). For cheap single-key
-        // comparisons the per-stream cursor/merge overhead dominates, so fewer,
-        // larger sorted runs are substantially faster (benchmarks show 1.4x-7x).
-        //
-        // Multi-column sorts are intentionally left as one run per batch: their
-        // comparisons are expensive enough that the row-format streaming merge
-        // of many small sorted runs beats sorting a few large runs with the
-        // lexicographic comparator (which would otherwise regress those cases).
-        //
-        // Each run is bounded by `sort_in_place_threshold_bytes`, the same limit
-        // the in-place concat path above already deems safe to materialize, so
-        // this does not raise the peak memory contract.
+        // For single-column sorts, coalesce the buffered batches into fewer,
+        // larger runs to cut the merge fan-in (where the cheap per-key compare is
+        // dominated by per-stream cursor/merge overhead). Multi-column sorts are
+        // left as one run per batch: the row-format merge of many small runs
+        // beats sorting a few large runs with the lexicographic comparator.
         let batches = std::mem::take(&mut self.in_mem_batches);
         let runs = if coalesce_runs && self.expr.len() == 1 {
             self.coalesce_in_mem_batches_into_runs(batches)?
@@ -676,16 +662,10 @@ impl ExternalSorter {
             .build()
     }
 
-    /// Greedily concatenates `batches` into a smaller number of larger runs,
-    /// each bounded by `sort_in_place_threshold_bytes`, to reduce merge fan-in.
-    ///
-    /// Adjacent batches are grouped until adding the next batch would exceed the
-    /// threshold, at which point the group is concatenated into a single run.
-    /// `self.reservation` is resized to match the coalesced runs' footprint so
-    /// the per-run reservation splits performed by the caller remain exact.
-    ///
-    /// Used only for the sort-then-merge path; the caller decides when coalescing
-    /// is beneficial (currently: single-column sorts).
+    /// Concatenates `batches` into fewer, larger runs, each bounded by
+    /// `sort_in_place_threshold_bytes`, to reduce merge fan-in. `self.reservation`
+    /// is resized to the coalesced footprint so the caller's per-run splits stay
+    /// exact.
     fn coalesce_in_mem_batches_into_runs(
         &mut self,
         batches: Vec<RecordBatch>,
@@ -695,8 +675,7 @@ impl ExternalSorter {
         let mut group: Vec<RecordBatch> = Vec::new();
         let mut group_bytes = 0usize;
 
-        // Concatenate a finished group into a single run, avoiding a copy when
-        // the group holds a single batch.
+        // Flush a group into a run, skipping the copy for a single-batch group.
         let flush = |group: &mut Vec<RecordBatch>,
                      runs: &mut Vec<RecordBatch>,
                      schema: &SchemaRef|
@@ -723,9 +702,7 @@ impl ExternalSorter {
         }
         flush(&mut group, &mut runs, &self.schema)?;
 
-        // Concatenation may produce a slightly different memory footprint than
-        // the sum of the original batches, so realign the reservation with the
-        // coalesced runs before the caller splits it per run.
+        // Realign the reservation: concatenation may shift the footprint slightly.
         let total: usize = runs
             .iter()
             .map(get_reserved_bytes_for_record_batch)
@@ -1730,13 +1707,9 @@ mod tests {
         Ok(())
     }
 
-    /// Exercises the single-column "sort then merge" path with run coalescing
-    /// (the `coalesce_in_mem_batches_into_runs` optimization): many small input
-    /// batches whose total size exceeds a deliberately tiny in-place threshold,
-    /// with ample memory so no spilling occurs. Verifies the output is a correct
-    /// total order (matching a reference sort) including NULL handling, so the
-    /// coalescing + multi-run merge produces exactly the same result as a plain
-    /// sort.
+    /// Single-column run coalescing: many small batches above a tiny in-place
+    /// threshold (with ample memory, so no spill) must still produce a correct
+    /// total order, including NULLs.
     #[tokio::test]
     async fn test_in_mem_sort_coalesced_runs() -> Result<()> {
         // Tiny in-place threshold forces the sort-then-merge path and, for a

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -374,7 +374,7 @@ impl ExternalSorter {
             // allocation. Only needed for the non-spill path; the spill
             // path transfers the reservation to the merge stream instead.
             self.merge_reservation.free();
-            self.in_mem_sort_stream(self.metrics.baseline.clone())
+            self.in_mem_sort_stream(self.metrics.baseline.clone(), true)
         }
     }
 
@@ -476,8 +476,10 @@ impl ExternalSorter {
         // reserved again for the next spill.
         self.merge_reservation.free();
 
+        // Do not coalesce on the spill path: it is already memory-constrained,
+        // and merging into fewer/larger runs raises per-run peak memory.
         let mut sorted_stream =
-            self.in_mem_sort_stream(self.metrics.baseline.intermediate())?;
+            self.in_mem_sort_stream(self.metrics.baseline.intermediate(), false)?;
         // After `in_mem_sort_stream()` is constructed, all `in_mem_batches` is taken
         // to construct a globally sorted stream.
         assert_or_internal_err!(
@@ -584,9 +586,14 @@ impl ExternalSorter {
     ///
     ///   in_mem_batches
     /// ```
+    /// `coalesce_runs` enables merging the buffered batches into a small number
+    /// of larger sorted runs to reduce merge fan-in (a throughput optimization).
+    /// It is disabled on the spill path, which already runs under memory
+    /// pressure and must keep per-run peak memory low.
     fn in_mem_sort_stream(
         &mut self,
         metrics: BaselineMetrics,
+        coalesce_runs: bool,
     ) -> Result<SendableRecordBatchStream> {
         if self.in_mem_batches.is_empty() {
             return Ok(Box::pin(EmptyRecordBatchStream::new(Arc::clone(
@@ -623,7 +630,30 @@ impl ExternalSorter {
             return self.sort_batch_stream(batch, &metrics, reservation);
         }
 
-        let streams = std::mem::take(&mut self.in_mem_batches)
+        // Take the buffered batches. For single-column sorts, coalesce them into
+        // a small number of larger runs (each bounded by
+        // `sort_in_place_threshold_bytes`) before sorting and merging. This
+        // drastically reduces the merge fan-in (e.g. from hundreds/thousands of
+        // tiny one-batch runs down to a handful). For cheap single-key
+        // comparisons the per-stream cursor/merge overhead dominates, so fewer,
+        // larger sorted runs are substantially faster (benchmarks show 1.4x-7x).
+        //
+        // Multi-column sorts are intentionally left as one run per batch: their
+        // comparisons are expensive enough that the row-format streaming merge
+        // of many small sorted runs beats sorting a few large runs with the
+        // lexicographic comparator (which would otherwise regress those cases).
+        //
+        // Each run is bounded by `sort_in_place_threshold_bytes`, the same limit
+        // the in-place concat path above already deems safe to materialize, so
+        // this does not raise the peak memory contract.
+        let batches = std::mem::take(&mut self.in_mem_batches);
+        let runs = if coalesce_runs && self.expr.len() == 1 {
+            self.coalesce_in_mem_batches_into_runs(batches)?
+        } else {
+            batches
+        };
+
+        let streams = runs
             .into_iter()
             .map(|batch| {
                 let metrics = self.metrics.baseline.intermediate();
@@ -644,6 +674,67 @@ impl ExternalSorter {
             .with_fetch(None)
             .with_reservation(self.merge_reservation.new_empty())
             .build()
+    }
+
+    /// Greedily concatenates `batches` into a smaller number of larger runs,
+    /// each bounded by `sort_in_place_threshold_bytes`, to reduce merge fan-in.
+    ///
+    /// Adjacent batches are grouped until adding the next batch would exceed the
+    /// threshold, at which point the group is concatenated into a single run.
+    /// `self.reservation` is resized to match the coalesced runs' footprint so
+    /// the per-run reservation splits performed by the caller remain exact.
+    ///
+    /// Used only for the sort-then-merge path; the caller decides when coalescing
+    /// is beneficial (currently: single-column sorts).
+    fn coalesce_in_mem_batches_into_runs(
+        &mut self,
+        batches: Vec<RecordBatch>,
+    ) -> Result<Vec<RecordBatch>> {
+        let target = self.sort_in_place_threshold_bytes.max(1);
+        let mut runs: Vec<RecordBatch> = Vec::new();
+        let mut group: Vec<RecordBatch> = Vec::new();
+        let mut group_bytes = 0usize;
+
+        // Concatenate a finished group into a single run, avoiding a copy when
+        // the group holds a single batch.
+        let flush = |group: &mut Vec<RecordBatch>,
+                     runs: &mut Vec<RecordBatch>,
+                     schema: &SchemaRef|
+         -> Result<()> {
+            match group.len() {
+                0 => {}
+                1 => runs.push(group.pop().unwrap()),
+                _ => {
+                    runs.push(concat_batches(schema, group.iter())?);
+                    group.clear();
+                }
+            }
+            Ok(())
+        };
+
+        for batch in batches {
+            let bytes = get_reserved_bytes_for_record_batch(&batch)?;
+            if !group.is_empty() && group_bytes.saturating_add(bytes) > target {
+                flush(&mut group, &mut runs, &self.schema)?;
+                group_bytes = 0;
+            }
+            group_bytes += bytes;
+            group.push(batch);
+        }
+        flush(&mut group, &mut runs, &self.schema)?;
+
+        // Concatenation may produce a slightly different memory footprint than
+        // the sum of the original batches, so realign the reservation with the
+        // coalesced runs before the caller splits it per run.
+        let total: usize = runs
+            .iter()
+            .map(get_reserved_bytes_for_record_batch)
+            .sum::<Result<usize>>()?;
+        self.reservation
+            .try_resize(total)
+            .map_err(Self::err_with_oom_context)?;
+
+        Ok(runs)
     }
 
     /// Sorts a single `RecordBatch` into a single stream.
@@ -1630,6 +1721,108 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].num_rows(), 400);
+        assert_eq!(
+            task_ctx.runtime_env().memory_pool.reserved(),
+            0,
+            "The sort should have returned all memory used back to the memory manager"
+        );
+
+        Ok(())
+    }
+
+    /// Exercises the single-column "sort then merge" path with run coalescing
+    /// (the `coalesce_in_mem_batches_into_runs` optimization): many small input
+    /// batches whose total size exceeds a deliberately tiny in-place threshold,
+    /// with ample memory so no spilling occurs. Verifies the output is a correct
+    /// total order (matching a reference sort) including NULL handling, so the
+    /// coalescing + multi-run merge produces exactly the same result as a plain
+    /// sort.
+    #[tokio::test]
+    async fn test_in_mem_sort_coalesced_runs() -> Result<()> {
+        // Tiny in-place threshold forces the sort-then-merge path and, for a
+        // single column, the coalescing branch. Ample memory => no spill.
+        let task_ctx = Arc::new(
+            TaskContext::default().with_session_config(
+                SessionConfig::new()
+                    .with_batch_size(64)
+                    .with_sort_in_place_threshold_bytes(1024),
+            ),
+        );
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+
+        // Build many small batches of shuffled values with interspersed NULLs,
+        // so coalescing produces several multi-row runs that must be merged.
+        let num_batches = 40;
+        let rows_per_batch = 50;
+        let mut all_values: Vec<Option<i32>> = Vec::new();
+        let mut batches = Vec::with_capacity(num_batches);
+        for b in 0..num_batches {
+            let mut col_values: Vec<Option<i32>> = Vec::with_capacity(rows_per_batch);
+            for r in 0..rows_per_batch {
+                let idx = (b * rows_per_batch + r) as i64;
+                // Deterministic scramble to avoid any pre-existing ordering.
+                let scrambled = ((idx.wrapping_mul(2_654_435_761)) % 1000) as i32;
+                let v = if idx % 7 == 0 { None } else { Some(scrambled) };
+                col_values.push(v);
+                all_values.push(v);
+            }
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from(col_values))],
+            )?;
+            batches.push(batch);
+        }
+        let total_rows = num_batches * rows_per_batch;
+
+        let options = SortOptions::default();
+        let sort_exec = Arc::new(SortExec::new(
+            [PhysicalSortExpr {
+                expr: col("a", &schema)?,
+                options,
+            }]
+            .into(),
+            TestMemoryExec::try_new_exec(
+                std::slice::from_ref(&batches),
+                Arc::clone(&schema),
+                None,
+            )?,
+        ));
+
+        let result = collect(
+            Arc::clone(&sort_exec) as Arc<dyn ExecutionPlan>,
+            Arc::clone(&task_ctx),
+        )
+        .await?;
+
+        // Flatten the sorted output.
+        let mut got: Vec<Option<i32>> = Vec::with_capacity(total_rows);
+        for batch in &result {
+            let arr = as_primitive_array::<Int32Type>(batch.column(0))?;
+            for i in 0..arr.len() {
+                got.push(if arr.is_null(i) {
+                    None
+                } else {
+                    Some(arr.value(i))
+                });
+            }
+        }
+        assert_eq!(got.len(), total_rows, "row count must be preserved");
+
+        // Reference: sort the original values with the same semantics
+        // (ascending, NULLs first per SortOptions::default()).
+        let mut expected = all_values.clone();
+        expected.sort_by(|a, b| match (a, b) {
+            (None, None) => std::cmp::Ordering::Equal,
+            (None, Some(_)) => std::cmp::Ordering::Less, // nulls_first
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (Some(x), Some(y)) => x.cmp(y),
+        });
+
+        assert_eq!(
+            got, expected,
+            "coalesced-run sort output must be totally ordered"
+        );
         assert_eq!(
             task_ctx.runtime_env().memory_pool.reserved(),
             0,


### PR DESCRIPTION
## Which issue does this PR close?

Closes: https://github.com/apache/datafusion/issues/23208

## Rationale for this change

When a sort exceeds `sort_in_place_threshold_bytes`, `ExternalSorter` sorts each buffered batch individually and merges them all. With many small input batches this gives a very high merge fan-in (hundreds/thousands of one-batch runs). For single-column sorts the per-stream cursor/merge overhead dominates, making this much slower than sorting a few larger runs.

```
--------------------
Benchmark sort_tpch1.json
--------------------
┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query ┃                               HEAD ┃ perf_sort-coalesce-single-column-runs ┃        Change ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ Q1    │  131.99 / 132.52 ±0.89 / 134.30 ms │     112.49 / 112.99 ±0.89 / 114.76 ms │ +1.17x faster │
│ Q2    │  117.48 / 119.42 ±1.61 / 121.68 ms │     100.90 / 101.61 ±1.02 / 103.62 ms │ +1.18x faster │
```

```
--------------------
Benchmark sort_tpch10.json
--------------------
┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Query ┃                                   HEAD ┃  perf_sort-coalesce-single-column-runs ┃        Change ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ Q1    │   1986.77 / 1991.21 ±4.28 / 1997.76 ms │   1625.73 / 1631.34 ±3.86 / 1636.10 ms │ +1.22x faster │
│ Q2    │  1647.04 / 1661.72 ±11.39 / 1680.12 ms │  1412.83 / 1445.07 ±19.05 / 1464.14 ms │ +1.15x faster │
```

## What changes are included in this PR?

For **single-column** sorts, coalesce the buffered batches into a small number of larger runs (each bounded by `sort_in_place_threshold_bytes`, the same limit the in-place concat path already uses) before sorting and merging.

### Why only single-column?

The optimal strategy flips with column count, so coalescing is gated to `expr.len() == 1`:

- **Single column** is *fan-in bound*: the merge uses typed `FieldCursorStream` cursors (native primitive/string compares), so the per-key compare is cheap and the per-stream cursor/merge overhead dominates. Collapsing hundreds/thousands of one-batch runs into a few larger runs is a clear win.
- **Multi-column** is *compare bound*: the merge already uses the Arrow row format (`RowCursorStream`). Streaming-merging many small row-format runs beats running a few large lexicographic-comparator sorts, so coalescing there *regresses* (all-string/dict tuples ~0.45×). Left as one run per batch.

Note we don't switch the single-column in-memory path to a single global row-format sort either: encoding every row to comparable bytes up front is pure overhead vs. `lexsort_to_indices` (which only sorts `u32` indices over the native arrays). Row-format sort only wins for single-column high-cardinality `StringView` (~25%) and loses for primitives.

Microbenchmarks (`benches/sort.rs`, single-column): i64/f64 ~2×, utf8/utf8view ~1.6–1.9×, dictionary up to 2.4×; **geomean ~1.77×** at 100k & 1M rows. Multi-column unchanged.

## Are these changes tested?

Existing + a new `test_in_mem_sort_coalesced_runs` verifying the coalesced multi-run merge produces a correct total order (incl. NULLs).

## Are there any user-facing changes?

No (internal performance change only).
