### PR TITLE
IN LIST: add Float16 bitmap filter

### DIFF
--- a/datafusion/physical-expr/benches/in_list_strategy.rs
+++ b/datafusion/physical-expr/benches/in_list_strategy.rs
@@ -34,7 +34,7 @@
 //! | Case | Types | Characteristics | List Sizes Tested |
 //! |------|-------|-----------------|-------------------|
 //! | Narrow integer cases | UInt8 | small value domain | 4, 16 |
-//! | Narrow integer cases | Int16 | larger value domain | 4, 64, 256 |
+//! | Narrow integer cases | Int16, Float16 | larger value domain | 4, 64, 256 |
 //! | 32-bit primitive cases | Int32, Float32 | small and large lists | 4, 32, 64, 256 |
 //! | 64-bit primitive cases | Int64, TimestampNs | small and large lists | 4, 16, 32, 128 |
 //! | Utf8 short-string cases | Utf8 | 8-byte strings | 4, 64, 256 |
@@ -51,6 +51,7 @@ use arrow::record_batch::RecordBatch;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use datafusion_common::ScalarValue;
 use datafusion_physical_expr::expressions::{col, in_list, lit};
+use half::f16;
 use rand::distr::Alphanumeric;
 use rand::prelude::*;
 use std::sync::Arc;
