### PR TITLE
Coalesce single-column sort runs during spill

### DIFF
--- a/datafusion/physical-plan/src/sorts/sort.rs
+++ b/datafusion/physical-plan/src/sorts/sort.rs
@@ -58,7 +58,7 @@ use crate::{
 
 use arrow::array::{RecordBatch, RecordBatchOptions};
 use arrow::compute::{concat_batches, lexsort_to_indices, take_arrays};
-use arrow::datatypes::SchemaRef;
+use arrow::datatypes::{DataType, SchemaRef};
 use datafusion_common::config::SpillCompression;
 use datafusion_common::{
     DataFusionError, Result, assert_or_internal_err, internal_datafusion_err,
@@ -476,9 +476,8 @@ impl ExternalSorter {
         // reserved again for the next spill.
         self.merge_reservation.free();
 
-        // No coalescing on the spill path: it raises per-run peak memory.
         let mut sorted_stream =
-            self.in_mem_sort_stream(self.metrics.baseline.intermediate(), false)?;
+            self.in_mem_sort_stream(self.metrics.baseline.intermediate(), true)?;
         // After `in_mem_sort_stream()` is constructed, all `in_mem_batches` is taken
         // to construct a globally sorted stream.
         assert_or_internal_err!(
@@ -627,13 +626,13 @@ impl ExternalSorter {
             return self.sort_batch_stream(batch, &metrics, reservation);
         }
 
-        // For single-column sorts, coalesce the buffered batches into fewer,
-        // larger runs to cut the merge fan-in (where the cheap per-key compare is
-        // dominated by per-stream cursor/merge overhead). Multi-column sorts are
-        // left as one run per batch: the row-format merge of many small runs
-        // beats sorting a few large runs with the lexicographic comparator.
+        // For single primitive-column sorts, coalesce the buffered batches into
+        // fewer, larger runs to cut the merge fan-in (where the cheap per-key
+        // compare is dominated by per-stream cursor/merge overhead). Multi-column
+        // sorts are left as one run per batch: the row-format merge of many small
+        // runs beats sorting a few large runs with the lexicographic comparator.
         let batches = std::mem::take(&mut self.in_mem_batches);
-        let runs = if coalesce_runs && self.expr.len() == 1 {
+        let runs = if coalesce_runs && self.should_coalesce_single_column_sort()? {
             self.coalesce_in_mem_batches_into_runs(batches)?
         } else {
             batches
@@ -660,6 +659,18 @@ impl ExternalSorter {
             .with_fetch(None)
             .with_reservation(self.merge_reservation.new_empty())
             .build()
+    }
+
+    fn should_coalesce_single_column_sort(&self) -> Result<bool> {
+        if self.expr.len() != 1 {
+            return Ok(false);
+        }
+
+        let data_type = self.expr[0].expr.data_type(&self.schema)?;
+        Ok(
+            matches!(data_type, DataType::Dictionary(_, ref value_type) if value_type.is_primitive())
+                || data_type.is_primitive(),
+        )
     }
 
     /// Concatenates `batches` into fewer, larger runs, each bounded by


### PR DESCRIPTION
## Which issue does this PR close?

Closes #23208.

## Rationale for this change

Single-column primitive sorts can produce many small sorted runs before spilling, increasing merge fan-in and merge overhead.

## What changes are included in this PR?

This enables in-memory run coalescing on the sort spill path for single primitive-column sorts, bounded by `sort_in_place_threshold_bytes`. Multi-column and non-primitive sorts keep the existing behavior.

## Are these changes tested?

Existing focused sort tests pass:

- `test_in_mem_sort_coalesced_runs`
- `test_sort_spill`
- `test_sort_spill_utf8_strings`

Also ran:

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`