### PR TITLE
chore: downsize `sql_planner_extended` `logical_plan_optimize` sample size to 5

### DIFF
--- a/datafusion/core/benches/sql_planner_extended.rs
+++ b/datafusion/core/benches/sql_planner_extended.rs
@@ -386,12 +386,16 @@ fn criterion_benchmark(c: &mut Criterion) {
     let df = build_test_data_frame(&baseline_ctx, &rt);
     let case_heavy_left_join_df = build_case_heavy_left_join_df(&case_heavy_ctx, &rt);
 
-    c.bench_function("logical_plan_optimize", |b| {
+    // really slow :(
+    let mut group = c.benchmark_group("sample_size_10");
+    group.sample_size(10);
+    group.bench_function("logical_plan_optimize", |b| {
         b.iter(|| {
             let df_clone = df.clone();
             black_box(rt.block_on(async { df_clone.into_optimized_plan().unwrap() }));
         })
     });
+    group.finish();
 
     c.bench_function("logical_plan_optimize_hotspot_case_heavy_left_join", |b| {
         b.iter(|| {

--- a/datafusion/core/benches/sql_planner_extended.rs
+++ b/datafusion/core/benches/sql_planner_extended.rs
@@ -387,8 +387,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let case_heavy_left_join_df = build_case_heavy_left_join_df(&case_heavy_ctx, &rt);
 
     // really slow :(
-    let mut group = c.benchmark_group("sample_size_10");
-    group.sample_size(10);
+    let mut group = c.benchmark_group("sample_size_5");
+    group.sample_size(5);
     group.bench_function("logical_plan_optimize", |b| {
         b.iter(|| {
             let df_clone = df.clone();


### PR DESCRIPTION
on my M4 Macbook pro, it estimates it would take 50 minutes (!) to run the benchmark

```sh
datafusion (main)$ cargo bench -p datafusion --bench sql_planner_extended logical_plan
   Compiling datafusion-common v54.0.0 (/Users/jeffrey/Code/datafusion/datafusion/common)
...
   Compiling datafusion v54.0.0 (/Users/jeffrey/Code/datafusion/datafusion/core)
    Finished `bench` profile [optimized] target(s) in 8m 11s
     Running benches/sql_planner_extended.rs (/Users/jeffrey/.cargo_target_cache/release/deps/sql_planner_extended-c026520b80bba716)
Gnuplot not found, using plotters backend
Benchmarking logical_plan_optimize: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 3077.4s, or reduce sample count to 10.
Benchmarking logical_plan_optimize: Collecting 100 samples in estimated 3077.4 s (100 iterations)
```

and running it via the bot just times out: https://github.com/apache/datafusion/pull/23215#issuecomment-4995729774

so might actually be useful to reduce the sample size so it can actually run and be of use to us