@@ -388,6 +389,23 @@ fn bench_narrow_integer(c: &mut Criterion) {
                     match_pct as f64 / 100.0,
                     |rng| rng.random(),
                     |v| ScalarValue::Int16(Some(v)),
+                ),
+            );
+        }
+    }
+
+    // Float16: same 65,536-value bit-pattern domain as Int16/UInt16.
+    for list_size in [4, 64, 256] {
+        for match_pct in MATCH_RATES {
+            bench_numeric::<f16, Float16Array>(
+                c,
+                "narrow_integer",
+                &format!("f16/list={list_size}/match={match_pct}%"),
+                &NumericBenchConfig::new(
+                    list_size,
+                    match_pct as f64 / 100.0,
+                    |rng| f16::from_f32(rng.random::<f32>() * 1000.0),
+                    |v| ScalarValue::Float16(Some(v)),
                 ),
             );
         }

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -3525,6 +3525,7 @@ mod tests {
             DataType::UInt16,
             DataType::UInt32,
             DataType::UInt64,
+            DataType::Float16,
             DataType::Float32,
             DataType::Float64,
         ];

--- a/datafusion/physical-expr/src/expressions/in_list/primitive_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/primitive_filter.rs
@@ -79,7 +79,7 @@ impl BitmapStorage for Box<[u64; 1024]> {
 ///
 /// Arrow already defines the Rust value type as `T::Native`. This trait only
 /// supplies the bitmap storage size and maps values to their bit-pattern index
-/// for the two integer domains that are small enough to represent with one bit
+/// for the primitive domains that are small enough to represent with one bit
 /// per possible value.
 pub(super) trait BitmapFilterType:
     ArrowPrimitiveType + Send + Sync + 'static
@@ -131,6 +131,17 @@ impl BitmapFilterType for UInt16Type {
     #[inline(always)]
     fn index(value: Self::Native) -> usize {
         value as usize
+    }
+}
+
+/// `Float16` has 65,536 possible bit patterns, so 1,024 `u64` words cover the
+/// full domain.
+impl BitmapFilterType for Float16Type {
+    type Storage = Box<[u64; 1024]>;
+
+    #[inline(always)]
+    fn index(value: Self::Native) -> usize {
+        value.to_bits() as usize
     }
 }
 
@@ -418,7 +429,10 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    use arrow::array::{DictionaryArray, Int8Array, Int16Array, UInt8Array, UInt16Array};
+    use arrow::array::{
+        DictionaryArray, Float16Array, Int8Array, Int16Array, UInt8Array, UInt16Array,
+    };
+    use half::f16;
 
     fn assert_contains(
         filter: &dyn StaticFilter,
@@ -530,6 +544,42 @@ mod tests {
         assert_eq!(
             filter.contains(&needles, true)?,
             BooleanArray::from(vec![Some(false), None, Some(false)])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn bitmap_filter_f16_handles_bit_patterns_and_slices() -> Result<()> {
+        let nan_a = f16::from_bits(0x7e01);
+        let nan_b = f16::from_bits(0x7e02);
+        let haystack: ArrayRef = Arc::new(
+            Float16Array::from(vec![
+                Some(f16::from_f32(9.0)),
+                Some(f16::from_f32(1.5)),
+                None,
+                Some(f16::from_f32(-0.0)),
+                Some(nan_a),
+            ])
+            .slice(1, 4),
+        );
+        let filter = BitmapFilter::<Float16Type>::try_new(&haystack)?;
+        let needles = Float16Array::from(vec![
+            Some(f16::from_f32(0.0)),
+            Some(f16::from_f32(-0.0)),
+            Some(nan_a),
+            Some(nan_b),
+            None,
+        ])
+        .slice(1, 4);
+
+        assert_eq!(
+            filter.contains(&needles, false)?,
+            BooleanArray::from(vec![Some(true), Some(true), None, None])
+        );
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), Some(false), None, None])
         );
 
         Ok(())

--- a/datafusion/physical-expr/src/expressions/in_list/strategy.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/strategy.rs
@@ -19,7 +19,9 @@ use std::sync::Arc;
 
 use arrow::array::ArrayRef;
 use arrow::compute::cast;
-use arrow::datatypes::{DataType, Int8Type, Int16Type, UInt8Type, UInt16Type};
+use arrow::datatypes::{
+    DataType, Float16Type, Int8Type, Int16Type, UInt8Type, UInt16Type,
+};
 use datafusion_common::Result;
 
 use super::array_static_filter::ArrayStaticFilter;
@@ -41,6 +43,9 @@ pub(super) fn instantiate_static_filter(
         DataType::UInt8 => Ok(Arc::new(BitmapFilter::<UInt8Type>::try_new(&in_array)?)),
         DataType::Int16 => Ok(Arc::new(BitmapFilter::<Int16Type>::try_new(&in_array)?)),
         DataType::UInt16 => Ok(Arc::new(BitmapFilter::<UInt16Type>::try_new(&in_array)?)),
+        DataType::Float16 => {
+            Ok(Arc::new(BitmapFilter::<Float16Type>::try_new(&in_array)?))
+        }
         DataType::Int32 => Ok(Arc::new(Int32StaticFilter::try_new(&in_array)?)),
         DataType::Int64 => Ok(Arc::new(Int64StaticFilter::try_new(&in_array)?)),
         DataType::UInt32 => Ok(Arc::new(UInt32StaticFilter::try_new(&in_array)?)),


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #19241.
- Based on #23299.
- Next in stack: #23014, after it is rebased onto this PR.

## Rationale for this change

#23299 extends the bitmap `IN` filter to the signed 1-byte and 2-byte integer types by handling each logical Arrow type directly. `Float16` is the remaining 2-byte primitive type that can use the same compact bitmap idea: it has 65,536 possible bit patterns, so an 8 KiB bitmap can represent every possible value.

This PR follows the same direct typed shape as #23299. It does not reinterpret whole arrays as `UInt16`; instead, the `Float16` bitmap filter maps each value to its IEEE-754 half-precision bit pattern with `to_bits()`. That keeps the logical array type intact while preserving bit-pattern equality semantics, including distinct NaN payloads and `+0.0` versus `-0.0`.

## What changes are included in this PR?

- Adds `Float16Type` support to the existing `BitmapFilter`.
- Routes `DataType::Float16` constant-list filtering to that bitmap path.
- Extends the existing type-combination coverage to include `Float16`.
- Adds focused coverage for slices, nulls, `NOT IN`, `+0.0` / `-0.0`, and NaN payload bit patterns.
- Adds focused `in_list_strategy` benchmark rows for `Float16`.

## Are these changes tested?

Yes.

- `cargo fmt --all`
- `cargo test -p datafusion-physical-expr bitmap_filter_f16 --lib`
- `cargo test -p datafusion-physical-expr test_in_list_from_array_type_combinations --lib`
- `cargo test -p datafusion-physical-expr --bench in_list_strategy --no-run`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

No. This is an internal performance optimization only.

## Local benchmark snapshot

Built and run with `release-nonlto`, filtered to the new Float16 rows:

```bash
cargo bench -p datafusion-physical-expr --profile release-nonlto --bench in_list_strategy -- narrow_integer/f16 --save-baseline <baseline>
```

Compared baselines: [#23299](https://github.com/apache/datafusion/pull/23299) -> [#23311](https://github.com/apache/datafusion/pull/23311)

Method: directly compared Criterion's raw sample minima (`min(time / iterations)`) from `sample.json`. Lower is better; changes within +/-5% are treated as noise.

Summary: 6 relevant rows, 6 faster, 0 slower, 0 within +/-5%.

| Benchmark | [#23299](https://github.com/apache/datafusion/pull/23299) | [#23311](https://github.com/apache/datafusion/pull/23311) | Change |
|---|---:|---:|---:|
| `narrow_integer/f16/list=4/match=0%` | 19.582 us | 3.911 us | -80.0% (5.01x faster) |
| `narrow_integer/f16/list=4/match=50%` | 44.138 us | 3.871 us | -91.2% (11.40x faster) |
| `narrow_integer/f16/list=64/match=0%` | 19.977 us | 3.878 us | -80.6% (5.15x faster) |
| `narrow_integer/f16/list=64/match=50%` | 55.792 us | 3.903 us | -93.0% (14.29x faster) |
| `narrow_integer/f16/list=256/match=0%` | 21.727 us | 3.885 us | -82.1% (5.59x faster) |
| `narrow_integer/f16/list=256/match=50%` | 51.737 us | 3.918 us | -92.4% (13.21x faster) |
