### PR TITLE
Perf: Short circuit expensive comparissions in GroupColumn 

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -215,6 +215,11 @@ pub struct GroupValuesColumn<const STREAMING: bool> {
     /// [`GroupValuesRows`]: crate::aggregates::group_values::GroupValuesRows
     group_values: Vec<Box<dyn GroupColumn>>,
 
+    /// Indices into `group_values` ordered cheapest → most expensive comparison
+    /// cost. Built once in `try_new` from the schema so that `vectorized_equal_to`
+    /// eliminates rows with cheap columns before paying the cost of expensive ones.
+    compare_order: Vec<usize>,
+
     /// reused buffer to store hashes
     hashes_buffer: Vec<u64>,
 
@@ -273,6 +278,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
     pub fn try_new(schema: SchemaRef) -> Result<Self> {
         let map = HashTable::with_capacity(0);
         let group_values = Self::build_group_columns(&schema)?;
+        let compare_order = Self::build_group_compare_order(&schema);
         Ok(Self {
             schema,
             map,
@@ -281,6 +287,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
             vectorized_operation_buffers: VectorizedOperationBuffers::default(),
             map_size: 0,
             group_values,
+            compare_order,
             hashes_buffer: Default::default(),
             random_state: crate::aggregates::AGGREGATION_HASH_SEED,
         })
@@ -293,6 +300,12 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
     /// `clear_shrink`). Centralising it keeps the post-condition that
     /// `self.group_values` always contains exactly one builder per schema
     /// field outside of those transient drain points.
+    fn build_group_compare_order(schema: &Schema) -> Vec<usize> {
+        let mut order: Vec<usize> = (0..schema.fields().len()).collect();
+        order.sort_by_key(|&i| compare_tier(schema.field(i).data_type()));
+        order
+    }
+
     fn build_group_columns(schema: &Schema) -> Result<Vec<Box<dyn GroupColumn>>> {
         let mut v: Vec<Box<dyn GroupColumn>> = Vec::with_capacity(schema.fields().len());
         for f in schema.fields().iter() {
@@ -651,8 +664,8 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         equal_to_results.truncate(0);
         equal_to_results.append_n(n, true);
 
-        for (col_idx, group_col) in self.group_values.iter().enumerate() {
-            group_col.vectorized_equal_to(
+        for &col_idx in &self.compare_order {
+            self.group_values[col_idx].vectorized_equal_to(
                 &self.vectorized_operation_buffers.equal_to_group_indices,
                 &cols[col_idx],
                 &self.vectorized_operation_buffers.equal_to_row_indices,
@@ -1075,6 +1088,35 @@ fn make_group_column(field: &Field) -> Result<Box<dyn GroupColumn>> {
         "make_group_column must push exactly one builder"
     );
     Ok(v.into_iter().next().unwrap())
+}
+/// Returns a comparison cost tier for `data_type` (1 = cheapest, 5 = most expensive).
+/// Used to order columns in [`GroupValuesColumn::compare_order`] so cheap comparisons
+/// eliminate rows before expensive ones are evaluated.
+/// see https://github.com/apache/datafusion/issues/23342
+fn compare_tier(data_type: &DataType) -> u8 {
+    match data_type {
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Timestamp(_, _) => 1,
+        DataType::Float32 | DataType::Float64 => 2,
+        DataType::Decimal128(_, _) | DataType::Boolean => 3,
+        DataType::Utf8View | DataType::BinaryView => 4,
+        DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Binary
+        | DataType::LargeBinary => 5,
+        _ => u8::MAX,
+    }
 }
 
 impl<const STREAMING: bool> GroupValues for GroupValuesColumn<STREAMING> {

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -864,7 +864,12 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
             for &group_idx in group_index_list {
                 let mut check_result = true;
                 for &i in &self.compare_order {
-                    if !check_row_equal(self.group_values[i].as_ref(), group_idx, &cols[i], row) {
+                    if !check_row_equal(
+                        self.group_values[i].as_ref(),
+                        group_idx,
+                        &cols[i],
+                        row,
+                    ) {
                         check_result = false;
                         break;
                     }
@@ -881,7 +886,12 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         } else {
             let group_idx = group_index_view.value() as usize;
             for &i in &self.compare_order {
-                if !check_row_equal(self.group_values[i].as_ref(), group_idx, &cols[i], row) {
+                if !check_row_equal(
+                    self.group_values[i].as_ref(),
+                    group_idx,
+                    &cols[i],
+                    row,
+                ) {
                     return false;
                 }
             }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -215,7 +215,7 @@ pub struct GroupValuesColumn<const STREAMING: bool> {
     /// [`GroupValuesRows`]: crate::aggregates::group_values::GroupValuesRows
     group_values: Vec<Box<dyn GroupColumn>>,
 
-    /// Indices into `group_values` ordered cheapest → most expensive comparison
+    /// Indices into `group_values` ordered cheapest to most expensive comparison
     /// cost. Built once in `try_new` from the schema so that `vectorized_equal_to`
     /// eliminates rows with cheap columns before paying the cost of expensive ones.
     compare_order: Vec<usize>,

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -300,18 +300,23 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
     /// `clear_shrink`). Centralising it keeps the post-condition that
     /// `self.group_values` always contains exactly one builder per schema
     /// field outside of those transient drain points.
-    fn build_group_compare_order(schema: &Schema) -> Vec<usize> {
-        let mut order: Vec<usize> = (0..schema.fields().len()).collect();
-        order.sort_by_key(|&i| compare_tier(schema.field(i).data_type()));
-        order
-    }
-
     fn build_group_columns(schema: &Schema) -> Result<Vec<Box<dyn GroupColumn>>> {
         let mut v: Vec<Box<dyn GroupColumn>> = Vec::with_capacity(schema.fields().len());
         for f in schema.fields().iter() {
             v.push(make_group_column(f.as_ref())?);
         }
         Ok(v)
+    }
+
+    /// Returns column indices sorted by cheapest-to-compare tier first.
+    ///
+    /// Uses a stable sort so columns within the same tier retain schema order,
+    /// keeping comparison deterministic and preventing `sort_unstable_by_key`
+    /// from silently breaking that invariant.
+    fn build_group_compare_order(schema: &Schema) -> Vec<usize> {
+        let mut order: Vec<usize> = (0..schema.fields().len()).collect();
+        order.sort_by_key(|&i| compare_tier(schema.field(i).data_type()));
+        order
     }
 
     // ========================================================================
@@ -397,9 +402,9 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
                         array_row.equal_to(lhs_row, array, rhs_row)
                     }
 
-                    for (i, group_val) in self.group_values.iter().enumerate() {
+                    for &i in &self.compare_order {
                         if !check_row_equal(
-                            group_val.as_ref(),
+                            self.group_values[i].as_ref(),
                             group_idx_view.value() as usize,
                             &cols[i],
                             row,
@@ -858,8 +863,8 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
 
             for &group_idx in group_index_list {
                 let mut check_result = true;
-                for (i, group_val) in self.group_values.iter().enumerate() {
-                    if !check_row_equal(group_val.as_ref(), group_idx, &cols[i], row) {
+                for &i in &self.compare_order {
+                    if !check_row_equal(self.group_values[i].as_ref(), group_idx, &cols[i], row) {
                         check_result = false;
                         break;
                     }
@@ -875,8 +880,8 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
             false
         } else {
             let group_idx = group_index_view.value() as usize;
-            for (i, group_val) in self.group_values.iter().enumerate() {
-                if !check_row_equal(group_val.as_ref(), group_idx, &cols[i], row) {
+            for &i in &self.compare_order {
+                if !check_row_equal(self.group_values[i].as_ref(), group_idx, &cols[i], row) {
                     return false;
                 }
             }
@@ -1120,6 +1125,10 @@ fn compare_tier(data_type: &DataType) -> u8 {
         | DataType::LargeBinary
         | DataType::Utf8View
         | DataType::BinaryView => 2,
+        // Unreachable in practice: `try_new` runs `build_group_columns` before
+        // `build_group_compare_order`, and `make_group_column` rejects any type
+        // not listed above. Acts as a catch-all so newly added types sort last
+        // rather than causing a compile error if this match isn't updated.
         _ => 3,
     }
 }
@@ -1994,5 +2003,19 @@ mod tests {
             |(hash, _)| *hash,
             &mut group_values.map_size,
         );
+    }
+
+    #[test]
+    fn compare_order_puts_cheap_columns_first() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("s", DataType::Utf8, false),
+            Field::new("i", DataType::Int64, false),
+            Field::new("v", DataType::Utf8View, false),
+            Field::new("b", DataType::Boolean, false),
+        ]));
+        let order = GroupValuesColumn::<false>::build_group_compare_order(&schema);
+        let pos = |i: usize| order.iter().position(|&x| x == i).unwrap();
+        assert!(pos(1) < pos(0), "int should come before utf8");
+        assert!(pos(3) < pos(2), "bool should come before utf8view");
     }
 }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -1089,12 +1089,13 @@ fn make_group_column(field: &Field) -> Result<Box<dyn GroupColumn>> {
     );
     Ok(v.into_iter().next().unwrap())
 }
-/// Returns a comparison cost tier for `data_type` (1 = cheapest, 5 = most expensive).
+/// Returns a comparison cost tier for `data_type` (1 = cheapest, 3 = most expensive).
 /// Used to order columns in [`GroupValuesColumn::compare_order`] so cheap comparisons
 /// eliminate rows before expensive ones are evaluated.
 /// see <https://github.com/apache/datafusion/issues/23342>
 fn compare_tier(data_type: &DataType) -> u8 {
     match data_type {
+        // Fixed-width numeric types and booleans: single word comparison.
         DataType::Int8
         | DataType::Int16
         | DataType::Int32
@@ -1103,19 +1104,23 @@ fn compare_tier(data_type: &DataType) -> u8 {
         | DataType::UInt16
         | DataType::UInt32
         | DataType::UInt64
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Decimal128(_, _)
         | DataType::Date32
         | DataType::Date64
         | DataType::Time32(_)
         | DataType::Time64(_)
-        | DataType::Timestamp(_, _) => 1,
-        DataType::Float32 | DataType::Float64 => 2,
-        DataType::Decimal128(_, _) | DataType::Boolean => 3,
-        DataType::Utf8View | DataType::BinaryView => 4,
+        | DataType::Timestamp(_, _)
+        | DataType::Boolean => 1,
+        // Variable-length binary and string blobs. pointer chasing
         DataType::Utf8
         | DataType::LargeUtf8
         | DataType::Binary
-        | DataType::LargeBinary => 5,
-        _ => u8::MAX,
+        | DataType::LargeBinary
+        | DataType::Utf8View
+        | DataType::BinaryView => 2,
+        _ => 3,
     }
 }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -1092,7 +1092,7 @@ fn make_group_column(field: &Field) -> Result<Box<dyn GroupColumn>> {
 /// Returns a comparison cost tier for `data_type` (1 = cheapest, 5 = most expensive).
 /// Used to order columns in [`GroupValuesColumn::compare_order`] so cheap comparisons
 /// eliminate rows before expensive ones are evaluated.
-/// see https://github.com/apache/datafusion/issues/23342
+/// see <https://github.com/apache/datafusion/issues/23342>
 fn compare_tier(data_type: &DataType) -> u8 {
     match data_type {
         DataType::Int8


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23342.

## Rationale for this change
see #23342 

**Note** : the exact ranking here is a bit arbitrary & i'm happy to change it. The core idea is that its much cheaper to do boolean checks and fixed size byte comparisons as opposed to chasing pointers to comparing strings. 
an alternative approach may be to split this into two tiers:
1. ints/bools/floats/  
2. bytes data


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Add `compare_tier()` to rank each supported DataType by comparison cost (1 = cheap fixed-width integers → 3 = expensive variable-length bytes)
- Add `compare_order`: Vec<usize> to GroupValuesColumn, built once at construction via `build_group_compare_order()`, so `vectorized_equal_to` evaluates columns cheapest-first and maximizes early-exit savings before reaching expensive string comparisons
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
This PR only change the order in which comparisons occurs. functionally nothing changes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
