### PR TITLE
fix: close the markdown block in docstring

### DIFF
--- a/datafusion/physical-plan/src/sorts/cursor.rs
+++ b/datafusion/physical-plan/src/sorts/cursor.rs
@@ -76,14 +76,10 @@ pub trait CursorValues {
 /// │                       │
 /// │     CursorValues      │
 /// └───────────────────────┘
+/// ```
 ///
-///
-/// Store logical rows using
-/// one of several  formats,
-/// with specialized
-/// implementations
-/// depending on the column
-/// types
+/// Store logical rows using one of several  formats, with specialized
+/// implementations depending on the column types
 #[derive(Debug)]
 pub struct Cursor<T: CursorValues> {
     offset: usize,


### PR DESCRIPTION

## Which issue does this PR close?
Similar to https://github.com/apache/datafusion/pull/22409


## Rationale for this change
Minor fix for something that's bothering my syntax highlighting in vim.

## What changes are included in this PR?
Minor docstring fix, also changed the over-restrictive text wrapping

## Are these changes tested?
Not needed

## Are there any user-facing changes?
No
