### PR TITLE
ci: Use `install-action` instead of `cargo install` to speed up CI

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -78,6 +78,7 @@ github:
           - "cargo test (macos-aarch64)"
           - "Verify Vendored Code"
           - "Check cargo fmt"
+          - "Check GitHub Actions install tooling"
           - "clippy"
           - "check Cargo.toml formatting"
           - "check configs.md and ***_functions.md is up-to-date"
@@ -114,4 +115,3 @@ github:
 # https://datafusion.apache.org/
 publish:
   whoami: asf-site
-

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Install cargo-machete
-        run: cargo install cargo-machete --version ^0.9 --locked
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c  # v2.82.10
+        with:
+          tool: cargo-machete@0.9
       - name: Detect unused dependencies
         run: cargo machete --with-metadata

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -38,8 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Install HawkEye
-      # This CI job is bound by installation time, use `--profile dev` to speed it up
-        run: cargo install hawkeye --version 6.2.0 --locked --profile dev
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c  # v2.82.10
+        with:
+          tool: hawkeye@6.2.0
       - name: Run license header check
         run: ci/scripts/license_header.sh
 
@@ -89,7 +90,9 @@ jobs:
       # Version fixed on purpose. It uses heuristics to detect typos, so upgrading
       # it may cause checks to fail more often.
       # We can upgrade it manually once a while.
-      - name: Install typos-cli
-        run: cargo install typos-cli --locked --version 1.37.0
+      - name: Install typos
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c  # v2.82.10
+        with:
+          tool: typos@1.37.0
       - name: Run typos check
         run: ci/scripts/typos_check.sh

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,12 +47,15 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --package datafusion-docs
-      - name: Install dependency graph tooling
+      - name: Install Graphviz
         run: |
           set -x
           sudo apt-get update
           sudo apt-get install -y graphviz
-          cargo install cargo-depgraph --version ^1.6 --locked
+      - name: Install cargo-depgraph
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c  # v2.82.10
+        with:
+          tool: cargo-depgraph@1.6
 
       - name: Build docs
         run: |

--- a/.github/workflows/docs_pr.yaml
+++ b/.github/workflows/docs_pr.yaml
@@ -53,12 +53,15 @@ jobs:
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
       - name: Install doc dependencies
         run: uv sync --package datafusion-docs
-      - name: Install dependency graph tooling
+      - name: Install Graphviz
         run: |
           set -x
           sudo apt-get update
           sudo apt-get install -y graphviz
-          cargo install cargo-depgraph --version ^1.6 --locked
+      - name: Install cargo-depgraph
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c  # v2.82.10
+        with:
+          tool: cargo-depgraph@1.6
       - name: Build docs html and check for warnings
         run: |
           set -x

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -628,6 +628,14 @@ jobs:
         run: |
           ci/scripts/rust_fmt.sh
 
+  check-workflow-tool-installs:
+    name: Check GitHub Actions install tooling
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Check workflow tool installs
+        run: ci/scripts/check_no_cargo_install_in_workflows.sh
+
   # Coverage job disabled due to
   # https://github.com/apache/datafusion/issues/3678
 
@@ -659,12 +667,15 @@ jobs:
   #         path: /home/runner/.cargo
   #         # this key is not equal because the user is different than on a container (runner vs github)
   #         key: cargo-coverage-cache3-
+  #     - name: Install cargo-tarpaulin
+  #       uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c  # v2.82.10
+  #       with:
+  #         tool: cargo-tarpaulin@0.20.1
   #     - name: Run coverage
   #       run: |
   #         export PATH=$PATH:$HOME/d/protoc/bin
   #         rustup toolchain install stable
   #         rustup default stable
-  #         cargo install --version 0.20.1 cargo-tarpaulin
   #         cargo tarpaulin --all --out Xml
   #     - name: Report coverage
   #       continue-on-error: true

--- a/ci/scripts/check_no_cargo_install_in_workflows.sh
+++ b/ci/scripts/check_no_cargo_install_in_workflows.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+WORKFLOWS_DIR=".github/workflows"
+
+if grep -R -n --include='*.yml' --include='*.yaml' -- 'cargo install' "${WORKFLOWS_DIR}"; then
+  echo "[${SCRIPT_NAME}] Found workflow Rust tool installs that should use taiki-e/install-action instead." >&2
+  exit 1
+fi
+
+echo "[${SCRIPT_NAME}] GitHub Actions workflow tool installs look good."

--- a/dev/rust_lint.sh
+++ b/dev/rust_lint.sh
@@ -106,6 +106,7 @@ declare -a WRITE_STEPS=(
 )
 
 declare -a READONLY_STEPS=(
+  "ci/scripts/check_no_cargo_install_in_workflows.sh|false"
   "ci/scripts/rust_docs.sh|false"
 )
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
For CI dependencies installed with `cargo install`, it's possible to use `install-action` instead for faster setup. (former compiles the binary, the latter directly download the release version) , each of them should get ~1min faster.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Use `install-action` instead of `cargo install` for existing CI jobs
- Add a new CI job to enforce this convention (`grep cargo install` for all Github Action scripts)

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
