### PR TITLE
fix: preserve precision in log() with mixed float-width arguments

### DIFF
--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -28,9 +28,7 @@ use arrow::datatypes::{
 use arrow::error::ArrowError;
 use arrow_buffer::i256;
 use datafusion_common::types::NativeType;
-use datafusion_common::{
-    Result, ScalarValue, exec_err, internal_err, plan_datafusion_err, plan_err,
-};
+use datafusion_common::{Result, ScalarValue, exec_err, internal_err, plan_err};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyContext};
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
@@ -97,6 +95,17 @@ impl LogFunc {
                 Volatility::Immutable,
             ),
         }
+    }
+}
+
+/// Ranks float types by width so the wider one drives the result type.
+/// Non-float types (e.g. decimals, which are computed in f64) rank as Float64.
+#[inline]
+fn float_rank(data_type: &DataType) -> u8 {
+    match data_type {
+        DataType::Float16 => 1,
+        DataType::Float32 => 2,
+        _ => 3,
     }
 }
 
@@ -195,12 +204,17 @@ impl ScalarUDFImpl for LogFunc {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        // Check last argument (value)
-        match &arg_types.last().ok_or(plan_datafusion_err!("No args"))? {
-            DataType::Float16 => Ok(DataType::Float16),
-            DataType::Float32 => Ok(DataType::Float32),
-            _ => Ok(DataType::Float64),
+        if arg_types.is_empty() {
+            return plan_err!("No args");
         }
+        // The result type is the widest float among the arguments so that, e.g.,
+        // log(Float64, Float32) is computed and returned in Float64 instead of
+        // narrowing the base to Float32 and losing precision.
+        Ok(match arg_types.iter().map(float_rank).max().unwrap_or(0) {
+            1 => DataType::Float16,
+            2 => DataType::Float32,
+            _ => DataType::Float64,
+        })
     }
 
     fn output_ordering(&self, input: &[ExprProperties]) -> Result<SortProperties> {
@@ -245,6 +259,19 @@ impl ScalarUDFImpl for LogFunc {
             )
         };
         let value = value.to_array(args.number_rows)?;
+
+        // If the base is a wider float than the value (e.g. log(Float64, Float32)),
+        // widen the value to the result type so the base is not narrowed to the
+        // value's type, which would lose precision. Decimal values are always
+        // computed in f64, so they are left untouched here.
+        let return_type = args.return_type();
+        let value = if matches!(value.data_type(), DataType::Float16 | DataType::Float32)
+            && float_rank(return_type) > float_rank(value.data_type())
+        {
+            arrow::compute::cast(&value, return_type)?
+        } else {
+            value
+        };
 
         let output: ArrayRef = match value.data_type() {
             DataType::Float16 => {
@@ -745,6 +772,53 @@ mod tests {
             }
         }
     }
+    #[test]
+    fn test_log_f64_base_f32_value() {
+        // log(Float64 base, Float32 value) must widen the value to f64 and return
+        // Float64 instead of narrowing the base to f32 (see issue #22581).
+        assert_eq!(
+            LogFunc::new()
+                .return_type(&[DataType::Float64, DataType::Float32])
+                .unwrap(),
+            DataType::Float64
+        );
+
+        let arg_fields = vec![
+            Field::new("b", DataType::Float64, false).into(),
+            Field::new("x", DataType::Float32, false).into(),
+        ];
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(16777217.0))), // base
+                ColumnarValue::Scalar(ScalarValue::Float32(Some(2.0))),        // num
+            ],
+            arg_fields,
+            number_rows: 1,
+            return_field: Field::new("f", DataType::Float64, true).into(),
+            config_options: Arc::new(ConfigOptions::default()),
+        };
+        let result = LogFunc::new()
+            .invoke_with_args(args)
+            .expect("failed to initialize function log");
+
+        match result {
+            ColumnarValue::Array(arr) => {
+                let floats = as_float64_array(&arr)
+                    .expect("failed to convert result to a Float64Array");
+                assert_eq!(floats.len(), 1);
+                let expected = 2.0_f64.log(16777217.0);
+                assert!(
+                    (floats.value(0) - expected).abs() < 1e-15,
+                    "got {}, expected {expected}",
+                    floats.value(0)
+                );
+            }
+            ColumnarValue::Scalar(_) => {
+                panic!("Expected an array value")
+            }
+        }
+    }
+
     #[test]
     // Test log() simplification errors
     fn test_log_simplify_errors() {

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -924,17 +924,34 @@ physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/
 query RT
 SELECT log(2.5, arrow_cast(10.9, 'Float16')), arrow_typeof(log(2.5, arrow_cast(10.9, 'Float16')));
 ----
-2.6074219 Float16
+2.606835742462 Float64
 
 query RT
 SELECT log(2.5, 10.9::float), arrow_typeof(log(2.5, 10.9::float));
 ----
-2.606992 Float32
+2.606992159958 Float64
 
 query RT
 SELECT log(2.5, 10.9::double), arrow_typeof(log(2.5, 10.9::double));
 ----
 2.606992198152 Float64
+
+# A Float64 (or integer) base must not narrow a Float32 value to Float32; the
+# value is widened to Float64 and a Float64 result is returned (issue #22581).
+query RT
+SELECT log(arrow_cast(16777217, 'Float64'), arrow_cast(2.0, 'Float32')), arrow_typeof(log(arrow_cast(16777217, 'Float64'), arrow_cast(2.0, 'Float32')));
+----
+0.041666666517 Float64
+
+query RT
+SELECT log(arrow_cast(16777217, 'Float64'), arrow_cast(2.0, 'Float16')), arrow_typeof(log(arrow_cast(16777217, 'Float64'), arrow_cast(2.0, 'Float16')));
+----
+0.041666666517 Float64
+
+query RT
+SELECT log(2, arrow_cast(2.0, 'Float32')), arrow_typeof(log(2, arrow_cast(2.0, 'Float32')));
+----
+1 Float64
 
 # lcm with array and scalar
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22581.

## Rationale for this change

`log(base, value)` currently dispatches on the type of the *value* (the last argument): `return_type` inspects only the value's type, and `invoke_with_args` computes the result in that type. When the base is a wider float than the value — e.g. `log(Float64, Float32)` — the base is narrowed down to the value's float type before the computation, which loses precision. This is the behavior reported in #22581.

The fix picks the widest float among all arguments as the result type, and widens a `Float16`/`Float32` value up to that type before computing, so the base no longer has to be narrowed.

> AI-assisted disclosure: I used an AI assistant while working on this. I understand and can justify the change end-to-end. One thing I'd flag for reviewers: I treat any non-float argument (e.g. an integer base, or decimals which are already computed in `f64`) as `Float64` for ranking purposes via a `float_rank` helper — this matches the existing "decimals compute in f64" path, but please sanity-check that assumption against any type-coercion expectations I might be missing.

## What changes are included in this PR?

- `return_type` now returns the widest float across all arguments instead of only looking at the value's type (via a small `float_rank` helper).
- In `invoke_with_args`, when the base is wider than a `Float16`/`Float32` value, the value is cast up to the result type before computation so the base is not narrowed. Decimal values are left untouched (still computed in `f64`).
- Added a unit test (`test_log_f64_base_f32_value`) and sqllogictest cases in `math.slt` covering `log(Float64, Float32)`, `log(Float64, Float16)`, and integer-base cases.

## Are these changes tested?

Yes.
- `cargo test -p datafusion-functions --lib math::` — green (includes the new `test_log_f64_base_f32_value`).
- `math.slt` sqllogictests — green (includes new mixed-width cases and updated expected types for previously-narrowing cases).

## Are there any user-facing changes?

**Yes — this is a user-facing behavior change to `log()` return types in mixed-float-width cases, and I'd like maintainers to confirm the desired semantics.**

Previously the return type of `log(base, value)` followed the *value's* type. Now it follows the *widest float among all arguments*. Concretely:

- `log(Float64, Float32)` now returns `Float64` (was `Float32`)
- `log(Float64, Float16)` now returns `Float64` (was `Float16`)
- `log(2, arrow_cast(2.0, 'Float32'))` (integer base) now returns `Float64` (was `Float32`)

The unary `log(value)` and same-width cases (`log(Float64, Float64)`, `log(Float32, Float32)`, etc.) are unchanged. Because output precision/width changes in the mixed cases, some existing `math.slt` expected values were updated accordingly.

Opening this as a **draft proposal** because widening the return type is a semantics decision: it fixes the precision loss in #22581, but it changes observed output types/precision for existing mixed-width queries. Does widening to the widest float match the intended `log` semantics, or would you prefer preserving the value's type (and accepting the precision loss, or handling it differently)? Happy to adjust. If this is considered a breaking change to the public output type, I can add the `api change` label.
