### PR TITLE
Add benchmarks smoke test job to extended tests

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -126,6 +126,63 @@ jobs:
           cargo test  --profile ci --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-sqllogictest --exclude datafusion-cli --workspace --lib --tests --features=force_hash_collisions,avro
           cargo clean
 
+  # Smoke test the benchmarks: verify that every benchmark target still
+  # compiles and that a representative subset runs end-to-end on small data
+  # (a single query each). This is NOT a performance measurement -- it only
+  # ensures the benchmarks keep working, since nothing else exercises them
+  # in CI. See https://github.com/apache/datafusion/issues/15511
+  #
+  # Only runs on merges to main / release branches (and manual dispatch), not
+  # on pull requests, to conserve CI resources.
+  benchmarks-smoke:
+    name: benchmarks smoke test (compile + minimal run)
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion', github.run_id) || 'ubuntu-latest' }}
+    steps:
+      - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc  # v2.2.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.inputs.pr_head_sha }} # will be empty if triggered by push
+          submodules: true
+          fetch-depth: 1
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup toolchain install
+      - name: Install Protobuf Compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+      - name: Check all benchmark targets compile
+        run: cargo check --profile ci -p datafusion-benchmarks --bins --benches
+      - name: Install tpchgen-cli
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c  # v2.82.10
+        with:
+          tool: tpchgen-cli
+      - name: Generate TPC-H SF1 data
+        run: |
+          cd benchmarks
+          ./bench.sh data tpch
+      - name: Smoke run benchmarks
+        env:
+          # ci-optimized keeps debug assertions enabled while being fast
+          # enough to actually run queries
+          CARGO_COMMAND: cargo run --profile ci-optimized
+          SQL_CARGO_COMMAND: cargo bench --profile ci-optimized --bench sql
+          RESULTS_NAME: smoke
+        run: |
+          cd benchmarks
+          # benchmarks that share the TPC-H SF1 dataset, one query each
+          ./bench.sh run tpch 1
+          ./bench.sh run tpch_mem 1
+          ./bench.sh run sort_tpch 1
+          ./bench.sh run external_aggr 1
+          # generates its own data
+          ./bench.sh run cancellation
+
   sqllogictest-sqlite:
     name: "Run sqllogictests with the sqlite test suite"
     runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=32,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion', github.run_id) || 'ubuntu-latest' }}

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -668,7 +668,8 @@ data_tpch() {
     else
         echo " Copying answers to ${TPCH_DIR}/answers"
         mkdir -p "${TPCH_DIR}/answers"
-        docker run -v "${TPCH_DIR}":/data -it --entrypoint /bin/bash --rm ghcr.io/scalytics/tpch-docker:main  -c "cp -f /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
+        # no -t: keeps the copy working in non-interactive environments (CI)
+        docker run -v "${TPCH_DIR}":/data --entrypoint /bin/bash --rm ghcr.io/scalytics/tpch-docker:main  -c "cp -f /opt/tpch/2.18.0_rc2/dbgen/answers/* /data/answers/"
     fi
 
     if [ "$FORMAT" = "parquet" ]; then


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #15511.

(Running literally *all* benchmarks is left for follow-ups once the approach looks right — see "coverage" below.)

## Rationale for this change

Benchmarks keep silently breaking because nothing exercises them in CI (see #15511). This adds a smoke-test job to the extended tests workflow so breakage is caught on merge to `main` instead of by the next person who tries to run them.

## What changes are included in this PR?

- A new `benchmarks-smoke` job in `.github/workflows/extended.yml` that:
  1. `cargo check`s every benchmark bin and bench target — this alone catches the most common "benchmark silently broken" failures cheaply, then
  2. runs a representative subset end-to-end on small data, one query each, as a "does it still run" check (explicitly **not** a performance measurement): `tpch`, `tpch_mem`, `sort_tpch`, `external_aggr` on tpchgen-generated TPC-H SF1, plus `cancellation` (which generates its own data). Runs use the `ci-optimized` profile so debug assertions stay enabled.

  The job only runs on push to `main`/`branch-*` and manual dispatch, not on pull requests, to conserve CI resources.
- A one-line `bench.sh` fix: the TPC-H answers copy used `docker run -it`, which fails without a TTY in CI (`the input device is not a TTY`).

**Coverage:** benchmarks requiring multi-GB downloads (clickbench, h2o, imdb, tpcds) are intentionally left out of this first pass. Happy to extend coverage, change the subset, or gate the job differently based on feedback.

## Are these changes tested?

Yes — validated by running the modified workflow end-to-end on a fork: [run](https://github.com/vito1317/datafusion/actions/runs/29319876025/job/87042402974) (all steps green, including the docker answers-copy path and the tpchgen data generation). `actionlint` passes on the workflow file.

Timing data from that run (free 4-core `ubuntu-latest`): compile check 2m, tpchgen install 3m, TPC-H SF1 data generation 11s, smoke runs 72m (dominated by the `ci-optimized` compile). On the repository's `runs-on` runners (16 cores) the compile-heavy part should shrink substantially; if it is still too slow I can drop the run subset to compile-check only, or trim it further.

## Are there any user-facing changes?

No. (`bench.sh data tpch` no longer allocates a TTY for the answers-copy container; behaviour is otherwise unchanged.)
