### PR TITLE
chore: add Cargo http options to handle download errors

### DIFF
--- a/.github/actions/setup-rust-runtime/action.yaml
+++ b/.github/actions/setup-rust-runtime/action.yaml
@@ -35,6 +35,10 @@ runs:
         # failures from curl when cargo fetches crates from crates.io.
         # Disabling HTTP/2 multiplexing forces cargo to serialize requests,
         # and raising retries makes transient network hiccups self-heal.
+        #
+        # Reference:
+        # https://doc.rust-lang.org/cargo/reference/config.html?#httpmultiplexing
+        # https://doc.rust-lang.org/cargo/reference/config.html?#netretry
         echo "CARGO_HTTP_MULTIPLEXING=false" >> $GITHUB_ENV
         echo "CARGO_NET_RETRY=10" >> $GITHUB_ENV
         echo "CARGO_HTTP_RETRY=10" >> $GITHUB_ENV

--- a/.github/actions/setup-rust-runtime/action.yaml
+++ b/.github/actions/setup-rust-runtime/action.yaml
@@ -31,3 +31,10 @@ runs:
       run: |
         echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
         echo "RUSTFLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV
+        # Work around intermittent "[16] Error in the HTTP2 framing layer"
+        # failures from curl when cargo fetches crates from crates.io.
+        # Disabling HTTP/2 multiplexing forces cargo to serialize requests,
+        # and raising retries makes transient network hiccups self-heal.
+        echo "CARGO_HTTP_MULTIPLEXING=false" >> $GITHUB_ENV
+        echo "CARGO_NET_RETRY=10" >> $GITHUB_ENV
+        echo "CARGO_HTTP_RETRY=10" >> $GITHUB_ENV


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

CI more and more often fails with HTTP errors, during downloading from Cargo. This leads the entire CI needs to be rerun in the merge queue. Adding retry for Cargo HTTP and network settings.

Example 

https://github.com/apache/datafusion/actions/runs/28677739346/job/85055401549?pr=23313


```
error: failed to get `windows` as a dependency of package `sysinfo v0.39.5`
    ... which satisfies dependency `sysinfo = "^0.39.3"` (locked to 0.39.5) of package `datafusion v54.0.0 (/__w/datafusion/datafusion/datafusion/core)`

Caused by:
  failed to load source for dependency `windows`

Caused by:
  unable to update registry `crates-io`

Caused by:
  download of wi/nd/windows failed

Caused by:
  curl failed

Caused by:
  [55] Failed sending data to the peer (OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 0)
Error: Process completed with exit code 101.
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
