### PR TITLE
perf: sort multi-column runs via row format and coalesce them

### DIFF
--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -274,6 +274,10 @@ name = "sort"
 
 [[bench]]
 harness = false
+name = "sort_indices"
+
+[[bench]]
+harness = false
 name = "topk_aggregate"
 
 [[bench]]

--- a/datafusion/core/benches/sort_indices.rs
+++ b/datafusion/core/benches/sort_indices.rs
@@ -1,0 +1,196 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Microbenchmark isolating the *sorted-index computation* strategy that
+//! underpins coalescing multi-column sort runs.
+//!
+//! For a single run of `N` rows, comparing two ways to produce the sorted
+//! permutation of row indices:
+//!
+//! * `lexsort` — `arrow::compute::lexsort_to_indices`, which compares rows
+//!   column-by-column with a per-comparison dynamic-dispatched comparator.
+//! * `rowsort` — encode the key columns once into the Arrow row format
+//!   (`RowConverter`) and argsort the row indices with a cheap `memcmp`.
+//!
+//! `take` is deliberately excluded: it is identical for both strategies, so
+//! the benchmark measures only the comparison/encoding cost that differs.
+
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, DictionaryArray, Int64Array, StringArray, StringViewArray, UInt32Array,
+};
+use arrow::compute::{SortColumn, SortOptions, lexsort_to_indices};
+use arrow::datatypes::Int32Type;
+use arrow::row::{RowConverter, SortField};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+/// Run sizes: 1k models a single small input batch (the current per-batch run
+/// size in the merge path), the larger sizes model coalesced runs.
+const SIZES: &[(usize, &str)] = &[(1_024, "1k"), (65_536, "64k"), (1_048_576, "1M")];
+
+/// Baseline: column-by-column lexicographic comparator.
+fn lexsort_indices(cols: &[SortColumn]) -> UInt32Array {
+    lexsort_to_indices(cols, None).unwrap()
+}
+
+/// Candidate: encode once into row format, then argsort indices via `memcmp`.
+fn rowsort_indices(cols: &[SortColumn]) -> UInt32Array {
+    let fields: Vec<SortField> = cols
+        .iter()
+        .map(|c| {
+            SortField::new_with_options(
+                c.values.data_type().clone(),
+                c.options.unwrap_or_default(),
+            )
+        })
+        .collect();
+    let converter = RowConverter::new(fields).unwrap();
+    let arrays: Vec<ArrayRef> = cols.iter().map(|c| Arc::clone(&c.values)).collect();
+    let rows = converter.convert_columns(&arrays).unwrap();
+    let mut indices: Vec<u32> = (0..rows.num_rows() as u32).collect();
+    indices.sort_unstable_by(|&a, &b| rows.row(a as usize).cmp(&rows.row(b as usize)));
+    UInt32Array::from(indices)
+}
+
+fn sort_col(values: ArrayRef) -> SortColumn {
+    SortColumn {
+        values,
+        options: Some(SortOptions::default()),
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Data generation (unsorted, fixed seed) for each key shape.
+// ----------------------------------------------------------------------------
+
+fn low_card(rng: &mut StdRng, n: usize) -> Vec<String> {
+    let dict: Vec<String> = (0..100).map(|s| format!("value{s}")).collect();
+    (0..n)
+        .map(|_| dict[rng.random_range(0..dict.len())].clone())
+        .collect()
+}
+
+fn high_card(rng: &mut StdRng, n: usize) -> Vec<String> {
+    (0..n)
+        .map(|_| {
+            (0..20)
+                .map(|_| (b'a' + rng.random_range(0..26u8)) as char)
+                .collect::<String>()
+        })
+        .collect()
+}
+
+fn i64_vals(rng: &mut StdRng, n: usize) -> Vec<i64> {
+    (0..n).map(|_| rng.random_range(0..n as i64)).collect()
+}
+
+fn str_array(v: &[String]) -> StringArray {
+    v.iter().map(|s| Some(s.as_str())).collect()
+}
+
+fn view_array(v: &[String]) -> StringViewArray {
+    v.iter().map(|s| Some(s.as_str())).collect()
+}
+
+fn dict_array(v: &[String]) -> DictionaryArray<Int32Type> {
+    v.iter().map(|s| Some(s.as_str())).collect()
+}
+
+/// Build the sort-key columns for a given key shape and size. Data is random
+/// (unsorted) with a fixed seed so the comparison is deterministic and the sort
+/// does real work.
+fn columns(kind: &str, n: usize) -> Vec<SortColumn> {
+    let mut rng = StdRng::seed_from_u64(42);
+    match kind {
+        // Single-column controls (expected: lexsort wins / ties).
+        "i64 (single)" => {
+            vec![sort_col(Arc::new(Int64Array::from(i64_vals(&mut rng, n))))]
+        }
+        "utf8 high (single)" => {
+            vec![sort_col(Arc::new(str_array(&high_card(&mut rng, n))))]
+        }
+        // Multi-column keys.
+        "utf8 tuple" => {
+            vec![
+                sort_col(Arc::new(str_array(&low_card(&mut rng, n)))),
+                sort_col(Arc::new(str_array(&low_card(&mut rng, n)))),
+                sort_col(Arc::new(str_array(&high_card(&mut rng, n)))),
+            ]
+        }
+        "utf8 view tuple" => {
+            vec![
+                sort_col(Arc::new(view_array(&low_card(&mut rng, n)))),
+                sort_col(Arc::new(view_array(&low_card(&mut rng, n)))),
+                sort_col(Arc::new(view_array(&high_card(&mut rng, n)))),
+            ]
+        }
+        "dict tuple" => {
+            vec![
+                sort_col(Arc::new(dict_array(&low_card(&mut rng, n)))),
+                sort_col(Arc::new(dict_array(&low_card(&mut rng, n)))),
+                sort_col(Arc::new(dict_array(&low_card(&mut rng, n)))),
+            ]
+        }
+        // Primitive-leading mixed tuple: (i64, utf8, utf8, i64).
+        "mixed tuple" => {
+            vec![
+                sort_col(Arc::new(Int64Array::from(i64_vals(&mut rng, n)))),
+                sort_col(Arc::new(str_array(&low_card(&mut rng, n)))),
+                sort_col(Arc::new(str_array(&low_card(&mut rng, n)))),
+                sort_col(Arc::new(Int64Array::from(i64_vals(&mut rng, n)))),
+            ]
+        }
+        other => panic!("unknown kind {other}"),
+    }
+}
+
+const KINDS: &[&str] = &[
+    "i64 (single)",
+    "utf8 high (single)",
+    "utf8 tuple",
+    "utf8 view tuple",
+    "dict tuple",
+    "mixed tuple",
+];
+
+fn bench(c: &mut Criterion) {
+    for kind in KINDS {
+        let mut group = c.benchmark_group(*kind);
+        for &(n, label) in SIZES {
+            let cols = columns(kind, n);
+            // Sanity: both strategies must agree on the produced ordering of keys.
+            debug_assert_eq!(lexsort_indices(&cols).len(), rowsort_indices(&cols).len());
+            group.bench_with_input(
+                BenchmarkId::new("lexsort", label),
+                &cols,
+                |b, cols| b.iter(|| lexsort_indices(cols)),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("rowsort", label),
+                &cols,
+                |b, cols| b.iter(|| rowsort_indices(cols)),
+            );
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -627,13 +627,13 @@ impl ExternalSorter {
             return self.sort_batch_stream(batch, &metrics, reservation);
         }
 
-        // For single-column sorts, coalesce the buffered batches into fewer,
-        // larger runs to cut the merge fan-in (where the cheap per-key compare is
-        // dominated by per-stream cursor/merge overhead). Multi-column sorts are
-        // left as one run per batch: the row-format merge of many small runs
-        // beats sorting a few large runs with the lexicographic comparator.
+        // Coalesce the buffered batches into fewer, larger runs to cut the merge
+        // fan-in. Single-column runs are sorted with `lexsort_to_indices`;
+        // multi-column runs are sorted via the Arrow row format (see
+        // `sorted_indices`), whose one-off encode is amortized over the larger
+        // run, so both column counts benefit from larger runs here.
         let batches = std::mem::take(&mut self.in_mem_batches);
-        let runs = if coalesce_runs && self.expr.len() == 1 {
+        let runs = if coalesce_runs {
             self.coalesce_in_mem_batches_into_runs(batches)?
         } else {
             batches

--- a/datafusion/physical-plan/src/sorts/stream.rs
+++ b/datafusion/physical-plan/src/sorts/stream.rs
@@ -18,9 +18,9 @@
 use crate::SendableRecordBatchStream;
 use crate::sorts::cursor::{ArrayValues, CursorArray, RowValues};
 use crate::{PhysicalExpr, PhysicalSortExpr};
-use arrow::array::{Array, UInt32Array};
-use arrow::compute::take_record_batch;
-use arrow::datatypes::Schema;
+use arrow::array::{Array, ArrayRef, UInt32Array};
+use arrow::compute::{SortColumn, take_record_batch};
+use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use arrow::row::{RowConverter, Rows, SortField};
 use arrow_ord::sort::lexsort_to_indices;
@@ -281,6 +281,67 @@ impl<T: CursorArray> PartitionedStream for FieldCursorStream<T> {
     }
 }
 
+/// Returns true when sorting `sort_columns` via the Arrow row format is
+/// expected to beat [`lexsort_to_indices`].
+///
+/// Benchmarks (`sort_indices` bench) show the row format wins for multi-column
+/// keys whose **leading** column is an expensive (variable-length or
+/// dictionary) comparison — there `lexsort`'s column-by-column comparator pays
+/// a heavy per-comparison cost. For a single column, or a cheap primitive
+/// leading column where `lexsort` short-circuits most comparisons on the first
+/// column, `lexsort` wins, so those keep the lexicographic path.
+fn use_row_format_sort(sort_columns: &[SortColumn]) -> bool {
+    sort_columns.len() > 1
+        && matches!(
+            sort_columns[0].values.data_type(),
+            DataType::Utf8
+                | DataType::LargeUtf8
+                | DataType::Utf8View
+                | DataType::Binary
+                | DataType::LargeBinary
+                | DataType::BinaryView
+                | DataType::FixedSizeBinary(_)
+                | DataType::Dictionary(_, _)
+        )
+}
+
+/// Compute the sorted permutation of row indices for `sort_columns`.
+///
+/// For multi-column keys with an expensive leading column (see
+/// [`use_row_format_sort`]) this encodes the key columns once into the Arrow
+/// row format (`RowConverter`) and argsorts the row indices with a cheap
+/// `memcmp`, avoiding the per-comparison column-by-column dynamic dispatch of
+/// [`lexsort_to_indices`]. The larger the run, the more the one-off encode is
+/// amortized. Everything else (single column, primitive-leading keys, and
+/// limited/`fetch` sorts which want a partial sort) uses [`lexsort_to_indices`].
+pub(crate) fn sorted_indices(
+    sort_columns: &[SortColumn],
+    fetch: Option<usize>,
+) -> Result<UInt32Array> {
+    if fetch.is_some() || !use_row_format_sort(sort_columns) {
+        return Ok(lexsort_to_indices(sort_columns, fetch)?);
+    }
+
+    let fields = sort_columns
+        .iter()
+        .map(|c| {
+            SortField::new_with_options(
+                c.values.data_type().clone(),
+                c.options.unwrap_or_default(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let converter = RowConverter::new(fields)?;
+    let arrays = sort_columns
+        .iter()
+        .map(|c| Arc::clone(&c.values))
+        .collect::<Vec<ArrayRef>>();
+    let rows = converter.convert_columns(&arrays)?;
+    let mut indices: Vec<u32> = (0..rows.num_rows() as u32).collect();
+    indices.sort_unstable_by(|&a, &b| rows.row(a as usize).cmp(&rows.row(b as usize)));
+    Ok(UInt32Array::from(indices))
+}
+
 /// A lazy, memory-efficient sort iterator used as a fallback during aggregate
 /// spill when there is not enough memory for an eager sort (which requires ~2x
 /// peak memory to hold both the unsorted and sorted copies simultaneously).
@@ -339,9 +400,9 @@ impl Iterator for IncrementalSortIterator {
                     Err(e) => return Some(Err(e)),
                 };
 
-                let indices = match lexsort_to_indices(&sort_columns, None) {
+                let indices = match sorted_indices(&sort_columns, None) {
                     Ok(indices) => indices,
-                    Err(e) => return Some(Err(e.into())),
+                    Err(e) => return Some(Err(e)),
                 };
                 self.indices = Some(indices);
 


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #23202 (coalesce single-column sort runs). No specific issue.

## Rationale for this change

#23202 coalesces buffered runs into fewer, larger runs to cut merge fan-in, but
**only for single-column sorts**. Multi-column runs were deliberately left one
run per batch, because coalescing them and sorting the larger run with
`lexsort_to_indices` *regresses*: `lexsort`'s comparator walks the key columns
one at a time with per-comparison dynamic dispatch (and heap touches for
strings/dictionaries), and that cost grows super-linearly with run size.

The fix is to change *how* a multi-column run is sorted, not just its size: for
keys whose leading column is an expensive (variable-length or dictionary)
comparison, encode the key once into the Arrow **row format** and argsort the
row indices with a cheap `memcmp`. This is the same comparison the streaming
merge already uses (`RowCursorStream`), so it is a natural fit — and it removes
exactly the comparator cost that made coalescing regress. With that in place we
can coalesce **all** multi-column runs.

A microbenchmark (`sort_indices`, added here) isolates the index-computation
cost — `lexsort_to_indices` vs. row-encode+argsort — by key shape and run size
(speedup = lexsort / rowsort; >1 means row format is faster):

| key shape | 1k | 64k | 1M |
|---|---|---|---|
| i64 (single) | 0.16× | 0.17× | 0.15× |
| utf8 high (single) | 0.22× | 0.31× | 0.66× |
| utf8 tuple | 1.86× | 2.46× | 3.38× |
| dict tuple | 2.06× | 2.66× | 2.72× |
| utf8 view tuple | 0.67× | 1.10× | 1.48× |
| mixed tuple (i64-leading) | 0.49× | 0.67× | 0.78× |

This is what motivates the gate: row format wins big for string/dict-leading
keys (and more as runs grow), but **loses** for single-column keys and for
primitive-leading keys (where `lexsort` short-circuits on the cheap first
column). So the row-format path is gated to multi-column keys with an expensive
leading column; everything else keeps `lexsort`.

End-to-end (`cargo bench --bench sort`, the `SortExec` cases, vs. current main):

| benchmark | speedup |
|---|---|
| sort utf8 tuple 100k / 1M | 1.34× / 1.19× |
| sort utf8 view tuple 100k / 1M | 1.22× / 1.17× |
| sort utf8 dictionary tuple 100k / 1M | 1.23× / 1.74× |
| sort mixed dictionary tuple 100k / 1M | 1.47× / 1.81× |
| sort mixed tuple 100k / 1M | 1.44× / 1.45× |
| sort mixed tuple with utf8 view 100k / 1M | 1.51× / 1.40× |
| sort i64 100k / 1M | ~unchanged (noise) |

String/dict-leading tuples win via coalesce + row-format sort; the
primitive-leading `mixed tuple` wins ~1.4× purely from coalesce + `lexsort` on
larger runs (it now also gets coalesced). Single-column sorts are unchanged.

## What changes are included in this PR?

- `sorted_indices()` in `sorts/stream.rs`: computes the sorted index permutation,
  choosing the Arrow row format for multi-column keys with an expensive leading
  column (`use_row_format_sort`) and `lexsort_to_indices` otherwise (single
  column, primitive-leading, or `fetch`/top-k).
- `IncrementalSortIterator` (the single point every in-memory sort run flows
  through) now calls `sorted_indices()`. No merge/cursor changes.
- `in_mem_sort_stream` now coalesces **all** runs, not just single-column ones.
- New microbenchmark `datafusion/core/benches/sort_indices.rs`.

## Are these changes tested?

Existing `sorts::` unit tests pass (NULLs, sort options, multi-column merge,
spill). Correctness of the row-format ordering is covered by the existing
multi-column sort tests; the new microbenchmark documents the perf rationale.

## Are there any user-facing changes?

No (internal performance change only).
