### PR TITLE
test: cover float IN list predicates

### DIFF
--- a/datafusion/sqllogictest/test_files/in_list.slt
+++ b/datafusion/sqllogictest/test_files/in_list.slt
@@ -236,3 +236,61 @@ nulls NULL NULL NULL NULL NULL NULL NULL NULL
 # Cleanup
 statement ok
 DROP TABLE in_list_ints_nullable
+
+####
+## Float IN List Specializations
+####
+
+statement ok
+CREATE TABLE in_list_floats AS
+SELECT
+  label,
+  arrow_cast(value, 'Float16') AS f16,
+  arrow_cast(value, 'Float32') AS f32,
+  arrow_cast(value, 'Float64') AS f64
+FROM (VALUES
+  ('match', 11.0),
+  ('no_match', 7.0),
+  ('nulls', NULL)
+) AS t(label, value);
+
+# Five element IN lists cover the specialized Float16/32/64 paths.
+query TTBBB
+SELECT
+  'Float16',
+  label,
+  f16 IN (arrow_cast(3.0,  'Float16'), arrow_cast(4.0, 'Float16'), arrow_cast(5.0, 'Float16'), arrow_cast(6.0, 'Float16'), arrow_cast(11.0, 'Float16')),
+  f16 IN (arrow_cast(NULL, 'Float16'), arrow_cast(3.0, 'Float16'), arrow_cast(4.0, 'Float16'), arrow_cast(5.0, 'Float16'), arrow_cast(11.0, 'Float16')),
+  f16 IN (arrow_cast(3.0,  'Float16'), arrow_cast(4.0, 'Float16'), arrow_cast(5.0, 'Float16'), arrow_cast(6.0, 'Float16'), arrow_cast(8.0,  'Float16'))
+FROM in_list_floats
+UNION ALL
+SELECT
+  'Float32',
+  label,
+  f32 IN (arrow_cast(3.0,  'Float32'), arrow_cast(4.0, 'Float32'), arrow_cast(5.0, 'Float32'), arrow_cast(6.0, 'Float32'), arrow_cast(11.0, 'Float32')),
+  f32 IN (arrow_cast(NULL, 'Float32'), arrow_cast(3.0, 'Float32'), arrow_cast(4.0, 'Float32'), arrow_cast(5.0, 'Float32'), arrow_cast(11.0, 'Float32')),
+  f32 IN (arrow_cast(3.0,  'Float32'), arrow_cast(4.0, 'Float32'), arrow_cast(5.0, 'Float32'), arrow_cast(6.0, 'Float32'), arrow_cast(8.0,  'Float32'))
+FROM in_list_floats
+UNION ALL
+SELECT
+  'Float64',
+  label,
+  f64 IN (arrow_cast(3.0,  'Float64'), arrow_cast(4.0, 'Float64'), arrow_cast(5.0, 'Float64'), arrow_cast(6.0, 'Float64'), arrow_cast(11.0, 'Float64')),
+  f64 IN (arrow_cast(NULL, 'Float64'), arrow_cast(3.0, 'Float64'), arrow_cast(4.0, 'Float64'), arrow_cast(5.0, 'Float64'), arrow_cast(11.0, 'Float64')),
+  f64 IN (arrow_cast(3.0,  'Float64'), arrow_cast(4.0, 'Float64'), arrow_cast(5.0, 'Float64'), arrow_cast(6.0, 'Float64'), arrow_cast(8.0,  'Float64'))
+FROM in_list_floats
+ORDER BY 1, 2
+----
+Float16 match true true false
+Float16 no_match false NULL false
+Float16 nulls NULL NULL NULL
+Float32 match true true false
+Float32 no_match false NULL false
+Float32 nulls NULL NULL NULL
+Float64 match true true false
+Float64 no_match false NULL false
+Float64 nulls NULL NULL NULL
+
+# Cleanup
+statement ok
+DROP TABLE in_list_floats


### PR DESCRIPTION
## Which issue does this PR close?

- part of https://github.com/apache/datafusion/issues/23307

## Rationale for this change

As @geoffreyclaude  adds additional special implementations for IN lists we should keep up with slt test coverage. Recently we added coverage for floats
- https://github.com/apache/datafusion/pull/23311

## What changes are included in this PR?

This adds sqllogictest coverage for Float16, Float32, and Float64 `IN` list predicates in `in_list.slt`, mirroring the existing integer `IN` list coverage shape:


## Are these changes tested?
Yes -- all tests
## Are there any user-facing changes?

No. This only adds test coverage.
