### PR TITLE
feat: Support BinaryView type in approx_distinct

### DIFF
--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -785,6 +785,7 @@ impl AggregateUDFImpl for ApproxDistinct {
             | DataType::LargeUtf8
             | DataType::Utf8View
             | DataType::Binary
+            | DataType::BinaryView
             | DataType::LargeBinary => Box::new(HLLAccumulator::new()),
             DataType::Null => {
                 Box::new(NoopAccumulator::new(ScalarValue::UInt64(Some(0))))
@@ -852,6 +853,7 @@ fn is_hll_groups_type(data_type: &DataType) -> bool {
             | DataType::LargeUtf8
             | DataType::Utf8View
             | DataType::Binary
+            | DataType::BinaryView
             | DataType::LargeBinary
     )
 }

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1936,6 +1936,23 @@ SELECT g, approx_distinct(arrow_cast(s, 'Utf8View')) FROM approx_distinct_group_
 3 0
 4 1
 
+# BinaryView non-grouped
+query I
+SELECT approx_distinct(arrow_cast(arrow_cast(s, 'Binary'), 'BinaryView')) FROM approx_distinct_group_test WHERE g = 2;
+----
+2
+
+
+# BinaryView grouped
+query II
+SELECT g, approx_distinct(arrow_cast(arrow_cast(s, 'Binary'), 'BinaryView')) FROM approx_distinct_group_test GROUP BY g ORDER BY g;
+----
+1 2
+2 2
+3 0
+4 1
+
+
 # Integers (Int32): group 1 -> {10,20}=2, group 2 -> {30,40}=2, group 3 -> 0, group 4 -> {50}=1
 query II
 SELECT g, approx_distinct(i) FROM approx_distinct_group_test GROUP BY g ORDER BY g;


### PR DESCRIPTION
## Which issue does this PR close?

- Relates to https://github.com/apache/datafusion/issues/22989 but does not close it. More types are coming.


## Rationale for this change

- Support the `BinaryView` type for `approx_distinct`
- The Arrow type `BinaryView` can be directly supported for `HLLAccumulator` and `HllGroupsAccumulator`

## What changes are included in this PR?

- Enable `HLLAccumulator` and `HllGroupsAccumulator` to support `BinaryView`
- Tests for the non-grouped and grouped path as part of `aggregate.slt` 

## Are these changes tested?

Yes

## Are there any user-facing changes?

Yes, `approx_distinct` supports now `BinaryView` but no breaking changes.

