### PR TITLE
Port `ScalarFunctionExpr` to `try_to_proto`/`try_from_proto` via typed ctx function-codec capabilities

### DIFF
--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -1453,3 +1453,91 @@ mod proto_helper_tests {
         ));
     }
 }
+
+/// Tests for the erroring defaults of the dispatch traits' capability
+/// channels: a serialization layer that implements only the required
+/// `encode`/`decode` must reject function-codec and session-config requests
+/// with errors naming the requested type, not panic or silently succeed.
+#[cfg(all(test, feature = "proto"))]
+mod proto_capability_default_tests {
+    use std::sync::Arc;
+
+    use arrow::datatypes::Schema;
+    use datafusion_common::{DataFusionError, Result};
+    use datafusion_proto_models::protobuf::PhysicalExprNode;
+
+    use crate::physical_expr::PhysicalExpr;
+    use crate::physical_expr::proto_decode::{PhysicalExprDecode, PhysicalExprDecodeCtx};
+    use crate::physical_expr::proto_encode::{PhysicalExprEncode, PhysicalExprEncodeCtx};
+
+    struct DefaultOnlyEncoder;
+
+    impl PhysicalExprEncode for DefaultOnlyEncoder {
+        fn encode(&self, _expr: &Arc<dyn PhysicalExpr>) -> Result<PhysicalExprNode> {
+            unreachable!("child encoding must not be reached")
+        }
+    }
+
+    struct DefaultOnlyDecoder;
+
+    impl PhysicalExprDecode for DefaultOnlyDecoder {
+        fn decode(
+            &self,
+            _node: &PhysicalExprNode,
+            _schema: &Schema,
+        ) -> Result<Arc<dyn PhysicalExpr>> {
+            unreachable!("child decoding must not be reached")
+        }
+    }
+
+    /// Stands in for a function type (e.g. `ScalarUDF`) the layer was never
+    /// taught about.
+    #[derive(Debug)]
+    struct NotAFunction;
+
+    #[test]
+    fn encode_function_default_errors_naming_requested_type() {
+        let encoder = DefaultOnlyEncoder;
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+
+        let err = ctx.encode_function(&NotAFunction).unwrap_err();
+        assert!(matches!(
+            err,
+            DataFusionError::Internal(msg)
+                if msg.contains("does not support encoding function objects")
+                    && msg.contains("NotAFunction")
+        ));
+    }
+
+    #[test]
+    fn decode_function_default_errors_naming_requested_type_and_name() {
+        let schema = Schema::empty();
+        let decoder = DefaultOnlyDecoder;
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let err = ctx
+            .decode_function::<NotAFunction>("my_udf", None)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DataFusionError::Internal(msg)
+                if msg.contains("does not support resolving function objects")
+                    && msg.contains("NotAFunction")
+                    && msg.contains("'my_udf'")
+        ));
+    }
+
+    #[test]
+    fn config_options_default_errors() {
+        let schema = Schema::empty();
+        let decoder = DefaultOnlyDecoder;
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let err = ctx.config_options().unwrap_err();
+        assert!(matches!(
+            err,
+            DataFusionError::Internal(msg)
+                if msg.contains("does not provide session configuration")
+        ));
+    }
+}

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -519,12 +519,18 @@ pub trait PhysicalExpr: Any + Send + Sync + Display + Debug + DynEq + DynHash {
 /// `datafusion-proto`, which is what lets `physical-expr-common` stay free
 /// of `datafusion-proto` as a dep.
 ///
-/// More specialized helpers (e.g. encoding UDFs/UDAFs/UDWFs through the
-/// extension codec) can be added to the context as expressions migrate;
-/// today they're not required because the encoder forwards to the existing
-/// codec via the proto converter.
+/// Beyond child-expression encoding, the context exposes *capabilities* of
+/// the serialization layer through generic, fully-typed accessors — see
+/// [`proto_encode::PhysicalExprEncodeCtx::encode_function`], which routes
+/// function objects (e.g. `datafusion_expr::ScalarUDF`) through the layer's
+/// extension codec. Those function types live *above* this crate in the
+/// dependency graph, so the accessors are generic over the requested type
+/// and the dispatch trait carries a type-erased channel internally; call
+/// sites never see the erasure. Which types a layer supports is part of its
+/// contract — requesting an unsupported one returns an error naming it.
 #[cfg(feature = "proto")]
 pub mod proto_encode {
+    use std::any::Any;
     use std::sync::Arc;
 
     use datafusion_common::Result;
@@ -574,6 +580,29 @@ pub mod proto_encode {
                 .map(|expr| self.encode_child(expr))
                 .collect()
         }
+
+        /// Serialize a function object through the serialization layer's
+        /// extension codec, returning the opaque payload for the node's
+        /// `fun_definition`-style field — `None` when the function can be
+        /// resolved by name alone on the decoding side (the common case for
+        /// built-in and registered functions).
+        ///
+        /// Which function types the layer supports is part of its contract:
+        /// `datafusion-proto` supports `datafusion_expr::ScalarUDF` (with
+        /// aggregate/window UDFs to follow as those expressions migrate).
+        /// Requesting an unsupported type returns an error naming it. Call
+        /// sites are fully typed — e.g. `ctx.encode_function(&*self.fun)`
+        /// with `fun: Arc<ScalarUDF>` — because the generic carries the type
+        /// across the internal erased channel; function types cannot be
+        /// named in this crate directly, as they live above it in the
+        /// dependency graph.
+        pub fn encode_function<F: Any + Send + Sync>(
+            &self,
+            function: &F,
+        ) -> Result<Option<Vec<u8>>> {
+            self.encoder
+                .encode_function_erased(function, std::any::type_name::<F>())
+        }
     }
 
     /// Internal dispatch trait. Implementors live in `datafusion-proto` and
@@ -583,6 +612,52 @@ pub mod proto_encode {
     pub trait PhysicalExprEncode {
         /// Encode an expression to a protobuf node.
         fn encode(&self, expr: &Arc<dyn PhysicalExpr>) -> Result<PhysicalExprNode>;
+
+        /// Erased channel behind [`PhysicalExprEncodeCtx::encode_function`].
+        ///
+        /// Implementations downcast `function` to each function type they
+        /// support (e.g. `datafusion_expr::ScalarUDF` routed through
+        /// `PhysicalExtensionCodec::try_encode_udf`) and error — naming
+        /// `type_name` — for the rest. The default supports none, so
+        /// encoders that never see function-bearing expressions need not
+        /// implement it.
+        ///
+        /// # Why the `dyn Any` erasure
+        ///
+        /// This is the one spot where the typed public API
+        /// ([`PhysicalExprEncodeCtx::encode_function<F>`]) degrades to
+        /// `&dyn Any`, and the reason is a hard crate-graph constraint rather
+        /// than a style choice.
+        ///
+        /// The function types that need special serialization — `ScalarUDF`
+        /// (and, as they migrate, `AggregateUDF` / `WindowUDF`) — are defined
+        /// in `datafusion-expr`. `datafusion-expr` **depends on** this crate
+        /// (`datafusion-physical-expr-common`) for `Arc<dyn PhysicalExpr>` in
+        /// its UDAF/UDWF APIs, so this crate sits *below* `datafusion-expr` in
+        /// the dependency graph and cannot name `ScalarUDF` in a signature
+        /// without forming a cycle. A compile-time-typed dispatch method would
+        /// require exactly that name, so the trip across this internal trait
+        /// erases to `dyn Any`. `datafusion-proto` sits above both crates,
+        /// can name the concrete types, and downcasts back on the far side —
+        /// which is why the erasure is confined here and never leaks into the
+        /// typed [`PhysicalExprEncodeCtx::encode_function<F>`] call sites.
+        ///
+        /// The only way to make this typed at compile time would be to move
+        /// `ScalarUDF` below this crate, which its logical half (`simplify`,
+        /// `call`, `preimage`, all of which reference physical exprs) rules
+        /// out. See #22430 / the epic in #22418 for the full discussion.
+        ///
+        /// [`PhysicalExprEncodeCtx::encode_function<F>`]: PhysicalExprEncodeCtx::encode_function
+        fn encode_function_erased(
+            &self,
+            _function: &(dyn Any + Send + Sync),
+            type_name: &'static str,
+        ) -> Result<Option<Vec<u8>>> {
+            datafusion_common::internal_err!(
+                "this serialization layer does not support encoding function \
+                 objects (requested `{type_name}`)"
+            )
+        }
     }
 }
 
@@ -611,10 +686,12 @@ pub mod proto_encode {
 /// [`PhysicalExprNode`]: datafusion_proto_models::protobuf::PhysicalExprNode
 #[cfg(feature = "proto")]
 pub mod proto_decode {
+    use std::any::{Any, TypeId};
     use std::sync::Arc;
 
     use arrow::datatypes::Schema;
     use datafusion_common::Result;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_proto_models::protobuf::PhysicalExprNode;
 
     use super::PhysicalExpr;
@@ -733,6 +810,49 @@ pub mod proto_decode {
         {
             nodes.into_iter().map(|node| self.decode(node)).collect()
         }
+
+        /// Resolve a function object from its name and the payload written
+        /// by [`encode_function`] on the encoding side (`None` if none was
+        /// written). The inverse of [`encode_function`]; the same contract
+        /// applies — which function types the deserialization layer supports
+        /// is part of its contract, and requesting an unsupported one
+        /// returns an error naming it.
+        ///
+        /// `datafusion-proto` resolves `datafusion_expr::ScalarUDF` by
+        /// preferring the codec for explicit payloads and falling back to
+        /// the session's function registry (then the codec with an empty
+        /// payload) for by-name references. Call sites are fully typed:
+        ///
+        /// ```ignore
+        /// let udf: Arc<ScalarUDF> = ctx.decode_function(&node.name, node.fun_definition.as_deref())?;
+        /// ```
+        ///
+        /// [`encode_function`]: super::proto_encode::PhysicalExprEncodeCtx::encode_function
+        pub fn decode_function<F: Any + Send + Sync>(
+            &self,
+            name: &str,
+            payload: Option<&[u8]>,
+        ) -> Result<Arc<F>> {
+            let type_name = std::any::type_name::<F>();
+            self.decoder
+                .decode_function_erased(name, payload, TypeId::of::<F>(), type_name)?
+                .downcast::<F>()
+                .map_err(|_| {
+                    datafusion_common::internal_datafusion_err!(
+                        "deserialization layer resolved function '{name}' to a \
+                         value that is not a `{type_name}`"
+                    )
+                })
+        }
+
+        /// Session configuration for expressions that carry it (e.g.
+        /// `ScalarFunctionExpr`). Errors when the deserialization layer has
+        /// no session — deliberately not defaulted to
+        /// [`ConfigOptions::default`], which would silently detach a decoded
+        /// expression from the session's actual configuration.
+        pub fn config_options(&self) -> Result<Arc<ConfigOptions>> {
+            self.decoder.config_options()
+        }
     }
 
     /// Unwrap a required non-expression proto field.
@@ -774,6 +894,47 @@ pub mod proto_decode {
             node: &PhysicalExprNode,
             schema: &Schema,
         ) -> Result<Arc<dyn PhysicalExpr>>;
+
+        /// Erased channel behind [`PhysicalExprDecodeCtx::decode_function`].
+        ///
+        /// Implementations route on `requested` (the [`TypeId`] of the
+        /// function type the caller asked for, e.g.
+        /// `datafusion_expr::ScalarUDF`) and must return a value of exactly
+        /// that type — [`PhysicalExprDecodeCtx::decode_function`] verifies
+        /// the downcast and turns a mismatch into an internal error. Error
+        /// messages should name `type_name`. The default supports no
+        /// function types, so decoders that never see function-bearing
+        /// expressions need not implement it.
+        ///
+        /// The `dyn Any` erasure here exists for the same crate-graph reason
+        /// as on the encode side — see
+        /// [`PhysicalExprEncode::encode_function_erased`] for the full
+        /// explanation of the circular-dependency constraint.
+        ///
+        /// [`PhysicalExprEncode::encode_function_erased`]: super::proto_encode::PhysicalExprEncode::encode_function_erased
+        fn decode_function_erased(
+            &self,
+            name: &str,
+            _payload: Option<&[u8]>,
+            _requested: TypeId,
+            type_name: &'static str,
+        ) -> Result<Arc<dyn Any + Send + Sync>> {
+            datafusion_common::internal_err!(
+                "this deserialization layer does not support resolving \
+                 function objects (requested `{type_name}` for '{name}')"
+            )
+        }
+
+        /// Session configuration handed to decoded expressions that carry
+        /// it. The default errors: a layer without a session must opt in
+        /// explicitly rather than silently substituting
+        /// [`ConfigOptions::default`].
+        fn config_options(&self) -> Result<Arc<ConfigOptions>> {
+            datafusion_common::internal_err!(
+                "this deserialization layer does not provide session \
+                 configuration"
+            )
+        }
     }
 }
 

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -349,6 +349,86 @@ impl PhysicalExpr for ScalarFunctionExpr {
             self.args.iter().map(|arg| arg.placement()).collect();
         self.fun.placement(&arg_placements)
     }
+
+    #[cfg(feature = "proto")]
+    fn try_to_proto(
+        &self,
+        ctx: &datafusion_physical_expr_common::physical_expr::proto_encode::PhysicalExprEncodeCtx<'_>,
+    ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalExprNode>> {
+        use datafusion_proto_models::protobuf;
+
+        Ok(Some(protobuf::PhysicalExprNode {
+            expr_id: None,
+            expr_type: Some(protobuf::physical_expr_node::ExprType::ScalarUdf(
+                protobuf::PhysicalScalarUdfNode {
+                    name: self.name.clone(),
+                    args: ctx.encode_children_expressions(&self.args)?,
+                    // Typed capability of the serialization layer; carries
+                    // the codec's opaque payload (`None` = resolvable by
+                    // name alone).
+                    fun_definition: ctx.encode_function(self.fun.as_ref())?,
+                    return_type: Some(self.return_type().try_into()?),
+                    nullable: self.nullable(),
+                    return_field_name: self.return_field.name().to_string(),
+                },
+            )),
+        }))
+    }
+}
+
+#[cfg(feature = "proto")]
+impl ScalarFunctionExpr {
+    /// Reconstruct a [`ScalarFunctionExpr`] from its protobuf representation.
+    ///
+    /// Takes the whole [`PhysicalExprNode`] so the decode signature matches
+    /// other migrated expressions and can inspect outer-node metadata if
+    /// needed in the future. The embedded [`ScalarUDF`] is resolved through
+    /// [`PhysicalExprDecodeCtx::decode_function`] (payload-first, then
+    /// by-name — the deserialization layer defines the lookup), and the
+    /// session configuration comes from
+    /// [`PhysicalExprDecodeCtx::config_options`].
+    ///
+    /// [`PhysicalExprNode`]: datafusion_proto_models::protobuf::PhysicalExprNode
+    /// [`PhysicalExprDecodeCtx::decode_function`]: datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx::decode_function
+    /// [`PhysicalExprDecodeCtx::config_options`]: datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx::config_options
+    pub fn try_from_proto(
+        node: &datafusion_proto_models::protobuf::PhysicalExprNode,
+        ctx: &datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprDecodeCtx<'_>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        use arrow::datatypes::Field;
+        use datafusion_physical_expr_common::expect_expr_variant;
+        use datafusion_physical_expr_common::physical_expr::proto_decode::require_proto_field;
+        use datafusion_proto_models::protobuf;
+
+        let scalar_udf = expect_expr_variant!(
+            node,
+            protobuf::physical_expr_node::ExprType::ScalarUdf,
+            "ScalarFunctionExpr",
+        );
+
+        let udf: Arc<ScalarUDF> =
+            ctx.decode_function(&scalar_udf.name, scalar_udf.fun_definition.as_deref())?;
+        let args = ctx.decode_children_expressions(&scalar_udf.args)?;
+        let return_type = require_proto_field(
+            scalar_udf.return_type.as_ref(),
+            "ScalarFunctionExpr",
+            "return_type",
+        )?;
+        let return_field =
+            Field::new(&scalar_udf.return_field_name, return_type.try_into()?, true)
+                .into();
+
+        Ok(Arc::new(
+            ScalarFunctionExpr::new(
+                &scalar_udf.name,
+                udf,
+                args,
+                return_field,
+                ctx.config_options()?,
+            )
+            .with_nullable(scalar_udf.nullable),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -424,5 +504,447 @@ mod tests {
         assert!(!stable_expr.is_volatile_node());
         let stable_arc: Arc<dyn PhysicalExpr> = Arc::new(stable_expr);
         assert!(!is_volatile(&stable_arc));
+    }
+}
+
+/// Tests for the `try_to_proto` / `try_from_proto` hooks.
+#[cfg(all(test, feature = "proto"))]
+mod proto_tests {
+    use std::any::{Any, TypeId};
+    use std::cell::Cell;
+
+    use super::*;
+    use crate::expressions::Column;
+    use crate::proto_test_util::{
+        StubDecoder, StubEncoder, UnreachableDecoder, column_node,
+    };
+    use arrow::datatypes::Field;
+    use datafusion_common::internal_err;
+    use datafusion_expr::Signature;
+    use datafusion_physical_expr_common::physical_expr::proto_decode::{
+        PhysicalExprDecode, PhysicalExprDecodeCtx,
+    };
+    use datafusion_physical_expr_common::physical_expr::proto_encode::{
+        PhysicalExprEncode, PhysicalExprEncodeCtx,
+    };
+    use datafusion_proto_models::datafusion_common::ArrowType;
+    use datafusion_proto_models::protobuf::{
+        PhysicalExprNode, PhysicalScalarUdfNode, physical_expr_node,
+    };
+
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    struct TestUdf {
+        signature: Signature,
+    }
+
+    impl ScalarUDFImpl for TestUdf {
+        fn name(&self) -> &str {
+            "test_udf"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+            Ok(DataType::Int32)
+        }
+
+        fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+            Ok(ColumnarValue::Scalar(ScalarValue::Int32(Some(42))))
+        }
+    }
+
+    fn test_udf() -> Arc<ScalarUDF> {
+        Arc::new(ScalarUDF::from(TestUdf {
+            signature: Signature::uniform(
+                1,
+                vec![DataType::Int32],
+                Volatility::Immutable,
+            ),
+        }))
+    }
+
+    /// A `ScalarFunctionExpr` calling [`test_udf`] over one `Int32` column,
+    /// type-erased so `try_to_proto` is exercised exactly as the serializer
+    /// calls it (through `dyn PhysicalExpr`).
+    fn scalar_fn_fixture() -> Arc<dyn PhysicalExpr> {
+        Arc::new(ScalarFunctionExpr::new(
+            "test_udf",
+            test_udf(),
+            vec![Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>],
+            Field::new("test_udf", DataType::Int32, true).into(),
+            Arc::new(ConfigOptions::default()),
+        ))
+    }
+
+    fn int32_arrow_type() -> ArrowType {
+        (&DataType::Int32).try_into().unwrap()
+    }
+
+    /// Build a `ScalarUdf` proto node with the given fields.
+    fn scalar_udf_node(
+        args: Vec<PhysicalExprNode>,
+        return_type: Option<ArrowType>,
+        nullable: bool,
+        fun_definition: Option<Vec<u8>>,
+    ) -> PhysicalExprNode {
+        PhysicalExprNode {
+            expr_id: None,
+            expr_type: Some(physical_expr_node::ExprType::ScalarUdf(
+                PhysicalScalarUdfNode {
+                    name: "test_udf".to_string(),
+                    args,
+                    fun_definition,
+                    return_type,
+                    nullable,
+                    return_field_name: "test_udf".to_string(),
+                },
+            )),
+        }
+    }
+
+    /// Encoder stub layering function-codec behavior over a [`StubEncoder`]
+    /// for child expressions: emits `payload` for every function object, or
+    /// fails when `fail` is set.
+    struct FnStubEncoder {
+        inner: StubEncoder,
+        payload: Option<Vec<u8>>,
+        fail: bool,
+    }
+
+    impl FnStubEncoder {
+        fn ok() -> Self {
+            Self {
+                inner: StubEncoder::ok(),
+                payload: None,
+                fail: false,
+            }
+        }
+    }
+
+    impl PhysicalExprEncode for FnStubEncoder {
+        fn encode(&self, expr: &Arc<dyn PhysicalExpr>) -> Result<PhysicalExprNode> {
+            self.inner.encode(expr)
+        }
+
+        fn encode_function_erased(
+            &self,
+            _function: &(dyn Any + Send + Sync),
+            _type_name: &'static str,
+        ) -> Result<Option<Vec<u8>>> {
+            if self.fail {
+                return internal_err!("function codec encode failure");
+            }
+            Ok(self.payload.clone())
+        }
+    }
+
+    /// Decoder stub layering function-codec + session-config behavior over a
+    /// [`StubDecoder`] for child expressions. Resolves every function name to
+    /// [`test_udf`] (recording the payload it was handed) and returns default
+    /// `ConfigOptions`.
+    struct FnStubDecoder {
+        inner: StubDecoder,
+        seen_payload: Cell<Option<Option<Vec<u8>>>>,
+    }
+
+    impl FnStubDecoder {
+        fn ok() -> Self {
+            Self {
+                inner: StubDecoder::ok(),
+                seen_payload: Cell::new(None),
+            }
+        }
+
+        fn failing_on(call: usize) -> Self {
+            Self {
+                inner: StubDecoder::failing_on(call),
+                seen_payload: Cell::new(None),
+            }
+        }
+    }
+
+    impl PhysicalExprDecode for FnStubDecoder {
+        fn decode(
+            &self,
+            node: &PhysicalExprNode,
+            schema: &Schema,
+        ) -> Result<Arc<dyn PhysicalExpr>> {
+            self.inner.decode(node, schema)
+        }
+
+        fn decode_function_erased(
+            &self,
+            _name: &str,
+            payload: Option<&[u8]>,
+            requested: TypeId,
+            type_name: &'static str,
+        ) -> Result<Arc<dyn Any + Send + Sync>> {
+            assert_eq!(
+                requested,
+                TypeId::of::<ScalarUDF>(),
+                "unexpected function type requested: {type_name}"
+            );
+            self.seen_payload.set(Some(payload.map(|p| p.to_vec())));
+            Ok(test_udf() as _)
+        }
+
+        fn config_options(&self) -> Result<Arc<ConfigOptions>> {
+            Ok(Arc::new(ConfigOptions::default()))
+        }
+    }
+
+    /// Decoder whose function resolution fails, to exercise error
+    /// propagation; child decoding must not be reached.
+    struct FailingFnDecoder;
+
+    impl PhysicalExprDecode for FailingFnDecoder {
+        fn decode(
+            &self,
+            _node: &PhysicalExprNode,
+            _schema: &Schema,
+        ) -> Result<Arc<dyn PhysicalExpr>> {
+            unreachable!("child decoding must not be reached")
+        }
+
+        fn decode_function_erased(
+            &self,
+            _name: &str,
+            _payload: Option<&[u8]>,
+            _requested: TypeId,
+            _type_name: &'static str,
+        ) -> Result<Arc<dyn Any + Send + Sync>> {
+            internal_err!("function codec decode failure")
+        }
+    }
+
+    /// Decoder that violates the `decode_function_erased` contract by
+    /// returning a value of the wrong type, to exercise the ctx's downcast
+    /// guard.
+    struct WrongTypeFnDecoder;
+
+    impl PhysicalExprDecode for WrongTypeFnDecoder {
+        fn decode(
+            &self,
+            _node: &PhysicalExprNode,
+            _schema: &Schema,
+        ) -> Result<Arc<dyn PhysicalExpr>> {
+            unreachable!("child decoding must not be reached")
+        }
+
+        fn decode_function_erased(
+            &self,
+            _name: &str,
+            _payload: Option<&[u8]>,
+            _requested: TypeId,
+            _type_name: &'static str,
+        ) -> Result<Arc<dyn Any + Send + Sync>> {
+            Ok(Arc::new("not a scalar udf") as _)
+        }
+    }
+
+    #[test]
+    fn try_to_proto_encodes_scalar_function_expr() {
+        let expr = scalar_fn_fixture();
+        let encoder = FnStubEncoder::ok();
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+
+        let node = expr
+            .try_to_proto(&ctx)
+            .unwrap()
+            .expect("ScalarFunctionExpr must serialize itself");
+
+        assert_eq!(node.expr_id, None);
+        let Some(physical_expr_node::ExprType::ScalarUdf(udf_node)) = node.expr_type
+        else {
+            panic!("expected ScalarUdf node");
+        };
+        assert_eq!(udf_node.name, "test_udf");
+        assert_eq!(udf_node.args, vec![column_node("child")]);
+        assert_eq!(udf_node.fun_definition, None);
+        assert_eq!(udf_node.return_type, Some(int32_arrow_type()));
+        assert!(udf_node.nullable);
+        assert_eq!(udf_node.return_field_name, "test_udf");
+    }
+
+    #[test]
+    fn try_to_proto_includes_codec_payload() {
+        let expr = scalar_fn_fixture();
+        let encoder = FnStubEncoder {
+            payload: Some(vec![1, 2, 3]),
+            ..FnStubEncoder::ok()
+        };
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+
+        let node = expr.try_to_proto(&ctx).unwrap().unwrap();
+        let Some(physical_expr_node::ExprType::ScalarUdf(udf_node)) = node.expr_type
+        else {
+            panic!("expected ScalarUdf node");
+        };
+        assert_eq!(udf_node.fun_definition, Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn try_to_proto_propagates_child_encode_error() {
+        let expr = scalar_fn_fixture();
+        let encoder = FnStubEncoder {
+            inner: StubEncoder::failing_on(1),
+            ..FnStubEncoder::ok()
+        };
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+
+        let err = expr.try_to_proto(&ctx).unwrap_err();
+        assert!(err.to_string().contains("stub encode failure"), "{err}");
+    }
+
+    #[test]
+    fn try_to_proto_propagates_function_encode_error() {
+        let expr = scalar_fn_fixture();
+        let encoder = FnStubEncoder {
+            fail: true,
+            ..FnStubEncoder::ok()
+        };
+        let ctx = PhysicalExprEncodeCtx::new(&encoder);
+
+        let err = expr.try_to_proto(&ctx).unwrap_err();
+        assert!(
+            err.to_string().contains("function codec encode failure"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn try_from_proto_decodes_scalar_function_expr() {
+        let node = scalar_udf_node(
+            vec![column_node("a")],
+            Some(int32_arrow_type()),
+            false,
+            Some(vec![7]),
+        );
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let decoder = FnStubDecoder::ok();
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let decoded = ScalarFunctionExpr::try_from_proto(&node, &ctx).unwrap();
+        let expr = decoded
+            .downcast_ref::<ScalarFunctionExpr>()
+            .expect("expected a ScalarFunctionExpr");
+
+        assert_eq!(expr.name(), "test_udf");
+        assert_eq!(expr.fun().name(), "test_udf");
+        assert_eq!(expr.args().len(), 1);
+        assert_eq!(expr.return_type(), &DataType::Int32);
+        assert!(!expr.nullable());
+        // The deserialization layer must receive the wire payload verbatim.
+        assert_eq!(decoder.seen_payload.take(), Some(Some(vec![7])));
+    }
+
+    #[test]
+    fn try_from_proto_rejects_non_scalar_udf_node() {
+        let node = column_node("a");
+        let schema = Schema::empty();
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &UnreachableDecoder);
+
+        let err = ScalarFunctionExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("PhysicalExprNode is not a ScalarFunctionExpr"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn try_from_proto_rejects_missing_return_type() {
+        let node = scalar_udf_node(vec![column_node("a")], None, true, None);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let decoder = FnStubDecoder::ok();
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let err = ScalarFunctionExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("missing required field 'return_type'"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn try_from_proto_propagates_child_decode_error() {
+        let node =
+            scalar_udf_node(vec![column_node("a")], Some(int32_arrow_type()), true, None);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let decoder = FnStubDecoder::failing_on(1);
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &decoder);
+
+        let err = ScalarFunctionExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(err.to_string().contains("stub decode failure"), "{err}");
+    }
+
+    #[test]
+    fn try_from_proto_propagates_function_decode_error() {
+        let node =
+            scalar_udf_node(vec![column_node("a")], Some(int32_arrow_type()), true, None);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &FailingFnDecoder);
+
+        let err = ScalarFunctionExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(
+            err.to_string().contains("function codec decode failure"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn try_from_proto_guards_against_wrong_function_type() {
+        let node =
+            scalar_udf_node(vec![column_node("a")], Some(int32_arrow_type()), true, None);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &WrongTypeFnDecoder);
+
+        let err = ScalarFunctionExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(
+            err.to_string().contains("is not a"),
+            "expected the ctx downcast guard to fire: {err}"
+        );
+    }
+
+    #[test]
+    fn try_from_proto_errors_without_session_config() {
+        // A decoder that resolves functions but provides no session must
+        // fail loudly rather than silently substituting default config.
+        struct NoConfigDecoder;
+
+        impl PhysicalExprDecode for NoConfigDecoder {
+            fn decode(
+                &self,
+                node: &PhysicalExprNode,
+                schema: &Schema,
+            ) -> Result<Arc<dyn PhysicalExpr>> {
+                StubDecoder::ok().decode(node, schema)
+            }
+
+            fn decode_function_erased(
+                &self,
+                _name: &str,
+                _payload: Option<&[u8]>,
+                _requested: TypeId,
+                _type_name: &'static str,
+            ) -> Result<Arc<dyn Any + Send + Sync>> {
+                Ok(test_udf() as _)
+            }
+        }
+
+        let node =
+            scalar_udf_node(vec![column_node("a")], Some(int32_arrow_type()), true, None);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let ctx = PhysicalExprDecodeCtx::new(&schema, &NoConfigDecoder);
+
+        let err = ScalarFunctionExpr::try_from_proto(&node, &ctx).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not provide session configuration"),
+            "{err}"
+        );
     }
 }

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use arrow::compute::SortOptions;
-use arrow::datatypes::{Field, Schema};
+use arrow::datatypes::Schema;
 use arrow::ipc::reader::StreamReader;
 use chrono::{TimeZone, Utc};
 use datafusion_common::{
@@ -40,9 +40,9 @@ use datafusion_datasource_json::file_format::JsonSink;
 use datafusion_datasource_parquet::file_format::ParquetSink;
 use datafusion_execution::object_store::ObjectStoreUrl;
 use datafusion_execution::{FunctionRegistry, TaskContext};
-use datafusion_expr::WindowFunctionDefinition;
 use datafusion_expr::dml::InsertOp;
 use datafusion_expr::execution_props::SubqueryIndex;
+use datafusion_expr::{ScalarUDF, WindowFunctionDefinition};
 use datafusion_physical_expr::expressions::{LambdaExpr, LambdaVariable};
 use datafusion_physical_expr::projection::{ProjectionExpr, ProjectionExprs};
 use datafusion_physical_expr::scalar_subquery::ScalarSubqueryExpr;
@@ -309,36 +309,7 @@ pub fn parse_physical_expr_with_converter(
         ExprType::Case(_) => CaseExpr::try_from_proto(proto, &decode_ctx)?,
         ExprType::Cast(_) => CastExpr::try_from_proto(proto, &decode_ctx)?,
         ExprType::TryCast(_) => TryCastExpr::try_from_proto(proto, &decode_ctx)?,
-        ExprType::ScalarUdf(e) => {
-            let udf = match &e.fun_definition {
-                Some(buf) => ctx.codec().try_decode_udf(&e.name, buf)?,
-                None => ctx
-                    .task_ctx()
-                    .udf(e.name.as_str())
-                    .or_else(|_| ctx.codec().try_decode_udf(&e.name, &[]))?,
-            };
-            let scalar_fun_def = Arc::clone(&udf);
-
-            let args = parse_physical_exprs(&e.args, ctx, input_schema, proto_converter)?;
-
-            let config_options = Arc::clone(ctx.task_ctx().session_config().options());
-
-            Arc::new(
-                ScalarFunctionExpr::new(
-                    e.name.as_str(),
-                    scalar_fun_def,
-                    args,
-                    Field::new(
-                        &e.return_field_name,
-                        convert_required!(e.return_type)?,
-                        true,
-                    )
-                    .into(),
-                    config_options,
-                )
-                .with_nullable(e.nullable),
-            )
-        }
+        ExprType::ScalarUdf(_) => ScalarFunctionExpr::try_from_proto(proto, &decode_ctx)?,
         ExprType::HigherOrderUdf(e) => {
             let func = match &e.fun_definition {
                 Some(buf) => {
@@ -828,6 +799,41 @@ impl datafusion_physical_expr_common::physical_expr::proto_decode::PhysicalExprD
     ) -> Result<Arc<dyn PhysicalExpr>> {
         self.proto_converter
             .proto_to_physical_expr(node, schema, self.ctx)
+    }
+
+    fn decode_function_erased(
+        &self,
+        name: &str,
+        payload: Option<&[u8]>,
+        requested: std::any::TypeId,
+        type_name: &'static str,
+    ) -> Result<Arc<dyn std::any::Any + Send + Sync>> {
+        // Function types supported by this deserialization layer. Aggregate
+        // and window UDFs can be added here when their expressions migrate
+        // to `try_from_proto`.
+        if requested == std::any::TypeId::of::<ScalarUDF>() {
+            let udf = match payload {
+                // An explicit payload always goes to the extension codec.
+                Some(buf) => self.ctx.codec().try_decode_udf(name, buf)?,
+                // By-name references prefer the session's function registry,
+                // falling back to the codec with an empty payload.
+                None => self
+                    .ctx
+                    .task_ctx()
+                    .udf(name)
+                    .or_else(|_| self.ctx.codec().try_decode_udf(name, &[]))?,
+            };
+            Ok(udf as Arc<dyn std::any::Any + Send + Sync>)
+        } else {
+            Err(internal_datafusion_err!(
+                "PhysicalExtensionCodec-backed decoding supports `ScalarUDF` \
+                 function objects, got `{type_name}` for '{name}'"
+            ))
+        }
+    }
+
+    fn config_options(&self) -> Result<Arc<datafusion_common::config::ConfigOptions>> {
+        Ok(Arc::clone(self.ctx.task_ctx().session_config().options()))
     }
 }
 

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -30,10 +30,10 @@ use datafusion_datasource_csv::file_format::CsvSink;
 use datafusion_datasource_json::file_format::JsonSink;
 #[cfg(feature = "parquet")]
 use datafusion_datasource_parquet::file_format::ParquetSink;
-use datafusion_expr::WindowFrame;
+use datafusion_expr::{ScalarUDF, WindowFrame};
 use datafusion_physical_expr::scalar_subquery::ScalarSubqueryExpr;
 use datafusion_physical_expr::window::{SlidingAggregateWindowExpr, StandardWindowExpr};
-use datafusion_physical_expr::{HigherOrderFunctionExpr, ScalarFunctionExpr};
+use datafusion_physical_expr::HigherOrderFunctionExpr;
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
 use datafusion_physical_plan::windows::{PlainAggregateWindowExpr, WindowUDFExpr};
@@ -269,6 +269,26 @@ impl datafusion_physical_expr_common::physical_expr::proto_encode::PhysicalExprE
         self.proto_converter
             .physical_expr_to_proto(expr, self.codec)
     }
+
+    fn encode_function_erased(
+        &self,
+        function: &(dyn std::any::Any + Send + Sync),
+        type_name: &'static str,
+    ) -> Result<Option<Vec<u8>>> {
+        // Function types supported by this serialization layer. Aggregate
+        // and window UDFs can be added here when their expressions migrate
+        // to `try_to_proto`.
+        if let Some(udf) = function.downcast_ref::<ScalarUDF>() {
+            let mut buf = Vec::new();
+            self.codec.try_encode_udf(udf, &mut buf)?;
+            Ok((!buf.is_empty()).then_some(buf))
+        } else {
+            internal_err!(
+                "PhysicalExtensionCodec-backed encoding supports `ScalarUDF` \
+                 function objects, got `{type_name}`"
+            )
+        }
+    }
 }
 
 /// Serialize a `PhysicalExpr` to default protobuf representation.
@@ -299,26 +319,7 @@ pub fn serialize_physical_expr_with_converter(
         return Ok(node);
     }
 
-    if let Some(expr) = expr.downcast_ref::<ScalarFunctionExpr>() {
-        let mut buf = Vec::new();
-        codec.try_encode_udf(expr.fun(), &mut buf)?;
-        Ok(protobuf::PhysicalExprNode {
-            expr_id,
-            expr_type: Some(protobuf::physical_expr_node::ExprType::ScalarUdf(
-                protobuf::PhysicalScalarUdfNode {
-                    name: expr.name().to_string(),
-                    args: serialize_physical_exprs(expr.args(), codec, proto_converter)?,
-                    fun_definition: (!buf.is_empty()).then_some(buf),
-                    return_type: Some(expr.return_type().try_into()?),
-                    nullable: expr.nullable(),
-                    return_field_name: expr
-                        .return_field(&Schema::empty())?
-                        .name()
-                        .to_string(),
-                },
-            )),
-        })
-    } else if let Some(expr) = expr.downcast_ref::<HigherOrderFunctionExpr>() {
+    if let Some(expr) = expr.downcast_ref::<HigherOrderFunctionExpr>() {
         let mut buf = Vec::new();
         codec.try_encode_higher_order_function(expr.fun(), &mut buf)?;
         Ok(protobuf::PhysicalExprNode {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22430.

Part of epic #22418. Alternative to #23415 — see "Rationale" for the relationship.

## Rationale for this change

`ScalarFunctionExpr` was the last expression on the central proto downcast chain whose serialization needs session-level objects: the embedded `ScalarUDF` must go through `PhysicalExtensionCodec` on encode and resolve via codec + function registry on decode, and the reconstructed expression needs the session's `ConfigOptions`.

The tension: the `try_to_proto` / `try_from_proto` contexts live in `datafusion-physical-expr-common`, which sits *below* `datafusion-expr` in the crate graph (`datafusion-expr` depends on it for `Arc<dyn PhysicalExpr>` in the UDAF/UDWF APIs), so the contexts cannot name `ScalarUDF` without a dependency cycle. #23415 resolves this with caller-visible type erasure — `encode_udf(&dyn Any)` / `decode_udf(..) -> Arc<dyn Any>` on the public ctx API, with docs saying "the concrete type is always `ScalarUDF`" and downcasts at every use — plus a `config_options()` default that silently fabricates `ConfigOptions::default()`.

This PR takes a different shape: **generic, fully-typed capability accessors on the contexts, with the erasure confined to the internal dispatch traits.**

```rust
// encode side — call site in ScalarFunctionExpr::try_to_proto:
fun_definition: ctx.encode_function(self.fun.as_ref())?,

// decode side — call site in ScalarFunctionExpr::try_from_proto:
let udf: Arc<ScalarUDF> = ctx.decode_function(&node.name, node.fun_definition.as_deref())?;
let config = ctx.config_options()?;
```

- `PhysicalExprEncodeCtx::encode_function<F: Any>(&F) -> Result<Option<Vec<u8>>>` and `PhysicalExprDecodeCtx::decode_function<F: Any>(name, payload) -> Result<Arc<F>>` are generic over the function type. Call sites — including third-party `PhysicalExpr` implementations that wrap a `ScalarUDF` (or later an `AggregateUDF`/`WindowUDF`) — are fully typed and never see `Any` or write a downcast.
- The internal dispatch traits (`PhysicalExprEncode`/`PhysicalExprDecode`, documented as implemented only by serialization layers) carry monomorphic erased channels (`encode_function_erased`, `decode_function_erased`) that route on `TypeId` and receive `type_name` for error messages. The ctx verifies the returned type and converts any contract violation into a clean internal error. Which function types a layer supports is an explicit, documented part of its contract; requesting an unsupported type errors naming it.
- `PhysicalExprDecodeCtx::config_options()` returns `Result` and the dispatch default **errors** — a layer without a session must opt in explicitly rather than silently substituting defaults (avoiding the footgun in the `ConfigOptions::default()` fallback).

With that in place, `ScalarFunctionExpr` rides the standard hooks like every other migrated expression: `try_to_proto` inside `impl PhysicalExpr`, `try_from_proto(node, ctx)` with the standard signature, one-line dispatch in `from_proto.rs`, **no downcast arm in `to_proto.rs` at all** — the encode chain shrinks by one special case, and `datafusion-proto` no longer imports `ScalarFunctionExpr` for encoding.

`datafusion-proto`'s `ConverterEncoder`/`ConverterDecoder` implement the erased channels by routing `ScalarUDF` through `try_encode_udf`/`try_decode_udf` with the task-context registry fallback (identical lookup order to the old inline arm). Aggregate/window UDFs slot into the same channels when their expressions migrate.

Honest limitation: which `F` a layer supports is a runtime contract, not a compile-time one. That is the floor imposed by the crate graph — a compile-time signature would need `ScalarUDF` below `physical-expr-common`, which its logical half (`simplify`, `call`, `preimage`) rules out.

## What changes are included in this PR?

Commit 1 — `datafusion/physical-expr-common/src/physical_expr.rs`:
- `PhysicalExprEncodeCtx::encode_function` / `PhysicalExprDecodeCtx::decode_function` / `PhysicalExprDecodeCtx::config_options` (typed public surface).
- `PhysicalExprEncode::encode_function_erased` / `PhysicalExprDecode::decode_function_erased` / `PhysicalExprDecode::config_options` (internal dispatch, erroring defaults so existing implementors keep compiling).
- Module docs describing the capability contract.

Commit 2:
- `datafusion/physical-expr/src/scalar_function.rs`: `try_to_proto` in `impl PhysicalExpr` (feature-gated `proto`), `try_from_proto` inherent fn with the standard signature, plus a `proto_tests` module.
- `datafusion/proto/src/physical_plan/to_proto.rs`: `ConverterEncoder::encode_function_erased`; the `ScalarFunctionExpr` downcast arm is **deleted**.
- `datafusion/proto/src/physical_plan/from_proto.rs`: `ConverterDecoder::decode_function_erased` + `config_options`; the inline `ExprType::ScalarUdf` arm becomes the standard one-line dispatch.

The wire format is byte-for-byte unchanged: same `PhysicalScalarUdfNode` fields, `fun_definition` only set when the codec writes bytes, `return_field_name` from the stored return field (identical to the old `return_field(&Schema::empty())?.name()`), `expr_id: None` (`ScalarFunctionExpr` never overrides `expression_id`, so the old arm always wrote `None` here too).

## Are these changes tested?

- 11 new direct tests in `scalar_function.rs::proto_tests`, driving `try_to_proto` through `dyn PhysicalExpr` (so inherent-method shadowing cannot silently pass): encode happy path (field-by-field), codec payload passthrough in both directions, decode happy path, wrong `ExprType` variant, missing `return_type`, child + function-codec error propagation on both sides, the ctx downcast guard against a contract-violating layer, and the no-session `config_options` error.
- `cargo test -p datafusion-proto --test proto_integration`: 190 passed. With both inline arms deleted, scalar-UDF roundtrip coverage can only pass through the new hooks.
- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

## Are there any user-facing changes?

No wire-format or behavior changes. New public API: the three typed ctx methods and the three defaulted dispatch-trait methods (all feature `proto`, all additive/non-breaking). No existing signatures change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MmNo1SfPHXZNaMW26KmaG
