### PR TITLE
minor: validate config `minimum_parallel_output_files` when setting it

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -867,7 +867,7 @@ config_namespace! {
         /// RecordBatches will be distributed in round robin fashion to each
         /// parallel writer. Each writer is closed and a new file opened once
         /// soft_max_rows_per_output_file is reached.
-        pub minimum_parallel_output_files: usize, default = 4
+        pub minimum_parallel_output_files: ConfigNonZeroUsize, default = non_zero_usize_default(4)
 
         /// Target number of rows in output files when writing multiple.
         /// This is a soft max, so it can be exceeded slightly. There also

--- a/datafusion/datasource/src/write/demux.rs
+++ b/datafusion/datasource/src/write/demux.rs
@@ -155,7 +155,7 @@ async fn row_count_demuxer(
 
     let max_rows_per_file = exec_options.soft_max_rows_per_output_file;
     let max_buffered_batches = exec_options.max_buffered_batches_per_output_file;
-    let minimum_parallel_files = exec_options.minimum_parallel_output_files;
+    let minimum_parallel_files = exec_options.minimum_parallel_output_files.get();
     let mut part_idx = 0;
     let write_id = rand::distr::Alphanumeric.sample_string(&mut rand::rng(), 16);
 

--- a/datafusion/sqllogictest/test_files/set_variable.slt
+++ b/datafusion/sqllogictest/test_files/set_variable.slt
@@ -724,6 +724,9 @@ SET datafusion.runtime.list_files_cache_ttl = '1m18446744073709551556s'
 statement error DataFusion error: Invalid or Unsupported Configuration: value must be greater than 0
 SET datafusion.execution.batch_size = 0
 
+statement error DataFusion error: Invalid or Unsupported Configuration: value must be greater than 0
+SET datafusion.execution.minimum_parallel_output_files = 0
+
 # Config reset
 statement ok
 RESET datafusion.catalog.create_default_catalog_and_schema


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of https://github.com/apache/datafusion/issues/17498

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This is logically the same change as #23592, but for another configuration.

This value represents number of concurrent writer, and 0 is a invalid value. So validate it must be non-zero

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
