### PR TITLE
Support reading files with a boolean SBBF written by Parquet Java

### DIFF
--- a/datafusion/datasource-parquet/src/bloom_filter.rs
+++ b/datafusion/datasource-parquet/src/bloom_filter.rs
@@ -97,7 +97,12 @@ impl BloomFilterStatistics {
             | ScalarValue::BinaryView(Some(v))
             | ScalarValue::LargeBinary(Some(v)) => sbbf.check(v),
             ScalarValue::FixedSizeBinary(_size, Some(v)) => sbbf.check(v),
-            ScalarValue::Boolean(Some(v)) => sbbf.check(v),
+            // Parquet Java doesn't update boolean values in a Bloom filter,
+            // which results in a empty filter, for which `sbbf.check()` always returns `false`.
+            // See https://github.com/apache/parquet-java/blob/52c0a5e8c5ff7680cc299ce5aad60acef3a9054d/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnValueCollector.java#L75
+            // In order to correctly read such files with SBBF, we have to skip the check and return `true`
+            // because values may be present in the data file even if they are not in the filter.
+            ScalarValue::Boolean(Some(_)) => true,
             ScalarValue::Float64(Some(v)) => sbbf.check(v),
             ScalarValue::Float32(Some(v)) => sbbf.check(v),
             ScalarValue::Int64(Some(v)) => sbbf.check(v),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

When https://github.com/apache/parquet-java/ writes a bloom filter for a boolean column, it does not actually update the values, so the filter ends up empty. At https://github.com/apache/parquet-java/blob/52c0a5e8c5ff7680cc299ce5aad60acef3a9054d/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnValueCollector.java#L75 , all `write()` functions call `bloomFilter.insertHash`, except the `write(boolean)` one. 

The DataFusion reader then incorrectly assumes that such a file contains no values, and skips it while reading. 

## What changes are included in this PR?

This change makes is so that we always assume that a boolean column has values, essentially ignoring the filter. 

## Are these changes tested?

Not yet.

## Are there any user-facing changes?

This may affect performance in cases where the SBBF was written correctly, and thus legitimately excludes some data files. With this change, those files will still be scanned. 

There are no changes to the API. 