### PR TITLE
fix: align dictionary coercion across typed signatures

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -33,7 +33,9 @@ use datafusion_common::utils::{
 use datafusion_common::{
     Result, exec_err, internal_err, plan_err, types::NativeType, utils::list_ndims,
 };
-use datafusion_expr_common::signature::{ArrayFunctionArgument, EncodingPreservation};
+use datafusion_expr_common::signature::{
+    ArrayFunctionArgument, EncodingPreservation, TypeSignatureClass,
+};
 use datafusion_expr_common::type_coercion::binary::type_union_resolution;
 use datafusion_expr_common::{
     signature::{ArrayFunctionSignature, FIXED_SIZE_LIST_WILDCARD, TIMEZONE_WILDCARD},
@@ -873,16 +875,19 @@ fn get_valid_types(
         TypeSignature::Coercible(param_types) => {
             function_length_check(function_name, current_types.len(), param_types.len())?;
 
-            fn cast_origin(
-                current_type: &DataType,
-                encoding_preservation: EncodingPreservation,
-            ) -> &DataType {
-                if encoding_preservation.preserve_dictionary()
-                    && let DataType::Dictionary(_, value_type) = current_type
-                {
-                    value_type
-                } else {
-                    current_type
+            fn coercion_value_type<'a>(
+                current_type: &'a DataType,
+                desired_type: &TypeSignatureClass,
+            ) -> &'a DataType {
+                if matches!(desired_type, TypeSignatureClass::Any) {
+                    return current_type;
+                }
+
+                match current_type {
+                    DataType::Dictionary(_, value_type) => {
+                        coercion_value_type(value_type, desired_type)
+                    }
+                    _ => current_type,
                 }
             }
 
@@ -892,10 +897,17 @@ fn get_valid_types(
                 encoding_preservation: EncodingPreservation,
             ) -> DataType {
                 if encoding_preservation.preserve_dictionary()
-                    && let DataType::Dictionary(key_type, _) = current_type
+                    && let DataType::Dictionary(key_type, value_type) = current_type
                     && !matches!(casted_type, DataType::Dictionary(_, _))
                 {
-                    DataType::Dictionary(key_type.clone(), Box::new(casted_type))
+                    DataType::Dictionary(
+                        key_type.clone(),
+                        Box::new(preserve_encoding(
+                            value_type,
+                            casted_type,
+                            encoding_preservation,
+                        )),
+                    )
                 } else {
                     casted_type
                 }
@@ -905,7 +917,8 @@ fn get_valid_types(
             for (current_type, param) in current_types.iter().zip(param_types.iter()) {
                 let current_native_type: NativeType = current_type.into();
                 let encoding_preservation = param.encoding_preservation();
-                let cast_origin = cast_origin(current_type, encoding_preservation);
+                let coercion_value_type =
+                    coercion_value_type(current_type, param.desired_type());
 
                 if param
                     .desired_type()
@@ -913,7 +926,7 @@ fn get_valid_types(
                 {
                     let casted_type = param
                         .desired_type()
-                        .default_casted_type(&current_native_type, cast_origin)?;
+                        .default_casted_type(&current_native_type, coercion_value_type)?;
 
                     new_types.push(preserve_encoding(
                         current_type,
@@ -928,7 +941,7 @@ fn get_valid_types(
                     // If the condition is met which means `implicit coercion`` is provided so we can safely unwrap
                     let default_casted_type = param.default_casted_type().unwrap();
                     let casted_type =
-                        default_casted_type.default_cast_for(cast_origin)?;
+                        default_casted_type.default_cast_for(coercion_value_type)?;
                     new_types.push(preserve_encoding(
                         current_type,
                         casted_type,
@@ -1851,16 +1864,33 @@ mod tests {
         ))?;
         assert_eq!(vec![DataType::Int64], output);
 
-        // Dictionary gets passed through if we use TypeSignatureClass apart from Native
-        let output = dictionary_input(Coercion::new_exact(TypeSignatureClass::Integer))?;
+        // Any always preserves the original physical type
+        let output = dictionary_input(Coercion::new_exact(TypeSignatureClass::Any))?;
         assert_eq!(vec![dictionary.clone()], output);
+
+        let output = dictionary_input(
+            Coercion::new_exact(TypeSignatureClass::Any)
+                .with_encoding_preservation(EncodingPreservation::dictionary()),
+        )?;
+        assert_eq!(vec![dictionary.clone()], output);
+
+        // Typed non-Native classes materialize dictionaries by default
+        let output = dictionary_input(Coercion::new_exact(TypeSignatureClass::Integer))?;
+        assert_eq!(vec![DataType::Int64], output);
 
         let output = dictionary_input(Coercion::new_implicit(
             TypeSignatureClass::Integer,
             vec![],
             NativeType::Int64,
         ))?;
-        assert_eq!(vec![dictionary.clone()], output);
+        assert_eq!(vec![DataType::Int64], output);
+
+        // Typed non-Native classes preserve dictionaries only when requested
+        let output = dictionary_input(
+            Coercion::new_exact(TypeSignatureClass::Integer)
+                .with_encoding_preservation(EncodingPreservation::dictionary()),
+        )?;
+        assert_eq!(vec![dictionary], output);
 
         Ok(())
     }
@@ -1936,7 +1966,7 @@ mod tests {
                 Box::new(DataType::Int64),
             )]
         );
-        // Contrast: without encoding_preservation, non-Native already passes through
+        // Without encoding_preservation, non-Native classes materialize dictionaries
         assert_eq!(
             dictionary_input(
                 DataType::Int32,
@@ -1946,12 +1976,9 @@ mod tests {
                     NativeType::Int64,
                 ),
             )?,
-            vec![DataType::Dictionary(
-                Box::new(DataType::Int8),
-                Box::new(DataType::Int32),
-            )]
+            vec![DataType::Int32]
         );
-        // With encoding_preservation, same result — no difference for non-Native
+        // With encoding_preservation, non-Native classes preserve dictionaries
         assert_eq!(
             dictionary_input(
                 DataType::Int32,
@@ -1967,6 +1994,36 @@ mod tests {
                 Box::new(DataType::Int32),
             )]
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_coercible_nested_dictionary() -> Result<()> {
+        let nested_dictionary = DataType::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(DataType::Dictionary(
+                Box::new(DataType::Int16),
+                Box::new(DataType::Int32),
+            )),
+        );
+        let nested_dictionary_input = |coercion| -> Result<Vec<DataType>> {
+            fields_with_udf(
+                &[Field::new("field", nested_dictionary.clone(), true).into()],
+                &MockUdf(Signature::coercible(vec![coercion], Volatility::Immutable)),
+            )
+            .map(|v| v.into_iter().map(|f| f.data_type().clone()).collect())
+        };
+
+        let output =
+            nested_dictionary_input(Coercion::new_exact(TypeSignatureClass::Integer))?;
+        assert_eq!(vec![DataType::Int32], output);
+
+        let output = nested_dictionary_input(
+            Coercion::new_exact(TypeSignatureClass::Integer)
+                .with_encoding_preservation(EncodingPreservation::dictionary()),
+        )?;
+        assert_eq!(vec![nested_dictionary], output);
 
         Ok(())
     }

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -894,22 +894,28 @@ fn get_valid_types(
             fn preserve_encoding(
                 current_type: &DataType,
                 casted_type: DataType,
+                desired_type: &TypeSignatureClass,
                 encoding_preservation: EncodingPreservation,
             ) -> DataType {
-                if encoding_preservation.preserve_dictionary()
-                    && let DataType::Dictionary(key_type, value_type) = current_type
-                    && !matches!(casted_type, DataType::Dictionary(_, _))
-                {
-                    DataType::Dictionary(
-                        key_type.clone(),
-                        Box::new(preserve_encoding(
+                if matches!(desired_type, TypeSignatureClass::Any) {
+                    return casted_type;
+                }
+
+                match current_type {
+                    DataType::Dictionary(key_type, value_type) => {
+                        let casted_type = preserve_encoding(
                             value_type,
                             casted_type,
+                            desired_type,
                             encoding_preservation,
-                        )),
-                    )
-                } else {
-                    casted_type
+                        );
+                        if encoding_preservation.preserve_dictionary() {
+                            DataType::Dictionary(key_type.clone(), Box::new(casted_type))
+                        } else {
+                            casted_type
+                        }
+                    }
+                    _ => casted_type,
                 }
             }
 
@@ -931,6 +937,7 @@ fn get_valid_types(
                     new_types.push(preserve_encoding(
                         current_type,
                         casted_type,
+                        param.desired_type(),
                         encoding_preservation,
                     ));
                 } else if param
@@ -945,6 +952,7 @@ fn get_valid_types(
                     new_types.push(preserve_encoding(
                         current_type,
                         casted_type,
+                        param.desired_type(),
                         encoding_preservation,
                     ));
                 } else {
@@ -2015,15 +2023,45 @@ mod tests {
             .map(|v| v.into_iter().map(|f| f.data_type().clone()).collect())
         };
 
+        // Without preservation, recursively unwrap dictionaries to the unchanged leaf.
         let output =
             nested_dictionary_input(Coercion::new_exact(TypeSignatureClass::Integer))?;
         assert_eq!(vec![DataType::Int32], output);
 
+        // With preservation, restore the complete dictionary stack around the leaf.
         let output = nested_dictionary_input(
             Coercion::new_exact(TypeSignatureClass::Integer)
                 .with_encoding_preservation(EncodingPreservation::dictionary()),
         )?;
-        assert_eq!(vec![nested_dictionary], output);
+        assert_eq!(vec![nested_dictionary.clone()], output);
+
+        let int64_coercion = || {
+            Coercion::new_implicit(
+                TypeSignatureClass::Native(logical_int64()),
+                vec![TypeSignatureClass::Integer],
+                NativeType::Int64,
+            )
+        };
+
+        // Without preservation, materialize the coerced leaf type.
+        let output = nested_dictionary_input(int64_coercion())?;
+        assert_eq!(vec![DataType::Int64], output);
+
+        // With preservation, restore the complete dictionary stack around the coerced leaf.
+        let output = nested_dictionary_input(
+            int64_coercion()
+                .with_encoding_preservation(EncodingPreservation::dictionary()),
+        )?;
+        assert_eq!(
+            vec![DataType::Dictionary(
+                Box::new(DataType::Int8),
+                Box::new(DataType::Dictionary(
+                    Box::new(DataType::Int16),
+                    Box::new(DataType::Int64),
+                )),
+            )],
+            output
+        );
 
         Ok(())
     }

--- a/datafusion/spark/src/function/bitmap/bitmap_count.rs
+++ b/datafusion/spark/src/function/bitmap/bitmap_count.rs
@@ -28,8 +28,8 @@ use arrow::datatypes::{DataType, FieldRef, Int8Type, Int16Type, Int32Type, Int64
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{Result, internal_err};
 use datafusion_expr::{
-    Coercion, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature,
-    TypeSignatureClass, Volatility,
+    Coercion, ColumnarValue, EncodingPreservation, ScalarFunctionArgs, ScalarUDFImpl,
+    Signature, TypeSignatureClass, Volatility,
 };
 use datafusion_functions::downcast_arg;
 use datafusion_functions::utils::make_scalar_function;
@@ -49,7 +49,10 @@ impl BitmapCount {
     pub fn new() -> Self {
         Self {
             signature: Signature::coercible(
-                vec![Coercion::new_exact(TypeSignatureClass::Binary)],
+                vec![
+                    Coercion::new_exact(TypeSignatureClass::Binary)
+                        .with_encoding_preservation(EncodingPreservation::dictionary()),
+                ],
                 Volatility::Immutable,
             ),
         }

--- a/datafusion/spark/src/function/math/hex.rs
+++ b/datafusion/spark/src/function/math/hex.rs
@@ -34,8 +34,8 @@ use datafusion_common::{
     exec_datafusion_err, exec_err,
 };
 use datafusion_expr::{
-    Coercion, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
-    TypeSignatureClass, Volatility,
+    Coercion, ColumnarValue, EncodingPreservation, ScalarFunctionArgs, ScalarUDFImpl,
+    Signature, TypeSignature, TypeSignatureClass, Volatility,
 };
 /// <https://spark.apache.org/docs/latest/api/sql/index.html#hex>
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -60,7 +60,8 @@ impl SparkHex {
 
         let string = Coercion::new_exact(TypeSignatureClass::Native(logical_string()));
 
-        let binary = Coercion::new_exact(TypeSignatureClass::Binary);
+        let binary = Coercion::new_exact(TypeSignatureClass::Binary)
+            .with_encoding_preservation(EncodingPreservation::dictionary());
 
         let variants = vec![
             // accepts numeric types

--- a/datafusion/sqllogictest/test_files/expr.slt
+++ b/datafusion/sqllogictest/test_files/expr.slt
@@ -850,6 +850,15 @@ SELECT to_hex(0)
 ----
 0
 
+query T
+SELECT to_hex(arrow_cast(a, 'Dictionary(Int32, Int64)'))
+FROM (VALUES (0), (10), (255), (NULL)) AS t(a)
+----
+0
+a
+ff
+NULL
+
 # negative values (two's complement encoding)
 query T
 SELECT to_hex(-1)

--- a/datafusion/sqllogictest/test_files/spark/bitmap/bitmap_count.slt
+++ b/datafusion/sqllogictest/test_files/spark/bitmap/bitmap_count.slt
@@ -68,6 +68,21 @@ SELECT bitmap_count(arrow_cast(a, 'Dictionary(Int32, Binary)')) FROM (VALUES (X'
 16
 NULL
 
+# The CAST to Dictionary below comes from the explicit arrow_cast. There must
+# not be an additional outer CAST(... AS Binary) before bitmap_count.
+query TT
+EXPLAIN SELECT bitmap_count(arrow_cast(a, 'Dictionary(Int32, Binary)'))
+FROM (VALUES (X'1010'), (X'0AB0'), (X'FFFF'), (NULL)) AS t(a);
+----
+logical_plan
+01)Projection: bitmap_count(CAST(t.a AS Dictionary(Int32, Binary))) AS bitmap_count(arrow_cast(t.a,Utf8("Dictionary(Int32, Binary)")))
+02)--SubqueryAlias: t
+03)----Projection: column1 AS a
+04)------Values: (Binary("16,16")), (Binary("10,176")), (Binary("255,255")), (Binary(NULL))
+physical_plan
+01)ProjectionExec: expr=[bitmap_count(CAST(column1@0 AS Dictionary(Int32, Binary))) as bitmap_count(arrow_cast(t.a,Utf8("Dictionary(Int32, Binary)")))]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
 query I
 SELECT bitmap_count(arrow_cast(a, 'Dictionary(Int8, Binary)')) FROM (VALUES (X'1010'), (X'0AB0'), (X'FFFF'), (NULL)) AS t(a);
 ----

--- a/docs/source/library-user-guide/upgrading/55.0.0.md
+++ b/docs/source/library-user-guide/upgrading/55.0.0.md
@@ -168,8 +168,10 @@ unchanged.
 ### `Coercion` supports dictionary encoding preservation
 
 `datafusion_expr_common::signature::Coercion` now supports optional dictionary
-encoding preservation. When enabled for `TypeSignatureClass::Native(...)`
-coercions, DataFusion coerces dictionary inputs to
+encoding preservation. Typed coercions materialize dictionary inputs by
+default, including both `TypeSignatureClass::Native(...)` and broader classes
+such as `Integer`, `Numeric`, and `Binary`. When preservation is enabled,
+DataFusion instead coerces dictionary inputs to
 `Dictionary(original_key_type, coerced_value_type)` instead of materializing them
 to the coerced value type.
 
@@ -185,6 +187,11 @@ This changes the coerced argument type passed to the function. If a function
 derives its return type from that coerced argument type, code that checks exact
 result types may need to update its expectations or add an explicit cast to
 materialize the result.
+
+This changes the previous behavior of typed non-native classes such as
+`Integer` and `Binary`, which retained the physical dictionary type by default.
+UDFs relying on that behavior must now explicitly enable dictionary
+preservation. `TypeSignatureClass::Any` is unaffected.
 
 ### `GroupsAccumulator::merge_batch` no longer takes `opt_filter`
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Follow-up to #22905.
- Part of https://github.com/apache/datafusion/issues/19458

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

#22905 introduced explicit dictionary encoding preservation for coercible function signatures, but dictionary inputs were still handled differently across `TypeSignatureClass` variants:

| Signature category | Before | After |
| --- | --- | --- |
| `Native(...)` | Materialized by default; preserved when explicitly requested | Same default/opt-in contract |
| Typed non-Native (e.g. `Integer`, `Numeric`, `Binary`) | Retained the physical dictionary type by default | Materialized by default; preserved when explicitly requested |
| `Any` | Passed through the original physical input type | Unchanged |

This PR makes the encoding preservation contract consistent across all typed signature classes: coercion operates on the dictionary value type, and the dictionary encoding is restored only when `EncodingPreservation::dictionary()` is enabled.

An audit of the affected built-ins found two functions, Spark hex and bitmap_count, that intentionally handle dictionary inputs; both now opt in explicitly. Other affected functions generally expect materialized value arrays, so the new default also avoids cases where signature matching accepted a dictionary but the function implementation rejected it at execution time. Functions that continue to materialize dictionary inputs do not gain dictionary-aware execution efficiency yet, but they can opt in later if they add support for encoded inputs.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Align dictionary coercion across typed signature classes and preserve dictionary encoding when explicitly requested.
- Explicitly enable dictionary preservation for Spark `bitmap_count` and the binary variant of Spark `hex`.
- Document the behavior change and migration guidance in the DataFusion 55.0.0 upgrade guide.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

- Unit tests cover materialization and preservation for Native, non-Native, and `Any` inputs. 
- SLTs cover `to_hex` materialization and verify that `bitmap_count` preserves its dictionary input without an additional cast to `Binary`.
- Existing Spark `hex` dictionary tests cover its opt-in preservation behavior.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

This is a behavioral API change for UDFs using typed non-Native classes such as `Integer` or `Binary`. UDFs relying on implicit dictionary preservation must now enable `EncodingPreservation::dictionary()` explicitly.

`TypeSignatureClass::Any` is unaffected. The upgrade guide has been updated, and this PR should carry the `api change` label.