### PR TITLE
perf(hash-join): eliminate intermediate array allocations in probe-side collision filter

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -217,7 +217,7 @@ pub(super) struct JoinLeftData {
     /// Shared atomic flag indicating if any probe partition saw NULL in join keys (for null-aware anti joins)
     pub(super) probe_side_has_null: AtomicBool,
     /// `true` if any hash bucket holds build rows with differing join keys
-    /// (real hash collisions). When `false`, every chain is "pure" and the
+    /// (hash collisions). When `false`, every chain is "pure" and the
     /// probe side can validate a chain with a single key check at its head
     /// instead of re-checking every duplicate. Computed once at build time.
     has_key_collisions: bool,
@@ -2103,9 +2103,7 @@ async fn collect_left_input(
     // Detect whether the build side has real hash collisions (a bucket with
     // differing keys). When it doesn't, the probe side can validate each chain
     // with a single key check at its head instead of re-checking every
-    // duplicate — a large win for high-fanout joins. The ArrayMap (perfect
-    // hash) never collides and never reaches the recheck path, so it is always
-    // collision-free here.
+    // duplicate.
     let has_key_collisions = match &join_hash_map {
         Map::HashMap(hashmap) => {
             hashmap.has_key_collisions(&left_values, null_equality)?

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -216,9 +216,21 @@ pub(super) struct JoinLeftData {
     pub(super) probe_side_non_empty: AtomicBool,
     /// Shared atomic flag indicating if any probe partition saw NULL in join keys (for null-aware anti joins)
     pub(super) probe_side_has_null: AtomicBool,
+    /// `true` if any hash bucket holds build rows with differing join keys
+    /// (real hash collisions). When `false`, every chain is "pure" and the
+    /// probe side can validate a chain with a single key check at its head
+    /// instead of re-checking every duplicate. Computed once at build time.
+    has_key_collisions: bool,
 }
 
 impl JoinLeftData {
+    /// Returns `true` if the build side has any real hash collisions (a bucket
+    /// holding rows with differing join keys). When `false`, the probe side can
+    /// skip the per-duplicate key recheck. See [`Self::has_key_collisions`].
+    pub(super) fn has_key_collisions(&self) -> bool {
+        self.has_key_collisions
+    }
+
     /// return a reference to the map
     pub(super) fn map(&self) -> &Map {
         &self.map
@@ -2088,6 +2100,19 @@ async fn collect_left_input(
             (Map::HashMap(hashmap), batch, left_values)
         };
 
+    // Detect whether the build side has real hash collisions (a bucket with
+    // differing keys). When it doesn't, the probe side can validate each chain
+    // with a single key check at its head instead of re-checking every
+    // duplicate — a large win for high-fanout joins. The ArrayMap (perfect
+    // hash) never collides and never reaches the recheck path, so it is always
+    // collision-free here.
+    let has_key_collisions = match &join_hash_map {
+        Map::HashMap(hashmap) => {
+            hashmap.has_key_collisions(&left_values, null_equality)?
+        }
+        Map::ArrayMap(_) => false,
+    };
+
     // Reserve additional memory for visited indices bitmap and create shared builder
     let visited_indices_bitmap = if with_visited_indices_bitmap {
         let bitmap_size = bit_util::ceil(batch.num_rows(), 8);
@@ -2144,6 +2169,7 @@ async fn collect_left_input(
         membership,
         probe_side_non_empty: AtomicBool::new(false),
         probe_side_has_null: AtomicBool::new(false),
+        has_key_collisions,
     };
 
     Ok(data)
@@ -4688,6 +4714,8 @@ mod tests {
             None,
             8192,
             (0, None),
+            // Exercise the per-pair recheck path.
+            true,
             &mut probe_indices_buffer,
             &mut build_indices_buffer,
         )?;
@@ -4750,6 +4778,8 @@ mod tests {
             None,
             8192,
             (0, None),
+            // Exercise the per-pair recheck path.
+            true,
             &mut probe_indices_buffer,
             &mut build_indices_buffer,
         )?;

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -448,10 +448,7 @@ pub(super) fn lookup_join_hashmap(
         let mut start = 0;
         while start < probes.len() {
             let probe_idx = probes[start];
-            let mut end = start + 1;
-            while end < probes.len() && probes[end] == probe_idx {
-                end += 1;
-            }
+            let end = start + probes[start..].partition_point(|&p| p == probe_idx);
             if comparator.is_equal(builds[start] as usize, probe_idx as usize) {
                 build_out.extend_from_slice(&builds[start..end]);
                 probe_out.extend_from_slice(&probes[start..end]);

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -33,7 +33,7 @@ use crate::joins::hash_join::shared_bounds::{
     PartitionBounds, PartitionBuildData, SharedBuildAccumulator,
 };
 use crate::joins::utils::{
-    OnceFut, equal_rows_arr, get_final_indices_from_shared_bitmap, matchable_join_keys,
+    JoinKeyComparator, OnceFut, get_final_indices_from_shared_bitmap, matchable_join_keys,
 };
 use crate::stream::EmptyRecordBatchStream;
 use crate::{
@@ -402,6 +402,7 @@ pub(super) fn lookup_join_hashmap(
     valid_keys: Option<&NullBuffer>,
     limit: usize,
     offset: MapOffset,
+    has_key_collisions: bool,
     probe_indices_buffer: &mut Vec<u32>,
     build_indices_buffer: &mut Vec<u64>,
 ) -> Result<(UInt64Array, UInt32Array, Option<MapOffset>)> {
@@ -414,26 +415,56 @@ pub(super) fn lookup_join_hashmap(
         build_indices_buffer,
     );
 
-    let build_indices_unfiltered: UInt64Array =
-        std::mem::take(build_indices_buffer).into();
-    let probe_indices_unfiltered: UInt32Array =
-        std::mem::take(probe_indices_buffer).into();
-
-    // TODO: optimize equal_rows_arr to avoid allocation of intermediate arrays
-    // https://github.com/apache/datafusion/issues/12131
-    let (build_indices, probe_indices) = equal_rows_arr(
-        &build_indices_unfiltered,
-        &probe_indices_unfiltered,
+    // Validate the candidate (build, probe) pairs against the join key to drop
+    // hash collisions. We compare values in place via a prebuilt comparator,
+    // avoiding the take() + eq_dyn_null() + FilterBuilder allocations that
+    // equal_rows_arr performs at O(matched_pairs) scale.
+    // See: https://github.com/apache/datafusion/issues/12131
+    let comparator = JoinKeyComparator::for_equality(
         build_side_values,
         probe_side_values,
         null_equality,
     )?;
 
-    // Reclaim buffers
-    *build_indices_buffer = build_indices_unfiltered.into_parts().1.into();
-    *probe_indices_buffer = probe_indices_unfiltered.into_parts().1.into();
+    let mut build_out: Vec<u64> = Vec::with_capacity(build_indices_buffer.len());
+    let mut probe_out: Vec<u32> = Vec::with_capacity(probe_indices_buffer.len());
 
-    Ok((build_indices, probe_indices, next_offset))
+    if has_key_collisions {
+        // A bucket may mix keys, so every candidate pair must be rechecked.
+        for (b, p) in build_indices_buffer.iter().zip(probe_indices_buffer.iter()) {
+            if comparator.is_equal(*b as usize, *p as usize) {
+                build_out.push(*b);
+                probe_out.push(*p);
+            }
+        }
+    } else {
+        // Collision-free build side: every bucket holds a single key, so all
+        // pairs sharing one probe row (a contiguous run, since the chain walk
+        // emits a probe row's matches consecutively) have identical build
+        // keys. Check the key once per run at its head and accept or reject
+        // the whole run — turning F key comparisons per probe row into 1.
+        let builds = build_indices_buffer.as_slice();
+        let probes = probe_indices_buffer.as_slice();
+        let mut start = 0;
+        while start < probes.len() {
+            let probe_idx = probes[start];
+            let mut end = start + 1;
+            while end < probes.len() && probes[end] == probe_idx {
+                end += 1;
+            }
+            if comparator.is_equal(builds[start] as usize, probe_idx as usize) {
+                build_out.extend_from_slice(&builds[start..end]);
+                probe_out.extend_from_slice(&probes[start..end]);
+            }
+            start = end;
+        }
+    }
+
+    // Reclaim buffers for the next call
+    build_indices_buffer.clear();
+    probe_indices_buffer.clear();
+
+    Ok((build_out.into(), probe_out.into(), next_offset))
 }
 
 /// Counts the number of distinct elements in the input array.
@@ -808,6 +839,7 @@ impl HashJoinStream {
                 state.valid_keys.as_ref(),
                 self.batch_size,
                 state.offset,
+                build_side.left_data.has_key_collisions(),
                 &mut self.probe_indices_buffer,
                 &mut self.build_indices_buffer,
             )?,

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -438,17 +438,22 @@ pub(super) fn lookup_join_hashmap(
             }
         }
     } else {
-        // Collision-free build side: every bucket holds a single key, so all
-        // pairs sharing one probe row (a contiguous run, since the chain walk
-        // emits a probe row's matches consecutively) have identical build
-        // keys. Check the key once per run at its head and accept or reject
-        // the whole run — turning F key comparisons per probe row into 1.
+        // Collision-free build side: all pairs in one probe row's run share
+        // the same build key, so checking the key once at the run head
+        // accepts or rejects the whole run (F comparisons per probe row -> 1).
         let builds = build_indices_buffer.as_slice();
         let probes = probe_indices_buffer.as_slice();
         let mut start = 0;
         while start < probes.len() {
             let probe_idx = probes[start];
-            let end = start + probes[start..].partition_point(|&p| p == probe_idx);
+            // Find the end of this probe row's run (equal probe indices are
+            // contiguous). Peek the next index for the common 1:1 case; fall
+            // back to a binary search for long runs (high fanout).
+            let end = if start + 1 >= probes.len() || probes[start + 1] != probe_idx {
+                start + 1
+            } else {
+                start + probes[start..].partition_point(|&p| p == probe_idx)
+            };
             if comparator.is_equal(builds[start] as usize, probe_idx as usize) {
                 build_out.extend_from_slice(&builds[start..end]);
                 probe_out.extend_from_slice(&probes[start..end]);

--- a/datafusion/physical-plan/src/joins/join_hash_map.rs
+++ b/datafusion/physical-plan/src/joins/join_hash_map.rs
@@ -22,9 +22,11 @@
 use std::fmt::{self, Debug};
 use std::ops::Sub;
 
-use arrow::array::BooleanArray;
+use crate::joins::utils::JoinKeyComparator;
+use arrow::array::{ArrayRef, BooleanArray};
 use arrow::buffer::{BooleanBuffer, NullBuffer};
 use arrow::datatypes::ArrowNativeType;
+use datafusion_common::{NullEquality, Result};
 use hashbrown::HashTable;
 use hashbrown::hash_table::Entry::{Occupied, Vacant};
 
@@ -131,6 +133,27 @@ pub trait JoinHashMapType: Send + Sync {
         match_indices: &mut Vec<u64>,
     ) -> Option<MapOffset>;
 
+    /// Detects whether any hash bucket holds build rows with differing join
+    /// keys — i.e. real hash collisions.
+    ///
+    /// Returns `false` only when every chain is "pure": all rows sharing a
+    /// bucket also share the same join key. In that case the probe side can
+    /// check the key once per chain head and emit the rest of the chain
+    /// without re-checking each duplicate (see `lookup_join_hashmap`). When
+    /// `true`, callers must fall back to a per-pair recheck.
+    ///
+    /// `left_values` are the build-side join key columns. The default is the
+    /// conservative `true` (always recheck); the concrete chained maps
+    /// override it with an O(build_rows) scan.
+    fn has_key_collisions(
+        &self,
+        left_values: &[ArrayRef],
+        null_equality: NullEquality,
+    ) -> Result<bool> {
+        let _ = (left_values, null_equality);
+        Ok(true)
+    }
+
     /// Returns a BooleanArray indicating which of the provided hashes exist in the map.
     fn contain_hashes(&self, hash_values: &[u64]) -> BooleanArray;
 
@@ -206,6 +229,14 @@ impl JoinHashMapType for JoinHashMapU32 {
             input_indices,
             match_indices,
         )
+    }
+
+    fn has_key_collisions(
+        &self,
+        left_values: &[ArrayRef],
+        null_equality: NullEquality,
+    ) -> Result<bool> {
+        detect_key_collisions(&self.next, left_values, null_equality)
     }
 
     fn contain_hashes(&self, hash_values: &[u64]) -> BooleanArray {
@@ -286,6 +317,14 @@ impl JoinHashMapType for JoinHashMapU64 {
             input_indices,
             match_indices,
         )
+    }
+
+    fn has_key_collisions(
+        &self,
+        left_values: &[ArrayRef],
+        null_equality: NullEquality,
+    ) -> Result<bool> {
+        detect_key_collisions(&self.next, left_values, null_equality)
     }
 
     fn contain_hashes(&self, hash_values: &[u64]) -> BooleanArray {
@@ -489,6 +528,41 @@ pub fn contain_hashes<T>(map: &HashTable<(u64, T)>, hash_values: &[u64]) -> Bool
         map.find(hash, |(h, _)| hash == *h).is_some()
     });
     BooleanArray::new(buffer, None)
+}
+
+/// Scans the collision chain to detect whether any bucket holds rows with
+/// differing join keys (real hash collisions).
+///
+/// Each entry of `next` links a build row to the previous row inserted into
+/// the same bucket (`next[i]` stores `prev_row + 1`, `0` marks the end of a
+/// chain). Two rows joined by a link share a hash, so comparing the keys
+/// across every link covers every chain: if all linked pairs are equal, no
+/// bucket mixes keys and the map is collision-free. Returns `true` on the
+/// first differing link. O(build_rows) comparisons, run once at build time.
+fn detect_key_collisions<T>(
+    next: &[T],
+    left_values: &[ArrayRef],
+    null_equality: NullEquality,
+) -> Result<bool>
+where
+    T: ArrowNativeType + Into<u64>,
+{
+    if next.is_empty() {
+        return Ok(false);
+    }
+    let comparator =
+        JoinKeyComparator::for_equality(left_values, left_values, null_equality)?;
+    for (row, &link) in next.iter().enumerate() {
+        let link: u64 = link.into();
+        if link != 0 {
+            // `link` is `prev_row + 1`; both rows live in the same bucket.
+            let prev = (link - 1) as usize;
+            if !comparator.is_equal(row, prev) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 #[cfg(test)]

--- a/datafusion/physical-plan/src/joins/join_hash_map.rs
+++ b/datafusion/physical-plan/src/joins/join_hash_map.rs
@@ -133,18 +133,9 @@ pub trait JoinHashMapType: Send + Sync {
         match_indices: &mut Vec<u64>,
     ) -> Option<MapOffset>;
 
-    /// Detects whether any hash bucket holds build rows with differing join
-    /// keys — i.e. real hash collisions.
-    ///
-    /// Returns `false` only when every chain is "pure": all rows sharing a
-    /// bucket also share the same join key. In that case the probe side can
-    /// check the key once per chain head and emit the rest of the chain
-    /// without re-checking each duplicate (see `lookup_join_hashmap`). When
-    /// `true`, callers must fall back to a per-pair recheck.
-    ///
-    /// `left_values` are the build-side join key columns. The default is the
-    /// conservative `true` (always recheck); the concrete chained maps
-    /// override it with an O(build_rows) scan.
+    /// Returns `true` if any bucket holds build rows with differing join keys
+    /// (real hash collisions). When `false`, the probe can check once per
+    /// chain head and accept the whole run. Scanned once at build time.
     fn has_key_collisions(
         &self,
         left_values: &[ArrayRef],
@@ -530,15 +521,14 @@ pub fn contain_hashes<T>(map: &HashTable<(u64, T)>, hash_values: &[u64]) -> Bool
     BooleanArray::new(buffer, None)
 }
 
-/// Scans the collision chain to detect whether any bucket holds rows with
-/// differing join keys (real hash collisions).
+/// Scans the `next` chain to detect real hash collisions (two build rows in
+/// the same bucket with different keys). `next[i]` stores `prev_row + 1`
+/// (`0` = end of chain). Checking every adjacent linked pair is sufficient:
+/// any two distinct keys in the same bucket must appear as neighbors somewhere.
 ///
-/// Each entry of `next` links a build row to the previous row inserted into
-/// the same bucket (`next[i]` stores `prev_row + 1`, `0` marks the end of a
-/// chain). Two rows joined by a link share a hash, so comparing the keys
-/// across every link covers every chain: if all linked pairs are equal, no
-/// bucket mixes keys and the map is collision-free. Returns `true` on the
-/// first differing link. O(build_rows) comparisons, run once at build time.
+/// Example — keys `["cat", "cat", "dog"]`, next `[0, 1, 2]`:
+///   row 1 → prev 0: "cat"=="cat" ✓
+///   row 2 → prev 1: "dog"!="cat" → return true (collision found)
 fn detect_key_collisions<T>(
     next: &[T],
     left_values: &[ArrayRef],

--- a/datafusion/physical-plan/src/joins/join_hash_map.rs
+++ b/datafusion/physical-plan/src/joins/join_hash_map.rs
@@ -633,4 +633,31 @@ mod tests {
         assert_eq!(input_indices, vec![1, 1]);
         assert_eq!(match_indices, vec![3, 1]);
     }
+
+    #[test]
+    fn test_has_key_collisions_same_key() -> Result<()> {
+        // 5 build rows all with key 10 chained in the same bucket — no collision.
+        // next: [0, 1, 2, 3, 4] → chain 4→3→2→1→0→end
+        use arrow::array::Int32Array;
+        use std::sync::Arc;
+        let next: Vec<u32> = vec![0, 1, 2, 3, 4];
+        let map = JoinHashMapU32::new(HashTable::new(), next);
+        let keys: ArrayRef = Arc::new(Int32Array::from(vec![10, 10, 10, 10, 10]));
+        assert!(!map.has_key_collisions(&[keys], NullEquality::NullEqualsNothing)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_has_key_collisions_distinct_keys() -> Result<()> {
+        // 5 build rows, 4 with key 10 and 1 with key 20 buried in the chain.
+        // next: [0, 1, 2, 3, 4] → chain 4→3→2→1→0→end
+        // Row 2 has key 20 — adjacent pair (row 2, row 1) differs → collision.
+        use arrow::array::Int32Array;
+        use std::sync::Arc;
+        let next: Vec<u32> = vec![0, 1, 2, 3, 4];
+        let map = JoinHashMapU32::new(HashTable::new(), next);
+        let keys: ArrayRef = Arc::new(Int32Array::from(vec![10, 10, 20, 10, 10]));
+        assert!(map.has_key_collisions(&[keys], NullEquality::NullEqualsNothing)?);
+        Ok(())
+    }
 }

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -2332,6 +2332,19 @@ impl JoinKeyComparator {
         Ok(Self { first, rest })
     }
 
+    /// Build equality-only comparators for each join key column pair.
+    ///
+    /// Unlike [`Self::new`], no `SortOptions` are required — `SortOptions::default()`
+    /// is used internally, which is correct because callers only test `== Equal`.
+    pub fn for_equality(
+        left_arrays: &[ArrayRef],
+        right_arrays: &[ArrayRef],
+        null_equality: NullEquality,
+    ) -> Result<Self> {
+        let sort_options = vec![SortOptions::default(); left_arrays.len()];
+        Self::new(left_arrays, right_arrays, &sort_options, null_equality)
+    }
+
     /// Compare row `left` (in the left arrays) with row `right` (in the right
     /// arrays). Returns the lexicographic ordering across all key columns.
     #[inline]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/23237

## Rationale for this change

When HashJoinExec builds the probe the hash table, it collects all candidate (build_idx, probe_idx) pairs and then rechecks every pair with `equal_rows_arr` (shows in the profile, taking 20% of the query CPU) to filter out hash collisions. This recheck materializes intermediate Arrow arrays sized to the number of matched pairs (`take` + `eq_dyn_null` + `FilterBuilder`), making it O(matched_pairs) in both allocations and comparisons.

For high-fanout joins (many build rows per distinct key), matched_pairs = probe_rows × fanout. At fanout 78× over 2.3M probe rows this produces ~176M pairs — and the recheck runs on all of them, even though nearly all pass.

This cost is most visible when:

- The build side has duplicate keys 
- The join output is large (high fanout × large probe side)
- Hash partition skew concentrates most matched pairs onto a single partition, making the per-partition allocation cost directly observable as query latency

## What changes are included in this PR?

Step 1: Replace `equal_rows_arr` with an in-place `JoinKeyComparator` loop , eliminating the O(matched_pairs) Arrow allocations in the fallback path.

Step 2: At build time, scan the next chain once to detect whether the map is collision-free (all adjacent linked pairs share the same key). If so, the probe phase checks once per run of consecutive same-probe-idx pairs and accepts the entire run. 

<br class="Apple-interchange-newline">


## Are these changes tested?

Existing tests pass, I also added some tests for the new function that detects hash collisions `detect_key_collisions`

I did some profiling on the added Q23 (this query replicates the level of skew where just 1 partition does the entire join):

- [profile of Q23 main](https://share.firefox.dev/4atAYU9)
- [profile](https://share.firefox.dev/3SzQFTF) 

<img width="2804" height="450" alt="image" src="https://github.com/user-attachments/assets/81bd2ba4-c2d5-4e33-bec7-c8c36c8177e2" />
<img width="2908" height="416" alt="image" src="https://github.com/user-attachments/assets/d5eb37b8-fa3d-49de-a8a7-5d60b112e75f" />

We can see the CPU for the HashJoin was cut in half.
Also the benchmarks results show Q23 runs ~x2.5 times faster:
- main: 1.01s
- this PR: 0.42s

## Are there any user-facing changes?

No