### PR TITLE
fix: gate debug-only assertions in physical planner test test_optimization_invariant_checker

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -4681,10 +4681,8 @@ digraph {
     }
 
     /// Extension Node which fails the [`OptimizationInvariantChecker`].
-    #[cfg(debug_assertions)]
     #[derive(Debug)]
     struct InvariantFailsExtensionNode;
-    #[cfg(debug_assertions)]
     impl ExecutionPlan for InvariantFailsExtensionNode {
         fn name(&self) -> &str {
             "InvariantFailsExtensionNode"
@@ -4722,7 +4720,6 @@ digraph {
             unimplemented!()
         }
     }
-    #[cfg(debug_assertions)]
     impl DisplayAs for InvariantFailsExtensionNode {
         fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "{}", self.name())
@@ -4773,33 +4770,36 @@ digraph {
             .unwrap_err();
         assert!(expected_err.to_string().contains("PhysicalOptimizer rule 'OptimizerRuleWithSchemaCheck' failed. Schema mismatch. Expected original schema"));
 
-        // These checks rely on the recursive `check_invariants` walk, which only
-        // runs under `debug_assertions` (see `OptimizationInvariantChecker::check`).
-        #[cfg(debug_assertions)]
-        {
-            // Test: should fail when extension node fails it's own invariant check
-            let failing_node: Arc<dyn ExecutionPlan> =
-                Arc::new(InvariantFailsExtensionNode);
-            let expected_err = OptimizationInvariantChecker::new(&rule)
-                .check(&failing_node, &ok_plan.schema())
-                .unwrap_err();
-            assert!(expected_err.to_string().contains(
-                "extension node failed it's user-defined always-invariant check"
-            ));
+        // The recursive `check_invariants` walk only runs under `debug_assertions`
+        // (see `OptimizationInvariantChecker::check`). In release builds the walk is
+        // skipped, so the checker returns `Ok` rather than surfacing the node's error.
 
-            // Test: should fail when descendent extension node fails
-            let failing_node: Arc<dyn ExecutionPlan> =
-                Arc::new(InvariantFailsExtensionNode);
-            let invalid_plan = ok_node.with_new_children(vec![
-                Arc::clone(&child).with_new_children(vec![Arc::clone(&failing_node)])?,
-                Arc::clone(&child),
-            ])?;
-            let expected_err = OptimizationInvariantChecker::new(&rule)
-                .check(&invalid_plan, &ok_plan.schema())
-                .unwrap_err();
-            assert!(expected_err.to_string().contains(
+        // Test: should fail when extension node fails it's own invariant check
+        let failing_node: Arc<dyn ExecutionPlan> = Arc::new(InvariantFailsExtensionNode);
+        let result = OptimizationInvariantChecker::new(&rule)
+            .check(&failing_node, &ok_plan.schema());
+        if cfg!(debug_assertions) {
+            assert!(result.unwrap_err().to_string().contains(
                 "extension node failed it's user-defined always-invariant check"
             ));
+        } else {
+            assert!(result.is_ok());
+        }
+
+        // Test: should fail when descendent extension node fails
+        let failing_node: Arc<dyn ExecutionPlan> = Arc::new(InvariantFailsExtensionNode);
+        let invalid_plan = ok_node.with_new_children(vec![
+            Arc::clone(&child).with_new_children(vec![Arc::clone(&failing_node)])?,
+            Arc::clone(&child),
+        ])?;
+        let result = OptimizationInvariantChecker::new(&rule)
+            .check(&invalid_plan, &ok_plan.schema());
+        if cfg!(debug_assertions) {
+            assert!(result.unwrap_err().to_string().contains(
+                "extension node failed it's user-defined always-invariant check"
+            ));
+        } else {
+            assert!(result.is_ok());
         }
 
         Ok(())

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -4681,8 +4681,10 @@ digraph {
     }
 
     /// Extension Node which fails the [`OptimizationInvariantChecker`].
+    #[cfg(debug_assertions)]
     #[derive(Debug)]
     struct InvariantFailsExtensionNode;
+    #[cfg(debug_assertions)]
     impl ExecutionPlan for InvariantFailsExtensionNode {
         fn name(&self) -> &str {
             "InvariantFailsExtensionNode"
@@ -4720,6 +4722,7 @@ digraph {
             unimplemented!()
         }
     }
+    #[cfg(debug_assertions)]
     impl DisplayAs for InvariantFailsExtensionNode {
         fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "{}", self.name())
@@ -4770,31 +4773,34 @@ digraph {
             .unwrap_err();
         assert!(expected_err.to_string().contains("PhysicalOptimizer rule 'OptimizerRuleWithSchemaCheck' failed. Schema mismatch. Expected original schema"));
 
-        // Test: should fail when extension node fails it's own invariant check
-        let failing_node: Arc<dyn ExecutionPlan> = Arc::new(InvariantFailsExtensionNode);
-        let expected_err = OptimizationInvariantChecker::new(&rule)
-            .check(&failing_node, &ok_plan.schema())
-            .unwrap_err();
-        assert!(
-            expected_err.to_string().contains(
+        // These checks rely on the recursive `check_invariants` walk, which only
+        // runs under `debug_assertions` (see `OptimizationInvariantChecker::check`).
+        #[cfg(debug_assertions)]
+        {
+            // Test: should fail when extension node fails it's own invariant check
+            let failing_node: Arc<dyn ExecutionPlan> =
+                Arc::new(InvariantFailsExtensionNode);
+            let expected_err = OptimizationInvariantChecker::new(&rule)
+                .check(&failing_node, &ok_plan.schema())
+                .unwrap_err();
+            assert!(expected_err.to_string().contains(
                 "extension node failed it's user-defined always-invariant check"
-            )
-        );
+            ));
 
-        // Test: should fail when descendent extension node fails
-        let failing_node: Arc<dyn ExecutionPlan> = Arc::new(InvariantFailsExtensionNode);
-        let invalid_plan = ok_node.with_new_children(vec![
-            Arc::clone(&child).with_new_children(vec![Arc::clone(&failing_node)])?,
-            Arc::clone(&child),
-        ])?;
-        let expected_err = OptimizationInvariantChecker::new(&rule)
-            .check(&invalid_plan, &ok_plan.schema())
-            .unwrap_err();
-        assert!(
-            expected_err.to_string().contains(
+            // Test: should fail when descendent extension node fails
+            let failing_node: Arc<dyn ExecutionPlan> =
+                Arc::new(InvariantFailsExtensionNode);
+            let invalid_plan = ok_node.with_new_children(vec![
+                Arc::clone(&child).with_new_children(vec![Arc::clone(&failing_node)])?,
+                Arc::clone(&child),
+            ])?;
+            let expected_err = OptimizationInvariantChecker::new(&rule)
+                .check(&invalid_plan, &ok_plan.schema())
+                .unwrap_err();
+            assert!(expected_err.to_string().contains(
                 "extension node failed it's user-defined always-invariant check"
-            )
-        );
+            ));
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #20786

## Rationale for this change
`test_optimization_invariant_checker` panics under `release-nonlto` profile which has debug_assertions=false. Thus, we need to gate

## What changes are included in this PR?
Make sure debug_assertion required places are behind that gate

## Are these changes tested?
Yes and this is test only change.

```
cargo test physical_planner --profile release-nonlto
```

now passes since we skip these checks as they are not supported in that profile

## Are there any user-facing changes?
No