### PR TITLE
Fix ordering for UNION ALL over heterogeneous constants

### DIFF
--- a/datafusion/physical-expr/src/equivalence/class.rs
+++ b/datafusion/physical-expr/src/equivalence/class.rs
@@ -551,7 +551,19 @@ impl EquivalenceGroup {
         sort_exprs
             .into_iter()
             .map(|sort_expr| self.normalize_sort_expr(sort_expr))
-            .filter(|sort_expr| self.is_expr_constant(&sort_expr.expr).is_none())
+            .filter(|sort_expr| !self.is_uniform_constant(&sort_expr.expr))
+    }
+
+    /// Returns `true` when `expr` is a *globally* constant column, safe to drop
+    /// from a required ordering. Only [`AcrossPartitions::Uniform`] qualifies; a
+    /// [`AcrossPartitions::Heterogeneous`] value is constant within a partition
+    /// but varies across partitions, so it still discriminates the order once
+    /// partitions are merged and must be kept.
+    fn is_uniform_constant(&self, expr: &Arc<dyn PhysicalExpr>) -> bool {
+        matches!(
+            self.is_expr_constant(expr),
+            Some(AcrossPartitions::Uniform(_))
+        )
     }
 
     /// Normalizes the given sort requirement according to this group. The
@@ -582,7 +594,7 @@ impl EquivalenceGroup {
         sort_reqs
             .into_iter()
             .map(|req| self.normalize_sort_requirement(req))
-            .filter(|req| self.is_expr_constant(&req.expr).is_none())
+            .filter(|req| !self.is_uniform_constant(&req.expr))
     }
 
     /// Perform an indirect projection of `expr` by consulting the equivalence

--- a/datafusion/physical-optimizer/src/utils.rs
+++ b/datafusion/physical-optimizer/src/utils.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use datafusion_common::Result;
 use datafusion_physical_expr::{
-    AcrossPartitions, Distribution, EquivalenceProperties, LexOrdering, LexRequirement,
-    Partitioning, PhysicalExpr, physical_exprs_equal,
+    Distribution, EquivalenceProperties, LexOrdering, LexRequirement, Partitioning,
+    PhysicalExpr, physical_exprs_equal,
 };
 use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
@@ -31,25 +31,6 @@ use datafusion_physical_plan::tree_node::PlanContext;
 use datafusion_physical_plan::union::UnionExec;
 use datafusion_physical_plan::windows::{BoundedWindowAggExec, WindowAggExec};
 use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
-
-/// Returns `true` when `expr` is a *globally* constant column in `eq_properties`
-/// and can therefore be safely dropped from a required ordering.
-///
-/// Only [`AcrossPartitions::Uniform`] qualifies. An
-/// [`AcrossPartitions::Heterogeneous`] value is constant *within* each partition
-/// but may differ *across* partitions, so it must be kept in the sort key: the
-/// `SortExec` these helpers build preserves partitioning, and its output is
-/// merged across partitions downstream, where the column is still an ordering
-/// discriminator. Dropping it there silently loses the global ordering.
-fn is_uniform_constant(
-    eq_properties: &EquivalenceProperties,
-    expr: &Arc<dyn PhysicalExpr>,
-) -> bool {
-    matches!(
-        eq_properties.is_expr_constant(expr),
-        Some(AcrossPartitions::Uniform(_))
-    )
-}
 
 /// This utility function adds a `SortExec` above an operator according to the
 /// given ordering requirements while preserving the original partitioning.
