### PR TITLE
Complete migration of remaining string UDFs to fallible string builder APIs

### DIFF
--- a/datafusion/functions/src/core/overlay.rs
+++ b/datafusion/functions/src/core/overlay.rs
@@ -175,12 +175,11 @@ fn apply_overlay<B: BulkNullStringArrayBuilder>(
         return exec_err!("overlay start position must be at least 1: {start_pos}");
     }
     let (prefix_end, suffix_start) = overlay_bounds(string, start_pos, replace_len);
-    builder.append_with(|w| {
+    builder.try_append_with(|w| {
         w.write_str(&string[..prefix_end]);
         w.write_str(characters);
         w.write_str(&string[suffix_start..]);
-    });
-    Ok(())
+    })
 }
 
 #[inline]
@@ -276,7 +275,7 @@ where
     if let Some(nulls_ref) = nulls.as_ref() {
         for i in 0..len {
             if nulls_ref.is_null(i) {
-                builder.append_placeholder();
+                builder.try_append_placeholder()?;
                 continue;
             }
             // SAFETY: `i < len`, and null bitmap check implies not-null

--- a/datafusion/functions/src/string/chr.rs
+++ b/datafusion/functions/src/string/chr.rs
@@ -45,7 +45,7 @@ fn chr_array(integer_array: &Int64Array) -> Result<ArrayRef> {
     if let Some(n) = nulls {
         for i in 0..len {
             if n.is_null(i) {
-                builder.append_placeholder();
+                builder.try_append_placeholder()?;
                 continue;
             }
             // SAFETY: bounds + null check above.
@@ -53,7 +53,7 @@ fn chr_array(integer_array: &Int64Array) -> Result<ArrayRef> {
             if let Ok(u) = u32::try_from(integer)
                 && let Some(c) = core::char::from_u32(u)
             {
-                builder.append_value(c.encode_utf8(&mut buf));
+                builder.try_append_value(c.encode_utf8(&mut buf))?;
                 continue;
             }
             return exec_err!("invalid Unicode scalar value: {integer}");
@@ -65,7 +65,7 @@ fn chr_array(integer_array: &Int64Array) -> Result<ArrayRef> {
             if let Ok(u) = u32::try_from(integer)
                 && let Some(c) = core::char::from_u32(u)
             {
-                builder.append_value(c.encode_utf8(&mut buf));
+                builder.try_append_value(c.encode_utf8(&mut buf))?;
                 continue;
             }
             return exec_err!("invalid Unicode scalar value: {integer}");

--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -312,6 +312,24 @@ where
         }
     }
 
+    #[inline]
+    fn append_repeated_string<B: BulkNullStringArrayBuilder>(
+        builder: &mut B,
+        buffer: &mut Vec<u8>,
+        string: &str,
+        count: i64,
+    ) -> Result<()> {
+        if count > 0 {
+            repeat_to_buffer(buffer, string, count as usize);
+            // SAFETY: buffer contains valid UTF-8 since we only copy from a valid &str
+            builder.try_append_value(unsafe {
+                std::str::from_utf8_unchecked(buffer.as_slice())
+            })
+        } else {
+            builder.try_append_value("")
+        }
+    }
+
     // Output is null IFF either input is null
     let nulls = NullBuffer::union(string_array.nulls(), number_array.nulls());
 
@@ -324,30 +342,14 @@ where
             // SAFETY: index `i` in both arrays is valid
             let string = unsafe { string_array.value_unchecked(i) };
             let count = unsafe { number_array.value_unchecked(i) };
-            if count > 0 {
-                repeat_to_buffer(&mut buffer, string, count as usize);
-                // SAFETY: buffer contains valid UTF-8 since we only copy from a valid &str
-                builder.try_append_value(unsafe {
-                    std::str::from_utf8_unchecked(&buffer)
-                })?;
-            } else {
-                builder.try_append_value("")?;
-            }
+            append_repeated_string(&mut builder, &mut buffer, string, count)?;
         }
     } else {
         for i in 0..string_array.len() {
             // SAFETY: no nulls, so every index in both arrays is valid
             let string = unsafe { string_array.value_unchecked(i) };
             let count = unsafe { number_array.value_unchecked(i) };
-            if count > 0 {
-                repeat_to_buffer(&mut buffer, string, count as usize);
-                // SAFETY: buffer contains valid UTF-8 since we only copy from a valid &str
-                builder.try_append_value(unsafe {
-                    std::str::from_utf8_unchecked(&buffer)
-                })?;
-            } else {
-                builder.try_append_value("")?;
-            }
+            append_repeated_string(&mut builder, &mut buffer, string, count)?;
         }
     }
 

--- a/datafusion/functions/src/string/repeat.rs
+++ b/datafusion/functions/src/string/repeat.rs
@@ -318,7 +318,7 @@ where
     if let Some(ref n) = nulls {
         for i in 0..string_array.len() {
             if n.is_null(i) {
-                builder.append_placeholder();
+                builder.try_append_placeholder()?;
                 continue;
             }
             // SAFETY: index `i` in both arrays is valid
@@ -327,9 +327,11 @@ where
             if count > 0 {
                 repeat_to_buffer(&mut buffer, string, count as usize);
                 // SAFETY: buffer contains valid UTF-8 since we only copy from a valid &str
-                builder.append_value(unsafe { std::str::from_utf8_unchecked(&buffer) });
+                builder.try_append_value(unsafe {
+                    std::str::from_utf8_unchecked(&buffer)
+                })?;
             } else {
-                builder.append_value("");
+                builder.try_append_value("")?;
             }
         }
     } else {
@@ -340,9 +342,11 @@ where
             if count > 0 {
                 repeat_to_buffer(&mut buffer, string, count as usize);
                 // SAFETY: buffer contains valid UTF-8 since we only copy from a valid &str
-                builder.append_value(unsafe { std::str::from_utf8_unchecked(&buffer) });
+                builder.try_append_value(unsafe {
+                    std::str::from_utf8_unchecked(&buffer)
+                })?;
             } else {
-                builder.append_value("");
+                builder.try_append_value("")?;
             }
         }
     }

--- a/datafusion/functions/src/string/split_part.rs
+++ b/datafusion/functions/src/string/split_part.rs
@@ -634,8 +634,7 @@ fn append_split_part<B: BulkNullStringArrayBuilder>(
             return exec_err!("field position must not be zero");
         }
     };
-    builder.try_append_value(result.unwrap_or(""))?;
-    Ok(())
+    builder.try_append_value(result.unwrap_or(""))
 }
 
 #[cfg(test)]

