### PR TITLE
fix: cardinality returns incorrect results for ragged nested arrays

### DIFF
--- a/datafusion/functions-nested/src/cardinality.rs
+++ b/datafusion/functions-nested/src/cardinality.rs
@@ -146,14 +146,38 @@ fn generic_list_cardinality<O: OffsetSizeTrait>(
     let result = array
         .iter()
         .map(|arr| match arr {
-            Some(arr) if arr.is_empty() => Ok(Some(0u64)),
-            arr => match crate::utils::compute_array_dims(arr)? {
-                Some(vector) => {
-                    Ok(Some(vector.iter().map(|x| x.unwrap()).product::<u64>()))
-                }
-                None => Ok(None),
-            },
+            Some(arr) => value_cardinality(arr).map(Some),
+            None => Ok(None),
         })
         .collect::<Result<UInt64Array>>()?;
     Ok(Arc::new(result) as ArrayRef)
+}
+
+fn value_cardinality(array: ArrayRef) -> Result<u64> {
+    match array.data_type() {
+        List(_) => {
+            let list = as_list_array(&array)?;
+            sum_list_cardinality(list.iter())
+        }
+        LargeList(_) => {
+            let list = as_large_list_array(&array)?;
+            sum_list_cardinality(list.iter())
+        }
+        _ => Ok(array.len() as u64),
+    }
+}
+
+fn sum_list_cardinality<I>(mut iter: I) -> Result<u64>
+where
+    I: Iterator<Item = Option<ArrayRef>>,
+{
+    iter.try_fold(0u64, |total, arr| {
+        let value_count = match arr {
+            Some(arr) => value_cardinality(arr)?,
+            None => 0,
+        };
+        total.checked_add(value_count).ok_or_else(|| {
+            datafusion_common::exec_datafusion_err!("cardinality overflowed u64")
+        })
+    })
 }

--- a/datafusion/functions-nested/src/cardinality.rs
+++ b/datafusion/functions-nested/src/cardinality.rs
@@ -23,10 +23,15 @@ use arrow::array::{
 };
 use arrow::datatypes::{
     DataType,
-    DataType::{LargeList, List, Map, Null, UInt64},
+    DataType::{
+        FixedSizeList, LargeList, LargeListView, List, ListView, Map, Null, UInt64,
+    },
 };
 use datafusion_common::Result;
