### PR TITLE
perf: optimize regexp_count in datafusion-functions

### DIFF
--- a/datafusion/functions/src/regex/regexpcount.rs
+++ b/datafusion/functions/src/regex/regexpcount.rs
@@ -565,6 +565,26 @@ fn count_matches(
             ));
         }
 
+        // Fast path for the default (and most common) case: `start == 1` always
+        // resolves to a byte offset of 0, so the search runs over the whole
+        // value and the character-counting scan below can be skipped entirely.
+        if start == 1 {
+            return Ok(pattern.find_iter(value).count() as i64);
+        }
+
+        // ASCII fast path: character indices equal byte indices, so the start
+        // position maps directly to a byte offset without scanning the value to
+        // count characters or resolve a `char_indices` boundary. A `start_index`
+        // equal to the length yields an empty slice (matching the general path),
+        // and one strictly past the end yields no matches.
+        if value.is_ascii() {
+            let start_index = (start as usize) - 1;
+            if start_index > value.len() {
+                return Ok(0);
+            }
+            return Ok(pattern.find_iter(&value[start_index..]).count() as i64);
+        }
+
         let char_len = value.chars().count();
         let start_index = (start as usize).saturating_sub(1);
 


### PR DESCRIPTION
> This PR was created by an LLM as a draft PR. I will mark it as ready for review after human review.


## Which issue does this PR close?

N/A — autonomous exploratory PR.

## Rationale for this change

Added start==1 and ASCII fast paths in count_matches to skip the per-row chars().count()/char_indices() scans (wasted on the default 2-arg form, redundant for ASCII), leaving only the regex find_iter.

## What changes are included in this PR?

Added start==1 and ASCII fast paths in count_matches to skip the per-row chars().count()/char_indices() scans (wasted on the default 2-arg form, redundant for ASCII), leaving only the regex find_iter.

## Are these changes tested?

Correctness: unit tests + seeded differential fuzz (bit-identical Arrow output vs `main`).

Benchmark (criterion):

- regexp_count_no_start [size=1024, str_len=32]: -1.095% faster (base 40983ns -> cand 41432ns)
- regexp_count_no_start [size=1024, str_len=128]: 10.188% faster (base 68356ns -> cand 61392ns)
- regexp_count_with_start [size=1024, str_len=128]: -0.686% faster (base 66664ns -> cand 67121ns)
- regexp_count_with_start [size=1024, str_len=32]: 6.192% faster (base 42125ns -> cand 39516ns)
- regexp_count_with_start [size=4096, str_len=32]: 13.631% faster (base 179812ns -> cand 155302ns)
- regexp_count_with_start [size=4096, str_len=128]: 9.641% faster (base 303717ns -> cand 274437ns)
- regexp_count_no_start [size=4096, str_len=32]: 4.067% faster (base 166029ns -> cand 159276ns)
- regexp_count_no_start [size=4096, str_len=128]: 14.911% faster (base 307809ns -> cand 261912ns)


## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
