### PR TITLE
Fix coalesce string numeric union coercion

### DIFF
--- a/datafusion/expr-common/src/type_coercion/binary.rs
+++ b/datafusion/expr-common/src/type_coercion/binary.rs
@@ -777,7 +777,7 @@ fn type_union_resolution_coercion(
             .or_else(|| temporal_coercion_nonstrict_timezone(lhs_type, rhs_type))
             .or_else(|| string_coercion(lhs_type, rhs_type))
             .or_else(|| null_coercion(lhs_type, rhs_type))
-            .or_else(|| string_numeric_coercion(lhs_type, rhs_type))
+            .or_else(|| string_numeric_union_coercion(lhs_type, rhs_type))
             .or_else(|| binary_coercion(lhs_type, rhs_type)),
     }
 }

--- a/datafusion/expr-common/src/type_coercion/binary/tests/comparison.rs
+++ b/datafusion/expr-common/src/type_coercion/binary/tests/comparison.rs
@@ -890,6 +890,24 @@ fn test_type_union_coercion_prefers_string() {
     );
 }
 
+/// Tests that `type_union_resolution` uses union semantics for numeric and
+/// string types rather than comparison semantics.
+#[test]
+fn test_type_union_resolution_prefers_string() {
+    assert_eq!(
+        type_union_resolution(&[DataType::Int64, DataType::Utf8]),
+        Some(DataType::Utf8)
+    );
+    assert_eq!(
+        type_union_resolution(&[DataType::Float64, DataType::LargeUtf8]),
+        Some(DataType::LargeUtf8)
+    );
+    assert_eq!(
+        type_union_resolution(&[DataType::Utf8View, DataType::Int16]),
+        Some(DataType::Utf8View)
+    );
+}
+
 #[test]
 fn test_type_union_coercion_prefers_finer_timestamp_unit() {
     assert_eq!(

--- a/datafusion/sqllogictest/test_files/coalesce.slt
+++ b/datafusion/sqllogictest/test_files/coalesce.slt
@@ -184,6 +184,11 @@ select
 ----
 (empty) test
 
+query TT
+select coalesce(1, ''), arrow_typeof(coalesce(1, ''));
+----
+1 Utf8
+
 # coalesce utf8 and large utf8
 query TT
 select
@@ -318,11 +323,11 @@ select coalesce(null, 34, arrow_cast(123, 'Dictionary(Int32, Int8)'));
 ----
 34
 
-# numeric string coercion
-query RT
+# numeric/string union coercion
+query TT
 select coalesce(2.0, 1, '3'), arrow_typeof(coalesce(2.0, 1, '3'));
 ----
-2 Float64
+2.0 Utf8
 
 # explicitly cast to Int8, and it will implicitly cast to Int64
 query IT
@@ -353,8 +358,8 @@ SELECT COALESCE(c1, c2) FROM test
 1
 NULL
 
-# numeric string is coerced to numeric in both Postgres and DuckDB
-query I
+# numeric/string union coercion prefers string
+query T
 SELECT COALESCE(c1, c2, '-1') FROM test;
 ----
 0


### PR DESCRIPTION
## What changed

Fixes #23045 by making `type_union_resolution` use the union-context numeric/string coercion rule instead of the comparison-context rule.

This means union-resolution contexts such as `COALESCE` prefer a string type when combining numeric and string inputs. That avoids inserting casts like `CAST('' AS Int64)` for `coalesce(1, '')`, because arbitrary strings are not guaranteed to parse as numbers.

## Why

`type_union_coercion` already documents and tests this distinction:

- comparison contexts prefer numeric semantics for numeric/string pairs
- union contexts prefer string semantics because every number can be represented as text, but not every string can be represented as a number

`type_union_resolution` was still using `string_numeric_coercion`, which is the comparison-style numeric preference. `COALESCE` calls `try_type_union_resolution`, so `coalesce(1, '')` was typed as `Int64`.

## Testing

```text
cargo test -p datafusion-expr-common type_union
cargo test -p datafusion-expr-common string_numeric_coercion
cargo test -p datafusion-sqllogictest --test sqllogictests -- test_files/coalesce.slt
cargo fmt --all --check
git diff --check
```
