### PR TITLE
[branch-54] perf: avoid intermediate slice allocation in Spark slice function (backport #23481)

### DIFF
--- a/datafusion/spark/src/function/array/slice.rs
+++ b/datafusion/spark/src/function/array/slice.rs
@@ -157,7 +157,7 @@ fn calculate_start_end(args: &[ArrayRef]) -> Result<(ArrayRef, ArrayRef)> {
         }
         let start = start.value(row);
         let length = length.value(row);
-        let value_length = values.value(row).len() as i64;
+        let value_length = values.value_length(row) as i64;
 
         if start == 0 {
             return exec_err!("Start index must not be zero");


### PR DESCRIPTION
## Which issue does this PR close?

- Backport of #23481 to `branch-54` (for 54.1.0, tracked in #22547).

## Rationale for this change

Performance improvement with minimal blast radius.

## What changes are included in this PR?

Clean cherry-pick of #23481. No adaptation required.

## Are these changes tested?

Yes, existing tests.

## Are there any user-facing changes?

No.
