### PR TITLE
Minor: Make `BloomFilterStatistics` and `RowGroupAccessPlanFilter::prune_by_bloom_filters` public

### DIFF
--- a/datafusion/datasource-parquet/src/bloom_filter.rs
+++ b/datafusion/datasource-parquet/src/bloom_filter.rs
@@ -33,7 +33,7 @@ use parquet::data_type::Decimal;
 /// This structure implements [`PruningStatistics`] and is used to prune
 /// Parquet row groups and data pages based on the query predicate.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct BloomFilterStatistics {
+pub struct BloomFilterStatistics {
     /// Per-column Bloom filters keyed by predicate column name.
     column_sbbf: HashMap<String, ColumnBloomFilter>,
 }
@@ -50,19 +50,20 @@ struct ColumnBloomFilter {
 
 impl BloomFilterStatistics {
     /// Create an empty [`BloomFilterStatistics`]
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Default::default()
     }
 
     /// Create an empty [`BloomFilterStatistics`] with the specified capacity
-    pub(crate) fn with_capacity(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
             column_sbbf: HashMap::with_capacity(capacity),
         }
     }
 
-    /// Add a Bloom filter and type for the specified column
-    pub(crate) fn insert(
+    /// Add a Bloom filter for the specified column, along with the column's
+    /// Parquet physical [`Type`] and type length from the column descriptor.
+    pub fn insert(
         &mut self,
         column: impl Into<String>,
         sbbf: Sbbf,

--- a/datafusion/datasource-parquet/src/mod.rs
+++ b/datafusion/datasource-parquet/src/mod.rs
@@ -47,6 +47,7 @@ mod virtual_column;
 mod writer;
 
 pub use access_plan::{ParquetAccessPlan, ParquetRowSelection, RowGroupAccess};
+pub use bloom_filter::BloomFilterStatistics;
 pub use file_format::*;
 pub use metrics::ParquetFileMetrics;
 pub use page_filter::PagePruningAccessPlanFilter;

--- a/datafusion/datasource-parquet/src/opener/mod.rs
+++ b/datafusion/datasource-parquet/src/opener/mod.rs
@@ -30,10 +30,11 @@ use crate::push_decoder::{
     DecoderBuilderConfig, PushDecoderStreamState, RgPlanEntry, RowGroupPruner,
 };
 use crate::row_filter::RowFilterGenerator;
-use crate::row_group_filter::{BloomFilterStatistics, RowGroupAccessPlanFilter};
+use crate::row_group_filter::RowGroupAccessPlanFilter;
 use crate::{
-    Int96Coercer, ParquetAccessPlan, ParquetFileMetrics, ParquetFileReaderFactory,
-    ParquetRowSelection, ParquetVirtualColumn, apply_file_schema_type_coercions,
+    BloomFilterStatistics, Int96Coercer, ParquetAccessPlan, ParquetFileMetrics,
+    ParquetFileReaderFactory, ParquetRowSelection, ParquetVirtualColumn,
+    apply_file_schema_type_coercions,
 };
 use arrow::array::RecordBatch;
 use arrow::datatypes::DataType;

--- a/datafusion/datasource-parquet/src/row_group_filter.rs
+++ b/datafusion/datasource-parquet/src/row_group_filter.rs
@@ -19,9 +19,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use super::{ParquetAccessPlan, ParquetFileMetrics, RowGroupAccess};
-// Re-exported so the existing `crate::row_group_filter::BloomFilterStatistics`
-// path keeps resolving for in-crate callers (e.g. `opener`).
-pub(crate) use crate::bloom_filter::BloomFilterStatistics;
+use crate::bloom_filter::BloomFilterStatistics;
 use arrow::array::{ArrayRef, BooleanArray, UInt64Array};
 use arrow::datatypes::Schema;
 use datafusion_common::pruning::PruningStatistics;
@@ -420,7 +418,7 @@ impl RowGroupAccessPlanFilter {
     ///
     /// # Panics
     /// if `row_group_bloom_filters` does not have the same number of row groups as this set
-    pub(crate) fn prune_by_bloom_filters(
+    pub fn prune_by_bloom_filters(
         &mut self,
         predicate: &PruningPredicate,
         metrics: &ParquetFileMetrics,


### PR DESCRIPTION
## Which issue does this PR close?

- N/A 

## Rationale for this change

`RowGroupAccessPlanFilter` is already public and re-exported at the crate root, and its `prune_by_statistics`, `prune_by_range`, and `prune_by_limit` methods are all `pub` — but `prune_by_bloom_filters` is still `pub(crate)`, and `BloomFilterStatistics` (the `PruningStatistics` adapter it consumes) is crate-private. So a custom `FileOpener` / `TableProvider` that builds its own `ParquetAccessPlan` can prune row groups by statistics, range, and limit through the public API, but has to carry a copy of the bloom-filter evaluation code to prune by bloom filters.

We hit this downstream: a custom parquet opener that scans row groups in reverse order (for `ORDER BY ... DESC LIMIT k` workloads) currently maintains a private copy of this logic. Making these two symbols public lets such implementations reuse DataFusion's bloom-filter predicate evaluation and brings `prune_by_bloom_filters` to parity with its sibling `prune_by_*` methods.

## What changes are included in this PR?

- Make `BloomFilterStatistics` and its `new` / `with_capacity` / `insert` methods `pub`, and re-export the type at the crate root. The `bloom_filter` module itself stays private (matching how `row_group_filter` is handled) to keep the added API surface minimal.
- Make `RowGroupAccessPlanFilter::prune_by_bloom_filters` `pub`.
- Drop the now-redundant `pub(crate)` re-export in `row_group_filter` and route the `opener` import through the crate root.

Visibility only — no behavior change.

## Are these changes tested?

Covered by existing tests (`cargo test -p datafusion-datasource-parquet` passes, including the `bloom_filter` pruning tests). No new behavior to test.

## Are there any user-facing changes?

Two additions to the public API of `datafusion-datasource-parquet`: `BloomFilterStatistics` (crate-root re-export) and `RowGroupAccessPlanFilter::prune_by_bloom_filters`. No breaking changes.
