### PR TITLE
Make shared string builders fallible end-to-end with `try_*` APIs

### DIFF
--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -344,6 +344,8 @@ fn string_view_overflow_error(field: &str) -> DataFusionError {
 }
 
 fn try_string_view_part(field: &str, value: usize) -> Result<u32> {
+    // StringView stores these fields as u32, but Arrow limits lengths,
+    // offsets, and buffer indices to i32::MAX.
     Ok(i32::try_from(value).map_err(|_| string_view_overflow_error(field))? as u32)
 }
 
@@ -907,6 +909,8 @@ impl StringViewArrayBuilder {
             builder: self,
         };
         f(&mut writer);
+        // Destructure `writer` to end its mutable borrow of `self` before
+        // mutating the builder below.
         let StringViewWriter {
             inline_buf,
             inline_len,

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -1333,6 +1333,7 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
     }
 }
 
+// `pub(crate)` for reuse by tests outside this module.
 #[cfg(test)]
 pub(crate) struct FailingStringWriter;
 
@@ -1343,6 +1344,7 @@ impl StringWriter for FailingStringWriter {
     fn write_char(&mut self, _c: char) {}
 }
 
+// `pub(crate)` for reuse by tests outside this module.
 #[cfg(test)]
 pub(crate) struct FailingBulkNullStringArrayBuilder;
 

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -918,13 +918,13 @@ impl StringViewArrayBuilder {
             self.in_progress.truncate(old_len);
             return Err(error);
         }
-        match self.push_view_from_writer(&inline_buf, inline_len, spill_cursor) {
-            Ok(()) => Ok(()),
-            Err(error) => {
-                self.in_progress.truncate(old_len);
-                Err(error)
-            }
+        if let Err(error) =
+            self.push_view_from_writer(&inline_buf, inline_len, spill_cursor)
+        {
+            self.in_progress.truncate(old_len);
+            return Err(error);
         }
+        Ok(())
     }
 
     /// See [`BulkNullStringArrayBuilder::append_with`].
@@ -1056,9 +1056,12 @@ impl StringWriter for StringViewWriter<'_> {
             return;
         }
 
-        let Ok(length) = try_string_view_part("value length", new_len) else {
-            self.fail(string_view_overflow_error("value length"));
-            return;
+        let length = match try_string_view_part("value length", new_len) {
+            Ok(length) => length,
+            Err(error) => {
+                self.fail(error);
+                return;
+            }
         };
         if let Err(error) = self.builder.try_ensure_long_capacity(length) {
             self.fail(error);
@@ -1095,9 +1098,12 @@ impl StringWriter for StringViewWriter<'_> {
             return;
         }
 
-        let Ok(length) = try_string_view_part("value length", new_len) else {
-            self.fail(string_view_overflow_error("value length"));
-            return;
+        let length = match try_string_view_part("value length", new_len) {
+            Ok(length) => length,
+            Err(error) => {
+                self.fail(error);
+                return;
+            }
         };
         if let Err(error) = self.builder.try_ensure_long_capacity(length) {
             self.fail(error);
@@ -1320,51 +1326,6 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
     }
     fn finish(self, nulls: Option<NullBuffer>) -> Result<ArrayRef> {
         Ok(Arc::new(StringViewArrayBuilder::finish(self, nulls)?))
-    }
-}
-
-#[cfg(test)]
-pub(crate) struct FailingStringWriter;
-
-#[cfg(test)]
-impl StringWriter for FailingStringWriter {
-    fn write_str(&mut self, _s: &str) {}
-
-    fn write_char(&mut self, _c: char) {}
-}
-
-#[cfg(test)]
-pub(crate) struct FailingBulkNullStringArrayBuilder;
-
-#[cfg(test)]
-impl BulkNullStringArrayBuilder for FailingBulkNullStringArrayBuilder {
-    type Writer<'a> = FailingStringWriter;
-
-    fn try_append_value(&mut self, _value: &str) -> Result<()> {
-        Err(exec_datafusion_err!("byte array offset overflow"))
-    }
-
-    fn try_append_placeholder(&mut self) -> Result<()> {
-        Err(exec_datafusion_err!("byte array offset overflow"))
-    }
-
-    fn try_append_with<F>(&mut self, _f: F) -> Result<()>
-    where
-        F: for<'a> FnOnce(&mut Self::Writer<'a>),
-    {
-        Err(exec_datafusion_err!("byte array offset overflow"))
-    }
-
-    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
-        &mut self,
-        _src: &[u8],
-        _map: F,
-    ) -> Result<()> {
-        Err(exec_datafusion_err!("byte array offset overflow"))
-    }
-
-    fn finish(self, _nulls: Option<NullBuffer>) -> Result<ArrayRef> {
-        internal_err!("failing test builder cannot finish")
     }
 }
 
@@ -1926,6 +1887,51 @@ mod tests {
             err.contains("byte array offset overflow"),
             "unexpected error: {err}"
         );
+    }
+
+    struct FailingStringWriter;
+
+    impl StringWriter for FailingStringWriter {
+        fn write_str(&mut self, _s: &str) {}
+
+        fn write_char(&mut self, _c: char) {}
+    }
+
+    struct FailingBulkNullStringArrayBuilder;
+
+    fn failing_overflow() -> Result<()> {
+        Err(exec_datafusion_err!("byte array offset overflow"))
+    }
+
+    impl BulkNullStringArrayBuilder for FailingBulkNullStringArrayBuilder {
+        type Writer<'a> = FailingStringWriter;
+
+        fn try_append_value(&mut self, _value: &str) -> Result<()> {
+            failing_overflow()
+        }
+
+        fn try_append_placeholder(&mut self) -> Result<()> {
+            failing_overflow()
+        }
+
+        fn try_append_with<F>(&mut self, _f: F) -> Result<()>
+        where
+            F: for<'a> FnOnce(&mut Self::Writer<'a>),
+        {
+            failing_overflow()
+        }
+
+        unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+            &mut self,
+            _src: &[u8],
+            _map: F,
+        ) -> Result<()> {
+            failing_overflow()
+        }
+
+        fn finish(self, _nulls: Option<NullBuffer>) -> Result<ArrayRef> {
+            internal_err!("failing test builder cannot finish")
+        }
     }
 
     #[test]

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -447,7 +447,8 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
             .expect("byte array offset overflow");
     }
 
