### PR TITLE
test: Fix data_pagesize_limit extraction in parquet writer props roundtrip test

### DIFF
--- a/datafusion/common/src/file_options/parquet_writer.rs
+++ b/datafusion/common/src/file_options/parquet_writer.rs
@@ -473,7 +473,7 @@ mod tests {
             writer_version,
             compression: Some("zstd(22)".into()),
             dictionary_enabled: Some(!defaults.dictionary_enabled.unwrap_or(false)),
-            dictionary_page_size_limit: 42,
+            dictionary_page_size_limit: 43,
             statistics_enabled: Some("chunk".into()),
             max_row_group_size: 42,
             max_row_group_bytes: Some(MaxRowGroupBytes::try_new(42).unwrap()),
@@ -579,7 +579,7 @@ mod tests {
         TableParquetOptions {
             global: ParquetOptions {
                 // global options
-                data_pagesize_limit: props.dictionary_page_size_limit(),
+                data_pagesize_limit: props.data_page_size_limit(),
                 write_batch_size: props.write_batch_size(),
                 writer_version: props.writer_version().into(),
                 dictionary_page_size_limit: props.dictionary_page_size_limit(),


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

In the test helper `session_config_from_writer_props`, `data_pagesize_limit` is extracted from `props.dictionary_page_size_limit()` instead of `props.data_page_size_limit()`. The bug is masked because `parquet_options_with_non_defaults` sets both limits to the same value (42), so the roundtrip test cannot catch a mixed-up mapping between these two options.

## What changes are included in this PR?

- Extract `data_pagesize_limit` from `props.data_page_size_limit()`.
- Use distinct values for `data_pagesize_limit` (42) and `dictionary_page_size_limit` (43) in the test options so the roundtrip test can detect such mix-ups.

## Are these changes tested?

Yes, covered by the existing `table_parquet_opts_to_writer_props` roundtrip test. Verified that reverting the extraction fix now makes the test fail.

## Are there any user-facing changes?

No, test-only change.