-use datafusion_common::cast::{as_large_list_array, as_list_array, as_map_array};
+use datafusion_common::cast::{
+    as_fixed_size_list_array, as_large_list_array, as_large_list_view_array,
+    as_list_array, as_list_view_array, as_map_array,
+};
 use datafusion_common::exec_err;
 use datafusion_common::utils::{ListCoercion, take_function_args};
 use datafusion_expr::{
@@ -146,14 +151,14 @@ fn generic_list_cardinality<O: OffsetSizeTrait>(
     let result = array
         .iter()
         .map(|arr| match arr {
-            Some(arr) => value_cardinality(arr).map(Some),
+            Some(arr) => value_cardinality(&arr).map(Some),
             None => Ok(None),
         })
         .collect::<Result<UInt64Array>>()?;
     Ok(Arc::new(result) as ArrayRef)
 }
 
-fn value_cardinality(array: ArrayRef) -> Result<u64> {
+fn value_cardinality(array: &ArrayRef) -> Result<u64> {
     match array.data_type() {
         List(_) => {
             let list = as_list_array(&array)?;
@@ -161,6 +166,18 @@ fn value_cardinality(array: ArrayRef) -> Result<u64> {
         }
         LargeList(_) => {
             let list = as_large_list_array(&array)?;
+            sum_list_cardinality(list.iter())
+        }
+        ListView(_) => {
+            let list = as_list_view_array(&array)?;
+            sum_list_cardinality(list.iter())
+        }
+        LargeListView(_) => {
+            let list = as_large_list_view_array(&array)?;
+            sum_list_cardinality(list.iter())
+        }
+        FixedSizeList(..) => {
+            let list = as_fixed_size_list_array(&array)?;
             sum_list_cardinality(list.iter())
         }
         _ => Ok(array.len() as u64),
@@ -173,7 +190,7 @@ where
 {
     iter.try_fold(0u64, |total, arr| {
         let value_count = match arr {
-            Some(arr) => value_cardinality(arr)?,
+            Some(arr) => value_cardinality(&arr)?,
             None => 0,
         };
         total.checked_add(value_count).ok_or_else(|| {

--- a/datafusion/sqllogictest/test_files/array/cardinality.slt
+++ b/datafusion/sqllogictest/test_files/array/cardinality.slt
@@ -51,6 +51,27 @@ select cardinality(arrow_cast([[1, 2], [3, 4], [5, 6]], 'FixedSizeList(3, List(I
 ----
 6
 
+# cardinality counts actual leaf elements in ragged nested arrays
+query III
+select cardinality([[1], [2, 3]]),
+       cardinality([[1, 2, 3], []]),
+       cardinality([[], [1, 2]]);
+----
+3 3 2
+
+query I
+select cardinality(arrow_cast([[1], [2, 3]], 'LargeList(List(Int64))'));
+----
+3
+
+query IIII
+select cardinality([[NULL], [1, 2]]),
+       cardinality([[[1]], [[2, 3], []]]),
+       cardinality(arrow_cast([[], [1, 2]], 'LargeList(List(Int64))')),
+       cardinality(make_array(NULL::int[], [1, 2]));
+----
+3 3 2 2
+
 # cardinality scalar function #3
 query II
 select cardinality(make_array()), cardinality(make_array(make_array()))

--- a/datafusion/sqllogictest/test_files/array/cardinality.slt
+++ b/datafusion/sqllogictest/test_files/array/cardinality.slt
@@ -59,10 +59,20 @@ select cardinality([[1], [2, 3]]),
 ----
 3 3 2
 
-query I
-select cardinality(arrow_cast([[1], [2, 3]], 'LargeList(List(Int64))'));
+query IIII
+select cardinality(arrow_cast([[1], [2, 3]], 'ListView(List(Int64))')),
+       cardinality(arrow_cast([[1], [2, 3]], 'LargeListView(List(Int64))')),
+       cardinality(arrow_cast([[1, 2], [3, 4]], 'List(FixedSizeList(2, Int64))')),
+       cardinality(arrow_cast([[1], [2, 3]], 'LargeList(List(Int64))'));
 ----
-3
+3 3 4 3
+
+query III
+select cardinality(arrow_cast([[[1]], [[2, 3], []]], 'List(ListView(List(Int64)))')),
+       cardinality(arrow_cast([[[1]], [[2, 3], []]], 'List(LargeListView(List(Int64)))')),
+       cardinality(arrow_cast([[[1, 2]], [[3, 4]]], 'List(List(FixedSizeList(2, Int64)))'));
+----
+3 3 4
 
 query IIII
 select cardinality([[NULL], [1, 2]]),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23270.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`cardinality` used `compute_array_dims` and multiplied the inferred dimensions to compute nested array cardinality. That only works for rectangular nested arrays, where every nested list has the same shape.

For ragged nested arrays, `compute_array_dims` follows the first nested value shape and can return dimensions that do not describe the actual number of leaf elements. As a result, `cardinality` can return incorrect results for valid nested arrays.

Examples:

```sql
select cardinality([[1], [2, 3]]);
-- before: 2
-- after:  3

select cardinality([[1, 2, 3], []]);
-- before: 6
-- after:  3

select cardinality([[], [1, 2]]);
-- before: 0
-- after:  2
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR changes list cardinality computation to recursively count actual leaf elements instead of multiplying inferred dimensions.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, added sqllogictest coverage.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Bug fix only.

## Additional discussion

The root cause is that `cardinality()` used `compute_array_dims()` and multiplies the returned dimensions.

`compute_array_dims()` itself follows the first child array when computing nested dimensions. This behavior may also need a separate discussion for ragged nested arrays, because such arrays do not have a single rectangular dimension vector. For example, `array_dims([[1], [2, 3]])` currently returns `[2, 1]`.