### PR TITLE
minor: validate config `meta_fetch_concurrency` when setting it

### DIFF
--- a/datafusion/catalog-listing/src/table.rs
+++ b/datafusion/catalog-listing/src/table.rs
@@ -815,7 +815,7 @@ impl ListingTable {
         }))
         .await?;
         let meta_fetch_concurrency =
-            ctx.config_options().execution.meta_fetch_concurrency;
+            ctx.config_options().execution.meta_fetch_concurrency.get();
         let file_list = stream::iter(file_list).flatten_unordered(meta_fetch_concurrency);
         // collect the statistics and ordering if required by the config
         let files = file_list
@@ -832,7 +832,9 @@ impl ListingTable {
                     .with_ordering(ordering))
             })
             .boxed()
-            .buffer_unordered(ctx.config_options().execution.meta_fetch_concurrency);
+            .buffer_unordered(
+                ctx.config_options().execution.meta_fetch_concurrency.get(),
+            );
 
         get_files_with_limit(files, file_limit, ctx.config().collect_statistics()).await
     }

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -861,7 +861,7 @@ config_namespace! {
         pub max_spill_file_size_bytes: usize, default = 128 * 1024 * 1024
 
         /// Number of files to read in parallel when inferring schema and statistics
-        pub meta_fetch_concurrency: usize, default = 32
+        pub meta_fetch_concurrency: ConfigNonZeroUsize, default = non_zero_usize_default(32)
 
         /// Guarantees a minimum level of output files running in parallel.
         /// RecordBatches will be distributed in round robin fashion to each

--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -1932,7 +1932,8 @@ impl ConfigOptions {
                 }
                 return Ok(());
             }
-            return ConfigField::set(self, inner_key, value);
+            return ConfigField::set(self, inner_key, value)
+                .map_err(|e| e.context(format!("Error setting config {key}")));
         }
 
         if !self.extensions.0.contains_key(prefix)
