### PR TITLE
Fix memory size accounting for grouped `median` and `avg`

### DIFF
--- a/datafusion/functions-aggregate/src/average.rs
+++ b/datafusion/functions-aggregate/src/average.rs
@@ -970,11 +970,13 @@ where
     }
 
     fn size(&self) -> usize {
-    // Heap buffers
-    self.counts.capacity() * size_of::<u64>()
+        // Heap buffers
+        self.counts.capacity() * size_of::<u64>()
         + self.sums.capacity() * size_of::<T::Native>()
         // Vec struct overhead (ptr, len, cap) for each field
         + size_of::<Vec<u64>>()
         + size_of::<Vec<T::Native>>()
+        // Null tracking buffers
+        + self.null_state.size()
     }
 }

--- a/datafusion/functions-aggregate/src/average.rs
+++ b/datafusion/functions-aggregate/src/average.rs
@@ -970,6 +970,7 @@ where
     }
 
     fn size(&self) -> usize {
-        self.counts.capacity() * size_of::<u64>() + self.sums.capacity() * size_of::<T>()
+        self.counts.capacity() * size_of::<u64>()
+            + self.sums.capacity() * size_of::<T::Native>()
     }
 }

--- a/datafusion/functions-aggregate/src/average.rs
+++ b/datafusion/functions-aggregate/src/average.rs
@@ -970,7 +970,11 @@ where
     }
 
     fn size(&self) -> usize {
-        self.counts.capacity() * size_of::<u64>()
-            + self.sums.capacity() * size_of::<T::Native>()
+    // Heap buffers
+    self.counts.capacity() * size_of::<u64>()
+        + self.sums.capacity() * size_of::<T::Native>()
+        // Vec struct overhead (ptr, len, cap) for each field
+        + size_of::<Vec<u64>>()
+        + size_of::<Vec<T::Native>>()
     }
 }

--- a/datafusion/functions-aggregate/src/median.rs
+++ b/datafusion/functions-aggregate/src/median.rs
@@ -547,6 +547,7 @@ impl<T: ArrowNumericType + Send> GroupsAccumulator for MedianGroupsAccumulator<T
             .sum::<usize>()
             // account for size of self.group_values too
             + self.group_values.capacity() * size_of::<Vec<T::Native>>()
+            + size_of::<Vec<Vec<T::Native>>>()
     }
 }
 

--- a/datafusion/functions-aggregate/src/median.rs
+++ b/datafusion/functions-aggregate/src/median.rs
@@ -543,10 +543,10 @@ impl<T: ArrowNumericType + Send> GroupsAccumulator for MedianGroupsAccumulator<T
     fn size(&self) -> usize {
         self.group_values
             .iter()
-            .map(|values| values.capacity() * size_of::<T>())
+            .map(|values| values.capacity() * size_of::<T::Native>())
             .sum::<usize>()
-            // account for size of self.grou_values too
-            + self.group_values.capacity() * size_of::<Vec<T>>()
+            // account for size of self.group_values too
+            + self.group_values.capacity() * size_of::<Vec<T::Native>>()
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`AvgGroupsAccumulator` stores sums in `Vec<T::Native>`, and `MedianGroupsAccumulator` stores grouped values in `Vec<Vec<T::Native>>`, but their `size()` implementations used `size_of::<T>()` when accounting for those allocations.

This underreports memory usage for those grouped aggregate buffers.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Use `size_of::<T::Native>()` for grouped `avg` sum storage.
- Use `size_of::<T::Native>()` for grouped `median` value storage.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing aggregate tests pass.

## Are there any user-facing changes?

No. This only affects internal memory accounting.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
