### PR TITLE
perf: optimize `lcm`

### DIFF
--- a/datafusion/functions/src/math/common.rs
+++ b/datafusion/functions/src/math/common.rs
@@ -140,7 +140,9 @@ pub(crate) fn lcm_signed_int(x: i64, y: i64) -> Result<i64, ArrowError> {
     let a = x.unsigned_abs();
     let b = y.unsigned_abs();
 
-    let gcd = gcd_helper::<u64>(a, b)?;
+    // Use the binary GCD, matching `gcd_signed_int` and avoiding the
+    // per-iteration division of the Euclidean `gcd_helper`.
+    let gcd = unsigned_gcd(a, b);
     // gcd is not zero since both a and b are not zero, so the division is safe.
     (a / gcd)
         .checked_mul(b)


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Optimize existing function.

## What changes are included in this PR?

lcm now computes its internal GCD with the binary (Stein's) algorithm (unsigned_gcd) instead of the division-based Euclidean gcd_helper, replacing per-iteration integer division with shifts for identical results.

## Are these changes tested?

Existing tests.

Benchmark (criterion):

- lcm both array: 25.28% faster (base 1567271ns -> cand 1171061ns)


## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
