### PR TITLE
chore: use new `OffsetBuffer::subtract` helper

### DIFF
--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -1236,7 +1236,7 @@ pub fn adjust_offsets_for_slice<O: OffsetSizeTrait>(
 ) -> OffsetBuffer<O> {
     let offsets = list.offsets();
 
-    offsets.clone().subtract(*offsets[0])
+    offsets.clone().subtract(offsets[0])
 }
 
 /// For lists and large lists, truncates the sublist of null values

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -1236,16 +1236,7 @@ pub fn adjust_offsets_for_slice<O: OffsetSizeTrait>(
 ) -> OffsetBuffer<O> {
     let offsets = list.offsets();
 
-    if let (Some(first), Some(last)) = (offsets.first(), offsets.last())
-        && (!first.is_zero() || last.as_usize() != list.values().len())
-    {
-        let offsets = offsets.iter().map(|offset| *offset - *first).collect();
-
-        //todo: use unsafe Offset::new_unchecked?
-        return OffsetBuffer::new(offsets);
-    }
-
-    offsets.clone()
+    offsets.clone().subtract(*offsets[0])
 }
 
 /// For lists and large lists, truncates the sublist of null values

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -471,12 +471,7 @@ fn take_by_indices<OffsetSize: OffsetSizeTrait>(
 fn rebase_offsets<OffsetSize: OffsetSizeTrait>(
     offsets: &OffsetBuffer<OffsetSize>,
 ) -> OffsetBuffer<OffsetSize> {
-    if offsets[0].as_usize() == 0 {
-        offsets.clone()
-    } else {
-        let rebased: Vec<OffsetSize> = offsets.iter().map(|o| *o - offsets[0]).collect();
-        OffsetBuffer::new(rebased.into())
-    }
+    offsets.clone().subtract(*offsets[0])
 }
 
 fn order_desc(modifier: &str) -> Result<bool> {

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -471,7 +471,7 @@ fn take_by_indices<OffsetSize: OffsetSizeTrait>(
 fn rebase_offsets<OffsetSize: OffsetSizeTrait>(
     offsets: &OffsetBuffer<OffsetSize>,
 ) -> OffsetBuffer<OffsetSize> {
-    offsets.clone().subtract(*offsets[0])
+    offsets.clone().subtract(offsets[0])
 }
 
 fn order_desc(modifier: &str) -> Result<bool> {

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -27,7 +27,7 @@ use arrow::array::{
     Array, ArrayRef, AsArray, GenericStringArray, NullBufferBuilder, OffsetSizeTrait,
     StringViewArray, new_null_array,
 };
-use arrow::buffer::{Buffer, OffsetBuffer, ScalarBuffer};
+use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::DataType;
 use datafusion_common::Result;
 use datafusion_common::cast::{as_generic_string_array, as_string_view_array};
@@ -636,7 +636,10 @@ fn case_conversion_ascii_array<O: OffsetSizeTrait>(
     let values = Buffer::from_vec(converted);
 
     // Shift offsets from `start`-based to 0-based so they index into `values`.
-    let offsets = string_array.offsets().clone().subtract(*string_array.offsets()[0]);
+    let offsets = string_array
+        .offsets()
+        .clone()
+        .subtract(string_array.offsets()[0]);
 
     let nulls = string_array.nulls().cloned();
     // SAFETY: offsets are monotonic and in-bounds for `values`; nulls

--- a/datafusion/functions/src/string/common.rs
+++ b/datafusion/functions/src/string/common.rs
@@ -636,15 +636,7 @@ fn case_conversion_ascii_array<O: OffsetSizeTrait>(
     let values = Buffer::from_vec(converted);
 
     // Shift offsets from `start`-based to 0-based so they index into `values`.
-    let offsets = if start == 0 {
-        string_array.offsets().clone()
-    } else {
-        let s = O::usize_as(start);
-        let rebased: Vec<O> = value_offsets.iter().map(|&o| o - s).collect();
-        // SAFETY: subtracting a constant from monotonic offsets preserves
-        // monotonicity, and `start` is the minimum offset, so no underflow.
-        unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(rebased)) }
-    };
+    let offsets = string_array.offsets().clone().subtract(*string_array.offsets()[0]);
 
     let nulls = string_array.nulls().cloned();
     // SAFETY: offsets are monotonic and in-bounds for `values`; nulls

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -217,6 +217,9 @@ fn initcap_ascii_array<T: OffsetSizeTrait>(
     }
 
     let values = Buffer::from_vec(out);
+
+    // Rebase offsets for sliced arrays to reflect that the
+    // output only contains the bytes in the visible slice.
     let out_offsets = offsets.clone().subtract(offsets[0]);
 
     // SAFETY: ASCII case conversion preserves byte length, so the original

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -217,17 +217,7 @@ fn initcap_ascii_array<T: OffsetSizeTrait>(
     }
 
     let values = Buffer::from_vec(out);
-    let out_offsets = if first_offset == 0 {
-        offsets.clone()
-    } else {
-        // For sliced arrays, we need to rebase the offsets to reflect that the
-        // output only contains the bytes in the visible slice.
-        let rebased_offsets = offsets
-            .iter()
-            .map(|offset| T::usize_as(offset.as_usize() - first_offset))
-            .collect::<Vec<_>>();
-        OffsetBuffer::<T>::new(rebased_offsets.into())
-    };
+    let out_offsets = offsets.clone().subtract(*offsets[0]);
 
     // SAFETY: ASCII case conversion preserves byte length, so the original
     // string boundaries are preserved. `out_offsets` is either identical to

--- a/datafusion/functions/src/unicode/initcap.rs
+++ b/datafusion/functions/src/unicode/initcap.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use arrow::array::{Array, ArrayRef, GenericStringArray, OffsetSizeTrait};
-use arrow::buffer::{Buffer, OffsetBuffer};
+use arrow::buffer::Buffer;
 use arrow::datatypes::DataType;
 
 use crate::strings::{GenericStringArrayBuilder, StringViewArrayBuilder};
@@ -217,7 +217,7 @@ fn initcap_ascii_array<T: OffsetSizeTrait>(
     }
 
     let values = Buffer::from_vec(out);
-    let out_offsets = offsets.clone().subtract(*offsets[0]);
+    let out_offsets = offsets.clone().subtract(offsets[0]);
 
     // SAFETY: ASCII case conversion preserves byte length, so the original
     // string boundaries are preserved. `out_offsets` is either identical to


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Replace manually written code with the newly added helper I added to arrow-rs in:
- https://github.com/apache/arrow-rs/pull/10120 

## What changes are included in this PR?

use `OffsetBuffer::subtract`

## Are these changes tested?
Existing tests

## Are there any user-facing changes?
No