@@ -3771,6 +3772,7 @@ impl Display for OutputFormat {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "parquet")]
+    use crate::assert_contains;
     use crate::config::TableParquetOptions;
     use crate::config::{
         ConfigEntry, ConfigExtension, ConfigField, ConfigFileType, ExtensionOptions,
@@ -4331,7 +4333,7 @@ mod tests {
         let err = config
             .set("datafusion.execution.parquet.writer_version", "3.0")
             .unwrap_err();
-        assert_eq!(
+        assert_contains!(
             err.to_string(),
             "Invalid or Unsupported Configuration: Invalid parquet writer version: 3.0. Expected one of: 1.0, 2.0"
         );

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -539,7 +539,8 @@ mod tests {
             .state()
             .config_options()
             .execution
-            .meta_fetch_concurrency;
+            .meta_fetch_concurrency
+            .get();
         let expected_concurrency = files.len().min(meta_fetch_concurrency);
         let head_concurrency_store = ensure_head_concurrency(store, expected_concurrency);
 

--- a/datafusion/core/tests/config_from_env.rs
+++ b/datafusion/core/tests/config_from_env.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use datafusion::config::ConfigOptions;
+use datafusion_common::assert_contains;
 use std::env;
 
 #[test]
@@ -34,7 +35,7 @@ fn from_env() {
         // invalid testing
         env::set_var(env_key, "ttruee");
         let err = ConfigOptions::from_env().unwrap_err().strip_backtrace();
-        assert_eq!(
+        assert_contains!(
             err,
             "Error parsing 'ttruee' as bool\ncaused by\nExternal error: provided string was not `true` or `false`"
         );
@@ -50,7 +51,7 @@ fn from_env() {
         // for invalid testing
         env::set_var(env_key, "abc");
         let err = ConfigOptions::from_env().unwrap_err().strip_backtrace();
-        assert_eq!(
+        assert_contains!(
             err,
             "Error parsing 'abc' as usize\ncaused by\nExternal error: invalid digit found in string"
         );

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -367,7 +367,13 @@ impl FileFormat for ParquetFormat {
             })
             .boxed() // Workaround https://github.com/rust-lang/rust/issues/64552
             // fetch schemas concurrently, if requested
-            .buffer_unordered(state.config_options().execution.meta_fetch_concurrency)
+            .buffer_unordered(
+                state
+                    .config_options()
+                    .execution
+                    .meta_fetch_concurrency
+                    .get(),
+            )
             .try_collect()
             .await?;
 

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -533,8 +533,13 @@ query error DataFusion error: Error during planning: EXPLAIN VERBOSE with FORMAT
 explain verbose format tree select * from values (1);
 
 # valid explain format
-query error DataFusion error: Invalid or Unsupported Configuration: Invalid explain format. Expected 'indent', 'tree', 'pgjson' or 'graphviz'. Got 'xxx'
+query error
 set datafusion.explain.format = "xxx";
+----
+DataFusion error: Error setting config datafusion.explain.format
+caused by
+Invalid or Unsupported Configuration: Invalid explain format. Expected 'indent', 'tree', 'pgjson' or 'graphviz'. Got 'xxx'
+
 
 # verbose uses indent mode even when a different mode (e.g tree) is set
 

--- a/datafusion/sqllogictest/test_files/set_variable.slt
+++ b/datafusion/sqllogictest/test_files/set_variable.slt
@@ -93,10 +93,10 @@ datafusion.execution.coalesce_batches false
 statement ok
 set datafusion.catalog.information_schema = true
 
-statement error DataFusion error: Error parsing '1' as bool
+statement error DataFusion error: Error setting config datafusion\.execution\.coalesce_batches\ncaused by\nError parsing '1' as bool
 SET datafusion.execution.coalesce_batches to 1
 
-statement error DataFusion error: Error parsing 'abc' as bool
+statement error DataFusion error: Error setting config datafusion\.execution\.coalesce_batches\ncaused by\nError parsing 'abc' as bool
 SET datafusion.execution.coalesce_batches to abc
 
 # set u64 variable
@@ -132,10 +132,10 @@ datafusion.execution.batch_size 2
 statement ok
 set datafusion.catalog.information_schema = true
 
-statement error DataFusion error: Error parsing '-1' as usize
+statement error DataFusion error: Error setting config datafusion\.execution\.batch_size\ncaused by\nError parsing '-1' as usize
 SET datafusion.execution.batch_size to -1
 
-statement error DataFusion error: Error parsing 'abc' as usize
+statement error DataFusion error: Error setting config datafusion\.execution\.batch_size\ncaused by\nError parsing 'abc' as usize
 SET datafusion.execution.batch_size to abc
 
 statement error External error: invalid digit found in string
@@ -580,7 +580,7 @@ SHOW datafusion.format.date_format
 datafusion.format.date_format %Y-%m-%d
 
 # Invalid format option name
-statement error DataFusion error: Invalid or Unsupported Configuration: Config value "unknown_option" not found on FormatOptions
+statement error DataFusion error: Error setting config datafusion\.format\.unknown_option\ncaused by\nInvalid or Unsupported Configuration: Config value "unknown_option" not found on FormatOptions
 SET datafusion.format.unknown_option = true
 
 ############
@@ -721,10 +721,10 @@ statement error DataFusion error: Error during planning: Duration has overflowed
 SET datafusion.runtime.list_files_cache_ttl = '1m18446744073709551556s'
 
 # Set invalid value and ensures error
-statement error DataFusion error: Invalid or Unsupported Configuration: value must be greater than 0
+statement error DataFusion error: Error setting config datafusion\.execution\.batch_size\ncaused by\nInvalid or Unsupported Configuration: value must be greater than 0
 SET datafusion.execution.batch_size = 0
 
-statement error DataFusion error: Invalid or Unsupported Configuration: value must be greater than 0
+statement error DataFusion error: Error setting config datafusion\.execution\.meta_fetch_concurrency\ncaused by\nInvalid or Unsupported Configuration: value must be greater than 0
 SET datafusion.execution.meta_fetch_concurrency = 0
 
 # Config reset

--- a/datafusion/sqllogictest/test_files/set_variable.slt
+++ b/datafusion/sqllogictest/test_files/set_variable.slt
@@ -724,6 +724,9 @@ SET datafusion.runtime.list_files_cache_ttl = '1m18446744073709551556s'
 statement error DataFusion error: Invalid or Unsupported Configuration: value must be greater than 0
 SET datafusion.execution.batch_size = 0
 
+statement error DataFusion error: Invalid or Unsupported Configuration: value must be greater than 0
+SET datafusion.execution.meta_fetch_concurrency = 0
+
 # Config reset
 statement ok
 RESET datafusion.catalog.create_default_catalog_and_schema

--- a/datafusion/sqllogictest/test_files/spark/map/str_to_map.slt
+++ b/datafusion/sqllogictest/test_files/spark/map/str_to_map.slt
@@ -159,5 +159,9 @@ statement ok
 set datafusion.spark.map_key_dedup_policy = 'EXCEPTION';
 
 # Invalid policy values are rejected at SET time with a clear message.
-statement error DataFusion error: Invalid or Unsupported Configuration: Invalid MapKeyDedupPolicy: BOGUS\. Expected one of: EXCEPTION, LAST_WIN
+statement error
 set datafusion.spark.map_key_dedup_policy = 'BOGUS';
+----
+DataFusion error: Error setting config datafusion.spark.map_key_dedup_policy
+caused by
+Invalid or Unsupported Configuration: Invalid MapKeyDedupPolicy: BOGUS. Expected one of: EXCEPTION, LAST_WIN


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of https://github.com/apache/datafusion/issues/17498

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This is logically the same change as #23592, but for another configuration.

0 is an invalid value for concurrency level, so restricting it to be non-zero

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
