### PR TITLE
chore: group codeql action dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,6 +68,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels: [auto-dependencies]
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"
   - package-ecosystem: "pip"
     directory: "/docs"
     schedule:


### PR DESCRIPTION
see recent dependabot PRs

- https://github.com/apache/datafusion/pull/23553
- https://github.com/apache/datafusion/pull/23552

seems these updates should be done together and not separate PRs; add a group to the config to enable this