@@ -64,7 +45,10 @@ pub fn add_sort_above<T: Clone + Default>(
 ) -> PlanContext<T> {
     let mut sort_reqs: Vec<_> = sort_requirements.into();
     sort_reqs.retain(|sort_expr| {
-        !is_uniform_constant(node.plan.equivalence_properties(), &sort_expr.expr)
+        node.plan
+            .equivalence_properties()
+            .is_expr_constant(&sort_expr.expr)
+            .is_none()
     });
     let sort_exprs = sort_reqs.into_iter().map(Into::into).collect::<Vec<_>>();
     let Some(ordering) = LexOrdering::new(sort_exprs) else {
@@ -89,7 +73,10 @@ pub fn add_sort_above_with_distribution<T: Clone + Default>(
 ) -> PlanContext<T> {
     let mut sort_reqs: Vec<_> = sort_requirements.into();
     sort_reqs.retain(|sort_expr| {
-        !is_uniform_constant(node.plan.equivalence_properties(), &sort_expr.expr)
+        node.plan
+            .equivalence_properties()
+            .is_expr_constant(&sort_expr.expr)
+            .is_none()
     });
     let sort_exprs = sort_reqs.into_iter().map(Into::into).collect::<Vec<_>>();
     let Some(ordering) = LexOrdering::new(sort_exprs) else {
@@ -232,78 +219,4 @@ pub(crate) fn range_partitioning_satisfies_key_partitioning(
 /// i.e. either a [`LocalLimitExec`] or a [`GlobalLimitExec`].
 pub fn is_limit(plan: &Arc<dyn ExecutionPlan>) -> bool {
     plan.is::<GlobalLimitExec>() || plan.is::<LocalLimitExec>()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion_physical_expr::PhysicalSortRequirement;
-    use datafusion_physical_expr::expressions::{col, lit};
-    use datafusion_physical_expr::projection::ProjectionExpr;
-    use datafusion_physical_plan::displayable;
-    use datafusion_physical_plan::empty::EmptyExec;
-    use datafusion_physical_plan::projection::ProjectionExec;
-
-    /// A `UnionExec` whose `sample` column is 1 on the left branch and 2 on the
-    /// right makes `sample` a `Heterogeneous` constant: constant within each
-    /// partition, but different across them. A required ordering of
-    /// `[sample, other]` must retain `sample`; the `SortExec` built here
-    /// preserves partitioning and its output is merged across partitions
-    /// downstream, where `sample` is still the leading ordering discriminator.
-    /// Regression test: `add_sort_above` used to drop every constant, uniform
-    /// or not, and silently discarded the global ordering.
-    #[test]
-    fn add_sort_above_keeps_heterogeneous_constant_key() -> Result<()> {
-        let schema = Arc::new(Schema::new(vec![Field::new("c", DataType::Int32, true)]));
-
-        let branch = |value: i32| -> Result<Arc<dyn ExecutionPlan>> {
-            let source = Arc::new(EmptyExec::new(Arc::clone(&schema)));
-            let projection = ProjectionExec::try_new(
-                vec![
-                    ProjectionExpr {
-                        expr: lit(value),
-                        alias: "sample".to_string(),
-                    },
-                    ProjectionExpr {
-                        expr: col("c", &schema)?,
-                        alias: "other".to_string(),
-                    },
-                ],
-                source,
-            )?;
-            Ok(Arc::new(projection))
-        };
-
-        let union: Arc<dyn ExecutionPlan> =
-            UnionExec::try_new(vec![branch(1)?, branch(2)?])?;
-        let union_schema = union.schema();
-
-        // Precondition: the union reports `sample` as a heterogeneous constant.
-        let sample = col("sample", &union_schema)?;
-        assert!(matches!(
-            union.equivalence_properties().is_expr_constant(&sample),
-            Some(AcrossPartitions::Heterogeneous)
-        ));
-
-        let asc = SortOptions::default();
-        let requirement: LexRequirement = [
-            PhysicalSortRequirement::new(sample, Some(asc)),
-            PhysicalSortRequirement::new(col("other", &union_schema)?, Some(asc)),
-        ]
-        .into();
-
-        let node = PlanContext::<()>::new_default(union);
-        let result = add_sort_above(node, requirement, None);
-
-        let plan = displayable(result.plan.as_ref()).indent(true).to_string();
-        assert!(
-            plan.contains("sample@0 ASC"),
-            "add_sort_above dropped the heterogeneous-constant sort key:\n{plan}"
-        );
-
-        Ok(())
-    }
 }

--- a/datafusion/physical-optimizer/src/utils.rs
+++ b/datafusion/physical-optimizer/src/utils.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use datafusion_common::Result;
 use datafusion_physical_expr::{
-    Distribution, EquivalenceProperties, LexOrdering, LexRequirement, Partitioning,
-    PhysicalExpr, physical_exprs_equal,
+    AcrossPartitions, Distribution, EquivalenceProperties, LexOrdering, LexRequirement,
+    Partitioning, PhysicalExpr, physical_exprs_equal,
 };
 use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
@@ -31,6 +31,25 @@ use datafusion_physical_plan::tree_node::PlanContext;
 use datafusion_physical_plan::union::UnionExec;
 use datafusion_physical_plan::windows::{BoundedWindowAggExec, WindowAggExec};
 use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+
+/// Returns `true` when `expr` is a *globally* constant column in `eq_properties`
+/// and can therefore be safely dropped from a required ordering.
+///
+/// Only [`AcrossPartitions::Uniform`] qualifies. An
+/// [`AcrossPartitions::Heterogeneous`] value is constant *within* each partition
+/// but may differ *across* partitions, so it must be kept in the sort key: the
+/// `SortExec` these helpers build preserves partitioning, and its output is
+/// merged across partitions downstream, where the column is still an ordering
+/// discriminator. Dropping it there silently loses the global ordering.
+fn is_uniform_constant(
+    eq_properties: &EquivalenceProperties,
+    expr: &Arc<dyn PhysicalExpr>,
+) -> bool {
+    matches!(
+        eq_properties.is_expr_constant(expr),
+        Some(AcrossPartitions::Uniform(_))
+    )
+}
 
 /// This utility function adds a `SortExec` above an operator according to the
 /// given ordering requirements while preserving the original partitioning.
@@ -45,10 +64,7 @@ pub fn add_sort_above<T: Clone + Default>(
 ) -> PlanContext<T> {
     let mut sort_reqs: Vec<_> = sort_requirements.into();
     sort_reqs.retain(|sort_expr| {
-        node.plan
-            .equivalence_properties()
-            .is_expr_constant(&sort_expr.expr)
-            .is_none()
+        !is_uniform_constant(node.plan.equivalence_properties(), &sort_expr.expr)
     });
     let sort_exprs = sort_reqs.into_iter().map(Into::into).collect::<Vec<_>>();
     let Some(ordering) = LexOrdering::new(sort_exprs) else {
@@ -73,10 +89,7 @@ pub fn add_sort_above_with_distribution<T: Clone + Default>(
 ) -> PlanContext<T> {
     let mut sort_reqs: Vec<_> = sort_requirements.into();
     sort_reqs.retain(|sort_expr| {
-        node.plan
-            .equivalence_properties()
-            .is_expr_constant(&sort_expr.expr)
-            .is_none()
+        !is_uniform_constant(node.plan.equivalence_properties(), &sort_expr.expr)
     });
     let sort_exprs = sort_reqs.into_iter().map(Into::into).collect::<Vec<_>>();
     let Some(ordering) = LexOrdering::new(sort_exprs) else {
@@ -219,4 +232,78 @@ pub(crate) fn range_partitioning_satisfies_key_partitioning(
 /// i.e. either a [`LocalLimitExec`] or a [`GlobalLimitExec`].
 pub fn is_limit(plan: &Arc<dyn ExecutionPlan>) -> bool {
     plan.is::<GlobalLimitExec>() || plan.is::<LocalLimitExec>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow::compute::SortOptions;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_physical_expr::PhysicalSortRequirement;
+    use datafusion_physical_expr::expressions::{col, lit};
+    use datafusion_physical_expr::projection::ProjectionExpr;
+    use datafusion_physical_plan::displayable;
+    use datafusion_physical_plan::empty::EmptyExec;
+    use datafusion_physical_plan::projection::ProjectionExec;
+
+    /// A `UnionExec` whose `sample` column is 1 on the left branch and 2 on the
+    /// right makes `sample` a `Heterogeneous` constant: constant within each
+    /// partition, but different across them. A required ordering of
+    /// `[sample, other]` must retain `sample`; the `SortExec` built here
+    /// preserves partitioning and its output is merged across partitions
+    /// downstream, where `sample` is still the leading ordering discriminator.
+    /// Regression test: `add_sort_above` used to drop every constant, uniform
+    /// or not, and silently discarded the global ordering.
+    #[test]
+    fn add_sort_above_keeps_heterogeneous_constant_key() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("c", DataType::Int32, true)]));
+
+        let branch = |value: i32| -> Result<Arc<dyn ExecutionPlan>> {
+            let source = Arc::new(EmptyExec::new(Arc::clone(&schema)));
+            let projection = ProjectionExec::try_new(
+                vec![
+                    ProjectionExpr {
+                        expr: lit(value),
+                        alias: "sample".to_string(),
+                    },
+                    ProjectionExpr {
+                        expr: col("c", &schema)?,
+                        alias: "other".to_string(),
+                    },
+                ],
+                source,
+            )?;
+            Ok(Arc::new(projection))
+        };
+
+        let union: Arc<dyn ExecutionPlan> =
+            UnionExec::try_new(vec![branch(1)?, branch(2)?])?;
+        let union_schema = union.schema();
+
+        // Precondition: the union reports `sample` as a heterogeneous constant.
+        let sample = col("sample", &union_schema)?;
+        assert!(matches!(
+            union.equivalence_properties().is_expr_constant(&sample),
+            Some(AcrossPartitions::Heterogeneous)
+        ));
+
+        let asc = SortOptions::default();
+        let requirement: LexRequirement = [
+            PhysicalSortRequirement::new(sample, Some(asc)),
+            PhysicalSortRequirement::new(col("other", &union_schema)?, Some(asc)),
+        ]
+        .into();
+
+        let node = PlanContext::<()>::new_default(union);
+        let result = add_sort_above(node, requirement, None);
+
+        let plan = displayable(result.plan.as_ref()).indent(true).to_string();
+        assert!(
+            plan.contains("sample@0 ASC"),
+            "add_sort_above dropped the heterogeneous-constant sort key:\n{plan}"
+        );
+
+        Ok(())
+    }
 }

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -1777,7 +1777,7 @@ reset datafusion.sql_parser.dialect;
 # so the physical plan must keep "a" in its ordering; dropping it (leaving only
 # [b@1 ASC]) silently loses the global order under the sink.
 statement ok
-CREATE TABLE t2(b INT) AS VALUES (10);
+CREATE TABLE t2(b INT) AS VALUES (10), (20);
 
 query TT
 EXPLAIN COPY (
@@ -1805,6 +1805,36 @@ physical_plan
 07)------SortExec: expr=[b@1 ASC NULLS LAST], preserve_partitioning=[false]
 08)--------ProjectionExec: expr=[1 as a, b@0 as b]
 09)----------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Actually execute the COPY and verify the rows written to the file are in
+# global (a, b) order, interleaving the two union branches. If "a" were
+# dropped from the sort, the file would instead contain rows ordered only
+# by "b" within each branch.
+query I
+COPY (
+  SELECT 2 AS a, b FROM t2
+  UNION ALL
+  SELECT 1 AS a, b FROM t2
+  ORDER BY a, b
+) TO 'test_files/scratch/order/sort_key_sink.parquet';
+----
+4
+
+statement ok
+CREATE EXTERNAL TABLE sort_key_sink STORED AS PARQUET
+LOCATION 'test_files/scratch/order/sort_key_sink.parquet';
+
+# Note: no ORDER BY here, so this checks the order rows were written in
+query II
+SELECT * FROM sort_key_sink;
+----
+1 10
+1 20
+2 10
+2 20
+
+statement ok
+DROP TABLE sort_key_sink;
 
 statement ok
 DROP TABLE t2;

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -1770,3 +1770,41 @@ reset datafusion.sql_parser.default_null_ordering;
 
 statement ok
 reset datafusion.sql_parser.dialect;
+
+# A global sort feeding a sink (CopyTo) must keep a leading key that is constant
+# within each partition but differs across them ("a" is 2 on one union branch,
+# 1 on the other). The merge above the union has to reorder rows across branches,
+# so the physical plan must keep "a" in its ordering; dropping it (leaving only
+# [b@1 ASC]) silently loses the global order under the sink.
+statement ok
+CREATE TABLE t2(b INT) AS VALUES (10);
+
+query TT
+EXPLAIN COPY (
+  SELECT 2 AS a, b FROM t2
+  UNION ALL
+  SELECT 1 AS a, b FROM t2
+  ORDER BY a, b
+) TO 'test_files/scratch/order/sort_key_sink.parquet';
+----
+logical_plan
+01)CopyTo: format=parquet output_url=test_files/scratch/order/sort_key_sink.parquet options: ()
+02)--Sort: a ASC NULLS LAST, b ASC NULLS LAST
+03)----Union
+04)------Projection: Int64(2) AS a, t2.b
+05)--------TableScan: t2 projection=[b]
+06)------Projection: Int64(1) AS a, t2.b
+07)--------TableScan: t2 projection=[b]
+physical_plan
+01)DataSinkExec: sink=ParquetSink(file_groups=[])
+02)--SortPreservingMergeExec: [a@0 ASC NULLS LAST, b@1 ASC NULLS LAST]
+03)----UnionExec
+04)------SortExec: expr=[b@1 ASC NULLS LAST], preserve_partitioning=[false]
+05)--------ProjectionExec: expr=[2 as a, b@0 as b]
+06)----------DataSourceExec: partitions=1, partition_sizes=[1]
+07)------SortExec: expr=[b@1 ASC NULLS LAST], preserve_partitioning=[false]
+08)--------ProjectionExec: expr=[1 as a, b@0 as b]
+09)----------DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement ok
+DROP TABLE t2;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`add_sort_above` and `add_sort_above_with_distribution` in physical-optimizer prune every expression that `EquivalenceProperties::is_expr_constant` reports as constant.
This treats `AcrossPartitions::Heterogeneous` the same as `AcrossPartitions::Uniform`, which is incorrect.

Check an example:

```sql
SELECT 2 AS sample, c FROM t
UNION ALL
SELECT 1 AS sample, c FROM t
ORDER BY sample, c
```

The union reports sample as a `Heterogeneous` constant and so it gets pruned, which breaks `ORDER BY`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Helper that activates pruning only for `AcrossPartitions::Uniform`, use it at both prune sites (`add_sort_above` and `add_sort_above_with_distribution`) so `Heterogeneous` constants are retained.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, a new unit-test added.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No API changes, just an internal logic bug-fix.