### PR TITLE
chore: Fix duplicated word typos in comments

### DIFF
--- a/datafusion-examples/examples/data_io/parquet_embedded_index.rs
+++ b/datafusion-examples/examples/data_io/parquet_embedded_index.rs
@@ -87,7 +87,7 @@
 //! 2. Read and deserialize the index.
 //!
 //! 3. Create a `TableProvider` that knows how to use the index to quickly find
-//!   the relevant files, row groups, data pages or rows based on on pushed down
+//!   the relevant files, row groups, data pages or rows based on pushed down
 //!   filters.
 //!
 //! # FAQ: Why do other Parquet readers skip over the custom index?

--- a/datafusion/common/src/pruning.rs
+++ b/datafusion/common/src/pruning.rs
@@ -305,7 +305,7 @@ impl PruningStatistics for PartitionPruningStatistics {
 /// that has statistics of its columns.
 ///
 /// It is up to the caller to decide what each container represents. For
-/// example, they can come from a file (e.g. [`PartitionedFile`]) or a set of of
+/// example, they can come from a file (e.g. [`PartitionedFile`]) or a set of
 /// files (e.g. [`FileGroup`])
 ///
 /// [`PartitionedFile`]: https://docs.rs/datafusion/latest/datafusion/datasource/listing/struct.PartitionedFile.html

--- a/datafusion/common/src/test_util.rs
+++ b/datafusion/common/src/test_util.rs
@@ -174,7 +174,7 @@ macro_rules! assert_contains {
 }
 
 /// A macro to assert that one string is NOT contained within another with
-/// a nice error message if they are are.
+/// a nice error message if they are.
 ///
 /// Usage: `assert_not_contains!(actual, unexpected)`
 ///

--- a/datafusion/core/tests/user_defined/user_defined_plan.rs
+++ b/datafusion/core/tests/user_defined/user_defined_plan.rs
@@ -518,7 +518,7 @@ impl OptimizerRule for TopKOptimizerRule {
         if let LogicalPlan::Sort(Sort { expr, input, .. }) = limit.input.as_ref()
             && expr.len() == 1
         {
-            // we found a sort with a single sort expr, replace with a a TopK
+            // we found a sort with a single sort expr, replace with a TopK
             return Ok(Transformed::yes(LogicalPlan::Extension(Extension {
                 node: Arc::new(TopKPlanNode {
                     k: fetch,

--- a/datafusion/datasource-arrow/src/source.rs
+++ b/datafusion/datasource-arrow/src/source.rs
@@ -340,7 +340,7 @@ impl FileSource for ArrowSource {
                 // The Arrow IPC stream format doesn't support range-based parallel reading
                 // because it lacks a footer with the information that would be needed to
                 // make range-based parallel reading practical. Without the data in the
-                // footer you would either need to read the the entire file and record the
+                // footer you would either need to read the entire file and record the
                 // offsets of the record batches and dictionaries, essentially recreating
                 // the footer's contents, or else each partition would need to read the
                 // entire file up to the correct offset which is a lot of duplicate I/O.

--- a/datafusion/datasource-csv/src/file_format.rs
+++ b/datafusion/datasource-csv/src/file_format.rs
@@ -168,7 +168,7 @@ impl CsvFormat {
         stream.boxed()
     }
 
-    /// Convert a stream of bytes into a stream of of [`Bytes`] containing newline
+    /// Convert a stream of bytes into a stream of [`Bytes`] containing newline
     /// delimited CSV records, while accounting for `\` and `"`.
     pub async fn read_to_delimited_chunks_from_stream<'a>(
         &self,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1733,7 +1733,7 @@ impl LogicalPlan {
     /// ```
     pub fn display_indent(&self) -> impl Display + '_ {
         // Boilerplate structure to wrap LogicalPlan with something
-        // that that can be formatted
+        // that can be formatted
         struct Wrapper<'a>(&'a LogicalPlan);
         impl Display for Wrapper<'_> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -1779,7 +1779,7 @@ impl LogicalPlan {
     /// ```
     pub fn display_indent_schema(&self) -> impl Display + '_ {
         // Boilerplate structure to wrap LogicalPlan with something
-        // that that can be formatted
+        // that can be formatted
         struct Wrapper<'a>(&'a LogicalPlan);
         impl Display for Wrapper<'_> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -1799,7 +1799,7 @@ impl LogicalPlan {
     /// Users can use this format to visualize the plan in existing plan visualization tools, for example [dalibo](https://explain.dalibo.com/)
     pub fn display_pg_json(&self) -> impl Display + '_ {
         // Boilerplate structure to wrap LogicalPlan with something
-        // that that can be formatted
+        // that can be formatted
         struct Wrapper<'a>(&'a LogicalPlan);
         impl Display for Wrapper<'_> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -1845,7 +1845,7 @@ impl LogicalPlan {
     /// ```
     pub fn display_graphviz(&self) -> impl Display + '_ {
         // Boilerplate structure to wrap LogicalPlan with something
-        // that that can be formatted
+        // that can be formatted
         struct Wrapper<'a>(&'a LogicalPlan);
         impl Display for Wrapper<'_> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -1896,7 +1896,7 @@ impl LogicalPlan {
     /// ```
     pub fn display(&self) -> impl Display + '_ {
         // Boilerplate structure to wrap LogicalPlan with something
-        // that that can be formatted
+        // that can be formatted
         struct Wrapper<'a>(&'a LogicalPlan);
         impl Display for Wrapper<'_> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/datafusion/physical-expr/src/aggregate.rs
+++ b/datafusion/physical-expr/src/aggregate.rs
@@ -858,7 +858,7 @@ impl AggregateFunctionExpr {
         // `retract_batch` method will not be called. In this case
         // having retract_batch is not a requirement.
         //
-        // This approach is a a bit different than window function
+        // This approach is a bit different than window function
         // approach. In window function (when they use a window frame)
         // they get all the desired range during evaluation.
         if !accumulator.supports_retract_batch() {

--- a/datafusion/physical-expr/src/window/standard.rs
+++ b/datafusion/physical-expr/src/window/standard.rs
@@ -128,7 +128,7 @@ impl WindowExpr for StandardWindowExpr {
             let mut window_frame_ctx =
                 WindowFrameContext::new(Arc::clone(&self.window_frame), sort_options);
             let mut last_range = Range { start: 0, end: 0 };
-            // We iterate on each row to calculate window frame range and and window function result
+            // We iterate on each row to calculate window frame range and window function result
             for idx in 0..num_rows {
                 let range = window_frame_ctx.calculate_range(
                     order_bys_ref,

--- a/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
+++ b/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
@@ -125,7 +125,7 @@ impl RecordBatchStream for ClassicPWMJStream {
 // Classic Joins
 //  1. `WaitBufferedSide` - Load in the buffered side data into memory.
 //  2. `FetchStreamBatch` -  Fetch + sort incoming stream batches. We switch the state to
-//     `Completed` if there are are still remaining partitions to process. It is only switched to
+//     `Completed` if there are still remaining partitions to process. It is only switched to
 //     `ExhaustedStreamBatch` if all partitions have been processed.
 //  3. `ProcessStreamBatch` - Compare stream batch row values against the buffered side data.
 //  4. `ExhaustedStreamBatch` - If the join type is Left or Inner we will return state as


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Remove duplicated words (e.g. `that that`, `of of`, `are are`) in code comments and doc comments.

## What changes are included in this PR?

Fix duplicated word typos in comments only, no functional change.

## Are these changes tested?

No functional change, covered by existing tests.

## Are there any user-facing changes?

No.