--- a/datafusion/functions/src/string/split_part.rs
+++ b/datafusion/functions/src/string/split_part.rs
@@ -378,18 +378,18 @@ where
     if let Some(ref n) = nulls {
         for i in 0..item_len {
             if n.is_null(i) {
-                builder.append_placeholder();
+                builder.try_append_placeholder()?;
             } else {
                 // SAFETY: `n.is_null(i)` was false in the branch above.
                 let s = unsafe { string_array.value_unchecked(i) };
-                builder.append_value(f(s).unwrap_or(""));
+                builder.try_append_value(f(s).unwrap_or(""))?;
             }
         }
     } else {
         for i in 0..item_len {
             // SAFETY: no null buffer means every index is valid.
             let s = unsafe { string_array.value_unchecked(i) };
-            builder.append_value(f(s).unwrap_or(""));
+            builder.try_append_value(f(s).unwrap_or(""))?;
         }
     }
 
@@ -571,7 +571,7 @@ where
     if let Some(ref n) = nulls {
         for i in 0..string_array.len() {
             if n.is_null(i) {
-                builder.append_placeholder();
+                builder.try_append_placeholder()?;
                 continue;
             }
 
@@ -634,7 +634,7 @@ fn append_split_part<B: BulkNullStringArrayBuilder>(
             return exec_err!("field position must not be zero");
         }
     };
-    builder.append_value(result.unwrap_or(""));
+    builder.try_append_value(result.unwrap_or(""))?;
     Ok(())
 }
 

--- a/datafusion/functions/src/string/uuid.rs
+++ b/datafusion/functions/src/string/uuid.rs
@@ -98,7 +98,7 @@ impl ScalarUDFImpl for UuidFunc {
             *x = *x & 0xFFFFFFFFFFFF4FFFBFFFFFFFFFFFFFFF | 0x40008000000000000000;
             let uuid = Uuid::from_u128(*x);
             let fmt = uuid::fmt::Hyphenated::from_uuid(uuid);
-            builder.append_value(fmt.encode_lower(&mut buffer));
+            builder.try_append_value(fmt.encode_lower(&mut buffer))?;
         }
 
         Ok(ColumnarValue::Array(Arc::new(builder.finish(None)?)))

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -425,6 +425,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
     /// # Panics
     ///
     /// Panics if the cumulative byte length exceeds `O::MAX`.
