### PR TITLE
[branch-54] fix: Avoid panicing when stats are not available for a file group split (backport #23277)

### DIFF
--- a/datafusion/datasource/src/statistics.rs
+++ b/datafusion/datasource/src/statistics.rs
@@ -97,8 +97,16 @@ impl MinMaxStatistics {
                             .zip(s.column_statistics[i].max_value.get_value().cloned())
                             .ok_or_else(|| plan_datafusion_err!("statistics not found"))
                     } else {
-                        let partition_value = &pv[i - s.column_statistics.len()];
-                        Ok((partition_value.clone(), partition_value.clone()))
+                        if let Some(partition_value) =
+                            pv.get(i - s.column_statistics.len())
+                        {
+                            Ok((partition_value.clone(), partition_value.clone()))
+                        } else {
+                            Err(plan_datafusion_err!(
+                                "statistics not found for partition, expected at most {}",
+                                s.column_statistics.len()
+                            ))
+                        }
                     }
                 })
                 .collect::<Result<Vec<_>>>()?
@@ -889,5 +897,32 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn min_max_statistics_missing_column_stats_returns_error() {
+        let schema = test_schema();
+        let sort_order =
+            [PhysicalSortExpr::new_default(Arc::new(Column::new("a", 0)))].into();
+        let files = [
+            file_with_stats("f1.parquet", Statistics::default()),
+            file_with_stats("f2.parquet", Statistics::default()),
+        ];
+
+        let err = match MinMaxStatistics::new_from_files(
+            &sort_order,
+            &schema,
+            None,
+            files.iter(),
+        ) {
+            Ok(_) => panic!("expected missing statistics error"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("statistics not found for partition"),
+            "unexpected error: {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Backport of #23277 to `branch-54` (for 54.1.0, tracked in #22547).

Clean cherry-pick, all tests pass.