### PR TITLE
fix(substrait): roundtrip scalar subqueries in projections

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer/rel/join.rs
+++ b/datafusion/substrait/src/logical_plan/producer/rel/join.rs
@@ -18,11 +18,11 @@
 use crate::logical_plan::producer::SubstraitProducer;
 use datafusion::common::{JoinConstraint, JoinType, NullEquality, not_impl_err};
 use datafusion::logical_expr::utils::conjunction;
-use datafusion::logical_expr::{Expr, Join, Operator};
+use datafusion::logical_expr::{Expr, Join, Operator, lit};
 use datafusion::prelude::binary_expr;
 use std::sync::Arc;
 use substrait::proto::rel::RelType;
-use substrait::proto::{JoinRel, Rel, join_rel};
+use substrait::proto::{CrossRel, JoinRel, Rel, join_rel};
 
 pub fn from_join(
     producer: &mut impl SubstraitProducer,
@@ -38,16 +38,26 @@ pub fn from_join(
     let right = producer.handle_plan(join.right.as_ref())?;
     let join_type = to_substrait_jointype(join.join_type);
 
-    let join_expr =
-        to_substrait_join_expr(join.on.clone(), join.null_equality, join.filter.clone());
-    let join_expression = match join_expr {
-        Some(expr) => {
-            let in_join_schema = Arc::new(join.left.schema().join(join.right.schema())?);
-            let expression = producer.handle_expr(&expr, &in_join_schema)?;
-            Some(Box::new(expression))
+    let join_expr = match to_substrait_join_expr(
+        join.on.clone(),
+        join.null_equality,
+        join.filter.clone(),
+    ) {
+        Some(expr) => expr,
+        None if join.join_type == JoinType::Inner => {
+            return Ok(Box::new(Rel {
+                rel_type: Some(RelType::Cross(Box::new(CrossRel {
+                    common: None,
+                    left: Some(left),
+                    right: Some(right),
+                    advanced_extension: None,
+                }))),
+            }));
         }
-        None => None,
+        None => lit(true),
     };
+    let in_join_schema = Arc::new(join.left.schema().join(join.right.schema())?);
+    let join_expression = producer.handle_expr(&join_expr, &in_join_schema)?;
 
     Ok(Box::new(Rel {
         rel_type: Some(RelType::Join(Box::new(JoinRel {
@@ -55,7 +65,7 @@ pub fn from_join(
             left: Some(left),
             right: Some(right),
             r#type: join_type as i32,
-            expression: join_expression,
+            expression: Some(Box::new(join_expression)),
             post_join_filter: None,
             advanced_extension: None,
         }))),

--- a/datafusion/substrait/src/logical_plan/producer/rel/join.rs
+++ b/datafusion/substrait/src/logical_plan/producer/rel/join.rs
@@ -117,7 +117,7 @@ mod tests {
     use std::sync::Arc;
     use substrait::proto::expression::{RexType, ScalarFunction};
     use substrait::proto::rel::RelType;
-    use substrait::proto::{Expression, JoinRel, Rel, join_rel};
+    use substrait::proto::{CrossRel, Expression, JoinRel, Rel, join_rel};
 
     #[test]
     fn test_from_join() -> datafusion::common::Result<()> {
@@ -183,5 +183,46 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn conditionless_inner_join_is_cross_rel() {
+        let state = SessionStateBuilder::default().build();
+        let mut producer = DefaultSubstraitProducer::new(&state);
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let left = Arc::new(
+            table_scan(Some("t1"), &schema, None)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let right = Arc::new(
+            table_scan(Some("t2"), &schema, None)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+
+        let inner = Join::try_new(
+            Arc::clone(&left),
+            Arc::clone(&right),
+            vec![],
+            None,
+            JoinType::Inner,
+            JoinConstraint::On,
+            NullEquality::NullEqualsNothing,
+            false,
+        )
+        .unwrap();
+        let expected = Rel {
+            rel_type: Some(RelType::Cross(Box::new(CrossRel {
+                common: None,
+                left: Some(producer.handle_plan(&left).unwrap()),
+                right: Some(producer.handle_plan(&right).unwrap()),
+                advanced_extension: None,
+            }))),
+        };
+
+        assert_eq!(producer.handle_join(&inner).unwrap(), Box::new(expected));
     }
 }

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -732,6 +732,50 @@ async fn roundtrip_scalar_subquery_substrait() -> Result<()> {
 }
 
 #[tokio::test]
+async fn roundtrip_scalar_subquery_projection_with_join_rewrite() -> Result<()> {
+    let ctx = create_context().await?;
+    ctx.sql(
+        "SET datafusion.optimizer.enable_physical_uncorrelated_scalar_subquery = false",
+    )
+    .await?
+    .collect()
+    .await?;
+
+    let plan = generate_plan_from_sql_with_ctx(
+        "SELECT a, (SELECT MAX(b) FROM data2) AS max_b FROM data",
+        false,
+        true,
+        &ctx,
+    )
+    .await?;
+
+    assert_snapshot!(
+        plan,
+        @r"
+    Projection: data.a, max(data2.b) AS max_b
+      Left Join:
+        TableScan: data projection=[a]
+        Aggregate: groupBy=[[]], aggr=[[max(data2.b)]]
+          TableScan: data2 projection=[b], partial_filters=[Boolean(true)]
+    "
+    );
+
+    let results = DataFrame::new(ctx.state(), plan).collect().await?;
+    datafusion::assert_batches_sorted_eq!(
+        [
+            "+---+-------+",
+            "| a | max_b |",
+            "+---+-------+",
+            "| 1 | 4.5   |",
+            "| 3 | 4.5   |",
+            "+---+-------+",
+        ],
+        &results
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn roundtrip_exists_substrait() -> Result<()> {
     let ctx = create_context().await?;
     let plan = build_exists_filter_plan(&ctx, false).await?;

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -781,6 +781,50 @@ async fn roundtrip_scalar_subquery_substrait() -> Result<()> {
 }
 
 #[tokio::test]
+async fn roundtrip_scalar_subquery_projection_with_join_rewrite() -> Result<()> {
+    let ctx = create_context().await?;
+    ctx.sql(
+        "SET datafusion.optimizer.enable_physical_uncorrelated_scalar_subquery = false",
+    )
+    .await?
+    .collect()
+    .await?;
+
+    let plan = generate_plan_from_sql_with_ctx(
+        "SELECT a, (SELECT MAX(b) FROM data2) AS max_b FROM data",
+        false,
+        true,
+        &ctx,
+    )
+    .await?;
+
+    assert_snapshot!(
+        plan,
+        @r"
+    Projection: data.a, max(data2.b) AS max_b
+      Left Join:
+        TableScan: data projection=[a]
+        Aggregate: groupBy=[[]], aggr=[[max(data2.b)]]
+          TableScan: data2 projection=[b], partial_filters=[Boolean(true)]
+    "
+    );
+
+    let results = DataFrame::new(ctx.state(), plan).collect().await?;
+    datafusion::assert_batches_sorted_eq!(
+        [
+            "+---+-------+",
+            "| a | max_b |",
+            "+---+-------+",
+            "| 1 | 4.5   |",
+            "| 3 | 4.5   |",
+            "+---+-------+",
+        ],
+        &results
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn roundtrip_exists_substrait() -> Result<()> {
     let ctx = create_context().await?;
     let plan = build_exists_filter_plan(&ctx, false).await?;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18066.

## Rationale for this change

With `datafusion.optimizer.enable_physical_uncorrelated_scalar_subquery` disabled, DataFusion rewrites a scalar subquery in a projection as a left join. The optimizer can remove its `true` filter before Substrait serialization. This left `JoinRel.expression` unset, even though Substrait requires it, and the consumer failed with `Plan("join condition should not be empty")`.

#18068 tried to fix the same roundtrip in the consumer, but also treated a conditionless inner `JoinRel` as a cross join. Review questioned that behavior change, then the PR went stale. This version does not reinterpret an invalid `JoinRel`: the producer uses `CrossRel` for conditionless inner joins and a literal `true` expression for conditionless non-inner joins.

## What changes are included in this PR?

- Serialize conditionless inner joins as `CrossRel`.
- Serialize a literal `true` expression for conditionless non-inner joins.
- Add a scalar-subquery projection roundtrip test that checks the consumed plan and query result.

## Are these changes tested?

- The focused scalar-subquery projection roundtrip and conditionless inner-join `CrossRel` tests passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- The extended workspace Rust suites passed after excluding four host memory-measurement runners that also fail on current main in this environment.
- The SQL logic harness passed all 512 files.
- `cargo fmt --all -- --check` and `git diff --check` passed.

## Are there any user-facing changes?

Scalar subqueries in projections now roundtrip when this optimizer option is disabled. No public API change.
