### PR TITLE
feat: release memory for `LimitedBatchCoalescer` once reached the limit/finished

### DIFF
--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
 use arrow::array::RecordBatch;
 use arrow::compute::BatchCoalescer;
 use arrow::datatypes::SchemaRef;
 use arrow_schema::Schema;
 use datafusion_common::{Result, assert_or_internal_err};
+use std::sync::Arc;
 
 /// Concatenate multiple [`RecordBatch`]es and apply a limit
 ///

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -99,7 +99,6 @@ impl LimitedBatchCoalescer {
         if let Some(fetch) = self.fetch {
             // limit previously reached
             if self.total_rows >= fetch {
-                self.release_memory();
                 return Ok(PushBatchStatus::LimitReached);
             }
 
@@ -112,8 +111,6 @@ impl LimitedBatchCoalescer {
                 let batch_head = batch.slice(0, remaining_rows);
                 self.total_rows += batch_head.num_rows();
                 self.inner.push_batch(batch_head)?;
-
-                self.release_memory();
                 return Ok(PushBatchStatus::LimitReached);
             }
         }
@@ -136,7 +133,6 @@ impl LimitedBatchCoalescer {
     pub fn finish(&mut self) -> Result<()> {
         self.inner.finish_buffered_batch()?;
         self.finished = true;
-        self.release_memory();
         Ok(())
     }
 
@@ -144,9 +140,19 @@ impl LimitedBatchCoalescer {
         self.finished
     }
 
+    fn limit_reached(&self) -> bool {
+        self.fetch.is_some_and(|fetch| self.total_rows >= fetch)
+    }
+
     /// Return the next completed batch, if any
     pub fn next_completed_batch(&mut self) -> Option<RecordBatch> {
-        self.inner.next_completed_batch()
+        let next = self.inner.next_completed_batch();
+
+        if self.inner.is_empty() && (self.finished || self.limit_reached()) {
+            self.release_memory();
+        }
+
+        next
     }
 
     fn release_memory(&mut self) {

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
 use arrow::array::RecordBatch;
 use arrow::compute::BatchCoalescer;
 use arrow::datatypes::SchemaRef;
+use arrow_schema::Schema;
 use datafusion_common::{Result, assert_or_internal_err};
 
 /// Concatenate multiple [`RecordBatch`]es and apply a limit
@@ -97,6 +99,7 @@ impl LimitedBatchCoalescer {
         if let Some(fetch) = self.fetch {
             // limit previously reached
             if self.total_rows >= fetch {
+                self.release_memory();
                 return Ok(PushBatchStatus::LimitReached);
             }
 
@@ -109,6 +112,8 @@ impl LimitedBatchCoalescer {
                 let batch_head = batch.slice(0, remaining_rows);
                 self.total_rows += batch_head.num_rows();
                 self.inner.push_batch(batch_head)?;
+
+                self.release_memory();
                 return Ok(PushBatchStatus::LimitReached);
             }
         }
@@ -131,6 +136,7 @@ impl LimitedBatchCoalescer {
     pub fn finish(&mut self) -> Result<()> {
         self.inner.finish_buffered_batch()?;
         self.finished = true;
+        self.release_memory();
         Ok(())
     }
 
@@ -141,6 +147,10 @@ impl LimitedBatchCoalescer {
     /// Return the next completed batch, if any
     pub fn next_completed_batch(&mut self) -> Option<RecordBatch> {
         self.inner.next_completed_batch()
+    }
+
+    fn release_memory(&mut self) {
+        self.inner = BatchCoalescer::new(Arc::new(Schema::empty()), 1);
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

no need to hold on memory when no more data will be sent

## What changes are included in this PR?

on finish/limit we replace the `BatchCoalescer` with a mock one to drop all the data

## Are these changes tested?
No since there is no memory reservation (until #23385 is resolved)

## Are there any user-facing changes?

not public facing ones