### PR TITLE
perf: optimize to_char in datafusion-functions

### DIFF
--- a/datafusion/functions/src/datetime/to_char.rs
+++ b/datafusion/functions/src/datetime/to_char.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::cell::OnceCell;
 use std::sync::Arc;
 
 use arrow::array::builder::StringBuilder;
@@ -27,7 +28,9 @@ use arrow::datatypes::DataType::{
 };
 use arrow::datatypes::TimeUnit::{Microsecond, Millisecond, Nanosecond, Second};
 use arrow::util::display::{ArrayFormatter, DurationFormat, FormatOptions};
-use datafusion_common::{Result, ScalarValue, exec_err, utils::take_function_args};
+use datafusion_common::{
+    HashMap, Result, ScalarValue, exec_err, hash_map::Entry, utils::take_function_args,
+};
 use datafusion_expr::TypeSignature::Exact;
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
@@ -236,6 +239,28 @@ fn to_char_scalar(expression: &ColumnarValue, format: &str) -> Result<ColumnarVa
     }
 }
 
+/// Returns the [`ArrayFormatter`] for `format` from `cache`, building and
+/// caching it on first use.
+///
+/// Building a formatter parses the format string and is much more expensive
+/// than formatting a single value with it, so a query that uses only a handful
+/// of distinct format strings pays that cost once per format instead of once
+/// per row.
+fn cached_formatter<'a, 'c>(
+    cache: &'c mut HashMap<&'a str, ArrayFormatter<'a>>,
+    array: &'a dyn Array,
+    data_type: &DataType,
+    format: &'a str,
+) -> Result<&'c ArrayFormatter<'a>> {
+    match cache.entry(format) {
+        Entry::Occupied(entry) => Ok(entry.into_mut()),
+        Entry::Vacant(entry) => {
+            let format_options = build_format_options(data_type, format)?;
+            Ok(entry.insert(ArrayFormatter::try_new(array, &format_options)?))
+        }
+    }
+}
+
 fn to_char_array(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     let arrays = ColumnarValue::values_to_arrays(args)?;
     let data_array = &arrays[0];
@@ -248,10 +273,15 @@ fn to_char_array(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         StringBuilder::with_capacity(data_array.len(), data_array.len() * fmt_len);
     let mut buffer = String::with_capacity(fmt_len);
 
-    // Lazily computed Date64 cast of the entire array, used when a Date32
-    // format string contains time specifiers that the Date32 formatter
-    // cannot handle. Cast once and reuse for all subsequent rows
-    let mut date64_array: Option<ArrayRef> = None;
+    // Date64 cast of the whole array, used when formatting a Date32 value fails
+    // (see the retry arm below). Cast at most once, on first need. It must
+    // outlive `retry_formatters`, which borrows from it, and is held in a
+    // `OnceCell` rather than an `Option` so that it can still be populated while
+    // those formatters borrow it.
+    let date64_array: OnceCell<ArrayRef> = OnceCell::new();
+
+    let mut formatters: HashMap<&str, ArrayFormatter> = HashMap::new();
+    let mut retry_formatters: HashMap<&str, ArrayFormatter> = HashMap::new();
 
     for idx in 0..data_array.len() {
         if format_array.is_null(idx) || data_array.is_null(idx) {
@@ -260,8 +290,8 @@ fn to_char_array(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         }
 
         let format = format_array.value(idx);
-        let format_options = build_format_options(data_type, format)?;
-        let formatter = ArrayFormatter::try_new(data_array.as_ref(), &format_options)?;
+        let formatter =
+            cached_formatter(&mut formatters, data_array.as_ref(), data_type, format)?;
 
         buffer.clear();
 
@@ -271,17 +301,24 @@ fn to_char_array(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         // buffer and `append_value` on success.
         match formatter.value(idx).write(&mut buffer) {
             Ok(()) => builder.append_value(&buffer),
+            // Arrow's Date32 formatter only handles date specifiers, so retry
+            // against a Date64 cast, whose datetime formatter also handles time
+            // specifiers (with zero for the time components).
             Err(_) if data_type == &Date32 => {
                 buffer.clear();
-                let date64_ref = match &date64_array {
-                    Some(arr) => arr.as_ref(),
+                let date64_ref = match date64_array.get() {
+                    Some(array) => array,
                     None => {
-                        date64_array = Some(cast(data_array.as_ref(), &Date64)?);
-                        date64_array.as_ref().unwrap().as_ref()
+                        let casted = cast(data_array.as_ref(), &Date64)?;
+                        date64_array.get_or_init(|| casted)
                     }
                 };
-                let retry_options = build_format_options(&Date64, format)?;
-                let retry_fmt = ArrayFormatter::try_new(date64_ref, &retry_options)?;
+                let retry_fmt = cached_formatter(
+                    &mut retry_formatters,
+                    date64_ref.as_ref(),
+                    &Date64,
+                    format,
+                )?;
                 retry_fmt.value(idx).write(&mut buffer)?;
                 builder.append_value(&buffer);
             }


### PR DESCRIPTION
> This PR was created by an LLM as a draft PR. I will mark it as ready for review after human review.


## Which issue does this PR close?

N/A — autonomous exploratory PR.

## Rationale for this change

Cache ArrayFormatter per distinct format string (and per retry format) in to_char's array-format path instead of rebuilding one for every row, so each format is parsed once rather than N times.

## What changes are included in this PR?

Cache ArrayFormatter per distinct format string (and per retry format) in to_char's array-format path instead of rebuilding one for every row, so each format is parsed once rather than N times.

## Are these changes tested?

Correctness: unit tests + seeded differential fuzz (bit-identical Arrow output vs `main`).

Benchmark (criterion):

- to_char_scalar_datetime_pattern_1000: -0.298% faster (base 145108ns -> cand 145541ns)
- to_char_array_date32_datetime_patterns_1000: 8.589% faster (base 316946ns -> cand 289724ns)
- to_char_scalar_date_only_pattern_1000: -0.91% faster (base 72981ns -> cand 73645ns)
- to_char_array_date32_mixed_patterns_1000: 7.606% faster (base 214980ns -> cand 198629ns)
- to_char_array_date_only_patterns_1000: 3.603% faster (base 106325ns -> cand 102494ns)
- to_char_array_datetime_patterns_1000: 8.85% faster (base 185444ns -> cand 169032ns)
- to_char_array_mixed_patterns_1000: 11.564% faster (base 153095ns -> cand 135392ns)

Full criterion output:

```text
to_char_array_date_only_patterns_1000
                        time:   [102.42 µs 102.62 µs 102.82 µs]
                        change: [−3.9223% −3.6032% −3.3220%] (p = 0.00 < 0.05)
                        Performance has improved.

to_char_array_datetime_patterns_1000
                        time:   [168.71 µs 169.00 µs 169.28 µs]
                        change: [−9.0254% −8.8501% −8.6763%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

to_char_array_mixed_patterns_1000
                        time:   [134.99 µs 135.35 µs 135.72 µs]
                        change: [−11.792% −11.564% −11.331%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

to_char_scalar_date_only_pattern_1000
                        time:   [70.998 µs 74.479 µs 77.713 µs]
                        change: [−4.1934% +0.9103% +6.4073%] (p = 0.74 > 0.05)
                        No change in performance detected.

to_char_scalar_datetime_pattern_1000
                        time:   [139.28 µs 145.54 µs 151.23 µs]
                        change: [−4.8324% +0.2984% +6.0502%] (p = 0.90 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  14 (14.00%) low mild

to_char_array_date32_datetime_patterns_1000
                        time:   [289.36 µs 289.80 µs 290.33 µs]
                        change: [−8.7478% −8.5888% −8.4279%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

to_char_array_date32_mixed_patterns_1000
                        time:   [197.15 µs 197.85 µs 198.56 µs]
                        change: [−8.0355% −7.6059% −7.1932%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```


## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
