### PR TITLE
feat: Support Map type in approx_distinct

### DIFF
--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -842,6 +842,7 @@ impl AggregateUDFImpl for ApproxDistinct {
             | DataType::FixedSizeList(_, _)
             | DataType::ListView(_)
             | DataType::LargeListView(_)
+            | DataType::Map(_, _)
             | DataType::LargeBinary => Box::new(HLLAccumulator::new()),
             DataType::Null => {
                 Box::new(NoopAccumulator::new(ScalarValue::UInt64(Some(0))))
@@ -918,6 +919,7 @@ fn is_hll_groups_type(data_type: &DataType) -> bool {
             | DataType::FixedSizeList(_, _)
             | DataType::ListView(_)
             | DataType::LargeListView(_)
+            | DataType::Map(_, _)
     )
 }
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -2095,6 +2095,44 @@ SELECT approx_distinct(arrow_cast(l, 'FixedSizeList(2, Int32)')) FROM approx_dis
 statement ok
 DROP TABLE approx_distinct_list_test;
 
+# Map
+statement ok
+CREATE TABLE approx_distinct_map_test AS SELECT * FROM (VALUES
+  (1, MAP {'a': 1, 'b': 2}), (1, MAP {'a': 1, 'b': 2}), (1, MAP {'c': 3}),
+  (2, MAP {'d': 4}), (2, NULL),
+  (3, NULL), (3, NULL),
+  (4, MAP {'e': 5})
+) AS t(g, m);
+
+# Map non-grouped
+query I
+SELECT approx_distinct(m) FROM approx_distinct_map_test WHERE g = 1;
+----
+2
+
+# Map grouped
+# Group 1 -> {{a:1,b:2},{c:3}}=2,
+# Group 2 -> {{d:4}}=1 (NULL excluded),
+# Group 3 -> all null=0,
+# Group 4 -> {{e:5}}=1
+query II
+SELECT g, approx_distinct(m) FROM approx_distinct_map_test GROUP BY g ORDER BY g;
+----
+1 2
+2 1
+3 0
+4 1
+
+# The non-group path must agree with the grouped path on
+# the same data, and distinct maps across groups are still counted overall.
+query I
+SELECT approx_distinct(m) FROM approx_distinct_map_test;
+----
+4
+
+statement ok
+DROP TABLE approx_distinct_map_test;
+
 # Integers (Int32): group 1 -> {10,20}=2, group 2 -> {30,40}=2, group 3 -> 0, group 4 -> {50}=1
 query II
 SELECT g, approx_distinct(i) FROM approx_distinct_group_test GROUP BY g ORDER BY g;


### PR DESCRIPTION
## Which issue does this PR close?

- Relates to https://github.com/apache/datafusion/issues/22989 but does not close it. More types are coming.


## Rationale for this change

- Support the Arrow type `Map` type for `approx_distinct`

## What changes are included in this PR?

- Enable `HLLAccumulator` and `HllGroupsAccumulator` to support `Map`
- Tests for the non-grouped and grouped path as part of `aggregate.slt` 

## Are these changes tested?

Yes and  results are compared to DuckDB: 

```
D CREATE TABLE approx_distinct_map_test AS SELECT * FROM (VALUES
    (1, MAP {'a': 1, 'b': 2}), (1, MAP {'a': 1, 'b': 2}), (1, MAP {'c': 3}),
    (2, MAP {'d': 4}), (2, NULL),
    (3, NULL), (3, NULL),
    (4, MAP {'e': 5})
  ) AS t(g, m);

D SELECT approx_count_distinct(m) FROM approx_distinct_map_test WHERE g = 1;
┌──────────────────────────┐
│ approx_count_distinct(m) │
│          int64           │
├──────────────────────────┤
│            2             │
└──────────────────────────┘

D SELECT g, approx_count_distinct(m) FROM approx_distinct_map_test GROUP BY g ORDER BY g;
┌───────┬──────────────────────────┐
│   g   │ approx_count_distinct(m) │
│ int32 │          int64           │
├───────┼──────────────────────────┤
│     1 │                        2 │
│     2 │                        1 │
│     3 │                        0 │
│     4 │                        1 │
└───────┴──────────────────────────┘

D SELECT approx_count_distinct(m) FROM approx_distinct_map_test;
┌──────────────────────────┐
│ approx_count_distinct(m) │
│          int64           │
├──────────────────────────┤
│            4             │
└──────────────────────────┘
```

## Are there any user-facing changes?

Yes, `approx_distinct` supports now `Map` but no breaking changes.

