### PR TITLE
Fix CI failure by Ignore quick-xml audit advisories 

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -51,4 +51,6 @@ jobs:
       - name: Run audit check
         # Note: you can ignore specific RUSTSEC issues using the `--ignore` flag ,for example:
         # run: cargo audit --ignore RUSTSEC-2026-0001
-        run: cargo audit
+        # TODO: remove once object_store upgrades to quick-xml >= 0.41.0
+        # https://github.com/apache/datafusion/issues/23297
+        run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23297.

## Rationale for this change

The audit workflow is failing on main due to the quick-xml advisories:

- RUSTSEC-2026-0194
- RUSTSEC-2026-0195

quick-xml is pulled in transitively through object_store, and the released object_store version currently used by DataFusion does not yet depend on quick-xml >= 0.41.0.

## What changes are included in this PR?

This temporarily ignores the two quick-xml RustSec advisories in the audit workflow and documents that the ignores should be removed once object_store upgrades to quick-xml >= 0.41.0.

This is what I did in arrow-rs as well
- https://github.com/apache/arrow-rs/pull/10267


## Are these changes tested?

By CI


## Are there any user-facing changes?

No.