+    #[allow(dead_code)]
     #[inline]
     pub fn append_value(&mut self, value: &str) {
         self.try_append_value(value)
@@ -435,6 +436,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
     ///
     /// Note: new call sites that need recoverable overflow handling should
     /// prefer [`Self::try_append_placeholder`].
+    #[allow(dead_code)]
     #[inline]
     pub fn append_placeholder(&mut self) {
         self.try_append_placeholder()
@@ -476,6 +478,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
     /// # Panics
     ///
     /// Panics if the cumulative byte length exceeds `O::MAX`.
+    #[allow(dead_code)]
     #[inline]
     pub unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
         // SAFETY: caller upholds this method's UTF-8 contract.
@@ -520,6 +523,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
     /// # Panics
     ///
     /// Panics if the cumulative byte length exceeds `O::MAX`.
+    #[allow(dead_code)]
     #[inline]
     pub fn append_with<F>(&mut self, f: F)
     where
@@ -735,6 +739,7 @@ impl StringViewArrayBuilder {
     ///
     /// Panics under the same conditions that [`Self::try_append_value`] returns
     /// an error.
+    #[allow(dead_code)]
     #[inline]
     pub fn append_value(&mut self, value: &str) {
         self.try_append_value(value)
@@ -1069,15 +1074,15 @@ pub(crate) trait BulkNullStringArrayBuilder {
 
     /// Append `value` as the next row.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the resulting array would exceed the per-implementation
-    /// size limit. See the inherent method on each builder for specifics.
-    fn append_value(&mut self, value: &str);
+    /// Returns an error if the resulting array would exceed the
+    /// per-implementation size limit.
+    fn try_append_value(&mut self, value: &str) -> Result<()>;
 
     /// Append an empty placeholder row. The corresponding slot MUST be masked
     /// as null by the null buffer passed to [`finish`](Self::finish).
-    fn append_placeholder(&mut self);
+    fn try_append_placeholder(&mut self) -> Result<()>;
 
     /// Append a row whose bytes are produced by `f` calling write methods on
     /// the supplied [`StringWriter`].
@@ -1086,10 +1091,10 @@ pub(crate) trait BulkNullStringArrayBuilder {
     /// `StringWriter` zero or more times. Zero calls produces a row containing
     /// the empty string.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// See [`append_value`](Self::append_value).
-    fn append_with<F>(&mut self, f: F)
+    /// See [`try_append_value`](Self::try_append_value).
+    fn try_append_with<F>(&mut self, f: F) -> Result<()>
     where
         F: for<'a> FnOnce(&mut Self::Writer<'a>);
 
@@ -1098,7 +1103,7 @@ pub(crate) trait BulkNullStringArrayBuilder {
     ///
     /// Because the output length is known up front and the inner loop is
     /// straight-line, this is more efficient than
-    /// [`append_with`](Self::append_with) for byte-to-byte mappings and
+    /// [`try_append_with`](Self::try_append_with) for byte-to-byte mappings and
     /// autovectorizes well.
     ///
     /// # Safety
@@ -1106,10 +1111,14 @@ pub(crate) trait BulkNullStringArrayBuilder {
     /// The bytes produced by applying `map` to each byte of `src`, in order,
     /// must form valid UTF-8.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// See [`append_value`](Self::append_value).
-    unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F);
+    /// See [`try_append_value`](Self::try_append_value).
+    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        src: &[u8],
+        map: F,
+    ) -> Result<()>;
 
     /// Finalize into a concrete array using the caller-supplied null buffer.
     ///
@@ -1124,24 +1133,28 @@ impl<O: OffsetSizeTrait> BulkNullStringArrayBuilder for GenericStringArrayBuilde
     type Writer<'a> = GenericStringWriter<'a>;
 
     #[inline]
-    fn append_value(&mut self, value: &str) {
-        GenericStringArrayBuilder::<O>::append_value(self, value)
+    fn try_append_value(&mut self, value: &str) -> Result<()> {
+        GenericStringArrayBuilder::<O>::try_append_value(self, value)
     }
     #[inline]
-    fn append_placeholder(&mut self) {
-        GenericStringArrayBuilder::<O>::append_placeholder(self)
+    fn try_append_placeholder(&mut self) -> Result<()> {
+        GenericStringArrayBuilder::<O>::try_append_placeholder(self)
     }
     #[inline]
-    fn append_with<F>(&mut self, f: F)
+    fn try_append_with<F>(&mut self, f: F) -> Result<()>
     where
         F: for<'a> FnOnce(&mut Self::Writer<'a>),
     {
-        GenericStringArrayBuilder::<O>::append_with(self, f)
+        GenericStringArrayBuilder::<O>::try_append_with(self, f)
     }
     #[inline]
-    unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
+    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        src: &[u8],
+        map: F,
+    ) -> Result<()> {
         // SAFETY: contract forwarded.
-        unsafe { GenericStringArrayBuilder::<O>::append_byte_map(self, src, map) }
+        unsafe { GenericStringArrayBuilder::<O>::try_append_byte_map(self, src, map) }
     }
     fn finish(self, nulls: Option<NullBuffer>) -> Result<ArrayRef> {
         Ok(Arc::new(GenericStringArrayBuilder::<O>::finish(
@@ -1154,24 +1167,30 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
     type Writer<'a> = StringViewWriter<'a>;
 
     #[inline]
-    fn append_value(&mut self, value: &str) {
-        StringViewArrayBuilder::append_value(self, value)
+    fn try_append_value(&mut self, value: &str) -> Result<()> {
+        StringViewArrayBuilder::try_append_value(self, value)
     }
     #[inline]
-    fn append_placeholder(&mut self) {
-        StringViewArrayBuilder::append_placeholder(self)
+    fn try_append_placeholder(&mut self) -> Result<()> {
+        StringViewArrayBuilder::try_append_placeholder(self)
     }
     #[inline]
-    fn append_with<F>(&mut self, f: F)
+    fn try_append_with<F>(&mut self, f: F) -> Result<()>
     where
         F: for<'a> FnOnce(&mut Self::Writer<'a>),
     {
-        StringViewArrayBuilder::append_with(self, f)
+        StringViewArrayBuilder::append_with(self, f);
+        Ok(())
     }
     #[inline]
-    unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
+    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        src: &[u8],
+        map: F,
+    ) -> Result<()> {
         // SAFETY: contract forwarded.
-        unsafe { StringViewArrayBuilder::append_byte_map(self, src, map) }
+        unsafe { StringViewArrayBuilder::append_byte_map(self, src, map) };
+        Ok(())
     }
     fn finish(self, nulls: Option<NullBuffer>) -> Result<ArrayRef> {
         Ok(Arc::new(StringViewArrayBuilder::finish(self, nulls)?))
@@ -1491,8 +1510,8 @@ mod tests {
     where
         B: BulkNullStringArrayBuilder,
     {
-        builder.append_value("a");
-        builder.append_value("b");
+        builder.try_append_value("a").unwrap();
+        builder.try_append_value("b").unwrap();
         let nulls = NullBuffer::from(vec![true, false, true]);
         assert!(builder.finish(Some(nulls)).is_err());
     }

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -1047,22 +1047,22 @@ fn push_char_to_vec(v: &mut Vec<u8>, c: char) {
 /// Three methods append a non-null row; which method to pick depends on how the
 /// row is produced:
 ///
-/// - [`append_value`](Self::append_value) pushes an already-finished `&str`.
-///   Use it when the row is forwarded from an existing slice (e.g. an input
-///   column) — there is nothing to elide.
-/// - [`append_byte_map`](Self::append_byte_map) emits a row whose bytes are a
-///   byte-to-byte mapping of an input slice. Output length is known up front
-///   and the inner loop is straight-line, so this is the fastest path when the
-///   shape fits.
-/// - [`append_with`](Self::append_with) emits a row by feeding fragments to a
-///   [`StringWriter`]. Use it when the row is computed from multiple sources or
-///   when the output length is not known up front. Bytes are written directly
-///   into the builder, so it is typically faster than assembling a `String` and
-///   calling `append_value(&scratch)`.
+/// - [`try_append_value`](Self::try_append_value) pushes an already-finished
+///   `&str`. Use it when the row is forwarded from an existing slice (e.g. an
+///   input column) — there is nothing to elide.
+/// - [`try_append_byte_map`](Self::try_append_byte_map) emits a row whose bytes
+///   are a byte-to-byte mapping of an input slice. Output length is known up
+///   front and the inner loop is straight-line, so this is the fastest path
+///   when the shape fits.
+/// - [`try_append_with`](Self::try_append_with) emits a row by feeding fragments
+///   to a [`StringWriter`]. Use it when the row is computed from multiple
+///   sources or when the output length is not known up front. Bytes are written
+///   directly into the builder, so it is typically faster than assembling a
+///   `String` and calling `try_append_value(&scratch)`.
 ///
-/// For a NULL row, call [`append_placeholder`](Self::append_placeholder) to
-/// advance the row count without writing into the value buffer; the caller MUST
-/// clear the corresponding bit in the null buffer passed to
+/// For a NULL row, call [`try_append_placeholder`](Self::try_append_placeholder)
+/// to advance the row count without writing into the value buffer; the caller
+/// MUST clear the corresponding bit in the null buffer passed to
 /// [`finish`](Self::finish).
 pub(crate) trait BulkNullStringArrayBuilder {
     /// Per-builder concrete writer type, exposed as a GAT so generic callers
@@ -1179,6 +1179,8 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
     where
         F: for<'a> FnOnce(&mut Self::Writer<'a>),
     {
+        // StringView's closure-based path is still infallible; the Result
+        // keeps this trait uniform with offset-based builders.
         StringViewArrayBuilder::append_with(self, f);
         Ok(())
     }
@@ -1188,6 +1190,8 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
         src: &[u8],
         map: F,
     ) -> Result<()> {
+        // StringView's byte-map path is still infallible; the Result keeps this
+        // trait uniform with offset-based builders.
         // SAFETY: contract forwarded.
         unsafe { StringViewArrayBuilder::append_byte_map(self, src, map) };
         Ok(())

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -417,7 +417,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
         Ok(())
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_value`].
+    /// Infallible variant of [`Self::try_append_value`].
     ///
     /// Note: new call sites that need recoverable overflow handling should
     /// prefer [`Self::try_append_value`].
@@ -432,7 +432,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
             .expect("byte array offset overflow");
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_placeholder`].
+    /// Infallible variant of [`Self::try_append_placeholder`].
     ///
     /// Note: new call sites that need recoverable overflow handling should
     /// prefer [`Self::try_append_placeholder`].
@@ -465,7 +465,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
         })
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_byte_map`].
+    /// Infallible variant of [`Self::try_append_byte_map`].
     ///
     /// Note: new call sites that need recoverable overflow handling should
     /// prefer [`Self::try_append_byte_map`].
@@ -515,7 +515,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
         Ok(())
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_with`].
+    /// Infallible variant of [`Self::try_append_with`].
     ///
     /// Note: new call sites that need recoverable overflow handling should
     /// prefer [`Self::try_append_with`].
@@ -730,7 +730,7 @@ impl StringViewArrayBuilder {
         Ok(())
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_value`].
+    /// Infallible variant of [`Self::try_append_value`].
     ///
     /// Note: new call sites that need recoverable overflow handling should
     /// prefer [`Self::try_append_value`].
@@ -758,7 +758,7 @@ impl StringViewArrayBuilder {
         Ok(())
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_placeholder`].
+    /// Infallible variant of [`Self::try_append_placeholder`].
     ///
     /// Note: new call sites that need recoverable overflow handling should
     /// prefer [`Self::try_append_placeholder`].
@@ -793,6 +793,7 @@ impl StringViewArrayBuilder {
     /// flushing the current block and starting a new (doubled) one if not.
     /// Caller must invoke this only when no bytes of the current row are
     /// yet in `in_progress` — flushing mid-row would orphan partial data.
+    #[allow(dead_code)]
     #[inline]
     fn ensure_long_capacity(&mut self, length: u32) {
         self.try_ensure_long_capacity(length)
@@ -824,6 +825,25 @@ impl StringViewArrayBuilder {
     }
 
     #[inline]
+    fn try_string_view_u32(value: usize, name: &'static str) -> Result<u32> {
+        Ok(i32::try_from(value).map_err(|_| string_view_overflow_error(name))? as u32)
+    }
+
+    #[inline]
+    fn try_long_view_parts(
+        length: usize,
+        offset: usize,
+        buffer_count: usize,
+    ) -> Result<(u32, u32, u32)> {
+        Ok((
+            Self::try_string_view_u32(length, "value length")?,
+            Self::try_string_view_u32(offset, "offset")?,
+            Self::try_string_view_u32(buffer_count, "buffer count")?,
+        ))
+    }
+
+    #[allow(dead_code)]
+    #[inline]
     fn make_long_view(&self, length: u32, offset: u32, prefix_bytes: &[u8]) -> u128 {
         let buffer_index: u32 = i32::try_from(self.completed.len())
             .expect("buffer count exceeds i32::MAX")
@@ -831,7 +851,49 @@ impl StringViewArrayBuilder {
         Self::make_long_view_checked(length, buffer_index, offset, prefix_bytes)
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_byte_map`].
+    /// Fallible variant of [`Self::append_byte_map`].
+    ///
+    /// # Safety
+    ///
+    /// The bytes produced by applying `map` to each byte of `src`, in order,
+    /// must form valid UTF-8.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `src.len()`, the in-progress buffer offset, or the
+    /// number of completed buffers exceeds `i32::MAX`.
+    #[inline]
+    pub unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        src: &[u8],
+        mut map: F,
+    ) -> Result<()> {
+        let length = Self::try_string_view_u32(src.len(), "value length")?;
+        if length <= 12 {
+            let mut bytes = [0u8; 12];
+            for (d, &b) in bytes[..src.len()].iter_mut().zip(src) {
+                *d = map(b);
+            }
+            self.views.push(make_view(&bytes[..src.len()], 0, 0));
+            return Ok(());
+        }
+
+        self.try_ensure_long_capacity(length)?;
+
+        let start = self.in_progress.len();
+        let (length, offset, buffer_index) =
+            Self::try_long_view_parts(src.len(), start, self.completed.len())?;
+        self.in_progress.extend(src.iter().map(|&b| map(b)));
+        self.views.push(Self::make_long_view_checked(
+            length,
+            buffer_index,
+            offset,
+            &self.in_progress[start..],
+        ));
+        Ok(())
+    }
+
+    /// Infallible variant of [`Self::try_append_byte_map`].
     ///
     /// # Safety
     ///
@@ -843,35 +905,90 @@ impl StringViewArrayBuilder {
     /// Panics under the same conditions as [`Self::append_value`]: if
     /// `src.len()`, the in-progress buffer offset, or the number of completed
     /// buffers exceeds `i32::MAX`.
+    #[allow(dead_code)]
     #[inline]
-    pub unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], mut map: F) {
-        let length: u32 =
-            i32::try_from(src.len()).expect("value length exceeds i32::MAX") as u32;
-        if length <= 12 {
-            let mut bytes = [0u8; 12];
-            for (d, &b) in bytes[..src.len()].iter_mut().zip(src) {
-                *d = map(b);
-            }
-            self.views.push(make_view(&bytes[..src.len()], 0, 0));
-            return;
-        }
-
-        self.ensure_long_capacity(length);
-
-        let cursor = self.in_progress.len();
-        let offset: u32 = i32::try_from(cursor).expect("offset exceeds i32::MAX") as u32;
-        self.in_progress.extend(src.iter().map(|&b| map(b)));
-        self.views
-            .push(self.make_long_view(length, offset, &self.in_progress[cursor..]));
+    pub unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
+        // SAFETY: caller upholds this method's UTF-8 contract.
+        unsafe { self.try_append_byte_map(src, map) }
+            .expect("byte array offset overflow");
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_with`].
+    /// Fallible variant of [`Self::append_with`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the row's byte length, in-progress buffer offset, or
+    /// number of completed buffers exceeds `i32::MAX`.
+    #[inline]
+    pub fn try_append_with<F>(&mut self, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut StringViewWriter<'_>),
+    {
+        let mut writer = StringViewWriter {
+            inline_buf: [0u8; 12],
+            inline_len: 0,
+            spill_cursor: None,
+            error: None,
+            builder: self,
+        };
+        f(&mut writer);
+        // Destructure to release the borrow on `self` and pull out the
+        // inline-buffer state by-value. Copy types only; the &mut self is
+        // dropped here, ending the borrow.
+        let StringViewWriter {
+            inline_buf,
+            inline_len,
+            spill_cursor,
+            error,
+            ..
+        } = writer;
+
+        if let Some(e) = error {
+            if let Some(start) = spill_cursor {
+                self.in_progress.truncate(start);
+            }
+            return Err(e);
+        }
+
+        match spill_cursor {
+            None => {
+                self.views
+                    .push(make_view(&inline_buf[..inline_len as usize], 0, 0));
+            }
+            Some(start) => {
+                let end = self.in_progress.len();
+                let parts = end
+                    .checked_sub(start)
+                    .ok_or_else(|| string_view_overflow_error("value length"))
+                    .and_then(|length| {
+                        Self::try_long_view_parts(length, start, self.completed.len())
+                    });
+                let (length, offset, buffer_index) = match parts {
+                    Ok(parts) => parts,
+                    Err(e) => {
+                        self.in_progress.truncate(start);
+                        return Err(e);
+                    }
+                };
+                self.views.push(Self::make_long_view_checked(
+                    length,
+                    buffer_index,
+                    offset,
+                    &self.in_progress[start..],
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Infallible variant of [`Self::try_append_with`].
     ///
     /// # Panics
     ///
     /// Panics under the same conditions as [`Self::append_value`]: if the
     /// row's byte length, the in-progress buffer offset, or the number of
     /// completed buffers exceeds `i32::MAX`.
+    #[allow(dead_code)]
     #[inline]
     pub fn append_with<F>(&mut self, f: F)
     where
@@ -881,6 +998,7 @@ impl StringViewArrayBuilder {
             inline_buf: [0u8; 12],
             inline_len: 0,
             spill_cursor: None,
+            error: None,
             builder: self,
         };
         f(&mut writer);
@@ -974,43 +1092,103 @@ pub(crate) struct StringViewWriter<'a> {
     /// `None` while the row fits inline; becomes `Some(start)` (offset of
     /// the row's first byte in `in_progress`) at first spill.
     spill_cursor: Option<usize>,
+    error: Option<DataFusionError>,
     builder: &'a mut StringViewArrayBuilder,
+}
+
+impl StringViewWriter<'_> {
+    #[inline]
+    fn set_error(&mut self, error: DataFusionError) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+    }
+
+    #[inline]
+    fn validate_spilled_len(&mut self, additional: usize) -> bool {
+        let Some(start) = self.spill_cursor else {
+            return true;
+        };
+        let Some(current_len) = self.builder.in_progress.len().checked_sub(start) else {
+            self.set_error(string_view_overflow_error("value length"));
+            return false;
+        };
+        let Some(next_len) = current_len.checked_add(additional) else {
+            self.set_error(string_view_overflow_error("value length"));
+            return false;
+        };
+        if i32::try_from(next_len).is_err() {
+            self.set_error(string_view_overflow_error("value length"));
+            return false;
+        }
+        true
+    }
+
+    #[inline]
+    fn spill_inline_prefix(&mut self, new_len: usize) -> bool {
+        let Ok(length) =
+            StringViewArrayBuilder::try_string_view_u32(new_len, "value length")
+        else {
+            self.set_error(string_view_overflow_error("value length"));
+            return false;
+        };
+        if let Err(e) = self.builder.try_ensure_long_capacity(length) {
+            self.set_error(e);
+            return false;
+        }
+        let inline_len = self.inline_len as usize;
+        let cursor = self.builder.in_progress.len();
+        self.builder
+            .in_progress
+            .extend_from_slice(&self.inline_buf[..inline_len]);
+        self.spill_cursor = Some(cursor);
+        true
+    }
 }
 
 impl StringWriter for StringViewWriter<'_> {
     #[inline]
     fn write_str(&mut self, s: &str) {
+        if self.error.is_some() {
+            return;
+        }
         let bytes = s.as_bytes();
         if self.spill_cursor.is_some() {
-            self.builder.in_progress.extend_from_slice(bytes);
+            if self.validate_spilled_len(bytes.len()) {
+                self.builder.in_progress.extend_from_slice(bytes);
+            }
             return;
         }
 
         let inline_len = self.inline_len as usize;
-        let new_len = inline_len + bytes.len();
+        let Some(new_len) = inline_len.checked_add(bytes.len()) else {
+            self.set_error(string_view_overflow_error("value length"));
+            return;
+        };
         if new_len <= 12 {
             self.inline_buf[inline_len..new_len].copy_from_slice(bytes);
             self.inline_len = new_len as u8;
             return;
         }
 
-        // First spill of this row: `ensure_long_capacity` may flush the
+        // First spill of this row: `try_ensure_long_capacity` may flush the
         // current block, which is safe because no row-data for this row
         // is in it yet — the inline prefix is still in `inline_buf`.
-        self.builder.ensure_long_capacity(new_len as u32);
-        let cursor = self.builder.in_progress.len();
-        self.builder
-            .in_progress
-            .extend_from_slice(&self.inline_buf[..inline_len]);
-        self.builder.in_progress.extend_from_slice(bytes);
-        self.spill_cursor = Some(cursor);
+        if self.spill_inline_prefix(new_len) {
+            self.builder.in_progress.extend_from_slice(bytes);
+        }
     }
 
     #[inline]
     fn write_char(&mut self, c: char) {
+        if self.error.is_some() {
+            return;
+        }
         let len = c.len_utf8();
         if self.spill_cursor.is_some() {
-            push_char_to_vec(&mut self.builder.in_progress, c);
+            if self.validate_spilled_len(len) {
+                push_char_to_vec(&mut self.builder.in_progress, c);
+            }
             return;
         }
 
@@ -1022,13 +1200,9 @@ impl StringWriter for StringViewWriter<'_> {
             return;
         }
 
-        self.builder.ensure_long_capacity(new_len as u32);
-        let cursor = self.builder.in_progress.len();
-        self.builder
-            .in_progress
-            .extend_from_slice(&self.inline_buf[..inline_len]);
-        push_char_to_vec(&mut self.builder.in_progress, c);
-        self.spill_cursor = Some(cursor);
+        if self.spill_inline_prefix(new_len) {
+            push_char_to_vec(&mut self.builder.in_progress, c);
+        }
     }
 }
 
@@ -1179,10 +1353,7 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
     where
         F: for<'a> FnOnce(&mut Self::Writer<'a>),
     {
-        // StringView's closure-based path is still infallible; the Result
-        // keeps this trait uniform with offset-based builders.
-        StringViewArrayBuilder::append_with(self, f);
-        Ok(())
+        StringViewArrayBuilder::try_append_with(self, f)
     }
     #[inline]
     unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
@@ -1190,11 +1361,8 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
         src: &[u8],
         map: F,
     ) -> Result<()> {
-        // StringView's byte-map path is still infallible; the Result keeps this
-        // trait uniform with offset-based builders.
         // SAFETY: contract forwarded.
-        unsafe { StringViewArrayBuilder::append_byte_map(self, src, map) };
-        Ok(())
+        unsafe { StringViewArrayBuilder::try_append_byte_map(self, src, map) }
     }
     fn finish(self, nulls: Option<NullBuffer>) -> Result<ArrayRef> {
         Ok(Arc::new(StringViewArrayBuilder::finish(self, nulls)?))
@@ -1694,6 +1862,49 @@ mod tests {
         assert_eq!(array.value(0), "abc");
         assert!(array.is_null(1));
         assert_eq!(array.value(2), "a long string value");
+    }
+
+    #[test]
+    fn string_view_builder_try_append_with_and_byte_map_success_path() {
+        let mut builder = StringViewArrayBuilder::with_capacity(3);
+        builder
+            .try_append_with(|w| {
+                w.write_str("hello ");
+                w.write_char('🦀');
+            })
+            .unwrap();
+        // SAFETY: ASCII input and output.
+        unsafe {
+            builder
+                .try_append_byte_map(b"abc", |b| b.to_ascii_uppercase())
+                .unwrap();
+        }
+        builder
+            .try_append_with(|w| w.write_str("a long string value"))
+            .unwrap();
+
+        let array = builder.finish(None).unwrap();
+        assert_eq!(array.value(0), "hello 🦀");
+        assert_eq!(array.value(1), "ABC");
+        assert_eq!(array.value(2), "a long string value");
+    }
+
+    #[test]
+    fn string_view_builder_rejects_long_view_part_overflow() {
+        for (length, offset, buffer_count, field) in [
+            (i32::MAX as usize + 1, 0, 0, "value length"),
+            (0, i32::MAX as usize + 1, 0, "offset"),
+            (0, 0, i32::MAX as usize + 1, "buffer count"),
+        ] {
+            let err =
+                StringViewArrayBuilder::try_long_view_parts(length, offset, buffer_count)
+                    .unwrap_err()
+                    .to_string();
+            assert!(
+                err.contains("byte array offset overflow") && err.contains(field),
+                "unexpected error for {field}: {err}"
+            );
+        }
     }
 
     #[test]

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -252,12 +252,12 @@ fn initcap_utf8view(args: &[ArrayRef]) -> Result<ArrayRef> {
     if let Some(ref n) = nulls {
         for i in 0..len {
             if n.is_null(i) {
-                builder.append_placeholder();
+                builder.try_append_placeholder()?;
             } else {
                 // SAFETY: not null per check above.
                 let s = unsafe { string_view_array.value_unchecked(i) };
                 initcap_string(s, &mut container);
-                builder.append_value(&container);
+                builder.try_append_value(&container)?;
             }
         }
     } else {
@@ -265,7 +265,7 @@ fn initcap_utf8view(args: &[ArrayRef]) -> Result<ArrayRef> {
             // SAFETY: no null buffer means every index is valid.
             let s = unsafe { string_view_array.value_unchecked(i) };
             initcap_string(s, &mut container);
-            builder.append_value(&container);
+            builder.try_append_value(&container)?;
         }
     }
 

--- a/datafusion/functions/src/unicode/reverse.rs
+++ b/datafusion/functions/src/unicode/reverse.rs
@@ -136,18 +136,18 @@ where
     if let Some(ref n) = nulls {
         for i in 0..item_len {
             if n.is_null(i) {
-                array_builder.append_placeholder();
+                array_builder.try_append_placeholder()?;
             } else {
                 // SAFETY: `n.is_null(i)` was false in the branch above.
                 let s = unsafe { string_array.value_unchecked(i) };
-                append_reversed(s, &mut array_builder, &mut byte_buf, &mut string_buf);
+                append_reversed(s, &mut array_builder, &mut byte_buf, &mut string_buf)?;
             }
         }
     } else {
         for i in 0..item_len {
             // SAFETY: no null buffer means every index is valid.
             let s = unsafe { string_array.value_unchecked(i) };
-            append_reversed(s, &mut array_builder, &mut byte_buf, &mut string_buf);
+            append_reversed(s, &mut array_builder, &mut byte_buf, &mut string_buf)?;
         }
     }
 
@@ -160,20 +160,21 @@ fn append_reversed<B: BulkNullStringArrayBuilder>(
     builder: &mut B,
     byte_buf: &mut Vec<u8>,
     string_buf: &mut String,
-) {
+) -> Result<()> {
     if s.is_ascii() {
         // reverse bytes directly since ASCII characters are single bytes
         byte_buf.extend(s.as_bytes());
         byte_buf.reverse();
         // SAFETY: input was ASCII, so reversed bytes are still valid UTF-8.
         let reversed = unsafe { std::str::from_utf8_unchecked(byte_buf) };
-        builder.append_value(reversed);
+        builder.try_append_value(reversed)?;
         byte_buf.clear();
     } else {
         string_buf.extend(s.chars().rev());
-        builder.append_value(string_buf);
+        builder.try_append_value(string_buf)?;
         string_buf.clear();
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/datafusion/functions/src/unicode/substr.rs
+++ b/datafusion/functions/src/unicode/substr.rs
@@ -431,7 +431,7 @@ fn generic_string_substr_copy<T: OffsetSizeTrait>(
 
     for i in 0..len {
         if nulls.as_ref().is_some_and(|n| n.is_null(i)) {
-            result_builder.append_placeholder();
+            result_builder.try_append_placeholder()?;
             continue;
         }
 
@@ -440,7 +440,7 @@ fn generic_string_substr_copy<T: OffsetSizeTrait>(
         let count = count_array_opt.map(|a| a.value(i));
 
         let (byte_start, byte_end) = get_true_start_end(string, start, count, is_ascii)?;
-        result_builder.append_value(&string[byte_start..byte_end]);
+        result_builder.try_append_value(&string[byte_start..byte_end])?;
     }
 
     Ok(Arc::new(result_builder.finish(nulls)?) as ArrayRef)

--- a/datafusion/functions/src/unicode/translate.rs
+++ b/datafusion/functions/src/unicode/translate.rs
@@ -206,7 +206,7 @@ where
     if let Some(nulls_ref) = nulls.as_ref() {
         for i in 0..len {
             if nulls_ref.is_null(i) {
-                builder.append_placeholder();
+                builder.try_append_placeholder()?;
                 continue;
             }
 
@@ -214,7 +214,7 @@ where
             let string = unsafe { string_array.value_unchecked(i) };
             let from = unsafe { from_array.value_unchecked(i) };
             let to = unsafe { to_array.value_unchecked(i) };
-            append_translated_row(&mut builder, string, from, to, &mut from_map);
+            append_translated_row(&mut builder, string, from, to, &mut from_map)?;
         }
     } else {
         for i in 0..len {
@@ -222,7 +222,7 @@ where
             let string = unsafe { string_array.value_unchecked(i) };
             let from = unsafe { from_array.value_unchecked(i) };
             let to = unsafe { to_array.value_unchecked(i) };
-            append_translated_row(&mut builder, string, from, to, &mut from_map);
+            append_translated_row(&mut builder, string, from, to, &mut from_map)?;
         }
     }
 
@@ -236,10 +236,9 @@ fn append_translated_row<B: BulkNullStringArrayBuilder>(
     from: &str,
     to: &str,
     from_map: &mut HashMap<char, Option<char>>,
-) {
+) -> Result<()> {
     if let Some(ascii_table) = build_ascii_translate_table(from, to) {
-        append_translated_ascii(builder, string, &ascii_table);
-        return;
+        return append_translated_ascii(builder, string, &ascii_table);
     }
 
     from_map.clear();
@@ -249,7 +248,7 @@ fn append_translated_row<B: BulkNullStringArrayBuilder>(
         from_map.entry(c).or_insert(replacement);
     }
 
-    builder.append_with(|w| write_translated_chars(w, string, from_map));
+    builder.try_append_with(|w| write_translated_chars(w, string, from_map))
 }
 
 #[inline]
@@ -339,7 +338,7 @@ fn append_translated_ascii<B: BulkNullStringArrayBuilder>(
     builder: &mut B,
     input: &str,
     table: &AsciiTranslateTable,
-) {
+) -> Result<()> {
     // Fast path: equal-length byte-to-byte map when no deletions.
     if !table.has_delete {
         // SAFETY: ASCII source bytes map to ASCII replacements; non-ASCII
@@ -347,10 +346,10 @@ fn append_translated_ascii<B: BulkNullStringArrayBuilder>(
         // pass through unchanged. Output length equals input length and
         // remains valid UTF-8.
         unsafe {
-            builder.append_byte_map(input.as_bytes(), |b| table.map[b as usize]);
+            builder.try_append_byte_map(input.as_bytes(), |b| table.map[b as usize])
         }
     } else {
-        builder.append_with(|w| write_translated_ascii(w, input, table));
+        builder.try_append_with(|w| write_translated_ascii(w, input, table))
     }
 }
 
@@ -398,19 +397,19 @@ where
     if let Some(nulls_ref) = nulls.as_ref() {
         for i in 0..len {
             if nulls_ref.is_null(i) {
-                builder.append_placeholder();
+                builder.try_append_placeholder()?;
                 continue;
             }
 
             // SAFETY: input null buffer is non-null at i.
             let s = unsafe { string_array.value_unchecked(i) };
-            apply_translate_table(&mut builder, s, table);
+            apply_translate_table(&mut builder, s, table)?;
         }
     } else {
         for i in 0..len {
             // SAFETY: no null buffer means every index is valid.
             let s = unsafe { string_array.value_unchecked(i) };
-            apply_translate_table(&mut builder, s, table);
+            apply_translate_table(&mut builder, s, table)?;
         }
     }
 
@@ -422,11 +421,11 @@ fn apply_translate_table<B: BulkNullStringArrayBuilder>(
     builder: &mut B,
     input: &str,
     table: &TranslateTable,
-) {
+) -> Result<()> {
     match table {
         TranslateTable::Byte(t) => append_translated_ascii(builder, input, t),
         TranslateTable::Char(m) => {
-            builder.append_with(|w| write_translated_chars(w, input, m))
+            builder.try_append_with(|w| write_translated_chars(w, input, m))
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22688

## Rationale for this change

This PR completes the migration of the remaining string-producing UDFs to the fallible `BulkNullStringArrayBuilder` APIs introduced by earlier work on #22688.

Previously, several UDFs still used infallible builder methods (`append_value`, `append_placeholder`, `append_with`, and `append_byte_map`), which could panic if builder size limits were exceeded. This change propagates builder errors through the affected functions so byte array offset overflows are returned as `DataFusionError`s instead of panicking, completing the audit of the remaining call sites within the scope of this sub-issue.

## What changes are included in this PR?

* Migrate remaining string and Unicode UDFs to use `try_append_*` builder APIs and propagate errors with `?`.
* Update helper functions to return `Result<()>` where required so builder failures can be propagated.
* Extend `StringViewArrayBuilder` with fallible variants of:

  * `try_append_with`
  * `try_append_byte_map`
* Add shared helper routines for checked conversion of string view metadata and overflow validation.
* Update `StringViewWriter` to track and propagate builder errors instead of relying on panics.
* Retain infallible builder methods as wrappers around the new fallible implementations for compatibility, documenting them as infallible variants.
* Update `BulkNullStringArrayBuilder` to expose fallible `try_append_*` methods.
* Migrate the remaining audited UDFs, including:

  * `overlay`
  * `chr`
  * `repeat`
  * `split_part`
  * `uuid`
  * `initcap`
  * `reverse`
  * `substr`
  * `translate`

## Are these changes tested?

Yes.

This PR adds the following unit tests:

* `string_view_builder_try_append_with_and_byte_map_success_path`
* `string_view_builder_rejects_long_view_part_overflow`

It also updates existing builder tests to use the new fallible APIs where appropriate. Existing UDF tests continue to exercise the migrated implementations. 

## Are there any user-facing changes?

There are no intended user-facing behavioral changes for successful queries.

The observable change is that builder overflow conditions are propagated as recoverable `DataFusionError`s instead of relying on panics, completing the migration to the fallible builder APIs. This does not introduce a breaking public API change. 

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed.
