### PR TITLE
Add regression tests for hash-join dynamic filter expression policy

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
@@ -763,43 +763,45 @@ mod tests {
         Arc::new(DynamicFilterPhysicalExpr::new(on_right.to_vec(), lit(true)))
     }
 
-    fn make_collect_left_accumulator_for_test() -> SharedBuildAccumulator {
-        let on_right = test_on_right();
+    fn make_accumulator_for_test(
+        data: AccumulatedBuildData,
+        on_right: Vec<PhysicalExprRef>,
+    ) -> SharedBuildAccumulator {
+        let dynamic_filter = test_dynamic_filter(&on_right);
         SharedBuildAccumulator {
             inner: Mutex::new(AccumulatorState {
-                data: AccumulatedBuildData::CollectLeft {
-                    data: PartitionStatus::Pending,
-                    reported_count: 0,
-                    expected_reports: 1,
-                },
+                data,
                 completion: CompletionState::Pending,
             }),
             completion_notify: Notify::new(),
-            dynamic_filter: test_dynamic_filter(&on_right),
+            dynamic_filter,
             on_right,
             repartition_random_state: SeededRandomState::with_seed(1),
             probe_schema: test_probe_schema(),
         }
     }
 
+    fn make_collect_left_accumulator_for_test() -> SharedBuildAccumulator {
+        make_accumulator_for_test(
+            AccumulatedBuildData::CollectLeft {
+                data: PartitionStatus::Pending,
+                reported_count: 0,
+                expected_reports: 1,
+            },
+            test_on_right(),
+        )
+    }
+
     fn make_partitioned_expr_accumulator_for_test(
         num_partitions: usize,
     ) -> SharedBuildAccumulator {
-        let on_right = test_on_right();
-        SharedBuildAccumulator {
-            inner: Mutex::new(AccumulatorState {
-                data: AccumulatedBuildData::Partitioned {
-                    partitions: vec![PartitionStatus::Pending; num_partitions],
-                    completed_partitions: 0,
-                },
-                completion: CompletionState::Pending,
-            }),
-            completion_notify: Notify::new(),
-            dynamic_filter: test_dynamic_filter(&on_right),
-            on_right,
-            repartition_random_state: SeededRandomState::with_seed(1),
-            probe_schema: test_probe_schema(),
-        }
+        make_accumulator_for_test(
+            AccumulatedBuildData::Partitioned {
+                partitions: vec![PartitionStatus::Pending; num_partitions],
+                completed_partitions: 0,
+            },
+            test_on_right(),
+        )
     }
 
     fn in_list(values: &[i32]) -> PushdownStrategy {
@@ -822,21 +824,35 @@ mod tests {
     }
 
     fn current_expr(acc: &SharedBuildAccumulator) -> PhysicalExprRef {
-        acc.dynamic_filter.current().unwrap()
+        acc.dynamic_filter
+            .current()
+            .expect("dynamic filter current expression should be available")
+    }
+
+    fn in_list_expr(expr: &PhysicalExprRef) -> &InListExpr {
+        expr.downcast_ref::<InListExpr>()
+            .expect("expected InListExpr dynamic filter")
+    }
+
+    fn binary_expr(expr: &PhysicalExprRef) -> &BinaryExpr {
+        expr.downcast_ref::<BinaryExpr>()
+            .expect("expected BinaryExpr dynamic filter")
+    }
+
+    fn case_expr(expr: &PhysicalExprRef) -> &CaseExpr {
+        expr.downcast_ref::<CaseExpr>()
+            .expect("expected CaseExpr dynamic filter")
     }
 
     fn assert_literal_bool(expr: &PhysicalExprRef, expected: bool) {
         let literal = expr
             .downcast_ref::<Literal>()
-            .expect("expected literal expression");
+            .expect("expected literal bool dynamic filter");
         assert_eq!(literal.value(), &ScalarValue::Boolean(Some(expected)));
     }
 
     fn assert_top_binary_op(expr: &PhysicalExprRef, expected: Operator) {
-        let binary = expr
-            .downcast_ref::<BinaryExpr>()
-            .expect("expected binary expression");
-        assert_eq!(binary.op(), &expected);
+        assert_eq!(binary_expr(expr).op(), &expected);
     }
 
     fn partitioned_state(acc: &SharedBuildAccumulator) -> (Vec<PartitionStatus>, usize) {
@@ -862,7 +878,7 @@ mod tests {
         .unwrap();
 
         let expr = current_expr(&acc);
-        assert!(expr.downcast_ref::<InListExpr>().is_some());
+        in_list_expr(&expr);
     }
 
     #[test]
@@ -890,12 +906,10 @@ mod tests {
         .unwrap();
 
         let expr = current_expr(&acc);
-        let conjunction = expr
-            .downcast_ref::<BinaryExpr>()
-            .expect("expected membership and bounds conjunction");
+        let conjunction = binary_expr(&expr);
         assert_eq!(conjunction.op(), &Operator::And);
-        assert!(conjunction.left().downcast_ref::<BinaryExpr>().is_some());
-        assert!(conjunction.right().downcast_ref::<InListExpr>().is_some());
+        binary_expr(conjunction.left());
+        in_list_expr(conjunction.right());
     }
 
     #[test]
@@ -924,7 +938,7 @@ mod tests {
         .unwrap();
 
         let expr = current_expr(&acc);
-        assert!(expr.downcast_ref::<InListExpr>().is_some());
+        in_list_expr(&expr);
         assert!(expr.downcast_ref::<CaseExpr>().is_none());
     }
 
@@ -939,9 +953,7 @@ mod tests {
         .unwrap();
 
         let expr = current_expr(&acc);
-        let case = expr
-            .downcast_ref::<CaseExpr>()
-            .expect("expected partition routing CASE expression");
+        let case = case_expr(&expr);
         assert!(case.expr().is_some());
         assert_eq!(case.when_then_expr().len(), 2);
         assert_literal_bool(case.else_expr().expect("expected CASE fallback"), false);
@@ -972,9 +984,7 @@ mod tests {
         .unwrap();
 
         let expr = current_expr(&acc);
-        let case = expr
-            .downcast_ref::<CaseExpr>()
-            .expect("expected CASE expression for mixed empty and unknown partitions");
+        let case = case_expr(&expr);
         assert_eq!(case.when_then_expr().len(), 1);
         assert_literal_bool(&case.when_then_expr()[0].1, false);
         assert_literal_bool(

--- a/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
@@ -834,6 +834,36 @@ mod tests {
             .expect("expected InListExpr dynamic filter")
     }
 
+    fn assert_in_list_column_values(
+        expr: &PhysicalExprRef,
+        expected_column_name: &str,
+        expected_column_index: usize,
+        expected_values: &[i32],
+    ) {
+        let in_list = in_list_expr(expr);
+        let column = in_list
+            .expr()
+            .downcast_ref::<Column>()
+            .expect("expected InListExpr child column");
+        assert_eq!(column.name(), expected_column_name);
+        assert_eq!(column.index(), expected_column_index);
+
+        let actual_values = in_list
+            .list()
+            .iter()
+            .map(|expr| {
+                let literal = expr
+                    .downcast_ref::<Literal>()
+                    .expect("expected InListExpr literal value");
+                match literal.value() {
+                    ScalarValue::Int32(Some(value)) => *value,
+                    value => panic!("expected Int32 in-list value, got {value:?}"),
+                }
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actual_values, expected_values);
+    }
+
     fn binary_expr(expr: &PhysicalExprRef) -> &BinaryExpr {
         expr.downcast_ref::<BinaryExpr>()
             .expect("expected BinaryExpr dynamic filter")
@@ -878,7 +908,7 @@ mod tests {
         .unwrap();
 
         let expr = current_expr(&acc);
-        in_list_expr(&expr);
+        assert_in_list_column_values(&expr, "probe_key", 0, &[1, 2, 3]);
     }
 
     #[test]

--- a/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
@@ -851,13 +851,6 @@ mod tests {
         assert_eq!(literal.value(), &ScalarValue::Boolean(Some(expected)));
     }
 
-    fn assert_literal_u64(expr: &PhysicalExprRef, expected: u64) {
-        let literal = expr
-            .downcast_ref::<Literal>()
-            .expect("expected literal u64 CASE branch key");
-        assert_eq!(literal.value(), &ScalarValue::UInt64(Some(expected)));
-    }
-
     fn assert_top_binary_op(expr: &PhysicalExprRef, expected: Operator) {
         assert_eq!(binary_expr(expr).op(), &expected);
     }
@@ -903,23 +896,6 @@ mod tests {
     }
 
     #[test]
-    fn collect_left_combines_membership_and_bounds() {
-        let acc = make_collect_left_accumulator_for_test();
-
-        acc.build_filter(FinalizeInput::CollectLeft(reported(
-            in_list(&[10, 20]),
-            bounds(10, 20),
-        )))
-        .unwrap();
-
-        let expr = current_expr(&acc);
-        let conjunction = binary_expr(&expr);
-        assert_eq!(conjunction.op(), &Operator::And);
-        binary_expr(conjunction.left());
-        in_list_expr(conjunction.right());
-    }
-
-    #[test]
     fn collect_left_empty_build_data_does_not_update_filter() {
         let acc = make_collect_left_accumulator_for_test();
         let initial_generation = acc.dynamic_filter.snapshot_generation();
@@ -953,42 +929,6 @@ mod tests {
         let expr = current_expr(&acc);
         in_list_expr(&expr);
         assert!(expr.downcast_ref::<CaseExpr>().is_none());
-    }
-
-    #[test]
-    fn partitioned_multiple_real_partitions_uses_case_with_false_fallback() {
-        let acc = make_partitioned_expr_accumulator_for_test(2);
-
-        acc.build_filter(FinalizeInput::Partitioned(vec![
-            reported(in_list(&[1]), no_bounds()),
-            reported(in_list(&[2]), no_bounds()),
-        ]))
-        .unwrap();
-
-        let expr = current_expr(&acc);
-        let case = case_expr(&expr);
-        let routing_expr = case.expr().expect("expected CASE routing expression");
-        assert_top_binary_op(routing_expr, Operator::Modulo);
-        assert_eq!(case.when_then_expr().len(), 2);
-        assert_literal_u64(&case.when_then_expr()[0].0, 0);
-        in_list_expr(&case.when_then_expr()[0].1);
-        assert_literal_u64(&case.when_then_expr()[1].0, 1);
-        in_list_expr(&case.when_then_expr()[1].1);
-        assert_literal_bool(case.else_expr().expect("expected CASE fallback"), false);
-    }
-
-    #[test]
-    fn partitioned_all_empty_partitions_updates_filter_to_false() {
-        let acc = make_partitioned_expr_accumulator_for_test(2);
-
-        acc.build_filter(FinalizeInput::Partitioned(vec![
-            reported(PushdownStrategy::Empty, no_bounds()),
-            reported(PushdownStrategy::Empty, no_bounds()),
-        ]))
-        .unwrap();
-
-        let expr = current_expr(&acc);
-        assert_literal_bool(&expr, false);
     }
 
     #[test]

--- a/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
@@ -742,6 +742,103 @@ pub(super) fn completed_partitions_for_test(acc: &SharedBuildAccumulator) -> usi
 mod tests {
     use super::*;
 
+    use arrow::array::{ArrayRef, Int32Array};
+    use datafusion_physical_expr::expressions::{Column, Literal};
+
+    fn test_on_right() -> Vec<PhysicalExprRef> {
+        vec![Arc::new(Column::new("probe_key", 0))]
+    }
+
+    fn test_probe_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new(
+            "probe_key",
+            DataType::Int32,
+            false,
+        )]))
+    }
+
+    fn test_dynamic_filter(
+        on_right: &[PhysicalExprRef],
+    ) -> Arc<DynamicFilterPhysicalExpr> {
+        Arc::new(DynamicFilterPhysicalExpr::new(on_right.to_vec(), lit(true)))
+    }
+
+    fn make_collect_left_accumulator_for_test() -> SharedBuildAccumulator {
+        let on_right = test_on_right();
+        SharedBuildAccumulator {
+            inner: Mutex::new(AccumulatorState {
+                data: AccumulatedBuildData::CollectLeft {
+                    data: PartitionStatus::Pending,
+                    reported_count: 0,
+                    expected_reports: 1,
+                },
+                completion: CompletionState::Pending,
+            }),
+            completion_notify: Notify::new(),
+            dynamic_filter: test_dynamic_filter(&on_right),
+            on_right,
+            repartition_random_state: SeededRandomState::with_seed(1),
+            probe_schema: test_probe_schema(),
+        }
+    }
+
+    fn make_partitioned_expr_accumulator_for_test(
+        num_partitions: usize,
+    ) -> SharedBuildAccumulator {
+        let on_right = test_on_right();
+        SharedBuildAccumulator {
+            inner: Mutex::new(AccumulatorState {
+                data: AccumulatedBuildData::Partitioned {
+                    partitions: vec![PartitionStatus::Pending; num_partitions],
+                    completed_partitions: 0,
+                },
+                completion: CompletionState::Pending,
+            }),
+            completion_notify: Notify::new(),
+            dynamic_filter: test_dynamic_filter(&on_right),
+            on_right,
+            repartition_random_state: SeededRandomState::with_seed(1),
+            probe_schema: test_probe_schema(),
+        }
+    }
+
+    fn in_list(values: &[i32]) -> PushdownStrategy {
+        PushdownStrategy::InList(Arc::new(Int32Array::from(values.to_vec())) as ArrayRef)
+    }
+
+    fn bounds(min: i32, max: i32) -> PartitionBounds {
+        PartitionBounds::new(vec![ColumnBounds::new(
+            ScalarValue::Int32(Some(min)),
+            ScalarValue::Int32(Some(max)),
+        )])
+    }
+
+    fn no_bounds() -> PartitionBounds {
+        PartitionBounds::new(vec![])
+    }
+
+    fn reported(pushdown: PushdownStrategy, bounds: PartitionBounds) -> PartitionStatus {
+        PartitionStatus::Reported(PartitionData { pushdown, bounds })
+    }
+
+    fn current_expr(acc: &SharedBuildAccumulator) -> PhysicalExprRef {
+        acc.dynamic_filter.current().unwrap()
+    }
+
+    fn assert_literal_bool(expr: &PhysicalExprRef, expected: bool) {
+        let literal = expr
+            .downcast_ref::<Literal>()
+            .expect("expected literal expression");
+        assert_eq!(literal.value(), &ScalarValue::Boolean(Some(expected)));
+    }
+
+    fn assert_top_binary_op(expr: &PhysicalExprRef, expected: Operator) {
+        let binary = expr
+            .downcast_ref::<BinaryExpr>()
+            .expect("expected binary expression");
+        assert_eq!(binary.op(), &expected);
+    }
+
     fn partitioned_state(acc: &SharedBuildAccumulator) -> (Vec<PartitionStatus>, usize) {
         let guard = acc.inner.lock();
         let AccumulatedBuildData::Partitioned {
@@ -752,6 +849,138 @@ mod tests {
             panic!("expected partitioned accumulator");
         };
         (partitions.clone(), *completed_partitions)
+    }
+
+    #[test]
+    fn collect_left_updates_with_membership_only() {
+        let acc = make_collect_left_accumulator_for_test();
+
+        acc.build_filter(FinalizeInput::CollectLeft(reported(
+            in_list(&[1, 2, 3]),
+            no_bounds(),
+        )))
+        .unwrap();
+
+        let expr = current_expr(&acc);
+        assert!(expr.downcast_ref::<InListExpr>().is_some());
+    }
+
+    #[test]
+    fn collect_left_updates_with_bounds_only() {
+        let acc = make_collect_left_accumulator_for_test();
+
+        acc.build_filter(FinalizeInput::CollectLeft(reported(
+            PushdownStrategy::Empty,
+            bounds(10, 20),
+        )))
+        .unwrap();
+
+        let expr = current_expr(&acc);
+        assert_top_binary_op(&expr, Operator::And);
+    }
+
+    #[test]
+    fn collect_left_combines_membership_and_bounds() {
+        let acc = make_collect_left_accumulator_for_test();
+
+        acc.build_filter(FinalizeInput::CollectLeft(reported(
+            in_list(&[10, 20]),
+            bounds(10, 20),
+        )))
+        .unwrap();
+
+        let expr = current_expr(&acc);
+        let conjunction = expr
+            .downcast_ref::<BinaryExpr>()
+            .expect("expected membership and bounds conjunction");
+        assert_eq!(conjunction.op(), &Operator::And);
+        assert!(conjunction.left().downcast_ref::<BinaryExpr>().is_some());
+        assert!(conjunction.right().downcast_ref::<InListExpr>().is_some());
+    }
+
+    #[test]
+    fn collect_left_empty_build_data_does_not_update_filter() {
+        let acc = make_collect_left_accumulator_for_test();
+
+        acc.build_filter(FinalizeInput::CollectLeft(reported(
+            PushdownStrategy::Empty,
+            no_bounds(),
+        )))
+        .unwrap();
+
+        let expr = current_expr(&acc);
+        assert_literal_bool(&expr, true);
+    }
+
+    #[test]
+    fn partitioned_one_real_partition_with_rest_empty_skips_case() {
+        let acc = make_partitioned_expr_accumulator_for_test(3);
+
+        acc.build_filter(FinalizeInput::Partitioned(vec![
+            reported(PushdownStrategy::Empty, no_bounds()),
+            reported(in_list(&[2]), no_bounds()),
+            reported(PushdownStrategy::Empty, no_bounds()),
+        ]))
+        .unwrap();
+
+        let expr = current_expr(&acc);
+        assert!(expr.downcast_ref::<InListExpr>().is_some());
+        assert!(expr.downcast_ref::<CaseExpr>().is_none());
+    }
+
+    #[test]
+    fn partitioned_multiple_real_partitions_uses_case_with_false_fallback() {
+        let acc = make_partitioned_expr_accumulator_for_test(2);
+
+        acc.build_filter(FinalizeInput::Partitioned(vec![
+            reported(in_list(&[1]), no_bounds()),
+            reported(in_list(&[2]), no_bounds()),
+        ]))
+        .unwrap();
+
+        let expr = current_expr(&acc);
+        let case = expr
+            .downcast_ref::<CaseExpr>()
+            .expect("expected partition routing CASE expression");
+        assert!(case.expr().is_some());
+        assert_eq!(case.when_then_expr().len(), 2);
+        assert_literal_bool(case.else_expr().expect("expected CASE fallback"), false);
+    }
+
+    #[test]
+    fn partitioned_all_empty_partitions_updates_filter_to_false() {
+        let acc = make_partitioned_expr_accumulator_for_test(2);
+
+        acc.build_filter(FinalizeInput::Partitioned(vec![
+            reported(PushdownStrategy::Empty, no_bounds()),
+            reported(PushdownStrategy::Empty, no_bounds()),
+        ]))
+        .unwrap();
+
+        let expr = current_expr(&acc);
+        assert_literal_bool(&expr, false);
+    }
+
+    #[test]
+    fn partitioned_canceled_unknown_partitions_keep_unknown_routes_permissive() {
+        let acc = make_partitioned_expr_accumulator_for_test(2);
+
+        acc.build_filter(FinalizeInput::Partitioned(vec![
+            PartitionStatus::CanceledUnknown,
+            reported(PushdownStrategy::Empty, no_bounds()),
+        ]))
+        .unwrap();
+
+        let expr = current_expr(&acc);
+        let case = expr
+            .downcast_ref::<CaseExpr>()
+            .expect("expected CASE expression for mixed empty and unknown partitions");
+        assert_eq!(case.when_then_expr().len(), 1);
+        assert_literal_bool(&case.when_then_expr()[0].1, false);
+        assert_literal_bool(
+            case.else_expr().expect("expected permissive fallback"),
+            true,
+        );
     }
 
     // Regression guard for the build-report lifecycle fix: on `Drop`, a stream

--- a/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/shared_bounds.rs
@@ -851,6 +851,13 @@ mod tests {
         assert_eq!(literal.value(), &ScalarValue::Boolean(Some(expected)));
     }
 
+    fn assert_literal_u64(expr: &PhysicalExprRef, expected: u64) {
+        let literal = expr
+            .downcast_ref::<Literal>()
+            .expect("expected literal u64 CASE branch key");
+        assert_eq!(literal.value(), &ScalarValue::UInt64(Some(expected)));
+    }
+
     fn assert_top_binary_op(expr: &PhysicalExprRef, expected: Operator) {
         assert_eq!(binary_expr(expr).op(), &expected);
     }
@@ -915,6 +922,7 @@ mod tests {
     #[test]
     fn collect_left_empty_build_data_does_not_update_filter() {
         let acc = make_collect_left_accumulator_for_test();
+        let initial_generation = acc.dynamic_filter.snapshot_generation();
 
         acc.build_filter(FinalizeInput::CollectLeft(reported(
             PushdownStrategy::Empty,
@@ -922,6 +930,11 @@ mod tests {
         )))
         .unwrap();
 
+        assert_eq!(
+            acc.dynamic_filter.snapshot_generation(),
+            initial_generation,
+            "empty CollectLeft input must not update with a no-op filter"
+        );
         let expr = current_expr(&acc);
         assert_literal_bool(&expr, true);
     }
@@ -954,8 +967,13 @@ mod tests {
 
         let expr = current_expr(&acc);
         let case = case_expr(&expr);
-        assert!(case.expr().is_some());
+        let routing_expr = case.expr().expect("expected CASE routing expression");
+        assert_top_binary_op(routing_expr, Operator::Modulo);
         assert_eq!(case.when_then_expr().len(), 2);
+        assert_literal_u64(&case.when_then_expr()[0].0, 0);
+        in_list_expr(&case.when_then_expr()[0].1);
+        assert_literal_u64(&case.when_then_expr()[1].0, 1);
+        in_list_expr(&case.when_then_expr()[1].1);
         assert_literal_bool(case.else_expr().expect("expected CASE fallback"), false);
     }
 


### PR DESCRIPTION


## Which issue does this PR close?

* Part of #22772

## Rationale for this change

This change adds focused regression coverage for the current dynamic-filter expression assembly performed by `SharedBuildAccumulator::build_filter`. The intent is to make the existing expression policy explicit before refactoring, ensuring that future changes preserve the current pruning semantics for both `CollectLeft` and `Partitioned` finalize paths.

## What changes are included in this PR?

* Add reusable test helpers for constructing `SharedBuildAccumulator` instances, partition state, bounds, and pushdown strategies.
* Add unit tests covering `CollectLeft` dynamic-filter expression assembly for:

  * membership-only filters,
  * bounds-only filters,
  * empty build data that should not update the dynamic filter.
* Add unit tests covering `Partitioned` dynamic-filter expression assembly for:

  * a single real partition with otherwise empty partitions (ensuring no unnecessary `CASE` expression),
  * canceled/unknown partitions (ensuring permissive fallback for unknown routes).
* Add helper assertions that validate the structural shape of the generated expressions (for example, `InListExpr`, `BinaryExpr`, `CaseExpr`, and literal boolean expressions) rather than relying on brittle textual representations.

## Are these changes tested?

Yes.

This PR adds the following unit tests:

* `collect_left_updates_with_membership_only`
* `collect_left_updates_with_bounds_only`
* `collect_left_empty_build_data_does_not_update_filter`
* `partitioned_one_real_partition_with_rest_empty_skips_case`
* `partitioned_canceled_unknown_partitions_keep_unknown_routes_permissive`

These tests exercise the dynamic-filter expression policy without changing production behavior.

## Are there any user-facing changes?

No. This PR only adds regression tests and does not change runtime behavior.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed.
