### PR TITLE
[codex] chore: update Rust toolchain to 1.96.1

### DIFF
--- a/docs/source/contributor-guide/development_environment.md
+++ b/docs/source/contributor-guide/development_environment.md
@@ -108,7 +108,7 @@ DataFusion is written in Rust and it uses a standard rust toolkit:
 
 - `rustup update stable` DataFusion generally uses the latest stable release of Rust, though it may lag when new Rust toolchains release
   - See which toolchain is currently pinned in the [`rust-toolchain.toml`](https://github.com/apache/datafusion/blob/main/rust-toolchain.toml) file
-  - This can cause issues such as not having the rust-analyzer component installed for the specified toolchain, in which case just install it manually, e.g. `rustup component add --toolchain 1.96.0 rust-analyzer`
+  - This can cause issues such as not having the rust-analyzer component installed for the specified toolchain, in which case just install it manually, e.g. `rustup component add --toolchain 1.96.1 rust-analyzer`
 - `cargo build`
 - `cargo fmt` to format the code
 - etc.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,5 +19,5 @@
 # to compile this workspace and run CI jobs.
 
 [toolchain]
-channel = "1.96.0"
+channel = "1.96.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

DataFusion generally uses the latest stable Rust release for the workspace toolchain. `rustup check` reports an available stable update from `1.96.0` to `1.96.1`.

## What changes are included in this PR?

- Updates the root `rust-toolchain.toml` channel from `1.96.0` to `1.96.1`.
- Updates the contributor guide rust-analyzer command example to match the pinned toolchain.

## Are there any user-facing changes?

No runtime or API changes. Developers and CI will use Rust `1.96.1` as the pinned workspace toolchain.