-    /// Fallible variant of [`Self::append_byte_map`].
+    /// Fallibly append a row whose bytes are produced by mapping each byte of
+    /// `src` through `map`, in order.
     ///
     /// # Safety
     ///
@@ -469,27 +470,8 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
         })
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_byte_map`].
-    ///
-    /// Note: new call sites that need recoverable overflow handling should
-    /// prefer [`Self::try_append_byte_map`].
-    ///
-    /// # Safety
-    ///
-    /// The bytes produced by applying `map` to each byte of `src`, in order,
-    /// must form valid UTF-8.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the cumulative byte length exceeds `O::MAX`.
-    #[inline]
-    pub unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
-        // SAFETY: caller upholds this method's UTF-8 contract.
-        unsafe { self.try_append_byte_map(src, map) }
-            .expect("byte array offset overflow");
-    }
-
-    /// Fallible variant of [`Self::append_with`].
+    /// Fallibly append a row whose bytes are produced by `f` calling write
+    /// methods on the supplied [`StringWriter`].
     ///
     /// # Errors
     ///
@@ -516,22 +498,6 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
         };
         self.offsets_buffer.push(next_offset);
         Ok(())
-    }
-
-    /// See [`BulkNullStringArrayBuilder::append_with`].
-    ///
-    /// Note: new call sites that need recoverable overflow handling should
-    /// prefer [`Self::try_append_with`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the cumulative byte length exceeds `O::MAX`.
-    #[inline]
-    pub fn append_with<F>(&mut self, f: F)
-    where
-        F: FnOnce(&mut GenericStringWriter<'_>),
-    {
-        self.try_append_with(f).expect("byte array offset overflow");
     }
 
     /// Finalize into a [`GenericStringArray<O>`] using the caller-supplied
@@ -799,7 +765,8 @@ impl StringViewArrayBuilder {
         .into()
     }
 
-    /// Fallible variant of [`Self::append_byte_map`].
+    /// Fallibly append a row whose bytes are produced by mapping each byte of
+    /// `src` through `map`, in order.
     ///
     /// # Safety
     ///
@@ -840,27 +807,6 @@ impl StringViewArrayBuilder {
         Ok(())
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_byte_map`].
-    ///
-    /// Note: new call sites that need recoverable overflow handling should
-    /// prefer [`Self::try_append_byte_map`].
-    ///
-    /// # Safety
-    ///
-    /// The bytes produced by applying `map` to each byte of `src`, in order,
-    /// must form valid UTF-8.
-    ///
-    /// # Panics
-    ///
-    /// Panics under the same conditions that [`Self::try_append_byte_map`]
-    /// returns an error.
-    #[inline]
-    pub unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
-        // SAFETY: caller upholds this method's UTF-8 contract.
-        unsafe { self.try_append_byte_map(src, map) }
-            .expect("byte array offset overflow");
-    }
-
     #[inline]
     fn push_view_from_writer(
         &mut self,
@@ -890,7 +836,8 @@ impl StringViewArrayBuilder {
         Ok(())
     }
 
-    /// Fallible variant of [`Self::append_with`].
+    /// Fallibly append a row whose bytes are produced by `f` calling write
+    /// methods on the supplied [`StringWriter`].
     ///
     /// # Errors
     ///
@@ -929,23 +876,6 @@ impl StringViewArrayBuilder {
             return Err(error);
         }
         Ok(())
-    }
-
-    /// See [`BulkNullStringArrayBuilder::append_with`].
-    ///
-    /// Note: new call sites that need recoverable overflow handling should
-    /// prefer [`Self::try_append_with`].
-    ///
-    /// # Panics
-    ///
-    /// Panics under the same conditions that [`Self::try_append_with`] returns
-    /// an error.
-    #[inline]
-    pub fn append_with<F>(&mut self, f: F)
-    where
-        F: FnOnce(&mut StringViewWriter<'_>),
-    {
-        self.try_append_with(f).expect("byte array offset overflow");
     }
 
     fn flush_in_progress(&mut self) {

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -500,6 +500,28 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
         Ok(())
     }
 
+    /// See [`BulkNullStringArrayBuilder::append_with`].
+    ///
+    /// Note: new call sites that need recoverable overflow handling should
+    /// prefer [`Self::try_append_with`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the cumulative byte length exceeds `O::MAX`.
+    #[inline]
+    pub fn append_with<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut GenericStringWriter<'_>),
+    {
+        let mut writer = GenericStringWriter {
+            value_buffer: &mut self.value_buffer,
+        };
+        f(&mut writer);
+        let next_offset =
+            O::from_usize(self.value_buffer.len()).expect("byte array offset overflow");
+        self.offsets_buffer.push(next_offset);
+    }
+
     /// Finalize into a [`GenericStringArray<O>`] using the caller-supplied
     /// null buffer.
     ///
@@ -1214,6 +1236,13 @@ impl<O: OffsetSizeTrait> BulkNullStringArrayBuilder for GenericStringArrayBuilde
         F: for<'a> FnOnce(&mut Self::Writer<'a>),
     {
         GenericStringArrayBuilder::<O>::try_append_with(self, f)
+    }
+    #[inline]
+    fn append_with<F>(&mut self, f: F)
+    where
+        F: for<'a> FnOnce(&mut Self::Writer<'a>),
+    {
+        GenericStringArrayBuilder::<O>::append_with(self, f)
     }
     #[inline]
     unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -343,6 +343,10 @@ fn string_view_overflow_error(field: &str) -> DataFusionError {
     exec_datafusion_err!("byte array offset overflow: {field} exceeds i32::MAX")
 }
 
