### PR TITLE
bug: clear map contents after emit in GroupValuesColumns

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -1117,6 +1117,8 @@ impl<const STREAMING: bool> GroupValues for GroupValuesColumn<STREAMING> {
                 // a real Result rather than panicking.
                 let fresh = Self::build_group_columns(&self.schema)?;
                 let group_values = mem::replace(&mut self.group_values, fresh);
+                // clear map contents so subsequent intern() calls don't point to
+                // incorrect/stale group indices, capacity is maintained.
                 self.map.clear();
                 group_values
                     .into_iter()

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -1948,4 +1948,67 @@ mod tests {
             &mut group_values.map_size,
         );
     }
+    #[test]
+    fn test_emit_all_clears_map() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Utf8, true),
+        ]));
+        let mut gv = GroupValuesColumn::<false>::try_new(Arc::clone(&schema)).unwrap();
+
+        let col_a: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("x"), Some("y"), Some("z")]));
+        let col_b: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("p"), Some("q"), Some("r")]));
+        let mut groups = vec![];
+        gv.intern(&[Arc::clone(&col_a), Arc::clone(&col_b)], &mut groups)
+            .unwrap();
+        assert_eq!(groups, vec![0, 1, 2]);
+
+        let _ = gv.emit(EmitTo::All).unwrap();
+
+        let col_a: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("x"), Some("y"), Some("z")]));
+        let col_b: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("p"), Some("q"), Some("r")]));
+        let mut groups = vec![];
+        gv.intern(&[Arc::clone(&col_a), Arc::clone(&col_b)], &mut groups)
+            .unwrap();
+        assert_eq!(groups, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_emit_all_clears_map_mixed_keys() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+        let mut gv = GroupValuesColumn::<false>::try_new(Arc::clone(&schema)).unwrap();
+
+        let col_a: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("x"), Some("y"), Some("z")]));
+        let col_b: ArrayRef = Arc::new(arrow::array::Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3),
+        ]));
+        let mut groups = vec![];
+        gv.intern(&[Arc::clone(&col_a), Arc::clone(&col_b)], &mut groups)
+            .unwrap();
+        assert_eq!(groups, vec![0, 1, 2]);
+
+        let _ = gv.emit(EmitTo::All).unwrap();
+
+        let col_a: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("y"), Some("w"), Some("y")]));
+        let col_b: ArrayRef = Arc::new(arrow::array::Int32Array::from(vec![
+            Some(2),
+            Some(9),
+            Some(2),
+        ]));
+        let mut groups = vec![];
+        gv.intern(&[Arc::clone(&col_a), Arc::clone(&col_b)], &mut groups)
+            .unwrap();
+        assert_eq!(groups, vec![0, 1, 0]);
+    }
 }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -1117,7 +1117,7 @@ impl<const STREAMING: bool> GroupValues for GroupValuesColumn<STREAMING> {
                 // a real Result rather than panicking.
                 let fresh = Self::build_group_columns(&self.schema)?;
                 let group_values = mem::replace(&mut self.group_values, fresh);
-
+                self.map.clear();
                 group_values
                     .into_iter()
                     .map(|v| v.build())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- works towards  #22715

## Rationale for this change
I was implementing dictionary support for this trait when I noticed the `emit(emit_to::All)` path doesn't update the contents of the the hashtable/map
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
This PR adds test to catch future regressions as well as a simple `self.map.clear()` to clear the contents of the map on emit
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes, this PR adds two test
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
