### PR TITLE
Test: add more aggregation focused dictionary sql logic test

### DIFF
--- a/datafusion/sqllogictest/test_files/dictionary.slt
+++ b/datafusion/sqllogictest/test_files/dictionary.slt
@@ -515,3 +515,121 @@ DROP TABLE dict_hash_10;
 
 statement ok
 DROP TABLE dict_hash_src;
+
+statement ok
+CREATE TABLE dict_large_utf8 AS
+SELECT
+  arrow_cast(column1, 'Dictionary(Int32, LargeUtf8)') AS tag,
+  arrow_cast(column2, 'Float64') AS val
+FROM (VALUES ('alpha', 1.0), ('beta', 2.0), ('alpha', 3.0), ('gamma', 4.0), ('beta', 5.0), (NULL, 6.0));
+
+query TRI rowsort
+SELECT tag, SUM(val), COUNT(*) FROM dict_large_utf8 GROUP BY tag;
+----
+NULL 6 1
+alpha 4 2
+beta 7 2
+gamma 4 1
+
+statement ok
+DROP TABLE dict_large_utf8;
+
+# multiple dictionary columns as group keys
+
+statement ok
+CREATE TABLE dict_multi_key AS
+SELECT
+  arrow_cast(column1, 'Dictionary(Int32, Utf8)')  AS region,
+  arrow_cast(column2, 'Dictionary(Int16, Utf8)')  AS status,
+  arrow_cast(column3, 'Dictionary(Int8,  Utf8)')  AS tier,
+  arrow_cast(column4, 'Float64') AS amount
+FROM (
+  VALUES
+    ('us', 'active',   'gold',   100.0),
+    ('eu', 'active',   'silver', 200.0),
+    ('us', 'active',   'gold',   300.0),
+    ('eu', 'inactive', 'gold',   400.0),
+    ('us', 'inactive', 'silver', 500.0),
+    ('eu', 'inactive', 'gold',   600.0),
+    ('us', 'active',   'silver', 150.0),
+    ('eu', 'active',   'silver', 250.0),
+    (NULL, 'active',   'gold',   700.0)
+);
+
+query TTTRI rowsort
+SELECT region, status, tier, SUM(amount), COUNT(*) FROM dict_multi_key GROUP BY region, status, tier;
+----
+NULL active gold 700 1
+eu active silver 450 2
+eu inactive gold 1000 2
+us active gold 400 2
+us active silver 150 1
+us inactive silver 500 1
+
+statement ok
+DROP TABLE dict_multi_key;
+
+# mixed dict (2) and non-dict (2) group keys with nulls spread across all columns
+
+statement ok
+CREATE TABLE dict_mixed_nulls AS
+SELECT
+  arrow_cast(column1, 'Dictionary(Int32, Utf8)') AS region,
+  arrow_cast(column2, 'Dictionary(Int16, Utf8)') AS status,
+  arrow_cast(column3, 'Utf8') AS tier,
+  arrow_cast(column4, 'Int32') AS category,
+  arrow_cast(column5, 'Float64') AS amount
+FROM (
+  VALUES
+    ('us', 'active', 'gold',   1,    100.0),
+    ('us', 'active', 'gold',   1,    200.0),
+    ('eu', 'active', 'silver', 2,    300.0),
+    (NULL, 'active', 'gold',   1,    400.0),
+    ('us',  NULL,    'gold',   1,    500.0),
+    ('us', 'active',  NULL,    1,    600.0),
+    ('us', 'active', 'gold',   NULL, 700.0)
+);
+
+query TTTIRI rowsort
+SELECT region, status, tier, category, SUM(amount), COUNT(*) FROM dict_mixed_nulls GROUP BY region, status, tier, category;
+----
+NULL active gold 1 400 1
+eu active silver 2 300 1
+us NULL gold 1 500 1
+us active NULL 1 600 1
+us active gold 1 300 2
+us active gold NULL 700 1
+
+statement ok
+DROP TABLE dict_mixed_nulls;
+
+##########
+## Aggregation tests: COUNT(DISTINCT) on dictionary columns
+##########
+
+statement ok
+CREATE TABLE dict_count_distinct AS
+SELECT
+  arrow_cast(column1, 'Dictionary(Int64, Utf8)') AS region,
+  arrow_cast(column2, 'Dictionary(Int8, Utf8)') AS sensor
+FROM (
+  VALUES
+    ('north', 's1'), ('north', 's2'), ('north', 's1'), ('north', 's3'),
+    ('south', 's3'), ('south', 's3'), ('south', 's4'),
+    ('east',  's1'),
+    (NULL,    's5'),
+    ('north', NULL)
+);
+
+query TI rowsort
+SELECT region, COUNT(DISTINCT sensor) FROM dict_count_distinct GROUP BY region;
+----
+NULL 1
+east 1
+north 3
+south 2
+
+statement ok
+DROP TABLE dict_count_distinct;
+
+


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

works towards #22682.

## Rationale for this change
There is a lack of testing for multi-dictionary group bys. It make sense to introduce these test before the implementation of `Dict<K,V>` in #23187
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
introduces a couple test
- grouping by `Dict<_,largeutf8>`
- mixing grouping by dictionarys and non dictionary columns
-  a 3-way group by where each column is `dict<_,_>`
- the test also have nulls sprinkled in to verify null handling 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
the changes are test.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
