### PR TITLE
test: Fix malformed `regexp_instr` error tests and add slt coverage

### DIFF
--- a/datafusion/sqllogictest/test_files/regexp/regexp_instr.slt
+++ b/datafusion/sqllogictest/test_files/regexp/regexp_instr.slt
@@ -61,13 +61,14 @@ SELECT
 ----
 11
 
-statement error
-External error: query failed: DataFusion error: Arrow error: Compute error: regexp_instr() requires start to be 1 based
+statement error DataFusion error: Arrow error: Compute error: regexp_instr\(\) requires start to be 1-based
 SELECT regexp_instr('123123123123', '123', 0);
 
-statement error
-External error: query failed: DataFusion error: Arrow error: Compute error: regexp_instr() requires start to be 1 based
+statement error DataFusion error: Arrow error: Compute error: regexp_instr\(\) requires start to be 1-based
 SELECT regexp_instr('123123123123', '123', -3);
+
+statement error DataFusion error: Arrow error: Compute error: N must be 1 or greater
+SELECT regexp_instr('abcabcabc', 'abc', 1, 0);
 
 query I
 SELECT regexp_instr(str, pattern) FROM regexp_test_data;
@@ -189,8 +190,27 @@ NULL
 NULL
 NULL
 
+# The pattern column alternates between two regexes within a single batch, so
+# the compiled regex for 'abc' must be looked up again from the regex cache
+# after 'def' displaced it as the most recently used pattern
+statement ok
+CREATE TABLE t_alternating_pattern(str varchar, pattern varchar) AS VALUES
+  ('abcdef', 'abc'),
+  ('abcdef', 'def'),
+  ('abcdef', 'abc');
+
+query I
+SELECT regexp_instr(str, pattern) FROM t_alternating_pattern;
+----
+1
+4
+1
+
 statement ok
 DROP TABLE t_stringview;
 
 statement ok
 DROP TABLE empty_table;
+
+statement ok
+DROP TABLE t_alternating_pattern;


### PR DESCRIPTION
## Which issue does this PR close?

N/A (found while reviewing test coverage for #23540)

## Rationale for this change

While checking `cargo llvm-cov` coverage of `regexp_instr`, I found that the two `statement error` tests for `start < 1` in `regexp_instr.slt` never actually exercise the start validation. 

Coverage also showed two paths of `regexp_instr` untested anywhere:

- the `N must be 1 or greater` error for `nth < 1`
- looking up an already-compiled regex from the per-batch cache when the pattern column returns to a previously seen pattern (e.g. `['abc', 'def', 'abc']`). This path becomes more important with the memoization added in #23540.

## What changes are included in this PR?

- Fix the two malformed `statement error` tests so the expected error is matched inline against the real message
- Add a `statement error` test for `nth < 1`
- Add a test with a pattern column that alternates between two regexes within a single batch

## Are these changes tested?

Yes, this PR is only tests. 

## Are there any user-facing changes?

No
