### PR TITLE
feat: add metrics tracking for file sinks and update orchestration fo…

### DIFF
--- a/datafusion/datasource-csv/src/file_format.rs
+++ b/datafusion/datasource-csv/src/file_format.rs
@@ -43,14 +43,19 @@ use datafusion_datasource::file_format::{
     DEFAULT_SCHEMA_INFER_MAX_RECORD, FileFormat, FileFormatFactory,
 };
 use datafusion_datasource::file_scan_config::{FileScanConfig, FileScanConfigBuilder};
-use datafusion_datasource::file_sink_config::{FileSink, FileSinkConfig};
+use datafusion_datasource::file_sink_config::{
+    FileSink, FileSinkConfig, FileSinkMetrics,
+};
 use datafusion_datasource::sink::{DataSink, DataSinkExec};
 use datafusion_datasource::write::BatchSerializer;
 use datafusion_datasource::write::demux::DemuxedStreamReceiver;
-use datafusion_datasource::write::orchestration::spawn_writer_tasks_and_join;
+use datafusion_datasource::write::orchestration::{
+    StatelessWriterOptions, spawn_writer_tasks_and_join_with_metrics,
+};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::dml::InsertOp;
 use datafusion_physical_expr_common::sort_expr::LexRequirement;
+use datafusion_physical_plan::metrics::MetricsSet;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
 use datafusion_session::Session;
 
