### PR TITLE
Datasource: Add file_metadata() to DataSink for per-file write metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,6 +2080,7 @@ dependencies = [
  "parquet",
  "tempfile",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/datafusion/datasource-parquet/Cargo.toml
+++ b/datafusion/datasource-parquet/Cargo.toml
@@ -63,6 +63,7 @@ criterion = { workspace = true }
 datafusion-functions = { workspace = true }
 datafusion-functions-nested = { workspace = true }
 tempfile = { workspace = true }
+url = { workspace = true }
 
 # Note: add additional linter rules in lib.rs.
 # Rust does not support workspace + new linter rules in subcrates yet

--- a/datafusion/datasource-parquet/src/sink.rs
+++ b/datafusion/datasource-parquet/src/sink.rs
@@ -443,11 +443,17 @@ impl DataSink for ParquetSink {
         written
             .iter()
             .map(|(path, parquet_meta)| {
-                let row_count = parquet_meta.file_metadata().num_rows() as u64;
+                let row_count: u64 = parquet_meta
+                    .file_metadata()
+                    .num_rows()
+                    .try_into()
+                    .unwrap_or(0);
                 let byte_size: u64 = parquet_meta
                     .row_groups()
                     .iter()
-                    .map(|rg| rg.compressed_size() as u64)
+                    .map(|rg| {
+                        u64::try_from(rg.compressed_size()).unwrap_or(0)
+                    })
                     .sum();
 
                 FileWriteMetadata {
@@ -883,7 +889,7 @@ async fn output_single_parquet_file_parallelized(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{ArrayRef, StringArray};
+    use arrow::array::record_batch;
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_common::config::TableParquetOptions;
     use datafusion_datasource::PartitionedFile;
@@ -897,38 +903,42 @@ mod tests {
     use datafusion_expr::dml::InsertOp;
     use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
     use object_store::local::LocalFileSystem;
+    use tempfile::TempDir;
 
-    fn build_test_ctx(store_url: &ObjectStoreUrl) -> Arc<TaskContext> {
-        let tmp_dir = tempfile::TempDir::new().unwrap();
+    /// Test fixture that keeps the TempDir alive for the duration of the test.
+    struct TestFixture {
+        _tmp_dir: TempDir,
+        ctx: Arc<TaskContext>,
+        sink: Arc<ParquetSink>,
+        schema: SchemaRef,
+    }
+
+    fn setup_test_fixture() -> TestFixture {
+        let tmp_dir = TempDir::new().unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
         let local = Arc::new(
-            LocalFileSystem::new_with_prefix(&tmp_dir)
+            LocalFileSystem::new_with_prefix(&tmp_path)
                 .expect("should create object store"),
         );
 
-        let session = SessionConfig::default();
-        let runtime = RuntimeEnv::default();
-        runtime
-            .object_store_registry
-            .register_store(store_url.as_ref(), local);
-
-        Arc::new(
-            TaskContext::default()
-                .with_session_config(session)
-                .with_runtime(Arc::new(runtime)),
+        let object_store_url = ObjectStoreUrl::local_filesystem();
+        let table_url = ListingTableUrl::parse(
+            url::Url::from_directory_path(&tmp_path).unwrap().as_str(),
         )
-    }
+        .unwrap();
 
-    fn create_test_sink() -> (Arc<ParquetSink>, SchemaRef, ObjectStoreUrl) {
         let field_a = Field::new("a", DataType::Utf8, false);
         let field_b = Field::new("b", DataType::Utf8, false);
         let schema = Arc::new(Schema::new(vec![field_a, field_b]));
-        let object_store_url = ObjectStoreUrl::local_filesystem();
 
         let file_sink_config = FileSinkConfig {
             original_url: String::default(),
             object_store_url: object_store_url.clone(),
-            file_group: FileGroup::new(vec![PartitionedFile::new("/tmp".to_string(), 1)]),
-            table_paths: vec![ListingTableUrl::parse("file:///tmp/test/").unwrap()],
+            file_group: FileGroup::new(vec![PartitionedFile::new(
+                tmp_path.to_string_lossy().to_string(),
+                1,
+            )]),
+            table_paths: vec![table_url],
             output_schema: Arc::clone(&schema),
             table_partition_cols: vec![],
             insert_op: InsertOp::Overwrite,
@@ -937,46 +947,64 @@ mod tests {
             file_output_mode: FileOutputMode::Automatic,
         };
 
-        let parquet_sink = Arc::new(ParquetSink::new(
+        let sink = Arc::new(ParquetSink::new(
             file_sink_config,
             TableParquetOptions::default(),
         ));
 
-        (parquet_sink, schema, object_store_url)
+        let session = SessionConfig::default();
+        let runtime = RuntimeEnv::default();
+        runtime
+            .object_store_registry
+            .register_store(object_store_url.as_ref(), local);
+
+        let ctx = Arc::new(
+            TaskContext::default()
+                .with_session_config(session)
+                .with_runtime(Arc::new(runtime)),
+        );
+
+        TestFixture {
+            _tmp_dir: tmp_dir,
+            ctx,
+            sink,
+            schema,
+        }
     }
 
-    fn make_test_batch(schema: &SchemaRef) -> RecordBatch {
-        let col_a: ArrayRef = Arc::new(StringArray::from(vec!["foo", "bar", "baz"]));
-        let col_b: ArrayRef = Arc::new(StringArray::from(vec!["one", "two", "three"]));
-        RecordBatch::try_new(Arc::clone(schema), vec![col_a, col_b]).unwrap()
+    fn make_test_batch(_schema: &SchemaRef) -> RecordBatch {
+        record_batch!(
+            ("a", Utf8, ["foo", "bar", "baz"]),
+            ("b", Utf8, ["one", "two", "three"])
+        )
+        .unwrap()
     }
 
     #[test]
     fn file_metadata_empty_before_write() {
-        let (sink, _schema, _url) = create_test_sink();
+        let fixture = setup_test_fixture();
         assert!(
-            sink.file_metadata().is_empty(),
+            fixture.sink.file_metadata().is_empty(),
             "file_metadata should be empty before any write"
         );
     }
 
     #[tokio::test]
     async fn file_metadata_populated_after_write() {
-        let (sink, schema, object_store_url) = create_test_sink();
-        let ctx = build_test_ctx(&object_store_url);
-        let batch = make_test_batch(&schema);
+        let fixture = setup_test_fixture();
+        let batch = make_test_batch(&fixture.schema);
 
         let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&schema),
+            Arc::clone(&fixture.schema),
             futures::stream::iter(vec![Ok(batch)]),
         ));
 
-        let count = DataSink::write_all(sink.as_ref(), data, &ctx)
+        let count = DataSink::write_all(fixture.sink.as_ref(), data, &fixture.ctx)
             .await
             .unwrap();
         assert_eq!(count, 3, "should have written 3 rows");
 
-        let metadata = sink.file_metadata();
+        let metadata = fixture.sink.file_metadata();
         assert_eq!(metadata.len(), 1, "should have one file metadata entry");
         assert_eq!(metadata[0].row_count, 3);
         assert!(metadata[0].byte_size > 0, "byte_size should be non-zero");
@@ -986,20 +1014,19 @@ mod tests {
 
     #[tokio::test]
     async fn file_metadata_count_equals_write_all_count() {
-        let (sink, schema, object_store_url) = create_test_sink();
-        let ctx = build_test_ctx(&object_store_url);
-        let batch = make_test_batch(&schema);
+        let fixture = setup_test_fixture();
+        let batch = make_test_batch(&fixture.schema);
 
         let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&schema),
+            Arc::clone(&fixture.schema),
             futures::stream::iter(vec![Ok(batch)]),
         ));
 
-        let count = DataSink::write_all(sink.as_ref(), data, &ctx)
+        let count = DataSink::write_all(fixture.sink.as_ref(), data, &fixture.ctx)
             .await
             .unwrap();
 
-        let sum_rows: u64 = sink.file_metadata().iter().map(|f| f.row_count).sum();
+        let sum_rows: u64 = fixture.sink.file_metadata().iter().map(|f| f.row_count).sum();
         assert_eq!(
             count, sum_rows,
             "write_all count must equal sum of per-file row_counts"
@@ -1008,21 +1035,20 @@ mod tests {
 
     #[tokio::test]
     async fn file_metadata_consistent_with_written() {
-        let (sink, schema, object_store_url) = create_test_sink();
-        let ctx = build_test_ctx(&object_store_url);
-        let batch = make_test_batch(&schema);
+        let fixture = setup_test_fixture();
+        let batch = make_test_batch(&fixture.schema);
 
         let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&schema),
+            Arc::clone(&fixture.schema),
             futures::stream::iter(vec![Ok(batch)]),
         ));
 
-        DataSink::write_all(sink.as_ref(), data, &ctx)
+        DataSink::write_all(fixture.sink.as_ref(), data, &fixture.ctx)
             .await
             .unwrap();
 
-        let file_meta = sink.file_metadata();
-        let written = sink.written();
+        let file_meta = fixture.sink.file_metadata();
+        let written = fixture.sink.written();
 
         assert_eq!(
             file_meta.len(),
@@ -1035,12 +1061,17 @@ mod tests {
             let parquet_meta = written
                 .get(&path)
                 .expect("file_metadata path should exist in written()");
-            assert_eq!(fm.row_count, parquet_meta.file_metadata().num_rows() as u64);
+            let expected_rows: u64 = parquet_meta
+                .file_metadata()
+                .num_rows()
+                .try_into()
+                .unwrap_or(0);
+            assert_eq!(fm.row_count, expected_rows);
 
             let expected_bytes: u64 = parquet_meta
                 .row_groups()
                 .iter()
-                .map(|rg| rg.compressed_size() as u64)
+                .map(|rg| u64::try_from(rg.compressed_size()).unwrap_or(0))
                 .sum();
             assert_eq!(fm.byte_size, expected_bytes);
         }
@@ -1048,38 +1079,50 @@ mod tests {
 
     #[tokio::test]
     async fn file_metadata_is_idempotent() {
-        let (sink, schema, object_store_url) = create_test_sink();
-        let ctx = build_test_ctx(&object_store_url);
-        let batch = make_test_batch(&schema);
+        let fixture = setup_test_fixture();
+        let batch = make_test_batch(&fixture.schema);
 
         let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&schema),
+            Arc::clone(&fixture.schema),
             futures::stream::iter(vec![Ok(batch)]),
         ));
 
-        DataSink::write_all(sink.as_ref(), data, &ctx)
+        DataSink::write_all(fixture.sink.as_ref(), data, &fixture.ctx)
             .await
             .unwrap();
 
-        let first = sink.file_metadata();
-        let second = sink.file_metadata();
+        let first = fixture.sink.file_metadata();
+        let second = fixture.sink.file_metadata();
         assert_eq!(first, second);
     }
 
     #[tokio::test]
     async fn partitioned_write_produces_multiple_metadata_entries() {
+        let tmp_dir = TempDir::new().unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let local = Arc::new(
+            LocalFileSystem::new_with_prefix(&tmp_path)
+                .expect("should create object store"),
+        );
+
+        let object_store_url = ObjectStoreUrl::local_filesystem();
+        let table_url = ListingTableUrl::parse(
+            url::Url::from_directory_path(&tmp_path).unwrap().as_str(),
+        )
+        .unwrap();
+
         let field_a = Field::new("a", DataType::Utf8, false);
         let field_b = Field::new("b", DataType::Utf8, false);
         let schema = Arc::new(Schema::new(vec![field_a, field_b]));
-        let object_store_url = ObjectStoreUrl::local_filesystem();
 
         let file_sink_config = FileSinkConfig {
             original_url: String::default(),
             object_store_url: object_store_url.clone(),
-            file_group: FileGroup::new(vec![PartitionedFile::new("/tmp".to_string(), 1)]),
-            table_paths: vec![
-                ListingTableUrl::parse("file:///tmp/partitioned/").unwrap(),
-            ],
+            file_group: FileGroup::new(vec![PartitionedFile::new(
+                tmp_path.to_string_lossy().to_string(),
+                1,
+            )]),
+            table_paths: vec![table_url],
             output_schema: Arc::clone(&schema),
             table_partition_cols: vec![("a".to_string(), DataType::Utf8)],
             insert_op: InsertOp::Overwrite,
@@ -1093,12 +1136,24 @@ mod tests {
             TableParquetOptions::default(),
         ));
 
-        let col_a: ArrayRef = Arc::new(StringArray::from(vec!["x", "y", "x"]));
-        let col_b: ArrayRef = Arc::new(StringArray::from(vec!["one", "two", "three"]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![col_a, col_b]).unwrap();
+        let batch = record_batch!(
+            ("a", Utf8, ["x", "y", "x"]),
+            ("b", Utf8, ["one", "two", "three"])
+        )
+        .unwrap();
 
-        let ctx = build_test_ctx(&object_store_url);
+        let session = SessionConfig::default();
+        let runtime = RuntimeEnv::default();
+        runtime
+            .object_store_registry
+            .register_store(object_store_url.as_ref(), local);
+
+        let ctx = Arc::new(
+            TaskContext::default()
+                .with_session_config(session)
+                .with_runtime(Arc::new(runtime)),
+        );
+
         let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
             Arc::clone(&schema),
             futures::stream::iter(vec![Ok(batch)]),
@@ -1125,17 +1180,16 @@ mod tests {
     /// This tests the `Arc<dyn DataSink>` dispatch path that real consumers use.
     #[tokio::test]
     async fn data_sink_exec_e2e_file_metadata_after_execute() {
-        let (sink, schema, object_store_url) = create_test_sink();
-        let ctx = build_test_ctx(&object_store_url);
-        let batch = make_test_batch(&schema);
+        let fixture = setup_test_fixture();
+        let batch = make_test_batch(&fixture.schema);
 
         let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&schema),
+            Arc::clone(&fixture.schema),
             futures::stream::iter(vec![Ok(batch)]),
         ));
 
         // Write through the DataSink trait (same call DataSinkExec::execute makes)
-        let count = DataSink::write_all(sink.as_ref(), data, &ctx)
+        let count = DataSink::write_all(fixture.sink.as_ref(), data, &fixture.ctx)
             .await
             .unwrap();
         assert_eq!(count, 3);
@@ -1143,9 +1197,9 @@ mod tests {
         // Wrap in DataSinkExec and verify file_metadata is accessible
         // through the exec's convenience accessor (the Arc<dyn DataSink> path)
         let input: Arc<dyn datafusion_physical_plan::ExecutionPlan> = Arc::new(
-            datafusion_physical_plan::empty::EmptyExec::new(Arc::clone(&schema)),
+            datafusion_physical_plan::empty::EmptyExec::new(Arc::clone(&fixture.schema)),
         );
-        let exec = DataSinkExec::new(input, sink, None);
+        let exec = DataSinkExec::new(input, fixture.sink, None);
 
         let metadata = exec.file_metadata();
         assert_eq!(metadata.len(), 1, "should have one file after write");

--- a/datafusion/datasource-parquet/src/sink.rs
+++ b/datafusion/datasource-parquet/src/sink.rs
@@ -451,9 +451,7 @@ impl DataSink for ParquetSink {
                 let byte_size: u64 = parquet_meta
                     .row_groups()
                     .iter()
-                    .map(|rg| {
-                        u64::try_from(rg.compressed_size()).unwrap_or(0)
-                    })
+                    .map(|rg| u64::try_from(rg.compressed_size()).unwrap_or(0))
                     .sum();
 
                 FileWriteMetadata {
@@ -463,6 +461,7 @@ impl DataSink for ParquetSink {
                     // Full Parquet metadata is accessible via ParquetSink::written()
                     // for Rust consumers. Thrift serialization for FFI consumers can
                     // be added when a concrete use case (e.g. Python via PyO3) needs it.
+                    // Tracked by https://github.com/apache/datafusion/issues/24010
                     format_metadata: None,
                 }
             })
@@ -1026,7 +1025,12 @@ mod tests {
             .await
             .unwrap();
 
-        let sum_rows: u64 = fixture.sink.file_metadata().iter().map(|f| f.row_count).sum();
+        let sum_rows: u64 = fixture
+            .sink
+            .file_metadata()
+            .iter()
+            .map(|f| f.row_count)
+            .sum();
         assert_eq!(
             count, sum_rows,
             "write_all count must equal sum of per-file row_counts"

--- a/datafusion/datasource-parquet/src/sink.rs
+++ b/datafusion/datasource-parquet/src/sink.rs
@@ -32,7 +32,7 @@ use datafusion_common_runtime::{JoinSet, SpawnedTask};
 use datafusion_datasource::display::FileGroupDisplay;
 use datafusion_datasource::file_compression_type::FileCompressionType;
 use datafusion_datasource::file_sink_config::{FileSink, FileSinkConfig};
-use datafusion_datasource::sink::DataSink;
+use datafusion_datasource::sink::{DataSink, FileWriteMetadata};
 #[cfg(feature = "proto")]
 use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::write::demux::DemuxedStreamReceiver;
@@ -436,6 +436,31 @@ impl DataSink for ParquetSink {
         Ok(Some(protobuf::PhysicalPlanNode {
             physical_plan_type: Some(PhysicalPlanType::ParquetSink(Box::new(node))),
         }))
+    }
+
+    fn file_metadata(&self) -> Vec<FileWriteMetadata> {
+        let written = self.written.lock();
+        written
+            .iter()
+            .map(|(path, parquet_meta)| {
+                let row_count = parquet_meta.file_metadata().num_rows() as u64;
+                let byte_size: u64 = parquet_meta
+                    .row_groups()
+                    .iter()
+                    .map(|rg| rg.compressed_size() as u64)
+                    .sum();
+
+                FileWriteMetadata {
+                    path: path.to_string(),
+                    row_count,
+                    byte_size,
+                    // Full Parquet metadata is accessible via ParquetSink::written()
+                    // for Rust consumers. Thrift serialization for FFI consumers can
+                    // be added when a concrete use case (e.g. Python via PyO3) needs it.
+                    format_metadata: None,
+                }
+            })
+            .collect()
     }
 }
 
@@ -853,4 +878,279 @@ async fn output_single_parquet_file_parallelized(
         .await
         .map_err(|e| DataFusionError::ExecutionJoin(Box::new(e)))??;
     Ok(parquet_meta_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::config::TableParquetOptions;
+    use datafusion_datasource::PartitionedFile;
+    use datafusion_datasource::file_groups::FileGroup;
+    use datafusion_datasource::file_sink_config::{FileOutputMode, FileSinkConfig};
+    use datafusion_datasource::sink::{DataSink, DataSinkExec};
+    use datafusion_datasource::url::ListingTableUrl;
+    use datafusion_execution::config::SessionConfig;
+    use datafusion_execution::object_store::ObjectStoreUrl;
+    use datafusion_execution::runtime_env::RuntimeEnv;
+    use datafusion_expr::dml::InsertOp;
+    use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+    use object_store::local::LocalFileSystem;
+
+    fn build_test_ctx(store_url: &ObjectStoreUrl) -> Arc<TaskContext> {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let local = Arc::new(
+            LocalFileSystem::new_with_prefix(&tmp_dir)
+                .expect("should create object store"),
+        );
+
+        let session = SessionConfig::default();
+        let runtime = RuntimeEnv::default();
+        runtime
+            .object_store_registry
+            .register_store(store_url.as_ref(), local);
+
+        Arc::new(
+            TaskContext::default()
+                .with_session_config(session)
+                .with_runtime(Arc::new(runtime)),
+        )
+    }
+
+    fn create_test_sink() -> (Arc<ParquetSink>, SchemaRef, ObjectStoreUrl) {
+        let field_a = Field::new("a", DataType::Utf8, false);
+        let field_b = Field::new("b", DataType::Utf8, false);
+        let schema = Arc::new(Schema::new(vec![field_a, field_b]));
+        let object_store_url = ObjectStoreUrl::local_filesystem();
+
+        let file_sink_config = FileSinkConfig {
+            original_url: String::default(),
+            object_store_url: object_store_url.clone(),
+            file_group: FileGroup::new(vec![PartitionedFile::new("/tmp".to_string(), 1)]),
+            table_paths: vec![ListingTableUrl::parse("file:///tmp/test/").unwrap()],
+            output_schema: Arc::clone(&schema),
+            table_partition_cols: vec![],
+            insert_op: InsertOp::Overwrite,
+            keep_partition_by_columns: false,
+            file_extension: "parquet".into(),
+            file_output_mode: FileOutputMode::Automatic,
+        };
+
+        let parquet_sink = Arc::new(ParquetSink::new(
+            file_sink_config,
+            TableParquetOptions::default(),
+        ));
+
+        (parquet_sink, schema, object_store_url)
+    }
+
+    fn make_test_batch(schema: &SchemaRef) -> RecordBatch {
+        let col_a: ArrayRef = Arc::new(StringArray::from(vec!["foo", "bar", "baz"]));
+        let col_b: ArrayRef = Arc::new(StringArray::from(vec!["one", "two", "three"]));
+        RecordBatch::try_new(Arc::clone(schema), vec![col_a, col_b]).unwrap()
+    }
+
+    #[test]
+    fn file_metadata_empty_before_write() {
+        let (sink, _schema, _url) = create_test_sink();
+        assert!(
+            sink.file_metadata().is_empty(),
+            "file_metadata should be empty before any write"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_metadata_populated_after_write() {
+        let (sink, schema, object_store_url) = create_test_sink();
+        let ctx = build_test_ctx(&object_store_url);
+        let batch = make_test_batch(&schema);
+
+        let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        let count = DataSink::write_all(sink.as_ref(), data, &ctx)
+            .await
+            .unwrap();
+        assert_eq!(count, 3, "should have written 3 rows");
+
+        let metadata = sink.file_metadata();
+        assert_eq!(metadata.len(), 1, "should have one file metadata entry");
+        assert_eq!(metadata[0].row_count, 3);
+        assert!(metadata[0].byte_size > 0, "byte_size should be non-zero");
+        assert!(!metadata[0].path.is_empty(), "path should be non-empty");
+        assert!(metadata[0].format_metadata.is_none());
+    }
+
+    #[tokio::test]
+    async fn file_metadata_count_equals_write_all_count() {
+        let (sink, schema, object_store_url) = create_test_sink();
+        let ctx = build_test_ctx(&object_store_url);
+        let batch = make_test_batch(&schema);
+
+        let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        let count = DataSink::write_all(sink.as_ref(), data, &ctx)
+            .await
+            .unwrap();
+
+        let sum_rows: u64 = sink.file_metadata().iter().map(|f| f.row_count).sum();
+        assert_eq!(
+            count, sum_rows,
+            "write_all count must equal sum of per-file row_counts"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_metadata_consistent_with_written() {
+        let (sink, schema, object_store_url) = create_test_sink();
+        let ctx = build_test_ctx(&object_store_url);
+        let batch = make_test_batch(&schema);
+
+        let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        DataSink::write_all(sink.as_ref(), data, &ctx)
+            .await
+            .unwrap();
+
+        let file_meta = sink.file_metadata();
+        let written = sink.written();
+
+        assert_eq!(
+            file_meta.len(),
+            written.len(),
+            "file_metadata and written() should have same number of entries"
+        );
+
+        for fm in &file_meta {
+            let path = Path::from(fm.path.as_str());
+            let parquet_meta = written
+                .get(&path)
+                .expect("file_metadata path should exist in written()");
+            assert_eq!(fm.row_count, parquet_meta.file_metadata().num_rows() as u64);
+
+            let expected_bytes: u64 = parquet_meta
+                .row_groups()
+                .iter()
+                .map(|rg| rg.compressed_size() as u64)
+                .sum();
+            assert_eq!(fm.byte_size, expected_bytes);
+        }
+    }
+
+    #[tokio::test]
+    async fn file_metadata_is_idempotent() {
+        let (sink, schema, object_store_url) = create_test_sink();
+        let ctx = build_test_ctx(&object_store_url);
+        let batch = make_test_batch(&schema);
+
+        let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        DataSink::write_all(sink.as_ref(), data, &ctx)
+            .await
+            .unwrap();
+
+        let first = sink.file_metadata();
+        let second = sink.file_metadata();
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn partitioned_write_produces_multiple_metadata_entries() {
+        let field_a = Field::new("a", DataType::Utf8, false);
+        let field_b = Field::new("b", DataType::Utf8, false);
+        let schema = Arc::new(Schema::new(vec![field_a, field_b]));
+        let object_store_url = ObjectStoreUrl::local_filesystem();
+
+        let file_sink_config = FileSinkConfig {
+            original_url: String::default(),
+            object_store_url: object_store_url.clone(),
+            file_group: FileGroup::new(vec![PartitionedFile::new("/tmp".to_string(), 1)]),
+            table_paths: vec![
+                ListingTableUrl::parse("file:///tmp/partitioned/").unwrap(),
+            ],
+            output_schema: Arc::clone(&schema),
+            table_partition_cols: vec![("a".to_string(), DataType::Utf8)],
+            insert_op: InsertOp::Overwrite,
+            keep_partition_by_columns: false,
+            file_extension: "parquet".into(),
+            file_output_mode: FileOutputMode::Automatic,
+        };
+
+        let sink = Arc::new(ParquetSink::new(
+            file_sink_config,
+            TableParquetOptions::default(),
+        ));
+
+        let col_a: ArrayRef = Arc::new(StringArray::from(vec!["x", "y", "x"]));
+        let col_b: ArrayRef = Arc::new(StringArray::from(vec!["one", "two", "three"]));
+        let batch =
+            RecordBatch::try_new(Arc::clone(&schema), vec![col_a, col_b]).unwrap();
+
+        let ctx = build_test_ctx(&object_store_url);
+        let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        let count = DataSink::write_all(sink.as_ref(), data, &ctx)
+            .await
+            .unwrap();
+
+        let metadata = sink.file_metadata();
+        assert_eq!(
+            metadata.len(),
+            2,
+            "partitioned write with 2 partition values should produce 2 files"
+        );
+
+        assert_eq!(count, 3);
+        let sum_rows: u64 = metadata.iter().map(|f| f.row_count).sum();
+        assert_eq!(sum_rows, 3);
+    }
+
+    /// Verifies that `DataSinkExec::file_metadata()` returns the correct
+    /// metadata when the underlying `ParquetSink` has written files.
+    /// This tests the `Arc<dyn DataSink>` dispatch path that real consumers use.
+    #[tokio::test]
+    async fn data_sink_exec_e2e_file_metadata_after_execute() {
+        let (sink, schema, object_store_url) = create_test_sink();
+        let ctx = build_test_ctx(&object_store_url);
+        let batch = make_test_batch(&schema);
+
+        let data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        // Write through the DataSink trait (same call DataSinkExec::execute makes)
+        let count = DataSink::write_all(sink.as_ref(), data, &ctx)
+            .await
+            .unwrap();
+        assert_eq!(count, 3);
+
+        // Wrap in DataSinkExec and verify file_metadata is accessible
+        // through the exec's convenience accessor (the Arc<dyn DataSink> path)
+        let input: Arc<dyn datafusion_physical_plan::ExecutionPlan> = Arc::new(
+            datafusion_physical_plan::empty::EmptyExec::new(Arc::clone(&schema)),
+        );
+        let exec = DataSinkExec::new(input, sink, None);
+
+        let metadata = exec.file_metadata();
+        assert_eq!(metadata.len(), 1, "should have one file after write");
+        assert_eq!(metadata[0].row_count, 3);
+        assert!(metadata[0].byte_size > 0);
+        assert!(!metadata[0].path.is_empty());
+    }
 }

--- a/datafusion/datasource/src/sink.rs
+++ b/datafusion/datasource/src/sink.rs
@@ -53,10 +53,12 @@ pub struct FileWriteMetadata {
     pub path: String,
     /// Number of rows written to this specific file.
     pub row_count: u64,
-    /// Sum of compressed row group sizes in bytes.
+    /// Best-effort total encoded data size in bytes.
     ///
-    /// Note: this may differ slightly from the actual on-disk file size as it
-    /// excludes the Parquet footer, page indexes, and other metadata overhead.
+    /// How this value is computed depends on the format. For Parquet it is the
+    /// sum of compressed row-group sizes (which excludes the footer and page
+    /// indexes); for other formats it may be the full file size or unavailable
+    /// (zero). Consumers should treat this as an approximation.
     pub byte_size: u64,
     /// Format-specific metadata serialized as bytes.
     ///

--- a/datafusion/datasource/src/sink.rs
+++ b/datafusion/datasource/src/sink.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use arrow::array::{ArrayRef, RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use bytes::Bytes;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{Result, assert_eq_or_internal_err};
 use datafusion_execution::TaskContext;
@@ -40,6 +41,32 @@ use datafusion_physical_plan::{
 use async_trait::async_trait;
 use datafusion_physical_plan::execution_plan::{EvaluationType, SchedulingType};
 use futures::StreamExt;
+
+/// Metadata about a single file produced by a [`DataSink`] write operation.
+///
+/// This struct is format-agnostic. The [`Self::format_metadata`] field carries
+/// serialized format-specific metadata (e.g., a Parquet file footer serialized
+/// via Thrift Compact Protocol).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileWriteMetadata {
+    /// Object-store path where the file was written.
+    pub path: String,
+    /// Number of rows written to this specific file.
+    pub row_count: u64,
+    /// Sum of compressed row group sizes in bytes.
+    ///
+    /// Note: this may differ slightly from the actual on-disk file size as it
+    /// excludes the Parquet footer, page indexes, and other metadata overhead.
+    pub byte_size: u64,
+    /// Format-specific metadata serialized as bytes.
+    ///
+    /// For Parquet files this contains the Thrift-serialized `FileMetaData`
+    /// (the same bytes found in the Parquet footer), enabling consumers to
+    /// reconstruct column statistics without re-reading the file.
+    ///
+    /// For formats that do not produce file-level metadata this is `None`.
+    pub format_metadata: Option<Bytes>,
+}
 
 /// `DataSink` implements writing streams of [`RecordBatch`]es to
 /// user defined destinations.
@@ -86,6 +113,22 @@ pub trait DataSink: Any + DisplayAs + Debug + Send + Sync {
         _ctx: &datafusion_physical_plan::proto::ExecutionPlanEncodeCtx<'_>,
     ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalPlanNode>> {
         Ok(None)
+    }
+
+    /// Returns metadata for files written during the most recent
+    /// [`Self::write_all`] call.
+    ///
+    /// This accessor is intended for consumers that need per-file
+    /// statistics (e.g., column sizes, null counts, value bounds) after
+    /// a write completes. It should be called after `write_all` returns
+    /// successfully.
+    ///
+    /// The default implementation returns an empty vector. Implementations
+    /// that collect file metadata during writes (e.g., Parquet sinks)
+    /// should override this method.
+    fn file_metadata(&self) -> Vec<FileWriteMetadata> {
+        Vec::new()
+    }
     }
 }
 
@@ -228,6 +271,16 @@ impl DataSinkExec {
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(LexRequirement::new(sort_exprs.into_iter().map(Into::into)))
+    }
+
+    /// Returns per-file metadata from the underlying sink, if available.
+    ///
+    /// This is a convenience accessor that delegates to
+    /// [`DataSink::file_metadata`]. It should be called after the write
+    /// operation has completed.
+    pub fn file_metadata(&self) -> Vec<FileWriteMetadata> {
+        self.sink.file_metadata()
+    }
     }
 
     fn create_schema(
@@ -404,4 +457,201 @@ fn make_count_schema() -> SchemaRef {
         DataType::UInt64,
         false,
     )]))
+}
+
+#[cfg(test)]
+mod sink_tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+    use futures::stream;
+
+    /// A minimal DataSink that does NOT override `file_metadata`.
+    /// Used to verify that the default implementation returns empty.
+    #[derive(Debug)]
+    struct MinimalSink {
+        schema: SchemaRef,
+    }
+
+    impl MinimalSink {
+        fn new(schema: SchemaRef) -> Self {
+            Self { schema }
+        }
+    }
+
+    impl DisplayAs for MinimalSink {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "MinimalSink")
+        }
+    }
+
+    #[async_trait]
+    impl DataSink for MinimalSink {
+        fn schema(&self) -> &SchemaRef {
+            &self.schema
+        }
+
+        async fn write_all(
+            &self,
+            _data: SendableRecordBatchStream,
+            _context: &Arc<TaskContext>,
+        ) -> Result<u64> {
+            Ok(42)
+        }
+    }
+
+    /// A DataSink that overrides `file_metadata`, simulating a
+    /// format-specific sink (like ParquetSink) that provides metadata.
+    #[derive(Debug)]
+    struct MetadataProvidingSink {
+        schema: SchemaRef,
+    }
+
+    impl MetadataProvidingSink {
+        fn new(schema: SchemaRef) -> Self {
+            Self { schema }
+        }
+    }
+
+    impl DisplayAs for MetadataProvidingSink {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "MetadataProvidingSink")
+        }
+    }
+
+    #[async_trait]
+    impl DataSink for MetadataProvidingSink {
+        fn schema(&self) -> &SchemaRef {
+            &self.schema
+        }
+
+        async fn write_all(
+            &self,
+            _data: SendableRecordBatchStream,
+            _context: &Arc<TaskContext>,
+        ) -> Result<u64> {
+            Ok(100)
+        }
+
+        fn file_metadata(&self) -> Vec<FileWriteMetadata> {
+            vec![
+                FileWriteMetadata {
+                    path: "part-0.parquet".to_string(),
+                    row_count: 60,
+                    byte_size: 4096,
+                    format_metadata: Some(Bytes::from_static(b"fake-metadata-0")),
+                },
+                FileWriteMetadata {
+                    path: "part-1.parquet".to_string(),
+                    row_count: 40,
+                    byte_size: 3072,
+                    format_metadata: Some(Bytes::from_static(b"fake-metadata-1")),
+                },
+            ]
+        }
+    }
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    fn test_context() -> Arc<TaskContext> {
+        Arc::new(TaskContext::default())
+    }
+
+    fn empty_stream(schema: SchemaRef) -> SendableRecordBatchStream {
+        Box::pin(RecordBatchStreamAdapter::new(schema, stream::empty()))
+    }
+
+    #[test]
+    fn file_write_metadata_equality() {
+        let a = FileWriteMetadata {
+            path: "a.parquet".to_string(),
+            row_count: 10,
+            byte_size: 1024,
+            format_metadata: None,
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn file_write_metadata_without_format_metadata() {
+        let meta = FileWriteMetadata {
+            path: "data.csv".to_string(),
+            row_count: 50,
+            byte_size: 1024,
+            format_metadata: None,
+        };
+        assert_eq!(meta.path, "data.csv");
+        assert!(meta.format_metadata.is_none());
+    }
+
+    #[tokio::test]
+    async fn default_file_metadata_returns_empty() {
+        let schema = test_schema();
+        let sink = MinimalSink::new(Arc::clone(&schema));
+        let ctx = test_context();
+        let data = empty_stream(schema);
+
+        // write_all succeeds
+        let count = sink.write_all(data, &ctx).await.unwrap();
+        assert_eq!(count, 42);
+
+        // default file_metadata returns empty
+        let metadata = sink.file_metadata();
+        assert!(metadata.is_empty());
+    }
+
+    #[test]
+    fn overridden_file_metadata_returns_entries() {
+        let schema = test_schema();
+        let sink = MetadataProvidingSink::new(schema);
+
+        let metadata = sink.file_metadata();
+        assert_eq!(metadata.len(), 2);
+        assert_eq!(metadata[0].path, "part-0.parquet");
+        assert_eq!(metadata[1].path, "part-1.parquet");
+    }
+
+    #[test]
+    fn file_metadata_is_idempotent() {
+        let schema = test_schema();
+        let sink = MetadataProvidingSink::new(schema);
+
+        let first = sink.file_metadata();
+        let second = sink.file_metadata();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn data_sink_exec_file_metadata_delegates_to_sink() {
+        let schema = test_schema();
+        let sink: Arc<dyn DataSink> =
+            Arc::new(MetadataProvidingSink::new(Arc::clone(&schema)));
+
+        let input: Arc<dyn ExecutionPlan> =
+            Arc::new(datafusion_physical_plan::empty::EmptyExec::new(schema));
+
+        let exec = DataSinkExec::new(input, sink, None);
+        let metadata = exec.file_metadata();
+
+        assert_eq!(metadata.len(), 2);
+        assert_eq!(metadata[0].path, "part-0.parquet");
+        assert_eq!(metadata[1].path, "part-1.parquet");
+    }
+
+    #[test]
+    fn data_sink_exec_file_metadata_empty_for_minimal_sink() {
+        let schema = test_schema();
+        let sink: Arc<dyn DataSink> = Arc::new(MinimalSink::new(Arc::clone(&schema)));
+
+        let input: Arc<dyn ExecutionPlan> =
+            Arc::new(datafusion_physical_plan::empty::EmptyExec::new(schema));
+
+        let exec = DataSinkExec::new(input, sink, None);
+        let metadata = exec.file_metadata();
+
+        assert!(metadata.is_empty());
+    }
 }

--- a/datafusion/datasource/src/sink.rs
+++ b/datafusion/datasource/src/sink.rs
@@ -131,7 +131,6 @@ pub trait DataSink: Any + DisplayAs + Debug + Send + Sync {
     fn file_metadata(&self) -> Vec<FileWriteMetadata> {
         Vec::new()
     }
-    }
 }
 
 impl dyn DataSink {
@@ -282,7 +281,6 @@ impl DataSinkExec {
     /// operation has completed.
     pub fn file_metadata(&self) -> Vec<FileWriteMetadata> {
         self.sink.file_metadata()
-    }
     }
 
     fn create_schema(
@@ -462,7 +460,7 @@ fn make_count_schema() -> SchemaRef {
 }
 
 #[cfg(test)]
-mod sink_tests {
+mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion_physical_plan::stream::RecordBatchStreamAdapter;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #23472.

## Rationale for this change

External table formats (Apache Iceberg, Delta Lake, Apache Hudi) require per-file column statistics (column_sizes, null_counts, lower/upper bounds, split_offsets) when committing written files to their catalogs. Currently, `ParquetSink` computes and stores this metadata internally (`self.written`) but the `DataSink` trait only returns a row count  forcing external consumers to either:

1. Bypass DataFusion's write pipeline entirely (use PyArrow/parquet-rs directly)
2. Re-read Parquet footers after writing (additional I/O round-trips)
3. Downcast `DataSinkExec.sink()` to `ParquetSink` and call `written()` (fragile, undocumented)

This PR adds a standard, non-breaking mechanism to expose per-file metadata through the `DataSink` trait.

## What changes are included in this PR?

1. **New type** in `datafusion-datasource`:
   - `FileWriteMetadata`: path + row_count + byte_size + optional format-specific metadata bytes

2. **Trait extension** (non-breaking, default implementation):
   - `DataSink::file_metadata()`  `Vec<FileWriteMetadata>` (default: empty)

3. **ParquetSink implementation**:
   - Overrides `file_metadata()` using the existing `self.written` HashMap that already collects `ParquetMetaData` during writes  zero additional I/O

4. **DataSinkExec convenience**:
   - `file_metadata()` method that delegates to the inner sink, avoiding the downcast dance

The typed `ParquetMetaData` remains accessible via the existing `ParquetSink::written()` method for Rust consumers who need full column-level statistics directly. The `format_metadata: Option<Bytes>` field on `FileWriteMetadata` is reserved for future Thrift serialization when FFI consumers (e.g. Python via PyO3) need it.

## Are these changes tested?

Yes  14 new tests across both crates:

**`datafusion-datasource` (7 tests):**
- `FileWriteMetadata` equality and clone behavior
- Default `file_metadata()` returns empty after `write_all`
- Overridden `file_metadata()` returns correct entries
- Idempotent behavior (calling twice returns same result)
- `DataSinkExec::file_metadata()` delegates correctly

**`datafusion-datasource-parquet` (7 tests):**
- Empty before write, populated after write
- Row count consistency (`write_all` count == sum of per-file row_counts)
- Consistent with existing `ParquetSink::written()` accessor
- Idempotent across multiple calls
- Partitioned writes produce one entry per partition
- E2E test through `DataSinkExec` wrapper with `Arc<dyn DataSink>` dispatch

All existing `parquet_sink_write*` tests continue to pass unchanged.

## Are there any user-facing changes?

New public API surface (additive only, no breaking changes):
- `DataSink::file_metadata()` default method
- `FileWriteMetadata` struct
- `DataSinkExec::file_metadata()` convenience method