+fn try_string_view_part(field: &str, value: usize) -> Result<u32> {
+    Ok(i32::try_from(value).map_err(|_| string_view_overflow_error(field))? as u32)
+}
+
 fn try_offset<O: OffsetSizeTrait>(len: usize) -> Result<O> {
     if len > O::MAX_OFFSET {
         return Err(offset_overflow_error::<O>());
@@ -525,16 +529,7 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
     where
         F: FnOnce(&mut GenericStringWriter<'_>),
     {
-        // Do not delegate to `try_append_with`: it rolls back value_buffer on
-        // overflow before returning Err, which would change this infallible
-        // method's state if its panic is caught.
-        let mut writer = GenericStringWriter {
-            value_buffer: &mut self.value_buffer,
-        };
-        f(&mut writer);
-        let next_offset =
-            O::from_usize(self.value_buffer.len()).expect("byte array offset overflow");
-        self.offsets_buffer.push(next_offset);
+        self.try_append_with(f).expect("byte array offset overflow");
     }
 
     /// Finalize into a [`GenericStringArray<O>`] using the caller-supplied
@@ -700,9 +695,7 @@ impl StringViewArrayBuilder {
     #[inline]
     pub fn try_append_value(&mut self, value: &str) -> Result<()> {
         let v = value.as_bytes();
-        let length: u32 = i32::try_from(v.len())
-            .map_err(|_| string_view_overflow_error("value length"))?
-            as u32;
+        let length = try_string_view_part("value length", v.len())?;
         if length <= 12 {
             self.views.push(make_view(v, 0, 0));
             return Ok(());
@@ -710,12 +703,8 @@ impl StringViewArrayBuilder {
 
         self.try_ensure_long_capacity(length)?;
 
-        let offset: u32 = i32::try_from(self.in_progress.len())
-            .map_err(|_| string_view_overflow_error("offset"))?
-            as u32;
-        let buffer_index: u32 = i32::try_from(self.completed.len())
-            .map_err(|_| string_view_overflow_error("buffer count"))?
-            as u32;
+        let offset = try_string_view_part("offset", self.in_progress.len())?;
+        let buffer_index = try_string_view_part("buffer count", self.completed.len())?;
         self.in_progress.extend_from_slice(v);
         self.views.push(Self::make_long_view_checked(
             length,
@@ -784,16 +773,6 @@ impl StringViewArrayBuilder {
         Ok(())
     }
 
-    /// Ensure the in-progress block has room for `length` more bytes,
-    /// flushing the current block and starting a new (doubled) one if not.
-    /// Caller must invoke this only when no bytes of the current row are
-    /// yet in `in_progress` — flushing mid-row would orphan partial data.
-    #[inline]
-    fn ensure_long_capacity(&mut self, length: u32) {
-        self.try_ensure_long_capacity(length)
-            .expect("byte array offset overflow");
-    }
-
     /// Encode a long-form view referencing `length` bytes already written
     /// into the in-progress block at `offset`. `prefix_bytes` is the row's
     /// data slice (or any slice starting with the row's first 4 bytes).
@@ -818,15 +797,51 @@ impl StringViewArrayBuilder {
         .into()
     }
 
+    /// Fallible variant of [`Self::append_byte_map`].
+    ///
+    /// # Safety
+    ///
+    /// The bytes produced by applying `map` to each byte of `src`, in order,
+    /// must form valid UTF-8.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error under the same conditions as [`Self::try_append_value`].
     #[inline]
-    fn make_long_view(&self, length: u32, offset: u32, prefix_bytes: &[u8]) -> u128 {
-        let buffer_index: u32 = i32::try_from(self.completed.len())
-            .expect("buffer count exceeds i32::MAX")
-            as u32;
-        Self::make_long_view_checked(length, buffer_index, offset, prefix_bytes)
+    pub unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        src: &[u8],
+        mut map: F,
+    ) -> Result<()> {
+        let length = try_string_view_part("value length", src.len())?;
+        if length <= 12 {
+            let mut bytes = [0u8; 12];
+            for (d, &b) in bytes[..src.len()].iter_mut().zip(src) {
+                *d = map(b);
+            }
+            self.views.push(make_view(&bytes[..src.len()], 0, 0));
+            return Ok(());
+        }
+
+        self.try_ensure_long_capacity(length)?;
+
+        let cursor = self.in_progress.len();
+        let offset = try_string_view_part("offset", cursor)?;
+        let buffer_index = try_string_view_part("buffer count", self.completed.len())?;
+        self.in_progress.extend(src.iter().map(|&b| map(b)));
+        self.views.push(Self::make_long_view_checked(
+            length,
+            buffer_index,
+            offset,
+            &self.in_progress[cursor..],
+        ));
+        Ok(())
     }
 
     /// See [`BulkNullStringArrayBuilder::append_byte_map`].
+    ///
+    /// Note: new call sites that need recoverable overflow handling should
+    /// prefer [`Self::try_append_byte_map`].
     ///
     /// # Safety
     ///
@@ -835,60 +850,22 @@ impl StringViewArrayBuilder {
     ///
     /// # Panics
     ///
-    /// Panics under the same conditions as [`Self::append_value`]: if
-    /// `src.len()`, the in-progress buffer offset, or the number of completed
-    /// buffers exceeds `i32::MAX`.
+    /// Panics under the same conditions that [`Self::try_append_byte_map`]
+    /// returns an error.
     #[inline]
-    pub unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], mut map: F) {
-        let length: u32 =
-            i32::try_from(src.len()).expect("value length exceeds i32::MAX") as u32;
-        if length <= 12 {
-            let mut bytes = [0u8; 12];
-            for (d, &b) in bytes[..src.len()].iter_mut().zip(src) {
-                *d = map(b);
-            }
-            self.views.push(make_view(&bytes[..src.len()], 0, 0));
-            return;
-        }
-
-        self.ensure_long_capacity(length);
-
-        let cursor = self.in_progress.len();
-        let offset: u32 = i32::try_from(cursor).expect("offset exceeds i32::MAX") as u32;
-        self.in_progress.extend(src.iter().map(|&b| map(b)));
-        self.views
-            .push(self.make_long_view(length, offset, &self.in_progress[cursor..]));
+    pub unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
+        // SAFETY: caller upholds this method's UTF-8 contract.
+        unsafe { self.try_append_byte_map(src, map) }
+            .expect("byte array offset overflow");
     }
 
-    /// See [`BulkNullStringArrayBuilder::append_with`].
-    ///
-    /// # Panics
-    ///
-    /// Panics under the same conditions as [`Self::append_value`]: if the
-    /// row's byte length, the in-progress buffer offset, or the number of
-    /// completed buffers exceeds `i32::MAX`.
     #[inline]
-    pub fn append_with<F>(&mut self, f: F)
-    where
-        F: FnOnce(&mut StringViewWriter<'_>),
-    {
-        let mut writer = StringViewWriter {
-            inline_buf: [0u8; 12],
-            inline_len: 0,
-            spill_cursor: None,
-            builder: self,
-        };
-        f(&mut writer);
-        // Destructure to release the borrow on `self` and pull out the
-        // inline-buffer state by-value. Copy types only; the &mut self is
-        // dropped here, ending the borrow.
-        let StringViewWriter {
-            inline_buf,
-            inline_len,
-            spill_cursor,
-            ..
-        } = writer;
-
+    fn push_view_from_writer(
+        &mut self,
+        inline_buf: &[u8; 12],
+        inline_len: u8,
+        spill_cursor: Option<usize>,
+    ) -> Result<()> {
         match spill_cursor {
             None => {
                 self.views
@@ -896,18 +873,75 @@ impl StringViewArrayBuilder {
             }
             Some(start) => {
                 let end = self.in_progress.len();
-                let length: u32 = i32::try_from(end - start)
-                    .expect("value length exceeds i32::MAX")
-                    as u32;
-                let offset: u32 =
-                    i32::try_from(start).expect("offset exceeds i32::MAX") as u32;
-                self.views.push(self.make_long_view(
+                let length = try_string_view_part("value length", end - start)?;
+                let offset = try_string_view_part("offset", start)?;
+                let buffer_index =
+                    try_string_view_part("buffer count", self.completed.len())?;
+                self.views.push(Self::make_long_view_checked(
                     length,
+                    buffer_index,
                     offset,
                     &self.in_progress[start..],
                 ));
             }
         }
+        Ok(())
+    }
+
+    /// Fallible variant of [`Self::append_with`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error under the same conditions as [`Self::try_append_value`].
+    #[inline]
+    pub fn try_append_with<F>(&mut self, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut StringViewWriter<'_>),
+    {
+        let old_len = self.in_progress.len();
+        let mut writer = StringViewWriter {
+            inline_buf: [0u8; 12],
+            inline_len: 0,
+            spill_cursor: None,
+            error: None,
+            builder: self,
+        };
+        f(&mut writer);
+        let StringViewWriter {
+            inline_buf,
+            inline_len,
+            spill_cursor,
+            error,
+            ..
+        } = writer;
+        if let Some(error) = error {
+            self.in_progress.truncate(old_len);
+            return Err(error);
+        }
+        match self.push_view_from_writer(&inline_buf, inline_len, spill_cursor) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.in_progress.truncate(old_len);
+                Err(error)
+            }
+        }
+    }
+
+    /// See [`BulkNullStringArrayBuilder::append_with`].
+    ///
+    /// Note: new call sites that need recoverable overflow handling should
+    /// prefer [`Self::try_append_with`].
+    ///
+    /// # Panics
+    ///
+    /// Panics under the same conditions that [`Self::try_append_with`] returns
+    /// an error.
+    #[inline]
+    pub fn append_with<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut StringViewWriter<'_>),
+    {
+        self.try_append_with(f).expect("byte array offset overflow");
     }
 
     fn flush_in_progress(&mut self) {
@@ -969,30 +1003,67 @@ pub(crate) struct StringViewWriter<'a> {
     /// `None` while the row fits inline; becomes `Some(start)` (offset of
     /// the row's first byte in `in_progress`) at first spill.
     spill_cursor: Option<usize>,
+    error: Option<DataFusionError>,
     builder: &'a mut StringViewArrayBuilder,
+}
+
+impl StringViewWriter<'_> {
+    #[inline]
+    fn fail(&mut self, error: DataFusionError) {
+        self.error.get_or_insert(error);
+    }
+
+    #[inline]
+    fn write_spilled_bytes(&mut self, bytes: &[u8]) {
+        let Some(next_len) = self.builder.in_progress.len().checked_add(bytes.len())
+        else {
+            self.fail(string_view_overflow_error("string view block size"));
+            return;
+        };
+        let start = self.spill_cursor.expect("spilled writer has cursor");
+        if let Err(error) = try_string_view_part("value length", next_len - start) {
+            self.fail(error);
+            return;
+        }
+        if let Err(error) = try_string_view_part("offset", next_len) {
+            self.fail(error);
+            return;
+        }
+        self.builder.in_progress.extend_from_slice(bytes);
+    }
 }
 
 impl StringWriter for StringViewWriter<'_> {
     #[inline]
     fn write_str(&mut self, s: &str) {
+        if self.error.is_some() {
+            return;
+        }
         let bytes = s.as_bytes();
         if self.spill_cursor.is_some() {
-            self.builder.in_progress.extend_from_slice(bytes);
+            self.write_spilled_bytes(bytes);
             return;
         }
 
         let inline_len = self.inline_len as usize;
-        let new_len = inline_len + bytes.len();
+        let Some(new_len) = inline_len.checked_add(bytes.len()) else {
+            self.fail(string_view_overflow_error("value length"));
+            return;
+        };
         if new_len <= 12 {
             self.inline_buf[inline_len..new_len].copy_from_slice(bytes);
             self.inline_len = new_len as u8;
             return;
         }
 
-        // First spill of this row: `ensure_long_capacity` may flush the
-        // current block, which is safe because no row-data for this row
-        // is in it yet — the inline prefix is still in `inline_buf`.
-        self.builder.ensure_long_capacity(new_len as u32);
+        let Ok(length) = try_string_view_part("value length", new_len) else {
+            self.fail(string_view_overflow_error("value length"));
+            return;
+        };
+        if let Err(error) = self.builder.try_ensure_long_capacity(length) {
+            self.fail(error);
+            return;
+        }
         let cursor = self.builder.in_progress.len();
         self.builder
             .in_progress
@@ -1003,21 +1074,35 @@ impl StringWriter for StringViewWriter<'_> {
 
     #[inline]
     fn write_char(&mut self, c: char) {
+        if self.error.is_some() {
+            return;
+        }
         let len = c.len_utf8();
         if self.spill_cursor.is_some() {
-            push_char_to_vec(&mut self.builder.in_progress, c);
+            let mut buf = [0u8; 4];
+            self.write_spilled_bytes(c.encode_utf8(&mut buf).as_bytes());
             return;
         }
 
         let inline_len = self.inline_len as usize;
-        let new_len = inline_len + len;
+        let Some(new_len) = inline_len.checked_add(len) else {
+            self.fail(string_view_overflow_error("value length"));
+            return;
+        };
         if new_len <= 12 {
             c.encode_utf8(&mut self.inline_buf[inline_len..new_len]);
             self.inline_len = new_len as u8;
             return;
         }
 
-        self.builder.ensure_long_capacity(new_len as u32);
+        let Ok(length) = try_string_view_part("value length", new_len) else {
+            self.fail(string_view_overflow_error("value length"));
+            return;
+        };
+        if let Err(error) = self.builder.try_ensure_long_capacity(length) {
+            self.fail(error);
+            return;
+        }
         let cursor = self.builder.in_progress.len();
         self.builder
             .in_progress
@@ -1067,34 +1152,65 @@ pub(crate) trait BulkNullStringArrayBuilder {
     where
         Self: 'a;
 
+    /// Fallibly append `value` as the next row.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the resulting array would exceed the
+    /// per-implementation size limit. See the inherent method on each builder
+    /// for specifics.
+    fn try_append_value(&mut self, value: &str) -> Result<()>;
+
     /// Append `value` as the next row.
     ///
     /// # Panics
     ///
-    /// Panics if the resulting array would exceed the per-implementation
-    /// size limit. See the inherent method on each builder for specifics.
-    fn append_value(&mut self, value: &str);
+    /// Panics if [`Self::try_append_value`] returns an error.
+    fn append_value(&mut self, value: &str) {
+        self.try_append_value(value)
+            .expect("byte array offset overflow");
+    }
+
+    /// Fallibly append an empty placeholder row. The corresponding slot MUST
+    /// be masked as null by the null buffer passed to [`finish`](Self::finish).
+    fn try_append_placeholder(&mut self) -> Result<()>;
 
     /// Append an empty placeholder row. The corresponding slot MUST be masked
     /// as null by the null buffer passed to [`finish`](Self::finish).
-    fn append_placeholder(&mut self);
+    fn append_placeholder(&mut self) {
+        self.try_append_placeholder()
+            .expect("byte array offset overflow");
+    }
 
-    /// Append a row whose bytes are produced by `f` calling write methods on
-    /// the supplied [`StringWriter`].
+    /// Fallibly append a row whose bytes are produced by `f` calling write
+    /// methods on the supplied [`StringWriter`].
     ///
     /// The closure can call `write_str` or `write_char` on the supplied
     /// `StringWriter` zero or more times. Zero calls produces a row containing
     /// the empty string.
+    ///
+    /// # Errors
+    ///
+    /// See [`try_append_value`](Self::try_append_value).
+    fn try_append_with<F>(&mut self, f: F) -> Result<()>
+    where
+        F: for<'a> FnOnce(&mut Self::Writer<'a>);
+
+    /// Append a row whose bytes are produced by `f` calling write methods on
+    /// the supplied [`StringWriter`].
     ///
     /// # Panics
     ///
     /// See [`append_value`](Self::append_value).
     fn append_with<F>(&mut self, f: F)
     where
-        F: for<'a> FnOnce(&mut Self::Writer<'a>);
+        F: for<'a> FnOnce(&mut Self::Writer<'a>),
+    {
+        self.try_append_with(f).expect("byte array offset overflow");
+    }
 
-    /// Append a row whose bytes are produced by mapping each byte of `src`
-    /// through `map`, in order. Output length equals `src.len()`.
+    /// Fallibly append a row whose bytes are produced by mapping each byte of
+    /// `src` through `map`, in order. Output length equals `src.len()`.
     ///
     /// Because the output length is known up front and the inner loop is
     /// straight-line, this is more efficient than
@@ -1106,10 +1222,31 @@ pub(crate) trait BulkNullStringArrayBuilder {
     /// The bytes produced by applying `map` to each byte of `src`, in order,
     /// must form valid UTF-8.
     ///
+    /// # Errors
+    ///
+    /// See [`try_append_value`](Self::try_append_value).
+    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        src: &[u8],
+        map: F,
+    ) -> Result<()>;
+
+    /// Append a row whose bytes are produced by mapping each byte of `src`
+    /// through `map`, in order. Output length equals `src.len()`.
+    ///
+    /// # Safety
+    ///
+    /// The bytes produced by applying `map` to each byte of `src`, in order,
+    /// must form valid UTF-8.
+    ///
     /// # Panics
     ///
     /// See [`append_value`](Self::append_value).
-    unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F);
+    unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
+        // SAFETY: contract forwarded.
+        unsafe { self.try_append_byte_map(src, map) }
+            .expect("byte array offset overflow");
+    }
 
     /// Finalize into a concrete array using the caller-supplied null buffer.
     ///
@@ -1124,24 +1261,28 @@ impl<O: OffsetSizeTrait> BulkNullStringArrayBuilder for GenericStringArrayBuilde
     type Writer<'a> = GenericStringWriter<'a>;
 
     #[inline]
-    fn append_value(&mut self, value: &str) {
-        GenericStringArrayBuilder::<O>::append_value(self, value)
+    fn try_append_value(&mut self, value: &str) -> Result<()> {
+        GenericStringArrayBuilder::<O>::try_append_value(self, value)
     }
     #[inline]
-    fn append_placeholder(&mut self) {
-        GenericStringArrayBuilder::<O>::append_placeholder(self)
+    fn try_append_placeholder(&mut self) -> Result<()> {
+        GenericStringArrayBuilder::<O>::try_append_placeholder(self)
     }
     #[inline]
-    fn append_with<F>(&mut self, f: F)
+    fn try_append_with<F>(&mut self, f: F) -> Result<()>
     where
         F: for<'a> FnOnce(&mut Self::Writer<'a>),
     {
-        GenericStringArrayBuilder::<O>::append_with(self, f)
+        GenericStringArrayBuilder::<O>::try_append_with(self, f)
     }
     #[inline]
-    unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
+    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        src: &[u8],
+        map: F,
+    ) -> Result<()> {
         // SAFETY: contract forwarded.
-        unsafe { GenericStringArrayBuilder::<O>::append_byte_map(self, src, map) }
+        unsafe { GenericStringArrayBuilder::<O>::try_append_byte_map(self, src, map) }
     }
     fn finish(self, nulls: Option<NullBuffer>) -> Result<ArrayRef> {
         Ok(Arc::new(GenericStringArrayBuilder::<O>::finish(
@@ -1154,27 +1295,76 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
     type Writer<'a> = StringViewWriter<'a>;
 
     #[inline]
-    fn append_value(&mut self, value: &str) {
-        StringViewArrayBuilder::append_value(self, value)
+    fn try_append_value(&mut self, value: &str) -> Result<()> {
+        StringViewArrayBuilder::try_append_value(self, value)
     }
     #[inline]
-    fn append_placeholder(&mut self) {
-        StringViewArrayBuilder::append_placeholder(self)
+    fn try_append_placeholder(&mut self) -> Result<()> {
+        StringViewArrayBuilder::try_append_placeholder(self)
     }
     #[inline]
-    fn append_with<F>(&mut self, f: F)
+    fn try_append_with<F>(&mut self, f: F) -> Result<()>
     where
         F: for<'a> FnOnce(&mut Self::Writer<'a>),
     {
-        StringViewArrayBuilder::append_with(self, f)
+        StringViewArrayBuilder::try_append_with(self, f)
     }
     #[inline]
-    unsafe fn append_byte_map<F: FnMut(u8) -> u8>(&mut self, src: &[u8], map: F) {
+    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        src: &[u8],
+        map: F,
+    ) -> Result<()> {
         // SAFETY: contract forwarded.
-        unsafe { StringViewArrayBuilder::append_byte_map(self, src, map) }
+        unsafe { StringViewArrayBuilder::try_append_byte_map(self, src, map) }
     }
     fn finish(self, nulls: Option<NullBuffer>) -> Result<ArrayRef> {
         Ok(Arc::new(StringViewArrayBuilder::finish(self, nulls)?))
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct FailingStringWriter;
+
+#[cfg(test)]
+impl StringWriter for FailingStringWriter {
+    fn write_str(&mut self, _s: &str) {}
+
+    fn write_char(&mut self, _c: char) {}
+}
+
+#[cfg(test)]
+pub(crate) struct FailingBulkNullStringArrayBuilder;
+
+#[cfg(test)]
+impl BulkNullStringArrayBuilder for FailingBulkNullStringArrayBuilder {
+    type Writer<'a> = FailingStringWriter;
+
+    fn try_append_value(&mut self, _value: &str) -> Result<()> {
+        Err(exec_datafusion_err!("byte array offset overflow"))
+    }
+
+    fn try_append_placeholder(&mut self) -> Result<()> {
+        Err(exec_datafusion_err!("byte array offset overflow"))
+    }
+
+    fn try_append_with<F>(&mut self, _f: F) -> Result<()>
+    where
+        F: for<'a> FnOnce(&mut Self::Writer<'a>),
+    {
+        Err(exec_datafusion_err!("byte array offset overflow"))
+    }
+
+    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        _src: &[u8],
+        _map: F,
+    ) -> Result<()> {
+        Err(exec_datafusion_err!("byte array offset overflow"))
+    }
+
+    fn finish(self, _nulls: Option<NullBuffer>) -> Result<ArrayRef> {
+        internal_err!("failing test builder cannot finish")
     }
 }
 
@@ -1603,6 +1793,28 @@ mod tests {
     }
 
     #[test]
+    fn bulk_try_append_methods() {
+        check_on_all_builders!(
+            &[Some("hi"), None, Some("hello world"), Some("ABC")],
+            |b| {
+                b.try_append_value("hi").unwrap();
+                b.try_append_placeholder().unwrap();
+                b.try_append_with(|w| {
+                    w.write_str("hello");
+                    w.write_char(' ');
+                    w.write_str("world");
+                })
+                .unwrap();
+                // SAFETY: ASCII input and output.
+                unsafe {
+                    b.try_append_byte_map(b"abc", |x| x.to_ascii_uppercase())
+                        .unwrap();
+                }
+            },
+        );
+    }
+
+    #[test]
     fn bulk_finish_errors_on_null_buffer_length_mismatch() {
         assert_finish_errs_on_length_mismatch(
             GenericStringArrayBuilder::<i32>::with_capacity(2, 4),
@@ -1671,6 +1883,61 @@ mod tests {
         assert_eq!(array.value(0), "abc");
         assert!(array.is_null(1));
         assert_eq!(array.value(2), "a long string value");
+    }
+
+    #[test]
+    fn string_view_builder_try_append_with_and_byte_map_success_path() {
+        let mut builder = StringViewArrayBuilder::with_capacity(4);
+        builder
+            .try_append_with(|w| {
+                w.write_str("hello");
+                w.write_char(' ');
+                w.write_str("world");
+            })
+            .unwrap();
+        builder
+            .try_append_with(|w| w.write_str("a long string of 25 bytes"))
+            .unwrap();
+        // SAFETY: ASCII input and output.
+        unsafe {
+            builder
+                .try_append_byte_map(b"abc", |b| b.to_ascii_uppercase())
+                .unwrap();
+            builder
+                .try_append_byte_map(b"a long string of 25 bytes", |b| {
+                    if b == b' ' { b'_' } else { b }
+                })
+                .unwrap();
+        }
+
+        let array = builder.finish(None).unwrap();
+        assert_eq!(array.value(0), "hello world");
+        assert_eq!(array.value(1), "a long string of 25 bytes");
+        assert_eq!(array.value(2), "ABC");
+        assert_eq!(array.value(3), "a_long_string_of_25_bytes");
+    }
+
+    #[test]
+    fn string_view_builder_rejects_long_view_part_overflow() {
+        let err = try_string_view_part("value length", i32::MAX as usize + 1)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("byte array offset overflow"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn failing_bulk_builder_propagates_try_append_errors() {
+        let mut builder = FailingBulkNullStringArrayBuilder;
+        assert!(builder.try_append_value("x").is_err());
+        assert!(builder.try_append_placeholder().is_err());
+        assert!(builder.try_append_with(|w| w.write_str("x")).is_err());
+        // SAFETY: failing test builder never reads or writes bytes.
+        unsafe {
+            assert!(builder.try_append_byte_map(b"x", |b| b).is_err());
+        }
     }
 
     #[test]

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -476,50 +476,20 @@ impl<O: OffsetSizeTrait> GenericStringArrayBuilder<O> {
     /// # Errors
     ///
     /// Returns an error if the cumulative byte length exceeds this builder's
-    /// offset type limit.
+    /// offset type limit. If this method returns an error, the builder should
+    /// be discarded; it may contain uncommitted bytes from the failed row.
     #[inline]
     pub fn try_append_with<F>(&mut self, f: F) -> Result<()>
     where
         F: FnOnce(&mut GenericStringWriter<'_>),
     {
-        let old_len = self.value_buffer.len();
         let mut writer = GenericStringWriter {
             value_buffer: &mut self.value_buffer,
         };
         f(&mut writer);
-        let next_offset = match try_offset::<O>(self.value_buffer.len()) {
-            Ok(offset) => offset,
-            Err(e) => {
-                // SAFETY: `old_len` was the initialized length before `f` wrote to
-                // this owned buffer, so shrinking back preserves initialized data.
-                unsafe { self.value_buffer.set_len(old_len) };
-                return Err(e);
-            }
-        };
+        let next_offset = try_offset::<O>(self.value_buffer.len())?;
         self.offsets_buffer.push(next_offset);
         Ok(())
-    }
-
-    /// See [`BulkNullStringArrayBuilder::append_with`].
-    ///
-    /// Note: new call sites that need recoverable overflow handling should
-    /// prefer [`Self::try_append_with`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the cumulative byte length exceeds `O::MAX`.
-    #[inline]
-    pub fn append_with<F>(&mut self, f: F)
-    where
-        F: FnOnce(&mut GenericStringWriter<'_>),
-    {
-        let mut writer = GenericStringWriter {
-            value_buffer: &mut self.value_buffer,
-        };
-        f(&mut writer);
-        let next_offset =
-            O::from_usize(self.value_buffer.len()).expect("byte array offset overflow");
-        self.offsets_buffer.push(next_offset);
     }
 
     /// Finalize into a [`GenericStringArray<O>`] using the caller-supplied
@@ -1236,13 +1206,6 @@ impl<O: OffsetSizeTrait> BulkNullStringArrayBuilder for GenericStringArrayBuilde
         F: for<'a> FnOnce(&mut Self::Writer<'a>),
     {
         GenericStringArrayBuilder::<O>::try_append_with(self, f)
-    }
-    #[inline]
-    fn append_with<F>(&mut self, f: F)
-    where
-        F: for<'a> FnOnce(&mut Self::Writer<'a>),
-    {
-        GenericStringArrayBuilder::<O>::append_with(self, f)
     }
     #[inline]
     unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -344,8 +344,11 @@ fn string_view_overflow_error(field: &str) -> DataFusionError {
 }
 
 fn try_string_view_part(field: &str, value: usize) -> Result<u32> {
-    // StringView stores these fields as u32, but Arrow limits lengths,
-    // offsets, and buffer indices to i32::MAX.
+    // Long StringView parts are encoded as u32, but Arrow IPC represents
+    // length, offset, and buffer index as signed 32-bit fields. The buffer
+    // index guard is mainly a contract/precondition check for long-view
+    // encoding; hitting it would require more than i32::MAX completed data
+    // buffers, not merely many rows.
     Ok(i32::try_from(value).map_err(|_| string_view_overflow_error(field))? as u32)
 }
 
@@ -648,9 +651,10 @@ impl StringViewArrayBuilder {
     /// # Errors
     ///
     /// Returns an error if the value length, in-progress buffer offset, or
-    /// number of completed buffers exceeds `i32::MAX`. The ByteView spec uses
-    /// signed 32-bit integers for these fields; exceeding `i32::MAX` would
-    /// produce an array that does not round-trip through Arrow IPC (see
+    /// completed-buffer index exceeds `i32::MAX`. The buffer-index case is a
+    /// long-view encoding precondition, not an expected runtime limit. Arrow
+    /// IPC uses signed 32-bit integers for these fields; exceeding `i32::MAX`
+    /// would produce an array that does not round-trip through Arrow IPC (see
     /// <https://github.com/apache/arrow-rs/issues/6172>).
     #[inline]
     pub fn try_append_value(&mut self, value: &str) -> Result<()> {
@@ -666,7 +670,7 @@ impl StringViewArrayBuilder {
         let offset = try_string_view_part("offset", self.in_progress.len())?;
         let buffer_index = try_string_view_part("buffer count", self.completed.len())?;
         self.in_progress.extend_from_slice(v);
-        self.views.push(Self::make_long_view_checked(
+        self.views.push(Self::make_long_view_from_checked_parts(
             length,
             buffer_index,
             offset,
@@ -733,15 +737,16 @@ impl StringViewArrayBuilder {
         Ok(())
     }
 
-    /// Encode a long-form view referencing `length` bytes already written
-    /// into the in-progress block at `offset`. `prefix_bytes` is the row's
-    /// data slice (or any slice starting with the row's first 4 bytes).
+    /// Encode a long-form view from already-validated ByteView parts.
+    /// `prefix_bytes` is the row's data slice (or any slice starting with the
+    /// row's first 4 bytes). Length, buffer index, and offset must already fit
+    /// Arrow IPC's signed 32-bit long-view fields.
     ///
     /// Built inline rather than going through Arrow's `make_view`: that
     /// function is `[inline(never)]` and has to handle short strings, so
     /// building the view here ourselves is faster.
     #[inline]
-    fn make_long_view_checked(
+    fn make_long_view_from_checked_parts(
         length: u32,
         buffer_index: u32,
         offset: u32,
@@ -790,7 +795,7 @@ impl StringViewArrayBuilder {
         let offset = try_string_view_part("offset", cursor)?;
         let buffer_index = try_string_view_part("buffer count", self.completed.len())?;
         self.in_progress.extend(src.iter().map(|&b| map(b)));
-        self.views.push(Self::make_long_view_checked(
+        self.views.push(Self::make_long_view_from_checked_parts(
             length,
             buffer_index,
             offset,
@@ -817,7 +822,7 @@ impl StringViewArrayBuilder {
                 let offset = try_string_view_part("offset", start)?;
                 let buffer_index =
                     try_string_view_part("buffer count", self.completed.len())?;
-                self.views.push(Self::make_long_view_checked(
+                self.views.push(Self::make_long_view_from_checked_parts(
                     length,
                     buffer_index,
                     offset,
@@ -929,16 +934,25 @@ pub(crate) struct StringViewWriter<'a> {
     /// `None` while the row fits inline; becomes `Some(start)` (offset of
     /// the row's first byte in `in_progress`) at first spill.
     spill_cursor: Option<usize>,
+    /// First write error observed by this adapter. [`StringWriter`] methods
+    /// are infallible, so `try_append_with` reads this after the closure
+    /// returns and rolls back the in-progress row on error.
     error: Option<DataFusionError>,
     builder: &'a mut StringViewArrayBuilder,
 }
 
 impl StringViewWriter<'_> {
+    /// Store the first write error. The writer cannot return `Result` through
+    /// the [`StringWriter`] API, so subsequent writes become no-ops and
+    /// `try_append_with` reports this error after the closure finishes.
     #[inline]
     fn fail(&mut self, error: DataFusionError) {
         self.error.get_or_insert(error);
     }
 
+    /// Append bytes to an already-spilled row in `in_progress`. Validate the
+    /// resulting row length and next block offset before mutating the buffer so
+    /// `try_append_with` can roll back to the original block length on error.
     #[inline]
     fn write_spilled_bytes(&mut self, bytes: &[u8]) {
         let Some(next_len) = self.builder.in_progress.len().checked_add(bytes.len())

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -721,7 +721,7 @@ impl StringViewArrayBuilder {
         self.placeholder_count += 1;
     }
 
-    /// Fallible variant of [`Self::ensure_long_capacity`].
+    /// Ensure enough capacity for a long string row.
     #[inline]
     fn try_ensure_long_capacity(&mut self, length: u32) -> Result<()> {
         let required_cap = self

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -1329,6 +1329,56 @@ impl BulkNullStringArrayBuilder for StringViewArrayBuilder {
     }
 }
 
+#[cfg(test)]
+pub(crate) struct FailingStringWriter;
+
+#[cfg(test)]
+impl StringWriter for FailingStringWriter {
+    fn write_str(&mut self, _s: &str) {}
+
+    fn write_char(&mut self, _c: char) {}
+}
+
+#[cfg(test)]
+pub(crate) struct FailingBulkNullStringArrayBuilder;
+
+#[cfg(test)]
+fn failing_overflow() -> Result<()> {
+    Err(exec_datafusion_err!("byte array offset overflow"))
+}
+
+#[cfg(test)]
+impl BulkNullStringArrayBuilder for FailingBulkNullStringArrayBuilder {
+    type Writer<'a> = FailingStringWriter;
+
+    fn try_append_value(&mut self, _value: &str) -> Result<()> {
+        failing_overflow()
+    }
+
+    fn try_append_placeholder(&mut self) -> Result<()> {
+        failing_overflow()
+    }
+
+    fn try_append_with<F>(&mut self, _f: F) -> Result<()>
+    where
+        F: for<'a> FnOnce(&mut Self::Writer<'a>),
+    {
+        failing_overflow()
+    }
+
+    unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
+        &mut self,
+        _src: &[u8],
+        _map: F,
+    ) -> Result<()> {
+        failing_overflow()
+    }
+
+    fn finish(self, _nulls: Option<NullBuffer>) -> Result<ArrayRef> {
+        internal_err!("failing test builder cannot finish")
+    }
+}
+
 /// Append a new view to the views buffer with the given substr.
 ///
 /// Callers are responsible for their own null tracking.
@@ -1887,51 +1937,6 @@ mod tests {
             err.contains("byte array offset overflow"),
             "unexpected error: {err}"
         );
-    }
-
-    struct FailingStringWriter;
-
-    impl StringWriter for FailingStringWriter {
-        fn write_str(&mut self, _s: &str) {}
-
-        fn write_char(&mut self, _c: char) {}
-    }
-
-    struct FailingBulkNullStringArrayBuilder;
-
-    fn failing_overflow() -> Result<()> {
-        Err(exec_datafusion_err!("byte array offset overflow"))
-    }
-
-    impl BulkNullStringArrayBuilder for FailingBulkNullStringArrayBuilder {
-        type Writer<'a> = FailingStringWriter;
-
-        fn try_append_value(&mut self, _value: &str) -> Result<()> {
-            failing_overflow()
-        }
-
-        fn try_append_placeholder(&mut self) -> Result<()> {
-            failing_overflow()
-        }
-
-        fn try_append_with<F>(&mut self, _f: F) -> Result<()>
-        where
-            F: for<'a> FnOnce(&mut Self::Writer<'a>),
-        {
-            failing_overflow()
-        }
-
-        unsafe fn try_append_byte_map<F: FnMut(u8) -> u8>(
-            &mut self,
-            _src: &[u8],
-            _map: F,
-        ) -> Result<()> {
-            failing_overflow()
-        }
-
-        fn finish(self, _nulls: Option<NullBuffer>) -> Result<ArrayRef> {
-            internal_err!("failing test builder cannot finish")
-        }
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #22688

## Rationale for this change

This change moves the shared string builder infrastructure to fallible `try_*` APIs so overflow conditions can be propagated as `DataFusionError` instead of requiring panic-based handling. This provides a consistent error propagation path for downstream UDF migrations while preserving the existing infallible APIs as compatibility wrappers where appropriate.

This PR is preparatory work for migrating downstream string UDFs onto fallible append/write APIs end-to-end. The follow-up work will cover direct row emitters such as `chr`, `uuid`, `initcap`, and `substr`; helper-driven writers such as `overlay`, `reverse`, and `translate`; the larger `split_part` migration, including its index-normalization helpers; and output-amplifying functions such as `repeat`, `lpad`, and `rpad`, where oversized output must return `DataFusionError` rather than panic.

## What changes are included in this PR?

* Add shared helpers for validating `StringView` length, offset, and buffer index values against Arrow's `i32::MAX` limits.
* Introduce fallible `try_*` methods throughout `BulkNullStringArrayBuilder`:

  * `try_append_value`
  * `try_append_placeholder`
  * `try_append_with`
  * `try_append_byte_map`
* Keep the existing infallible `append_*` methods as compatibility shims that delegate to the corresponding `try_*` methods and panic on overflow.
* Convert `GenericStringArrayBuilder::append_with` to reuse the fallible implementation instead of duplicating logic.
* Refactor `StringViewArrayBuilder` to:

  * validate long-view metadata through shared helpers,
  * add fallible `try_append_with` and `try_append_byte_map`,
  * improve spill-path error handling and rollback so intermediate state is restored on failure.
* Add shared test-only utilities (`FailingBulkNullStringArrayBuilder` and `FailingStringWriter`) to support overflow propagation tests in this and downstream modules.
* Prepare shared string builder APIs for follow-up UDF migrations covering direct append call sites, helper-driven row writers, `split_part` index handling, and output-amplifying functions such as `repeat`, `lpad`, and `rpad`.

## Are these changes tested?

Yes.

This PR adds the following tests:

* `bulk_try_append_methods`
* `string_view_builder_try_append_with_and_byte_map_success_path`
* `string_view_builder_rejects_long_view_part_overflow`
* `failing_bulk_builder_propagates_try_append_errors`

It also continues to exercise existing string builder tests.

## Are there any user-facing changes?

No user-facing behavior is intended. This is shared internal infrastructure that enables downstream code to propagate overflow errors through fallible APIs while preserving the existing infallible compatibility methods.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed.
