### PR TITLE
Add NOT IN coverage for integer IN list tests

### DIFF
--- a/datafusion/sqllogictest/test_files/in_list.slt
+++ b/datafusion/sqllogictest/test_files/in_list.slt
@@ -147,3 +147,65 @@ min false false false false false false false false
 minus_one false false false false false false false false
 one false false false false false false false false
 zero false false false false false false false false
+
+statement ok
+DROP TABLE in_list_ints;
+
+# Table with nulls to test null handling for integer IN list specializations
+statement ok
+CREATE TABLE in_list_ints_nullable (
+  label VARCHAR,
+  i8 TINYINT,
+  u8 TINYINT UNSIGNED,
+  i16 SMALLINT,
+  u16 SMALLINT UNSIGNED,
+  i32 INT,
+  u32 INT UNSIGNED,
+  i64 BIGINT,
+  u64 BIGINT UNSIGNED
+) AS VALUES
+  ('match', 11, 11, 11, 11, 11, 11, 11, 11),
+  ('no_match', 7, 7, 7, 7, 7, 7, 7, 7),
+  ('nulls', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+# Null input values return NULL when the IN list has no nulls.
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (3, 4, 5, 6, 11),
+  u8 IN (3, 4, 5, 6, 11),
+  i16 IN (3, 258, 4097, 16385, 11),
+  u16 IN (3, 258, 4097, 16385, 11),
+  i32 IN (3, 258, 66051, 16909060, 11),
+  u32 IN (3, 258, 66051, 16909060, 11),
+  i64 IN (3, 258, 66051, 16909060, 11),
+  u64 IN (3, 258, 66051, 16909060, 11)
+FROM in_list_ints_nullable
+ORDER BY label
+----
+match true true true true true true true true
+no_match false false false false false false false false
+nulls NULL NULL NULL NULL NULL NULL NULL NULL
+
+# Null IN list values return true for matches and NULL for non-matches.
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (NULL, 3, 4, 5, 11),
+  u8 IN (NULL, 3, 4, 5, 11),
+  i16 IN (NULL, 3, 258, 4097, 11),
+  u16 IN (NULL, 3, 258, 4097, 11),
+  i32 IN (NULL, 3, 258, 66051, 11),
+  u32 IN (NULL, 3, 258, 66051, 11),
+  i64 IN (NULL, 3, 258, 66051, 11),
+  u64 IN (NULL, 3, 258, 66051, 11)
+FROM in_list_ints_nullable
+ORDER BY label
+----
+match true true true true true true true true
+no_match NULL NULL NULL NULL NULL NULL NULL NULL
+nulls NULL NULL NULL NULL NULL NULL NULL NULL
+
+
+statement ok
+DROP TABLE in_list_ints_nullable

--- a/datafusion/sqllogictest/test_files/in_list.slt
+++ b/datafusion/sqllogictest/test_files/in_list.slt
@@ -16,12 +16,19 @@
 # under the License.
 
 ##########
-## IN List Tests
+# IN List Tests
+#
+# This file focuses on the IN operator and its various specializations
+#
+# Note that "short" IN LISTS do not go through the InList implementation at all,
+# instead they are rewritten into a series of OR expressions. See:
+# https://github.com/apache/datafusion/blob/ed37b6c9555bc278130dc774ed833b8c0bd29bfa/datafusion/optimizer/src/simplify_expressions/inlist_simplifier.rs#L39-L88
 ##########
 
 
-# IN LIST has specializations for integer types. This test verifies the correctness
-# of the various specializations.
+# Tests for IN LIST integer specializations
+
+
 statement ok
 CREATE TABLE in_list_ints (
   label VARCHAR,
@@ -74,98 +81,24 @@ zero 0 0 0 0 0 0 0 0
 statement error .*Expected: an expression, found: \).*
 SELECT 1 IN ();
 
-query BBBBBBBB
+# Min for each type
+query TBBBBBBBB
 SELECT
-  i8 IN (NULL),
-  u8 IN (NULL),
-  i16 IN (NULL),
-  u16 IN (NULL),
-  i32 IN (NULL),
-  u32 IN (NULL),
-  i64 IN (NULL),
-  u64 IN (NULL)
+  label,
+  i8 IN (1, 2, 3, -128),
+  u8 IN (1, 2, 3, 0),
+  i16 IN (1, 2, 3, -32768),
+  u16 IN (1, 2, 3, 0),
+  i32 IN (1, 2, 3, -2147483648),
+  u32 IN (1, 2, 3, 0),
+  i64 IN (1, 2, 3, -9223372036854775808),
+  u64 IN (1, 2, 3, 0)
 FROM in_list_ints
 ORDER BY label
 ----
-NULL NULL NULL NULL NULL NULL NULL NULL
-NULL NULL NULL NULL NULL NULL NULL NULL
-NULL NULL NULL NULL NULL NULL NULL NULL
-NULL NULL NULL NULL NULL NULL NULL NULL
-NULL NULL NULL NULL NULL NULL NULL NULL
-NULL NULL NULL NULL NULL NULL NULL NULL
-
-query BBBBBBBB
-SELECT
-  i8 IN (-128),
-  u8 IN (0),
-  i16 IN (-32768),
-  u16 IN (0),
-  i32 IN (-2147483648),
-  u32 IN (0),
-  i64 IN (-9223372036854775808),
-  u64 IN (0)
-FROM in_list_ints
-ORDER BY label
-----
-false false false false false false false false
-false false false false false false false false
-true true true true true true true true
-false false false false false false false false
-false false false false false false false false
-false true false true false true false true
-
-query BBBBBBBB
-SELECT
-  i8 IN (127),
-  u8 IN (255),
-  i16 IN (32767),
-  u16 IN (65535),
-  i32 IN (2147483647),
-  u32 IN (4294967295),
-  i64 IN (9223372036854775807),
-  u64 IN (18446744073709551615)
-FROM in_list_ints
-ORDER BY label
-----
-false false false false false false false false
-true true true true true true true true
-false false false false false false false false
-false false false false false false false false
-false false false false false false false false
-false false false false false false false false
-
-query BBBBBBBB
-SELECT
-  i8 IN (11, 12),
-  u8 IN (11, 12),
-  i16 IN (11, 12),
-  u16 IN (11, 12),
-  i32 IN (11, 12),
-  u32 IN (11, 12),
-  i64 IN (11, 12),
-  u64 IN (11, 12)
-FROM in_list_ints
-ORDER BY label
-----
-true true true true true true true true
-false false false false false false false false
-false false false false false false false false
-false false false false false false false false
-false false false false false false false false
-false false false false false false false false
-
-query BBBB
-SELECT
-  i8 IN (12, -13),
-  i16 IN (12, -13),
-  i32 IN (12, -13),
-  i64 IN (12, -13)
-FROM in_list_ints
-ORDER BY label
-----
-false false false false
-false false false false
-false false false false
-false false false false
-false false false false
-false false false false
+eleven false false false false false false false false
+max false false false false false false false false
+min true true true true true true true true
+minus_one false true false true false true false true
+one true true true true true true true true
+zero false true false true false true false true

--- a/datafusion/sqllogictest/test_files/in_list.slt
+++ b/datafusion/sqllogictest/test_files/in_list.slt
@@ -99,6 +99,51 @@ ORDER BY label
 eleven false false false false false false false false
 max false false false false false false false false
 min true true true true true true true true
-minus_one false true false true false true false true
-one true true true true true true true true
+minus_one false false false false false false false false
+one false false false false false false false false
 zero false true false true false true false true
+
+# Max for each type (use values that cover the entire input range
+# so there are some values in each byte)
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (-64, -32, 32, 64, 127),
+  u8 IN (32, 64, 128, 200, 255),
+  i16 IN (-257, 257, 4097, 16385, 32767),
+  u16 IN (257, 4097, 16385, 60000, 65535),
+  i32 IN (-16711936, 66051, 16909060, 305419896, 2147483647),
+  u32 IN (66051, 16909060, 305419896, 2309737967, 4294967295),
+  i64 IN (-72057594037927936, 72623859790382856, 81985529216486895, 1234605616436508552, 9223372036854775807),
+  u64 IN (72623859790382856, 81985529216486895, 1234605616436508552, 18364758544493064720, 18446744073709551615)
+FROM in_list_ints
+ORDER BY label
+----
+eleven false false false false false false false false
+max true true true true true true true true
+min false false false false false false false false
+minus_one false false false false false false false false
+one false false false false false false false false
+zero false false false false false false false false
+
+# Five item IN list with no matches (also cover the entire range)
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (-64, -32, 32, 64, 100),
+  u8 IN (2, 32, 64, 128, 200),
+  i16 IN (-257, 257, 4097, 16385, 30000),
+  u16 IN (2, 257, 4097, 16385, 60000),
+  i32 IN (-16711936, 66051, 16909060, 305419896, 1076895760),
+  u32 IN (2, 66051, 16909060, 305419896, 2309737967),
+  i64 IN (-72057594037927936, 72623859790382856, 81985529216486895, 1234605616436508552, 819855292164868960),
+  u64 IN (2, 72623859790382856, 81985529216486895, 1234605616436508552, 18364758544493064720)
+FROM in_list_ints
+ORDER BY label
+----
+eleven false false false false false false false false
+max false false false false false false false false
+min false false false false false false false false
+minus_one false false false false false false false false
+one false false false false false false false false
+zero false false false false false false false false

--- a/datafusion/sqllogictest/test_files/in_list.slt
+++ b/datafusion/sqllogictest/test_files/in_list.slt
@@ -99,23 +99,23 @@ ORDER BY label
 eleven false false false false false false false false
 max false false false false false false false false
 min true true true true true true true true
-minus_one false false false false false false false false
-one false false false false false false false false
+minus_one false true false true false true false true
+one true true true true true true true true
 zero false true false true false true false true
 
 # Max for each type (use values that cover the entire input range
-# so there are some values in each byte)
+# e.g. values that have 1 non zero byte. 2 non zero bytes, etc)
 query TBBBBBBBB
 SELECT
   label,
   i8 IN (-64, -32, 32, 64, 127),
   u8 IN (32, 64, 128, 200, 255),
-  i16 IN (-257, 257, 4097, 16385, 32767),
-  u16 IN (257, 4097, 16385, 60000, 65535),
-  i32 IN (-16711936, 66051, 16909060, 305419896, 2147483647),
-  u32 IN (66051, 16909060, 305419896, 2309737967, 4294967295),
-  i64 IN (-72057594037927936, 72623859790382856, 81985529216486895, 1234605616436508552, 9223372036854775807),
-  u64 IN (72623859790382856, 81985529216486895, 1234605616436508552, 18364758544493064720, 18446744073709551615)
+  i16 IN (3, 258, 4097, 16385, 32767),
+  u16 IN (3, 258, 4097, 16385, 65535),
+  i32 IN (3, 258, 66051, 16909060, 2147483647),
+  u32 IN (3, 258, 66051, 16909060, 4294967295),
+  i64 IN (3, 258, 66051, 16909060, 9223372036854775807),
+  u64 IN (3, 258, 66051, 16909060, 18446744073709551615)
 FROM in_list_ints
 ORDER BY label
 ----

--- a/datafusion/sqllogictest/test_files/in_list.slt
+++ b/datafusion/sqllogictest/test_files/in_list.slt
@@ -148,8 +148,13 @@ minus_one false false false false false false false false
 one false false false false false false false false
 zero false false false false false false false false
 
+# Cleanup
 statement ok
 DROP TABLE in_list_ints;
+
+####
+## Integer Null Handling
+####
 
 # Table with nulls to test null handling for integer IN list specializations
 statement ok
@@ -206,6 +211,6 @@ match true true true true true true true true
 no_match NULL NULL NULL NULL NULL NULL NULL NULL
 nulls NULL NULL NULL NULL NULL NULL NULL NULL
 
-
+# Cleanup
 statement ok
 DROP TABLE in_list_ints_nullable

--- a/datafusion/sqllogictest/test_files/in_list.slt
+++ b/datafusion/sqllogictest/test_files/in_list.slt
@@ -20,6 +20,11 @@
 #
 # This file focuses on the IN operator and its various specializations
 #
+# Testing strategy notes
+# * Test `NOT IN` by comparing it to `IN` using `<>`, which should return true
+#   for non-null inverse results and preserves the `NOT IN` expression through
+#   simplification.
+#
 # Note that "short" IN LISTS do not go through the InList implementation at all,
 # instead they are rewritten into a series of OR expressions. See:
 # https://github.com/apache/datafusion/blob/ed37b6c9555bc278130dc774ed833b8c0bd29bfa/datafusion/optimizer/src/simplify_expressions/inlist_simplifier.rs#L39-L88
@@ -103,6 +108,28 @@ minus_one false true false true false true false true
 one true true true true true true true true
 zero false true false true false true false true
 
+# NOT IN should be the logical inverse of IN for non-null results.
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (1, 2, 3, -128) <> (i8 NOT IN (1, 2, 3, -128)),
+  u8 IN (1, 2, 3, 0) <> (u8 NOT IN (1, 2, 3, 0)),
+  i16 IN (1, 2, 3, -32768) <> (i16 NOT IN (1, 2, 3, -32768)),
+  u16 IN (1, 2, 3, 0) <> (u16 NOT IN (1, 2, 3, 0)),
+  i32 IN (1, 2, 3, -2147483648) <> (i32 NOT IN (1, 2, 3, -2147483648)),
+  u32 IN (1, 2, 3, 0) <> (u32 NOT IN (1, 2, 3, 0)),
+  i64 IN (1, 2, 3, -9223372036854775808) <> (i64 NOT IN (1, 2, 3, -9223372036854775808)),
+  u64 IN (1, 2, 3, 0) <> (u64 NOT IN (1, 2, 3, 0))
+FROM in_list_ints
+ORDER BY label
+----
+eleven true true true true true true true true
+max true true true true true true true true
+min true true true true true true true true
+minus_one true true true true true true true true
+one true true true true true true true true
+zero true true true true true true true true
+
 # Max for each type (use values that cover the entire input range
 # e.g. values that have 1 non zero byte. 2 non zero bytes, etc)
 query TBBBBBBBB
@@ -126,6 +153,28 @@ minus_one false false false false false false false false
 one false false false false false false false false
 zero false false false false false false false false
 
+# NOT IN should be the logical inverse of IN for non-null results.
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (-64, -32, 32, 64, 127) <> (i8 NOT IN (-64, -32, 32, 64, 127)),
+  u8 IN (32, 64, 128, 200, 255) <> (u8 NOT IN (32, 64, 128, 200, 255)),
+  i16 IN (3, 258, 4097, 16385, 32767) <> (i16 NOT IN (3, 258, 4097, 16385, 32767)),
+  u16 IN (3, 258, 4097, 16385, 65535) <> (u16 NOT IN (3, 258, 4097, 16385, 65535)),
+  i32 IN (3, 258, 66051, 16909060, 2147483647) <> (i32 NOT IN (3, 258, 66051, 16909060, 2147483647)),
+  u32 IN (3, 258, 66051, 16909060, 4294967295) <> (u32 NOT IN (3, 258, 66051, 16909060, 4294967295)),
+  i64 IN (3, 258, 66051, 16909060, 9223372036854775807) <> (i64 NOT IN (3, 258, 66051, 16909060, 9223372036854775807)),
+  u64 IN (3, 258, 66051, 16909060, 18446744073709551615) <> (u64 NOT IN (3, 258, 66051, 16909060, 18446744073709551615))
+FROM in_list_ints
+ORDER BY label
+----
+eleven true true true true true true true true
+max true true true true true true true true
+min true true true true true true true true
+minus_one true true true true true true true true
+one true true true true true true true true
+zero true true true true true true true true
+
 # Five item IN list with no matches (also cover the entire range)
 query TBBBBBBBB
 SELECT
@@ -147,6 +196,28 @@ min false false false false false false false false
 minus_one false false false false false false false false
 one false false false false false false false false
 zero false false false false false false false false
+
+# NOT IN should be the logical inverse of IN for non-null results.
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (-64, -32, 32, 64, 100) <> (i8 NOT IN (-64, -32, 32, 64, 100)),
+  u8 IN (2, 32, 64, 128, 200) <> (u8 NOT IN (2, 32, 64, 128, 200)),
+  i16 IN (-257, 257, 4097, 16385, 30000) <> (i16 NOT IN (-257, 257, 4097, 16385, 30000)),
+  u16 IN (2, 257, 4097, 16385, 60000) <> (u16 NOT IN (2, 257, 4097, 16385, 60000)),
+  i32 IN (-16711936, 66051, 16909060, 305419896, 1076895760) <> (i32 NOT IN (-16711936, 66051, 16909060, 305419896, 1076895760)),
+  u32 IN (2, 66051, 16909060, 305419896, 2309737967) <> (u32 NOT IN (2, 66051, 16909060, 305419896, 2309737967)),
+  i64 IN (-72057594037927936, 72623859790382856, 81985529216486895, 1234605616436508552, 819855292164868960) <> (i64 NOT IN (-72057594037927936, 72623859790382856, 81985529216486895, 1234605616436508552, 819855292164868960)),
+  u64 IN (2, 72623859790382856, 81985529216486895, 1234605616436508552, 18364758544493064720) <> (u64 NOT IN (2, 72623859790382856, 81985529216486895, 1234605616436508552, 18364758544493064720))
+FROM in_list_ints
+ORDER BY label
+----
+eleven true true true true true true true true
+max true true true true true true true true
+min true true true true true true true true
+minus_one true true true true true true true true
+one true true true true true true true true
+zero true true true true true true true true
 
 # Cleanup
 statement ok
@@ -192,6 +263,25 @@ match true true true true true true true true
 no_match false false false false false false false false
 nulls NULL NULL NULL NULL NULL NULL NULL NULL
 
+# NOT IN should be the logical inverse of IN for non-null results.
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (3, 4, 5, 6, 11) <> (i8 NOT IN (3, 4, 5, 6, 11)),
+  u8 IN (3, 4, 5, 6, 11) <> (u8 NOT IN (3, 4, 5, 6, 11)),
+  i16 IN (3, 258, 4097, 16385, 11) <> (i16 NOT IN (3, 258, 4097, 16385, 11)),
+  u16 IN (3, 258, 4097, 16385, 11) <> (u16 NOT IN (3, 258, 4097, 16385, 11)),
+  i32 IN (3, 258, 66051, 16909060, 11) <> (i32 NOT IN (3, 258, 66051, 16909060, 11)),
+  u32 IN (3, 258, 66051, 16909060, 11) <> (u32 NOT IN (3, 258, 66051, 16909060, 11)),
+  i64 IN (3, 258, 66051, 16909060, 11) <> (i64 NOT IN (3, 258, 66051, 16909060, 11)),
+  u64 IN (3, 258, 66051, 16909060, 11) <> (u64 NOT IN (3, 258, 66051, 16909060, 11))
+FROM in_list_ints_nullable
+ORDER BY label
+----
+match true true true true true true true true
+no_match true true true true true true true true
+nulls NULL NULL NULL NULL NULL NULL NULL NULL
+
 # Null IN list values return true for matches and NULL for non-matches.
 query TBBBBBBBB
 SELECT
@@ -211,6 +301,25 @@ match true true true true true true true true
 no_match NULL NULL NULL NULL NULL NULL NULL NULL
 nulls NULL NULL NULL NULL NULL NULL NULL NULL
 
+# NOT IN should be the logical inverse of IN for non-null results.
+query TBBBBBBBB
+SELECT
+  label,
+  i8 IN (NULL, 3, 4, 5, 11) <> (i8 NOT IN (NULL, 3, 4, 5, 11)),
+  u8 IN (NULL, 3, 4, 5, 11) <> (u8 NOT IN (NULL, 3, 4, 5, 11)),
+  i16 IN (NULL, 3, 258, 4097, 11) <> (i16 NOT IN (NULL, 3, 258, 4097, 11)),
+  u16 IN (NULL, 3, 258, 4097, 11) <> (u16 NOT IN (NULL, 3, 258, 4097, 11)),
+  i32 IN (NULL, 3, 258, 66051, 11) <> (i32 NOT IN (NULL, 3, 258, 66051, 11)),
+  u32 IN (NULL, 3, 258, 66051, 11) <> (u32 NOT IN (NULL, 3, 258, 66051, 11)),
+  i64 IN (NULL, 3, 258, 66051, 11) <> (i64 NOT IN (NULL, 3, 258, 66051, 11)),
+  u64 IN (NULL, 3, 258, 66051, 11) <> (u64 NOT IN (NULL, 3, 258, 66051, 11))
+FROM in_list_ints_nullable
+ORDER BY label
+----
+match true true true true true true true true
+no_match NULL NULL NULL NULL NULL NULL NULL NULL
+nulls NULL NULL NULL NULL NULL NULL NULL NULL
+
 # Cleanup
 statement ok
-DROP TABLE in_list_ints_nullable
+DROP TABLE in_list_ints_nullable;

--- a/datafusion/sqllogictest/test_files/in_list.slt
+++ b/datafusion/sqllogictest/test_files/in_list.slt
@@ -1,0 +1,171 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## IN List Tests
+##########
+
+
+# IN LIST has specializations for integer types. This test verifies the correctness
+# of the various specializations.
+statement ok
+CREATE TABLE in_list_ints (
+  label VARCHAR,
+  i8 TINYINT,
+  u8 TINYINT UNSIGNED,
+  i16 SMALLINT,
+  u16 SMALLINT UNSIGNED,
+  i32 INT,
+  u32 INT UNSIGNED,
+  i64 BIGINT,
+  u64 BIGINT UNSIGNED
+) AS VALUES
+  ('min', -128, 0, -32768, 0, -2147483648, 0, -9223372036854775808, 0),
+  ('minus_one', -1, 1, -1, 1, -1, 1, -1, 1),
+  ('zero', 0, 0, 0, 0, 0, 0, 0, 0),
+  ('one', 1, 1, 1, 1, 1, 1, 1, 1),
+  ('eleven', 11, 11, 11, 11, 11, 11, 11, 11),
+  ('max', 127, 255, 32767, 65535, 2147483647, 4294967295, 9223372036854775807, 18446744073709551615);
+
+# Verify that the Arrow types of the columns are as expected. This is important because the IN LIST specializations are based on the column types.
+query TTTTTTTT
+SELECT
+  arrow_typeof(i8),
+  arrow_typeof(u8),
+  arrow_typeof(i16),
+  arrow_typeof(u16),
+  arrow_typeof(i32),
+  arrow_typeof(u32),
+  arrow_typeof(i64),
+  arrow_typeof(u64)
+FROM in_list_ints
+LIMIT 1
+----
+Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64
+
+# Verify the data is as expected.
+query TIIIIIIII
+SELECT label, i8, u8, i16, u16, i32, u32, i64, u64
+FROM in_list_ints
+ORDER BY label
+----
+eleven 11 11 11 11 11 11 11 11
+max 127 255 32767 65535 2147483647 4294967295 9223372036854775807 18446744073709551615
+min -128 0 -32768 0 -2147483648 0 -9223372036854775808 0
+minus_one -1 1 -1 1 -1 1 -1 1
+one 1 1 1 1 1 1 1 1
+zero 0 0 0 0 0 0 0 0
+
+# Empty IN lists are rejected by the SQL parser.
+statement error .*Expected: an expression, found: \).*
+SELECT 1 IN ();
+
+query BBBBBBBB
+SELECT
+  i8 IN (NULL),
+  u8 IN (NULL),
+  i16 IN (NULL),
+  u16 IN (NULL),
+  i32 IN (NULL),
+  u32 IN (NULL),
+  i64 IN (NULL),
+  u64 IN (NULL)
+FROM in_list_ints
+ORDER BY label
+----
+NULL NULL NULL NULL NULL NULL NULL NULL
+NULL NULL NULL NULL NULL NULL NULL NULL
+NULL NULL NULL NULL NULL NULL NULL NULL
+NULL NULL NULL NULL NULL NULL NULL NULL
+NULL NULL NULL NULL NULL NULL NULL NULL
+NULL NULL NULL NULL NULL NULL NULL NULL
+
+query BBBBBBBB
+SELECT
+  i8 IN (-128),
+  u8 IN (0),
+  i16 IN (-32768),
+  u16 IN (0),
+  i32 IN (-2147483648),
+  u32 IN (0),
+  i64 IN (-9223372036854775808),
+  u64 IN (0)
+FROM in_list_ints
+ORDER BY label
+----
+false false false false false false false false
+false false false false false false false false
+true true true true true true true true
+false false false false false false false false
+false false false false false false false false
+false true false true false true false true
+
+query BBBBBBBB
+SELECT
+  i8 IN (127),
+  u8 IN (255),
+  i16 IN (32767),
+  u16 IN (65535),
+  i32 IN (2147483647),
+  u32 IN (4294967295),
+  i64 IN (9223372036854775807),
+  u64 IN (18446744073709551615)
+FROM in_list_ints
+ORDER BY label
+----
+false false false false false false false false
+true true true true true true true true
+false false false false false false false false
+false false false false false false false false
+false false false false false false false false
+false false false false false false false false
+
+query BBBBBBBB
+SELECT
+  i8 IN (11, 12),
+  u8 IN (11, 12),
+  i16 IN (11, 12),
+  u16 IN (11, 12),
+  i32 IN (11, 12),
+  u32 IN (11, 12),
+  i64 IN (11, 12),
+  u64 IN (11, 12)
+FROM in_list_ints
+ORDER BY label
+----
+true true true true true true true true
+false false false false false false false false
+false false false false false false false false
+false false false false false false false false
+false false false false false false false false
+false false false false false false false false
+
+query BBBB
+SELECT
+  i8 IN (12, -13),
+  i16 IN (12, -13),
+  i32 IN (12, -13),
+  i64 IN (12, -13)
+FROM in_list_ints
+ORDER BY label
+----
+false false false false
+false false false false
+false false false false
+false false false false
+false false false false
+false false false false


### PR DESCRIPTION
## Which issue does this PR close?
- Part of https://github.com/apache/datafusion/issues/19241
- part of https://github.com/apache/datafusion/issues/23307
- Follow on to https://github.com/apache/datafusion/pull/23305

## Rationale for this change

We are adding SQL-level coverage for the integer IN list specialization paths. https://github.com/apache/datafusion/pull/23305 adds the initial integer `IN` coverage.

This PR adds paired `NOT IN` coverage so the SLT file also exercises the negated IN list implementation paths while keeping the expected results easy to audit.

## What changes are included in this PR?
1. Add paired `NOT IN` checks for the existing integer IN list queries

## Are these changes tested?

Only tests

## Are there any user-facing changes?

No