@@ -740,6 +745,8 @@ pub struct CsvSink {
     /// Config options for writing data
     config: FileSinkConfig,
     writer_options: CsvWriterOptions,
+    /// Metrics for tracking write operations
+    metrics: FileSinkMetrics,
 }
 
 impl Debug for CsvSink {
@@ -770,6 +777,7 @@ impl CsvSink {
         Self {
             config,
             writer_options,
+            metrics: FileSinkMetrics::new(),
         }
     }
 
@@ -799,11 +807,12 @@ impl FileSink for CsvSink {
                 .with_builder(builder)
                 .with_header(header),
         ) as _;
-        spawn_writer_tasks_and_join(
+        spawn_writer_tasks_and_join_with_metrics(
             context,
             serializer,
-            self.writer_options.compression.into(),
-            self.writer_options.compression_level,
+            StatelessWriterOptions::new(self.writer_options.compression.into())
+                .with_compression_level(self.writer_options.compression_level)
+                .with_metrics(&self.metrics),
             object_store,
             demux_task,
             file_stream_rx,
@@ -814,6 +823,10 @@ impl FileSink for CsvSink {
 
 #[async_trait]
 impl DataSink for CsvSink {
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.snapshot())
+    }
+
     fn schema(&self) -> &SchemaRef {
         self.config.output_schema()
     }

--- a/datafusion/datasource-json/src/file_format.rs
+++ b/datafusion/datasource-json/src/file_format.rs
@@ -46,15 +46,20 @@ use datafusion_datasource::file_format::{
     DEFAULT_SCHEMA_INFER_MAX_RECORD, FileFormat, FileFormatFactory,
 };
 use datafusion_datasource::file_scan_config::{FileScanConfig, FileScanConfigBuilder};
-use datafusion_datasource::file_sink_config::{FileSink, FileSinkConfig};
+use datafusion_datasource::file_sink_config::{
+    FileSink, FileSinkConfig, FileSinkMetrics,
+};
 use datafusion_datasource::sink::{DataSink, DataSinkExec};
 use datafusion_datasource::source::DataSourceExec;
 use datafusion_datasource::write::BatchSerializer;
 use datafusion_datasource::write::demux::DemuxedStreamReceiver;
-use datafusion_datasource::write::orchestration::spawn_writer_tasks_and_join;
+use datafusion_datasource::write::orchestration::{
+    StatelessWriterOptions, spawn_writer_tasks_and_join_with_metrics,
+};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::dml::InsertOp;
 use datafusion_physical_expr_common::sort_expr::LexRequirement;
+use datafusion_physical_plan::metrics::MetricsSet;
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
 use datafusion_session::Session;
 
@@ -411,6 +416,8 @@ pub struct JsonSink {
     config: FileSinkConfig,
     /// Writer options for underlying Json writer
     writer_options: JsonWriterOptions,
+    /// Metrics for tracking write operations
+    metrics: FileSinkMetrics,
 }
 
 impl Debug for JsonSink {
@@ -441,6 +448,7 @@ impl JsonSink {
         Self {
             config,
             writer_options,
+            metrics: FileSinkMetrics::new(),
         }
     }
 
@@ -464,11 +472,12 @@ impl FileSink for JsonSink {
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<u64> {
         let serializer = Arc::new(JsonSerializer::new()) as _;
-        spawn_writer_tasks_and_join(
+        spawn_writer_tasks_and_join_with_metrics(
             context,
             serializer,
-            self.writer_options.compression.into(),
-            self.writer_options.compression_level,
+            StatelessWriterOptions::new(self.writer_options.compression.into())
+                .with_compression_level(self.writer_options.compression_level)
+                .with_metrics(&self.metrics),
             object_store,
             demux_task,
             file_stream_rx,
@@ -479,6 +488,10 @@ impl FileSink for JsonSink {
 
 #[async_trait]
 impl DataSink for JsonSink {
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.snapshot())
+    }
+
     fn schema(&self) -> &SchemaRef {
         self.config.output_schema()
     }

--- a/datafusion/datasource-parquet/src/sink.rs
+++ b/datafusion/datasource-parquet/src/sink.rs
@@ -31,7 +31,9 @@ use datafusion_common::{DataFusionError, HashMap, Result, internal_datafusion_er
 use datafusion_common_runtime::{JoinSet, SpawnedTask};
 use datafusion_datasource::display::FileGroupDisplay;
 use datafusion_datasource::file_compression_type::FileCompressionType;
-use datafusion_datasource::file_sink_config::{FileSink, FileSinkConfig};
+use datafusion_datasource::file_sink_config::{
+    FileSink, FileSinkConfig, FileSinkMetrics,
+};
 use datafusion_datasource::sink::DataSink;
 #[cfg(feature = "proto")]
 use datafusion_datasource::sink::DataSinkExec;
@@ -44,10 +46,7 @@ use datafusion_execution::runtime_env::RuntimeEnv;
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 #[cfg(feature = "proto")]
 use datafusion_physical_plan::ExecutionPlan;
-use datafusion_physical_plan::metrics::{
-    ElapsedComputeFutureExt, ExecutionPlanMetricsSet, MetricBuilder, MetricCategory,
-    MetricsSet, Time,
-};
+use datafusion_physical_plan::metrics::{ElapsedComputeFutureExt, MetricsSet, Time};
 use datafusion_physical_plan::{DisplayAs, DisplayFormatType};
 use object_store::ObjectStore;
 use object_store::buffered::BufWriter;
@@ -87,7 +86,7 @@ pub struct ParquetSink {
     /// Optional sorting columns to write to Parquet metadata
     sorting_columns: Option<Vec<SortingColumn>>,
     /// Metrics for tracking write operations
-    metrics: ExecutionPlanMetricsSet,
+    metrics: FileSinkMetrics,
 }
 
 impl Debug for ParquetSink {
@@ -120,7 +119,7 @@ impl ParquetSink {
             parquet_options,
             written: Default::default(),
             sorting_columns: None,
-            metrics: ExecutionPlanMetricsSet::new(),
+            metrics: FileSinkMetrics::new(),
         }
     }
 
@@ -267,16 +266,12 @@ impl FileSink for ParquetSink {
         mut file_stream_rx: DemuxedStreamReceiver,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<u64> {
-        let rows_written_counter = MetricBuilder::new(&self.metrics)
-            .with_category(MetricCategory::Rows)
-            .global_counter("rows_written");
+        let rows_written_counter = self.metrics.rows_written().clone();
         // Note: bytes_written is the sum of compressed row group sizes, which
         // may differ slightly from the actual on-disk file size (excludes footer,
         // page indexes, and other Parquet metadata overhead).
-        let bytes_written_counter = MetricBuilder::new(&self.metrics)
-            .with_category(MetricCategory::Bytes)
-            .global_counter("bytes_written");
-        let elapsed_compute = MetricBuilder::new(&self.metrics).elapsed_compute(0);
+        let bytes_written_counter = self.metrics.bytes_written().clone();
+        let elapsed_compute = self.metrics.elapsed_compute().clone();
 
         let parquet_opts = &self.parquet_options;
 
@@ -400,7 +395,7 @@ impl FileSink for ParquetSink {
 #[async_trait]
 impl DataSink for ParquetSink {
     fn metrics(&self) -> Option<MetricsSet> {
-        Some(self.metrics.clone_inner())
+        Some(self.metrics.snapshot())
     }
 
     fn schema(&self) -> &SchemaRef {

--- a/datafusion/datasource-parquet/src/sink.rs
+++ b/datafusion/datasource-parquet/src/sink.rs
@@ -266,12 +266,12 @@ impl FileSink for ParquetSink {
         mut file_stream_rx: DemuxedStreamReceiver,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<u64> {
-        let rows_written_counter = self.metrics.rows_written().clone();
+        let rows_written_counter = self.metrics.rows_written();
         // Note: bytes_written is the sum of compressed row group sizes, which
         // may differ slightly from the actual on-disk file size (excludes footer,
         // page indexes, and other Parquet metadata overhead).
-        let bytes_written_counter = self.metrics.bytes_written().clone();
-        let elapsed_compute = self.metrics.elapsed_compute().clone();
+        let bytes_written_counter = self.metrics.bytes_written();
+        let elapsed_compute = self.metrics.elapsed_compute();
 
         let parquet_opts = &self.parquet_options;
 

--- a/datafusion/datasource/src/file_compression_type.rs
+++ b/datafusion/datasource/src/file_compression_type.rs
@@ -168,11 +168,14 @@ impl FileCompressionType {
     ///
     /// If `compression_level` is `Some`, the encoder will use the specified
     /// compression level. If `None`, the default level for each algorithm is used.
-    pub fn convert_async_writer_with_level(
+    pub fn convert_async_writer_with_level<W>(
         &self,
-        w: BufWriter,
+        w: W,
         compression_level: Option<u32>,
-    ) -> Result<Box<dyn AsyncWrite + Send + Unpin>> {
+    ) -> Result<Box<dyn AsyncWrite + Send + Unpin>>
+    where
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
         #[cfg(feature = "compression")]
         use async_compression::Level;
 

--- a/datafusion/datasource/src/file_sink_config.rs
+++ b/datafusion/datasource/src/file_sink_config.rs
@@ -28,12 +28,75 @@ use datafusion_common_runtime::SpawnedTask;
 use datafusion_execution::object_store::ObjectStoreUrl;
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::dml::InsertOp;
+use datafusion_physical_plan::metrics::{
+    Count, ExecutionPlanMetricsSet, MetricBuilder, MetricCategory, MetricsSet, Time,
+};
 
 use async_trait::async_trait;
 use object_store::ObjectStore;
 
 #[cfg(feature = "proto")]
 mod proto;
+
+/// Common metrics exposed by file sinks.
+#[derive(Debug)]
+pub struct FileSinkMetrics {
+    metrics: ExecutionPlanMetricsSet,
+    rows_written: Count,
+    bytes_written: Count,
+    elapsed_compute: Time,
+}
+
+impl FileSinkMetrics {
+    /// Create a new set of file sink metrics.
+    pub fn new() -> Self {
+        let metrics = ExecutionPlanMetricsSet::new();
+        let rows_written = MetricBuilder::new(&metrics)
+            .with_category(MetricCategory::Rows)
+            .global_counter("rows_written");
+        let bytes_written = MetricBuilder::new(&metrics)
+            .with_category(MetricCategory::Bytes)
+            .global_counter("bytes_written");
+        let elapsed_compute = MetricBuilder::new(&metrics).elapsed_compute(0);
+
+        Self {
+            metrics,
+            rows_written,
+            bytes_written,
+            elapsed_compute,
+        }
+    }
+
+    /// Return the number of rows written.
+    pub fn rows_written(&self) -> &Count {
+        &self.rows_written
+    }
+
+    /// Return the number of bytes written.
+    ///
+    /// The exact meaning is format-specific. For stateless sinks, this is the
+    /// number of serialized bytes passed to the writer before any stream-level
+    /// compression is applied.
+    pub fn bytes_written(&self) -> &Count {
+        &self.bytes_written
+    }
+
+    /// Return the elapsed compute time.
+    pub fn elapsed_compute(&self) -> &Time {
+        &self.elapsed_compute
+    }
+
+    /// Return a snapshot of the metrics.
+    pub fn snapshot(&self) -> MetricsSet {
+        self.metrics.clone_inner()
+    }
+}
+
+impl Default for FileSinkMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Determines how `FileSink` output paths are interpreted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/datafusion/datasource/src/file_sink_config.rs
+++ b/datafusion/datasource/src/file_sink_config.rs
@@ -75,8 +75,7 @@ impl FileSinkMetrics {
     /// Return the number of bytes written.
     ///
     /// The exact meaning is format-specific. For stateless sinks, this is the
-    /// number of serialized bytes passed to the writer before any stream-level
-    /// compression is applied.
+    /// number of bytes written after any stream-level compression is applied.
     pub fn bytes_written(&self) -> &Count {
         &self.bytes_written
     }

--- a/datafusion/datasource/src/file_sink_config.rs
+++ b/datafusion/datasource/src/file_sink_config.rs
@@ -42,47 +42,33 @@ mod proto;
 #[derive(Debug)]
 pub struct FileSinkMetrics {
     metrics: ExecutionPlanMetricsSet,
-    rows_written: Count,
-    bytes_written: Count,
-    elapsed_compute: Time,
 }
 
 impl FileSinkMetrics {
     /// Create a new set of file sink metrics.
     pub fn new() -> Self {
-        let metrics = ExecutionPlanMetricsSet::new();
-        let rows_written = MetricBuilder::new(&metrics)
-            .with_category(MetricCategory::Rows)
-            .global_counter("rows_written");
-        let bytes_written = MetricBuilder::new(&metrics)
-            .with_category(MetricCategory::Bytes)
-            .global_counter("bytes_written");
-        let elapsed_compute = MetricBuilder::new(&metrics).elapsed_compute(0);
-
         Self {
-            metrics,
-            rows_written,
-            bytes_written,
-            elapsed_compute,
+            metrics: ExecutionPlanMetricsSet::new(),
         }
     }
 
-    /// Return the number of rows written.
-    pub fn rows_written(&self) -> &Count {
-        &self.rows_written
+    /// Create a counter for rows written by one sink execution.
+    pub fn rows_written(&self) -> Count {
+        MetricBuilder::new(&self.metrics)
+            .with_category(MetricCategory::Rows)
+            .global_counter("rows_written")
     }
 
-    /// Return the number of bytes written.
-    ///
-    /// The exact meaning is format-specific. For stateless sinks, this is the
-    /// number of bytes written after any stream-level compression is applied.
-    pub fn bytes_written(&self) -> &Count {
-        &self.bytes_written
+    /// Create a counter for bytes written by one sink execution.
+    pub fn bytes_written(&self) -> Count {
+        MetricBuilder::new(&self.metrics)
+            .with_category(MetricCategory::Bytes)
+            .global_counter("bytes_written")
     }
 
-    /// Return the elapsed compute time.
-    pub fn elapsed_compute(&self) -> &Time {
-        &self.elapsed_compute
+    /// Create an elapsed-compute metric for one sink execution.
+    pub fn elapsed_compute(&self) -> Time {
+        MetricBuilder::new(&self.metrics).elapsed_compute(0)
     }
 
     /// Return a snapshot of the metrics.
@@ -231,5 +217,23 @@ impl FileSinkConfig {
     /// Get output schema
     pub fn output_schema(&self) -> &SchemaRef {
         &self.output_schema
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_are_created_per_sink_execution() {
+        let metrics = FileSinkMetrics::new();
+
+        let first_rows = metrics.rows_written();
+        first_rows.add(3);
+
+        let second_rows = metrics.rows_written();
+
+        assert_eq!(first_rows.value(), 3);
+        assert_eq!(second_rows.value(), 0);
     }
 }

--- a/datafusion/datasource/src/write/mod.rs
+++ b/datafusion/datasource/src/write/mod.rs
@@ -19,7 +19,10 @@
 //! write support for the various file formats
 
 use std::io::Write;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
 
 use crate::file_compression_type::FileCompressionType;
 use crate::file_sink_config::FileSinkConfig;
@@ -64,6 +67,62 @@ impl Write for SharedBuffer {
     fn flush(&mut self) -> std::io::Result<()> {
         let mut buffer = self.buffer.try_lock().unwrap();
         Write::flush(&mut *buffer)
+    }
+}
+
+/// An async writer that counts the number of bytes written to its inner writer.
+#[derive(Debug)]
+struct CountingWriter<W> {
+    inner: W,
+    bytes_written: Arc<AtomicUsize>,
+}
+
+impl<W> CountingWriter<W> {
+    fn new(inner: W) -> (Self, Arc<AtomicUsize>) {
+        let bytes_written = Arc::new(AtomicUsize::new(0));
+
+        (
+            Self {
+                inner,
+                bytes_written: Arc::clone(&bytes_written),
+            },
+            bytes_written,
+        )
+    }
+}
+
+impl<W> AsyncWrite for CountingWriter<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+
+        match Pin::new(&mut this.inner).poll_write(cx, buf) {
+            Poll::Ready(Ok(written)) => {
+                this.bytes_written.fetch_add(written, Ordering::Relaxed);
+                Poll::Ready(Ok(written))
+            }
+            result => result,
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
     }
 }
 
@@ -228,5 +287,69 @@ impl ObjectWriterBuilder {
 
         file_compression_type
             .convert_async_writer_with_level(buf_writer, compression_level)
+    }
+
+    /// Build a compressed object writer and return a shared counter containing
+    /// the number of compressed bytes written to the object store writer.
+    pub(crate) fn build_with_byte_counter(
+        self,
+    ) -> Result<(Box<dyn AsyncWrite + Send + Unpin>, Arc<AtomicUsize>)> {
+        let Self {
+            file_compression_type,
+            location,
+            object_store,
+            buffer_size,
+            compression_level,
+        } = self;
+
+        let buf_writer = match buffer_size {
+            Some(size) => BufWriter::with_capacity(object_store, location, size),
+            None => BufWriter::new(object_store, location),
+        };
+
+        let (counting_writer, bytes_written) = CountingWriter::new(buf_writer);
+        let writer = file_compression_type
+            .convert_async_writer_with_level(counting_writer, compression_level)?;
+
+        Ok((writer, bytes_written))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use object_store::ObjectStoreExt;
+    use object_store::memory::InMemory;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn compressed_byte_counter_matches_object_size() {
+        let object_store = Arc::new(InMemory::new());
+        let location = Path::from("compressed.csv.gz");
+        let input = vec![b'a'; 16 * 1024];
+
+        let (mut writer, bytes_written) = ObjectWriterBuilder::new(
+            FileCompressionType::GZIP,
+            &location,
+            object_store.clone(),
+        )
+        .build_with_byte_counter()
+        .unwrap();
+
+        writer.write_all(&input).await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        let actual_size = object_store
+            .get(&location)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap()
+            .len();
+
+        assert_eq!(bytes_written.load(Ordering::Relaxed), actual_size);
+        assert!(actual_size < input.len());
     }
 }

--- a/datafusion/datasource/src/write/orchestration.rs
+++ b/datafusion/datasource/src/write/orchestration.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use super::demux::DemuxedStreamReceiver;
 use super::{BatchSerializer, ObjectWriterBuilder};
 use crate::file_compression_type::FileCompressionType;
+use crate::file_sink_config::FileSinkMetrics;
 use datafusion_common::error::Result;
 
 use arrow::array::RecordBatch;
@@ -50,6 +51,9 @@ pub(crate) enum SerializedRecordBatchResult {
 
         /// the number of rows successfully written
         row_count: usize,
+
+        /// the number of serialized bytes successfully written
+        bytes_written: usize,
     },
     Failure {
         /// As explained in [`serialize_rb_stream_to_object_store`]:
@@ -64,8 +68,12 @@ pub(crate) enum SerializedRecordBatchResult {
 
 impl SerializedRecordBatchResult {
     /// Create the success variant
-    pub fn success(writer: WriterType, row_count: usize) -> Self {
-        Self::Success { writer, row_count }
+    pub fn success(writer: WriterType, row_count: usize, bytes_written: usize) -> Self {
+        Self::Success {
+            writer,
+            row_count,
+            bytes_written,
+        }
     }
 
     pub fn failure(writer: Option<WriterType>, err: DataFusionError) -> Self {
@@ -111,9 +119,11 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
     });
 
     let mut row_count = 0;
+    let mut bytes_written = 0;
     while let Some(task) = rx.recv().await {
         match task.join().await {
             Ok(Ok((cnt, bytes))) => {
+                let byte_len = bytes.len();
                 match writer.write_all(&bytes).await {
                     Ok(_) => (),
                     Err(e) => {
@@ -124,6 +134,7 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
                     }
                 };
                 row_count += cnt;
+                bytes_written += byte_len;
             }
             Ok(Err(e)) => {
                 // Return the writer along with the error
@@ -151,10 +162,41 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
             );
         }
     }
-    SerializedRecordBatchResult::success(writer, row_count)
+    SerializedRecordBatchResult::success(writer, row_count, bytes_written)
 }
 
 type FileWriteBundle = (Receiver<RecordBatch>, SerializerType, WriterType);
+
+/// Options for stateless file writer tasks.
+pub struct StatelessWriterOptions<'a> {
+    compression: FileCompressionType,
+    compression_level: Option<u32>,
+    metrics: Option<&'a FileSinkMetrics>,
+}
+
+impl<'a> StatelessWriterOptions<'a> {
+    /// Create options for the specified compression type.
+    pub fn new(compression: FileCompressionType) -> Self {
+        Self {
+            compression,
+            compression_level: None,
+            metrics: None,
+        }
+    }
+
+    /// Set the compression level.
+    pub fn with_compression_level(mut self, compression_level: Option<u32>) -> Self {
+        self.compression_level = compression_level;
+        self
+    }
+
+    /// Record common file sink metrics while writing.
+    pub fn with_metrics(mut self, metrics: &'a FileSinkMetrics) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+}
+
 /// Contains the common logic for serializing RecordBatches and
 /// writing the resulting bytes to an ObjectStore.
 /// Serialization is assumed to be stateless, i.e.
@@ -162,9 +204,10 @@ type FileWriteBundle = (Receiver<RecordBatch>, SerializerType, WriterType);
 /// dependency on the RecordBatches before or after.
 pub(crate) async fn stateless_serialize_and_write_files(
     mut rx: Receiver<FileWriteBundle>,
-    tx: tokio::sync::oneshot::Sender<u64>,
+    tx: tokio::sync::oneshot::Sender<(u64, usize)>,
 ) -> Result<()> {
     let mut row_count = 0;
+    let mut bytes_written = 0;
     // tracks if any writers encountered an error triggering the need to abort
     let mut any_errors = false;
     // tracks the specific error triggering abort
@@ -185,9 +228,11 @@ pub(crate) async fn stateless_serialize_and_write_files(
                 SerializedRecordBatchResult::Success {
                     writer,
                     row_count: cnt,
+                    bytes_written: bytes,
                 } => {
                     finished_writers.push(writer);
                     row_count += cnt;
+                    bytes_written += bytes;
                 }
                 SerializedRecordBatchResult::Failure { writer, err } => {
                     finished_writers.extend(writer);
@@ -233,7 +278,7 @@ pub(crate) async fn stateless_serialize_and_write_files(
         }
     }
 
-    tx.send(row_count as u64).map_err(|_| {
+    tx.send((row_count as u64, bytes_written)).map_err(|_| {
         internal_datafusion_err!(
             "Error encountered while sending row count back to file sink!"
         )
@@ -251,8 +296,32 @@ pub async fn spawn_writer_tasks_and_join(
     compression_level: Option<u32>,
     object_store: Arc<dyn ObjectStore>,
     demux_task: SpawnedTask<Result<()>>,
+    file_stream_rx: DemuxedStreamReceiver,
+) -> Result<u64> {
+    spawn_writer_tasks_and_join_with_metrics(
+        context,
+        serializer,
+        StatelessWriterOptions::new(compression)
+            .with_compression_level(compression_level),
+        object_store,
+        demux_task,
+        file_stream_rx,
+    )
+    .await
+}
+
+/// Like [`spawn_writer_tasks_and_join`], and also records common file sink metrics.
+pub async fn spawn_writer_tasks_and_join_with_metrics(
+    context: &Arc<TaskContext>,
+    serializer: Arc<dyn BatchSerializer>,
+    options: StatelessWriterOptions<'_>,
+    object_store: Arc<dyn ObjectStore>,
+    demux_task: SpawnedTask<Result<()>>,
     mut file_stream_rx: DemuxedStreamReceiver,
 ) -> Result<u64> {
+    let _timer = options
+        .metrics
+        .map(|metrics| metrics.elapsed_compute().timer());
     let rb_buffer_size = &context
         .session_config()
         .options()
@@ -265,17 +334,20 @@ pub async fn spawn_writer_tasks_and_join(
         stateless_serialize_and_write_files(rx_file_bundle, tx_row_cnt).await
     });
     while let Some((location, rb_stream)) = file_stream_rx.recv().await {
-        let writer =
-            ObjectWriterBuilder::new(compression, &location, Arc::clone(&object_store))
-                .with_buffer_size(Some(
-                    context
-                        .session_config()
-                        .options()
-                        .execution
-                        .objectstore_writer_buffer_size,
-                ))
-                .with_compression_level(compression_level)
-                .build()?;
+        let writer = ObjectWriterBuilder::new(
+            options.compression,
+            &location,
+            Arc::clone(&object_store),
+        )
+        .with_buffer_size(Some(
+            context
+                .session_config()
+                .options()
+                .execution
+                .objectstore_writer_buffer_size,
+        ))
+        .with_compression_level(options.compression_level)
+        .build()?;
 
         if tx_file_bundle
             .send((rb_stream, Arc::clone(&serializer), writer))
@@ -298,8 +370,13 @@ pub async fn spawn_writer_tasks_and_join(
     r1.map_err(|e| DataFusionError::ExecutionJoin(Box::new(e)))??;
     r2.map_err(|e| DataFusionError::ExecutionJoin(Box::new(e)))??;
 
-    // Return total row count:
-    rx_row_cnt.await.map_err(|_| {
+    // Return total row count and update optional metrics:
+    let (rows_written, bytes_written) = rx_row_cnt.await.map_err(|_| {
         internal_datafusion_err!("Did not receive row count from write coordinator")
-    })
+    })?;
+    if let Some(metrics) = options.metrics {
+        metrics.rows_written().add(rows_written as usize);
+        metrics.bytes_written().add(bytes_written);
+    }
+    Ok(rows_written)
 }

--- a/datafusion/datasource/src/write/orchestration.rs
+++ b/datafusion/datasource/src/write/orchestration.rs
@@ -27,6 +27,7 @@ use super::{BatchSerializer, ObjectWriterBuilder};
 use crate::file_compression_type::FileCompressionType;
 use crate::file_sink_config::FileSinkMetrics;
 use datafusion_common::error::Result;
+use datafusion_physical_plan::metrics::Time;
 
 use arrow::array::RecordBatch;
 use datafusion_common::{
@@ -100,6 +101,7 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
     serializer: Arc<dyn BatchSerializer>,
     mut writer: WriterType,
     bytes_written: Arc<AtomicUsize>,
+    elapsed_compute: Option<Time>,
 ) -> SerializedRecordBatchResult {
     let (tx, mut rx) =
         mpsc::channel::<SpawnedTask<Result<(usize, Bytes), DataFusionError>>>(100);
@@ -109,9 +111,17 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
         let mut initial = true;
         while let Some(batch) = data_rx.recv().await {
             let serializer_clone = Arc::clone(&serializer);
+            let elapsed_compute = elapsed_compute.clone();
+
             let task = SpawnedTask::spawn(async move {
                 let num_rows = batch.num_rows();
-                let bytes = serializer_clone.serialize(batch, initial)?;
+
+                let bytes = {
+                    let _timer = elapsed_compute.as_ref().map(|metric| metric.timer());
+
+                    serializer_clone.serialize(batch, initial)?
+                };
+
                 Ok((num_rows, bytes))
             });
             if initial {
@@ -213,6 +223,7 @@ impl<'a> StatelessWriterOptions<'a> {
 pub(crate) async fn stateless_serialize_and_write_files(
     mut rx: Receiver<FileWriteBundle>,
     tx: tokio::sync::oneshot::Sender<(u64, usize)>,
+    elapsed_compute: Option<Time>,
 ) -> Result<()> {
     let mut row_count = 0;
     let mut bytes_written = 0;
@@ -225,12 +236,15 @@ pub(crate) async fn stateless_serialize_and_write_files(
     let mut any_abort_errors = false;
     let mut join_set = JoinSet::new();
     while let Some((data_rx, serializer, writer, bytes_written)) = rx.recv().await {
+        let elapsed_compute = elapsed_compute.clone();
+
         join_set.spawn(async move {
             serialize_rb_stream_to_object_store(
                 data_rx,
                 serializer,
                 writer,
                 bytes_written,
+                elapsed_compute,
             )
             .await
         });
@@ -338,9 +352,9 @@ pub async fn spawn_writer_tasks_and_join_with_metrics(
     demux_task: SpawnedTask<Result<()>>,
     mut file_stream_rx: DemuxedStreamReceiver,
 ) -> Result<u64> {
-    let _timer = options
+    let elapsed_compute = options
         .metrics
-        .map(|metrics| metrics.elapsed_compute().timer());
+        .map(|metrics| metrics.elapsed_compute().clone());
     let rb_buffer_size = &context
         .session_config()
         .options()
@@ -350,7 +364,8 @@ pub async fn spawn_writer_tasks_and_join_with_metrics(
     let (tx_file_bundle, rx_file_bundle) = mpsc::channel(rb_buffer_size.get() / 2);
     let (tx_row_cnt, rx_row_cnt) = tokio::sync::oneshot::channel();
     let write_coordinator_task = SpawnedTask::spawn(async move {
-        stateless_serialize_and_write_files(rx_file_bundle, tx_row_cnt).await
+        stateless_serialize_and_write_files(rx_file_bundle, tx_row_cnt, elapsed_compute)
+            .await
     });
     while let Some((location, rb_stream)) = file_stream_rx.recv().await {
         let (writer, bytes_written) = ObjectWriterBuilder::new(

--- a/datafusion/datasource/src/write/orchestration.rs
+++ b/datafusion/datasource/src/write/orchestration.rs
@@ -235,7 +235,7 @@ pub(crate) async fn stateless_serialize_and_write_files(
     // if true, we may not have a guarantee that all written data was cleaned up.
     let mut any_abort_errors = false;
     let mut join_set = JoinSet::new();
-    while let Some((data_rx, serializer, writer, bytes_written)) = rx.recv().await {
+    while let Some((data_rx, serializer, writer, byte_counter)) = rx.recv().await {
         let elapsed_compute = elapsed_compute.clone();
 
         join_set.spawn(async move {
@@ -243,7 +243,7 @@ pub(crate) async fn stateless_serialize_and_write_files(
                 data_rx,
                 serializer,
                 writer,
-                bytes_written,
+                byte_counter,
                 elapsed_compute,
             )
             .await

--- a/datafusion/datasource/src/write/orchestration.rs
+++ b/datafusion/datasource/src/write/orchestration.rs
@@ -20,6 +20,7 @@
 //! parallelization, and abort handling
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::demux::DemuxedStreamReceiver;
 use super::{BatchSerializer, ObjectWriterBuilder};
@@ -52,8 +53,8 @@ pub(crate) enum SerializedRecordBatchResult {
         /// the number of rows successfully written
         row_count: usize,
 
-        /// the number of serialized bytes successfully written
-        bytes_written: usize,
+        /// Counter for the compressed bytes written to the object store writer.
+        bytes_written: Arc<AtomicUsize>,
     },
     Failure {
         /// As explained in [`serialize_rb_stream_to_object_store`]:
@@ -68,7 +69,11 @@ pub(crate) enum SerializedRecordBatchResult {
 
 impl SerializedRecordBatchResult {
     /// Create the success variant
-    pub fn success(writer: WriterType, row_count: usize, bytes_written: usize) -> Self {
+    pub fn success(
+        writer: WriterType,
+        row_count: usize,
+        bytes_written: Arc<AtomicUsize>,
+    ) -> Self {
         Self::Success {
             writer,
             row_count,
@@ -94,6 +99,7 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
     mut data_rx: Receiver<RecordBatch>,
     serializer: Arc<dyn BatchSerializer>,
     mut writer: WriterType,
+    bytes_written: Arc<AtomicUsize>,
 ) -> SerializedRecordBatchResult {
     let (tx, mut rx) =
         mpsc::channel::<SpawnedTask<Result<(usize, Bytes), DataFusionError>>>(100);
@@ -119,11 +125,9 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
     });
 
     let mut row_count = 0;
-    let mut bytes_written = 0;
     while let Some(task) = rx.recv().await {
         match task.join().await {
             Ok(Ok((cnt, bytes))) => {
-                let byte_len = bytes.len();
                 match writer.write_all(&bytes).await {
                     Ok(_) => (),
                     Err(e) => {
@@ -134,7 +138,6 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
                     }
                 };
                 row_count += cnt;
-                bytes_written += byte_len;
             }
             Ok(Err(e)) => {
                 // Return the writer along with the error
@@ -165,7 +168,12 @@ pub(crate) async fn serialize_rb_stream_to_object_store(
     SerializedRecordBatchResult::success(writer, row_count, bytes_written)
 }
 
-type FileWriteBundle = (Receiver<RecordBatch>, SerializerType, WriterType);
+type FileWriteBundle = (
+    Receiver<RecordBatch>,
+    SerializerType,
+    WriterType,
+    Arc<AtomicUsize>,
+);
 
 /// Options for stateless file writer tasks.
 pub struct StatelessWriterOptions<'a> {
@@ -216,12 +224,19 @@ pub(crate) async fn stateless_serialize_and_write_files(
     // if true, we may not have a guarantee that all written data was cleaned up.
     let mut any_abort_errors = false;
     let mut join_set = JoinSet::new();
-    while let Some((data_rx, serializer, writer)) = rx.recv().await {
+    while let Some((data_rx, serializer, writer, bytes_written)) = rx.recv().await {
         join_set.spawn(async move {
-            serialize_rb_stream_to_object_store(data_rx, serializer, writer).await
+            serialize_rb_stream_to_object_store(
+                data_rx,
+                serializer,
+                writer,
+                bytes_written,
+            )
+            .await
         });
     }
     let mut finished_writers = Vec::new();
+    let mut byte_counters = Vec::new();
     while let Some(result) = join_set.join_next().await {
         match result {
             Ok(res) => match res {
@@ -231,8 +246,8 @@ pub(crate) async fn stateless_serialize_and_write_files(
                     bytes_written: bytes,
                 } => {
                     finished_writers.push(writer);
+                    byte_counters.push(bytes);
                     row_count += cnt;
-                    bytes_written += bytes;
                 }
                 SerializedRecordBatchResult::Failure { writer, err } => {
                     finished_writers.extend(writer);
@@ -258,6 +273,10 @@ pub(crate) async fn stateless_serialize_and_write_files(
         writer.shutdown()
                     .await
                     .map_err(|_| internal_datafusion_err!("Error encountered while finalizing writes! Partial results may have been written to ObjectStore!"))?;
+    }
+
+    for counter in byte_counters {
+        bytes_written += counter.load(Ordering::Relaxed);
     }
 
     if any_errors {
@@ -334,7 +353,7 @@ pub async fn spawn_writer_tasks_and_join_with_metrics(
         stateless_serialize_and_write_files(rx_file_bundle, tx_row_cnt).await
     });
     while let Some((location, rb_stream)) = file_stream_rx.recv().await {
-        let writer = ObjectWriterBuilder::new(
+        let (writer, bytes_written) = ObjectWriterBuilder::new(
             options.compression,
             &location,
             Arc::clone(&object_store),
@@ -347,10 +366,10 @@ pub async fn spawn_writer_tasks_and_join_with_metrics(
                 .objectstore_writer_buffer_size,
         ))
         .with_compression_level(options.compression_level)
-        .build()?;
+        .build_with_byte_counter()?;
 
         if tx_file_bundle
-            .send((rb_stream, Arc::clone(&serializer), writer))
+            .send((rb_stream, Arc::clone(&serializer), writer, bytes_written))
             .await
             .is_err()
         {

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -211,6 +211,26 @@ Plan with Metrics
 03)----ProjectionExec: expr=[col1@0 as col1, upper(col2@1) as col2_upper], metrics=[output_rows=2, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=1, expr_0_eval_time=<slt:ignore>, expr_1_eval_time=<slt:ignore>]
 04)------DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
 
+# Verify CsvSink exposes rows_written, bytes_written, and elapsed_compute metrics
+query TT
+EXPLAIN ANALYZE COPY (SELECT col1, upper(col2) AS col2_upper FROM source_table ORDER BY col1) TO 'test_files/scratch/copy/table_csv_metrics.csv' STORED AS CSV;
+----
+Plan with Metrics
+01)DataSinkExec: sink=CsvSink(file_groups=[]), metrics=[elapsed_compute=<slt:ignore>, bytes_written=<slt:ignore>, rows_written=2]
+02)--SortExec: expr=[col1@0 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=2, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=<slt:ignore>, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0]
+03)----ProjectionExec: expr=[col1@0 as col1, upper(col2@1) as col2_upper], metrics=[output_rows=2, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=1, expr_0_eval_time=<slt:ignore>, expr_1_eval_time=<slt:ignore>]
+04)------DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+# Verify JsonSink exposes rows_written, bytes_written, and elapsed_compute metrics
+query TT
+EXPLAIN ANALYZE COPY (SELECT col1, upper(col2) AS col2_upper FROM source_table ORDER BY col1) TO 'test_files/scratch/copy/table_json_metrics.json' STORED AS JSON;
+----
+Plan with Metrics
+01)DataSinkExec: sink=JsonSink(file_groups=[]), metrics=[elapsed_compute=<slt:ignore>, bytes_written=<slt:ignore>, rows_written=2]
+02)--SortExec: expr=[col1@0 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=2, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=<slt:ignore>, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0]
+03)----ProjectionExec: expr=[col1@0 as col1, upper(col2@1) as col2_upper], metrics=[output_rows=2, elapsed_compute=<slt:ignore>, output_bytes=<slt:ignore>, output_batches=1, expr_0_eval_time=<slt:ignore>, expr_1_eval_time=<slt:ignore>]
+04)------DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
 # Copy to directory as partitioned files with keep_partition_by_columns enabled
 query I
 COPY (values ('1', 'a'), ('2', 'b'), ('3', 'c')) TO 'test_files/scratch/copy/partitioned_table4/' STORED AS parquet PARTITIONED BY (column1)


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #20644.

## Rationale for this change

CSV and JSON sinks do not currently expose write metrics through `DataSinkExec`, while the Parquet sink exposes `rows_written`, `bytes_written`, and `elapsed_compute`.

This change provides consistent metrics for CSV and JSON sinks and centralizes the common file sink metrics wiring to reduce duplication across file formats.

## What changes are included in this PR?

- Add a shared `FileSinkMetrics` implementation for `rows_written`, `bytes_written`, and `elapsed_compute`.
- Create fresh metric instances for each sink execution, preventing metrics from carrying over when a sink is executed multiple times.
- Use the shared metrics implementation for Parquet, CSV, and JSON sinks.
- Track rows and actual bytes written after stream-level compression in the common stateless write orchestration.
- Preserve the existing `spawn_writer_tasks_and_join` API and add an opt-in metrics variant.
- Add SQL logic test coverage for `EXPLAIN ANALYZE COPY` with CSV and JSON output.

## Are these changes tested?

Yes. The affected datasource unit tests and the `copy.slt` SQL logic test pass.

A gzip-specific unit test verifies that `bytes_written` matches the actual object size after compression.
A FileSinkMetrics unit test verifies that counters are created independently for each sink execution.

```bash
cargo test -p datafusion-datasource \
  -p datafusion-datasource-csv \
  -p datafusion-datasource-json \
  -p datafusion-datasource-parquet --lib
```

```bash
cargo test -p datafusion-sqllogictest \
  --test sqllogictests -- copy.slt --complete
```

The affected crates also pass targeted Clippy checks with warnings denied.

## Are there any user-facing changes?

Yes. `EXPLAIN ANALYZE COPY` now reports `rows_written`, `bytes_written`, and `elapsed_compute` for CSV and JSON sinks, consistent with the existing Parquet sink metrics.
