### PR TITLE
perf: replace arrow concat_batches by concat_batches_owned

### DIFF
--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -22,8 +22,9 @@ use datafusion_common::{Result, assert_or_internal_err};
 
 /// Concatenate owned batches into a single [`RecordBatch`].
 ///
-/// Unlike https://docs.rs/arrow-select/59.1.0/arrow_select/concat/fn.concat_batches.html,
-/// This copies array types incrementally, allowing input batch to be released after it is copied.
+/// Unlike <https://docs.rs/arrow-select/59.1.0/arrow_select/concat/fn.concat_batches.html>,
+/// This copies array types incrementally, allowing input batches to be
+/// released after they are copied.
 pub(crate) fn concat_batches_owned(
     schema: SchemaRef,
     batches: Vec<RecordBatch>,

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -20,6 +20,31 @@ use arrow::compute::BatchCoalescer;
 use arrow::datatypes::SchemaRef;
 use datafusion_common::{Result, assert_or_internal_err};
 
+/// Concatenate owned batches into a single [`RecordBatch`].
+///
+/// Unlike https://docs.rs/arrow-select/59.1.0/arrow_select/concat/fn.concat_batches.html,
+/// This copies array types incrementally, allowing input batch to be released after it is copied.
+pub(crate) fn concat_batches_owned(
+    schema: SchemaRef,
+    batches: Vec<RecordBatch>,
+) -> Result<RecordBatch> {
+    let num_rows = batches.iter().map(RecordBatch::num_rows).sum();
+    if num_rows == 0 {
+        return Ok(RecordBatch::new_empty(schema));
+    }
+
+    let mut coalescer = BatchCoalescer::new(schema, num_rows);
+    for batch in batches {
+        coalescer.push_batch(batch)?;
+    }
+    coalescer.finish_buffered_batch()?;
+    coalescer.next_completed_batch().ok_or_else(|| {
+        datafusion_common::internal_datafusion_err!(
+            "BatchCoalescer did not produce a completed batch"
+        )
+    })
+}
+
 /// Concatenate multiple [`RecordBatch`]es and apply a limit
 ///
 /// See [`BatchCoalescer`] for more details on how this works.
@@ -150,9 +175,67 @@ mod tests {
     use std::ops::Range;
     use std::sync::Arc;
 
-    use arrow::array::UInt32Array;
+    use arrow::array::{RecordBatchOptions, StringArray, UInt32Array};
     use arrow::compute::concat_batches;
     use arrow::datatypes::{DataType, Field, Schema};
+
+    #[test]
+    fn test_concat_batches_owned() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("number", DataType::UInt32, false),
+            Field::new("string", DataType::Utf8, false),
+        ]));
+        let batches = vec![
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(UInt32Array::from(vec![1, 2])),
+                    Arc::new(StringArray::from(vec!["a", "b"])),
+                ],
+            )
+            .unwrap(),
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(UInt32Array::from(vec![3, 4])),
+                    Arc::new(StringArray::from(vec!["c", "d"])),
+                ],
+            )
+            .unwrap(),
+        ];
+        let expected = concat_batches(&schema, &batches).unwrap();
+
+        let actual = concat_batches_owned(schema, batches).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_concat_batches_owned_empty_input() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "number",
+            DataType::UInt32,
+            false,
+        )]));
+
+        let actual = concat_batches_owned(Arc::clone(&schema), vec![]).unwrap();
+
+        assert_eq!(actual, RecordBatch::new_empty(schema));
+    }
+
+    #[test]
+    fn test_concat_batches_owned_empty_schema() {
+        let schema = Arc::new(Schema::empty());
+        let options = RecordBatchOptions::new().with_row_count(Some(2));
+        let batch =
+            RecordBatch::try_new_with_options(Arc::clone(&schema), vec![], &options)
+                .unwrap();
+
+        let actual = concat_batches_owned(schema, vec![batch.clone(), batch]).unwrap();
+
+        assert_eq!(actual.num_rows(), 4);
+        assert_eq!(actual.num_columns(), 0);
+    }
 
     #[test]
     fn test_coalesce() {

--- a/datafusion/physical-plan/src/joins/cross_join.rs
+++ b/datafusion/physical-plan/src/joins/cross_join.rs
@@ -25,6 +25,7 @@ use super::utils::{
     OnceAsync, OnceFut, StatefulStreamResult, adjust_right_output_partitioning,
     reorder_output_after_swap,
 };
+use crate::coalesce::concat_batches_owned;
 use crate::execution_plan::{EmissionType, boundedness_from_children};
 use crate::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use crate::projection::{
@@ -40,7 +41,6 @@ use crate::{
 };
 
 use arrow::array::{RecordBatch, RecordBatchOptions};
-use arrow::compute::concat_batches;
 use arrow::datatypes::{Fields, Schema, SchemaRef};
 use datafusion_common::stats::Precision;
 use datafusion_common::{
@@ -223,7 +223,7 @@ async fn load_left_input(
         )
         .await?;
 
-    let merged_batch = concat_batches(&left_schema, &batches)?;
+    let merged_batch = concat_batches_owned(left_schema, batches)?;
 
     Ok(JoinLeftData {
         merged_batch,

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -23,6 +23,7 @@ use std::sync::{Arc, OnceLock};
 use std::vec;
 
 use crate::ExecutionPlanProperties;
+use crate::coalesce::concat_batches_owned;
 use crate::execution_plan::{
     EmissionType, boundedness_from_children, has_same_children_properties,
     stub_properties,
@@ -67,7 +68,6 @@ use crate::{
 };
 
 use arrow::array::{ArrayRef, BooleanBufferBuilder};
-use arrow::compute::concat_batches;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use arrow::util::bit_util;
@@ -103,17 +103,14 @@ pub(crate) const HASH_JOIN_SEED: SeededRandomState =
 
 const ARRAY_MAP_CREATED_COUNT_METRIC_NAME: &str = "array_map_created_count";
 
-#[expect(clippy::too_many_arguments)]
-fn try_create_array_map(
+fn array_map_bounds(
     bounds: &Option<PartitionBounds>,
-    schema: &SchemaRef,
     batches: &[RecordBatch],
     on_left: &[PhysicalExprRef],
-    reservation: &mut MemoryReservation,
     perfect_hash_join_small_build_threshold: usize,
     perfect_hash_join_min_key_density: f64,
     null_equality: NullEquality,
-) -> Result<Option<(ArrayMap, RecordBatch, Vec<ArrayRef>)>> {
+) -> Result<Option<(u64, u64)>> {
     if on_left.len() != 1 {
         return Ok(None);
     }
@@ -175,15 +172,7 @@ fn try_create_array_map(
         return Ok(None);
     }
 
-    let mem_size = ArrayMap::estimate_memory_size(min_val, max_val, num_row);
-    reservation.try_grow(mem_size)?;
-
-    let batch = concat_batches(schema, batches)?;
-    let left_values = evaluate_expressions_to_arrays(on_left, &batch)?;
-
-    let array_map = ArrayMap::try_new(&left_values[0], min_val, max_val)?;
-
-    Ok(Some((array_map, batch, left_values)))
+    Ok(Some((min_val, max_val)))
 }
 
 /// HashTable and input data for the left (build side) of a join
@@ -568,7 +557,7 @@ impl From<&HashJoinExec> for HashJoinExecBuilder {
 /// 4. build_side.num_rows() < u32::MAX
 /// 5. NullEqualsNothing || (NullEqualsNull && build side doesn't contain null)
 ///
-/// See [`try_create_array_map`] for more details.
+/// See [`array_map_bounds`] for more details.
 ///
 /// Note that when using [`PartitionMode::Partitioned`], the build side is split into multiple
 /// partitions. This can cause a dense build side to become sparse within each partition,
@@ -2009,7 +1998,7 @@ async fn collect_left_input(
         batches,
         num_rows,
         metrics,
-        mut reservation,
+        reservation,
         bounds_accumulators,
         memory_counter: _,
     } = state;
@@ -2026,21 +2015,28 @@ async fn collect_left_input(
         _ => None,
     };
 
+    let array_map_bounds = array_map_bounds(
+        &bounds,
+        &batches,
+        &on_left,
+        config.execution.perfect_hash_join_small_build_threshold,
+        config.execution.perfect_hash_join_min_key_density,
+        null_equality,
+    )?;
+
     let (join_hash_map, batch, left_values) =
-        if let Some((array_map, batch, left_value)) = try_create_array_map(
-            &bounds,
-            &schema,
-            &batches,
-            &on_left,
-            &mut reservation,
-            config.execution.perfect_hash_join_small_build_threshold,
-            config.execution.perfect_hash_join_min_key_density,
-            null_equality,
-        )? {
+        if let Some((min_val, max_val)) = array_map_bounds {
+            let mem_size = ArrayMap::estimate_memory_size(min_val, max_val, num_rows);
+            reservation.try_grow(mem_size)?;
+
+            let batch = concat_batches_owned(Arc::clone(&schema), batches)?;
+            let left_values = evaluate_expressions_to_arrays(&on_left, &batch)?;
+            let array_map = ArrayMap::try_new(&left_values[0], min_val, max_val)?;
+
             array_map_created_count.add(1);
             metrics.build_mem_used.add(array_map.size());
 
-            (Map::ArrayMap(array_map), batch, left_value)
+            (Map::ArrayMap(array_map), batch, left_values)
         } else {
             // Estimation of memory size, required for hashtable, prior to allocation.
             // Final result can be verified using `RawTable.allocation_info()`
@@ -2088,7 +2084,10 @@ async fn collect_left_input(
             }
 
             // Merge all batches into a single batch, so we can directly index into the arrays
-            let batch = concat_batches(&schema, batches_iter.clone())?;
+            let batch = concat_batches_owned(
+                Arc::clone(&schema),
+                batches.into_iter().rev().collect(),
+            )?;
 
             let left_values = evaluate_expressions_to_arrays(&on_left, &batch)?;
 

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -27,6 +27,7 @@ use super::utils::{
     asymmetric_join_output_partitioning, need_produce_result_in_final,
     reorder_output_after_swap, swap_join_projection,
 };
+use crate::coalesce::concat_batches_owned;
 use crate::common::can_project;
 use crate::execution_plan::{EmissionType, boundedness_from_children};
 use crate::joins::SharedBitmapBuilder;
@@ -852,7 +853,7 @@ async fn collect_left_input(
         )
         .await?;
 
-    let merged_batch = concat_batches(&schema, &batches)?;
+    let merged_batch = concat_batches_owned(schema, batches)?;
 
     // Reserve memory for visited_left_side bitmap if required by join type
     let visited_left_side = if with_visited_left_side {

--- a/datafusion/physical-plan/src/joins/piecewise_merge_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/piecewise_merge_join/exec.rs
@@ -18,7 +18,6 @@
 use arrow::array::Array;
 use arrow::{
     array::{ArrayRef, BooleanBufferBuilder, RecordBatch},
-    compute::concat_batches,
     util::bit_util,
 };
 use arrow_schema::{SchemaRef, SortOptions};
@@ -41,6 +40,7 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
+use crate::coalesce::concat_batches_owned;
 use crate::execution_plan::{EmissionType, boundedness_from_children};
 
 use crate::joins::piecewise_merge_join::classic_join::{
@@ -668,17 +668,16 @@ async fn build_buffered_data(
         })
         .await?;
 
-    let single_batch = concat_batches(&schema, batches.iter())?;
+    let single_batch = concat_batches_owned(schema, batches)?;
 
     // Evaluate physical expression on the buffered side.
     let buffered_values = on_buffered
         .evaluate(&single_batch)?
         .into_array(single_batch.num_rows())?;
 
-    // We add the single batch size + the memory of the join keys
-    // size of the size estimation
-    let size_estimation = get_record_batch_memory_size(&single_batch)
-        + buffered_values.get_array_memory_size();
+    // The existing reservation transfers from the consumed input batches to
+    // the concatenated batch, so only reserve additional join-key memory.
+    let size_estimation = buffered_values.get_array_memory_size();
     reservation.try_grow(size_estimation)?;
     metrics.build_mem_used.add(size_estimation);
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/23076

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

To avoid 2x memory amplification from concat_batches in joins 

> https://docs.rs/arrow-select/59.1.0/arrow_select/concat/fn.concat_batches.html
> Callers should budget for peak memory use to approach 2x the input size, as the input batches and output arrays co-exist during construction.

AS-IS
```bash
/usr/bin/time -l datafusion-cli -f /Users/qmac/Scripts/hj_mem.sql

100000001 row(s) fetched. (First 40 displayed. Use --maxrows to adjust)
Elapsed 0.512 seconds.

        0.54 real         0.43 user         0.11 sys
          2032107520  maximum resident set size                  <--- 2GB
```

TO-BE
```bash
/usr/bin/time -l datafusion-cli -f /Users/qmac/Scripts/hj_mem.sql

100000001 row(s) fetched. (First 40 displayed. Use --maxrows to adjust)
Elapsed 0.498 seconds.

        0.54 real         0.43 user         0.11 sys
          1732083712  maximum resident set size                  <--- 1.6GB
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add `concat_batches_owned`, which similar with https://docs.rs/arrow/latest/arrow/compute/struct.BatchCoalescer.html

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
