### PR TITLE
experiment feat(agg): TopK aggregation for count(*)/count(col) DESC/ASC LIMIT K

### DIFF
--- a/datafusion/physical-optimizer/src/topk_aggregation.rs
+++ b/datafusion/physical-optimizer/src/topk_aggregation.rs
@@ -25,8 +25,8 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_plan::ExecutionPlan;
-use datafusion_physical_plan::aggregates::LimitOptions;
-use datafusion_physical_plan::aggregates::{AggregateExec, topk_types_supported};
+use datafusion_physical_plan::aggregates::{AggregateExec, AggregateMode, LimitOptions};
+use datafusion_physical_plan::aggregates::{is_topk_count_pattern, topk_types_supported};
 use datafusion_physical_plan::execution_plan::CardinalityEffect;
 use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::sorts::sort::SortExec;
@@ -52,43 +52,52 @@ impl TopKAggregation {
         let (group_key, group_key_alias) =
             aggr.group_expr().expr().iter().exactly_one().ok()?;
         let kt = group_key.data_type(&aggr.input().schema()).ok()?;
-        let vt = if let Some((field, _)) = aggr.get_minmax_desc() {
-            field.data_type().clone()
-        } else {
-            kt.clone()
-        };
-        if !topk_types_supported(&kt, &vt) {
-            return None;
-        }
+
         if aggr.filter_expr().iter().any(|e| e.is_some()) {
             return None;
         }
 
-        // Check if this is ordering by an aggregate function (MIN/MAX)
-        if let Some((field, desc)) = aggr.get_minmax_desc() {
-            // ensure the sort direction matches aggregate function
+        // Three supported shapes:
+        //   1. MIN/MAX single-aggregate: ORDER BY MIN(x) / MAX(x)
+        //   2. GROUP-BY-only distinct-like: no aggregates, ORDER BY the group key
+        //   3. count(*)/count(col): ORDER BY count(...)  (Final/Single mode only)
+        let limit_options = if let Some((field, desc)) = aggr.get_minmax_desc() {
+            let vt = field.data_type().clone();
+            if !topk_types_supported(&kt, &vt) {
+                return None;
+            }
             if desc != order_desc {
                 return None;
             }
-            // ensure the sort is on the same field as the aggregate output
             if order_by != field.name() {
                 return None;
             }
+            LimitOptions::new_with_order(limit, order_desc)
         } else if aggr.aggr_expr().is_empty() {
-            // This is a GROUP BY without aggregates, check if ordering is on the group key itself
+            if !topk_types_supported(&kt, &kt) {
+                return None;
+            }
             if order_by != group_key_alias {
                 return None;
             }
+            LimitOptions::new_with_order(limit, order_desc)
+        } else if let Some(count_field) = is_topk_count_pattern(aggr)
+            && matches!(
+                aggr.mode(),
+                AggregateMode::Final
+                    | AggregateMode::FinalPartitioned
+                    | AggregateMode::Single
+                    | AggregateMode::SinglePartitioned
+            )
+            && order_by == count_field.name()
+        {
+            LimitOptions::new_count(limit, order_desc)
         } else {
-            // Has aggregates but not MIN/MAX, or doesn't DISTINCT
             return None;
-        }
+        };
 
         // We found what we want: clone, copy the limit down, and return modified node
-        let new_aggr = AggregateExec::with_new_limit_options(
-            aggr,
-            Some(LimitOptions::new_with_order(limit, order_desc)),
-        );
+        let new_aggr = AggregateExec::with_new_limit_options(aggr, Some(limit_options));
         Some(Arc::new(new_aggr))
     }
 

--- a/datafusion/physical-optimizer/src/topk_aggregation.rs
+++ b/datafusion/physical-optimizer/src/topk_aggregation.rs
@@ -48,20 +48,25 @@ impl TopKAggregation {
         order_desc: bool,
         limit: usize,
     ) -> Option<Arc<dyn ExecutionPlan>> {
-        // Current only support single group key
-        let (group_key, group_key_alias) =
-            aggr.group_expr().expr().iter().exactly_one().ok()?;
-        let kt = group_key.data_type(&aggr.input().schema()).ok()?;
-
         if aggr.filter_expr().iter().any(|e| e.is_some()) {
             return None;
         }
+
+        // MIN/MAX / distinct paths only support a single group key (their
+        // stream, `GroupedTopKAggregateStream`, is single-column). The
+        // count path uses `GroupValues` which handles any group-column
+        // combination, so `single_group` is checked only for the first two
+        // shapes and skipped for shape #3.
+        let single_group = aggr.group_expr().expr().iter().exactly_one().ok();
 
         // Three supported shapes:
         //   1. MIN/MAX single-aggregate: ORDER BY MIN(x) / MAX(x)
         //   2. GROUP-BY-only distinct-like: no aggregates, ORDER BY the group key
         //   3. count(*)/count(col): ORDER BY count(...)  (Final/Single mode only)
+        //      — supports single OR multi-column GROUP BY
         let limit_options = if let Some((field, desc)) = aggr.get_minmax_desc() {
+            let (group_key, _) = single_group?;
+            let kt = group_key.data_type(&aggr.input().schema()).ok()?;
             let vt = field.data_type().clone();
             if !topk_types_supported(&kt, &vt) {
                 return None;
@@ -74,6 +79,8 @@ impl TopKAggregation {
             }
             LimitOptions::new_with_order(limit, order_desc)
         } else if aggr.aggr_expr().is_empty() {
+            let (group_key, group_key_alias) = single_group?;
+            let kt = group_key.data_type(&aggr.input().schema()).ok()?;
             if !topk_types_supported(&kt, &kt) {
                 return None;
             }

--- a/datafusion/physical-optimizer/src/topk_aggregation.rs
+++ b/datafusion/physical-optimizer/src/topk_aggregation.rs
@@ -108,30 +108,10 @@ impl TopKAggregation {
         // We found what we want: clone, copy the limit down, and return modified node
         let new_aggr = AggregateExec::with_new_limit_options(aggr, Some(limit_options));
 
-        // For the Count path, also mark the upstream Partial aggregate
-        // (if there is one) with the SAME shared state, so its stream
-        // can gate rows against the partial-threshold hint that Final
-        // will publish once running.
-        let new_aggr = if limit_options.kind == TopKKind::Count
-            && matches!(
-                new_aggr.mode(),
-                AggregateMode::Final | AggregateMode::FinalPartitioned
-            ) {
-            let Some(shared) = new_aggr.count_topk_shared().cloned() else {
-                return Some(Arc::new(new_aggr));
-            };
-            let new_input =
-                mark_upstream_partial(new_aggr.input(), &shared, limit_options);
-            let new_aggr_arc: Arc<dyn ExecutionPlan> = Arc::new(new_aggr);
-            if let Some(new_input) = new_input {
-                new_aggr_arc.with_new_children(vec![new_input]).ok()?
-            } else {
-                new_aggr_arc
-            }
-        } else {
-            Arc::new(new_aggr)
-        };
-        Some(new_aggr)
+        // Partial-side CA temporarily disabled for correctness
+        // investigation (see PR discussion). Only mark the Final
+        // aggregate; the standard hash path handles Partial.
+        Some(Arc::new(new_aggr))
     }
 
     fn transform_sort(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {

--- a/datafusion/physical-optimizer/src/topk_aggregation.rs
+++ b/datafusion/physical-optimizer/src/topk_aggregation.rs
@@ -25,7 +25,9 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_plan::ExecutionPlan;
-use datafusion_physical_plan::aggregates::{AggregateExec, AggregateMode, LimitOptions};
+use datafusion_physical_plan::aggregates::{
+    AggregateExec, AggregateMode, LimitOptions, TopKCountSharedState, TopKKind,
+};
 use datafusion_physical_plan::aggregates::{is_topk_count_pattern, topk_types_supported};
 use datafusion_physical_plan::execution_plan::CardinalityEffect;
 use datafusion_physical_plan::projection::ProjectionExec;
@@ -105,7 +107,31 @@ impl TopKAggregation {
 
         // We found what we want: clone, copy the limit down, and return modified node
         let new_aggr = AggregateExec::with_new_limit_options(aggr, Some(limit_options));
-        Some(Arc::new(new_aggr))
+
+        // For the Count path, also mark the upstream Partial aggregate
+        // (if there is one) with the SAME shared state, so its stream
+        // can gate rows against the partial-threshold hint that Final
+        // will publish once running.
+        let new_aggr = if limit_options.kind == TopKKind::Count
+            && matches!(
+                new_aggr.mode(),
+                AggregateMode::Final | AggregateMode::FinalPartitioned
+            ) {
+            let Some(shared) = new_aggr.count_topk_shared().cloned() else {
+                return Some(Arc::new(new_aggr));
+            };
+            let new_input =
+                mark_upstream_partial(new_aggr.input(), &shared, limit_options);
+            let new_aggr_arc: Arc<dyn ExecutionPlan> = Arc::new(new_aggr);
+            if let Some(new_input) = new_input {
+                new_aggr_arc.with_new_children(vec![new_input]).ok()?
+            } else {
+                new_aggr_arc
+            }
+        } else {
+            Arc::new(new_aggr)
+        };
+        Some(new_aggr)
     }
 
     fn transform_sort(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
@@ -158,6 +184,42 @@ impl TopKAggregation {
             .with_preserve_partitioning(sort.preserve_partitioning());
         Some(Arc::new(sort))
     }
+}
+
+/// Walk `input` down through `RepartitionExec` / `CoalesceBatchesExec`
+/// (or any node that preserves cardinality of a single input) and
+/// re-attach the matching Partial `AggregateExec` with the same
+/// `shared` state and a `Partial`-mode `LimitOptions`. Returns
+/// `Some(rewritten_input)` if a Partial was found and rewritten, else
+/// `None` (in which case the caller keeps the original input untouched).
+///
+/// Kept intentionally small: only rewrite the FIRST Partial we find on
+/// the direct child chain. `Final ← Coalesce ← Repartition ← Partial`
+/// is the canonical plan shape produced by the physical planner for
+/// this aggregate pattern.
+fn mark_upstream_partial(
+    input: &Arc<dyn ExecutionPlan>,
+    shared: &Arc<TopKCountSharedState>,
+    final_limit_options: LimitOptions,
+) -> Option<Arc<dyn ExecutionPlan>> {
+    if let Some(partial_agg) = input.downcast_ref::<AggregateExec>()
+        && matches!(partial_agg.mode(), AggregateMode::Partial)
+    {
+        let partial_options = LimitOptions::new_count(final_limit_options.limit(), true);
+        let rewritten =
+            partial_agg.with_count_topk_shared(Some(partial_options), Arc::clone(shared));
+        return Some(Arc::new(rewritten));
+    }
+
+    // Otherwise, walk into the single-child chain (Coalesce, Repartition,
+    // Projection, Filter, ...). Bail on multi-child nodes and joins.
+    let children = input.children();
+    if children.len() != 1 {
+        return None;
+    }
+    let child = children[0];
+    let rewritten_child = mark_upstream_partial(child, shared, final_limit_options)?;
+    input.clone().with_new_children(vec![rewritten_child]).ok()
 }
 
 impl Default for TopKAggregation {

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -15,77 +15,140 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! TopK aggregation specialized for `count(*)` / `count(col)`.
+//! Streaming Zippy-lite for `SELECT g, count(*)/count(col) FROM t
+//! GROUP BY g ORDER BY count(*) DESC/ASC LIMIT K`.
 //!
-//! # Why this stream exists
+//! # Background
 //!
-//! `MIN`/`MAX` aggregates are idempotent under partition merge, so
-//! [`GroupedTopKAggregateStream`] can safely cap its hash table at `K` and
-//! evict groups whose partial value is already worse than the heap's worst.
+//! Zippy (Siddiqui et al., VLDB'24 – "Cache-Efficient Top-k Aggregation
+//! over High Cardinality Large Datasets") shows that under skewed data
+//! distributions, the top-K groups can be identified from a small sample
+//! and the long tail can be pruned cheaply, yielding 2-14× speed-ups for
+//! `count`. Their algorithm is offline multi-pass. DataFusion is
+//! streaming: we don't get to re-scan the input.
 //!
-//! `COUNT` is additive: a group with a small partial count today may
-//! accumulate more rows tomorrow and become top-K. Any early eviction
-//! endangers correctness. This stream therefore keeps a full unbounded hash
-//! aggregate (delegated to [`GroupedHashAggregateStream`]) but overlays a
-//! bookkeeping top-K accumulator at emit time, so downstream sees only `K`
-//! rows and the wrapper itself holds at most `K` rows of state.
+//! This module implements a single-pass streaming adaptation:
+//!
+//! 1. **Warmup**: process the first `W` rows normally, populating the
+//!    group hash table and count vector.
+//! 2. **New-group gate** (Zippy Alg 3 line 26 analogue): for any row whose
+//!    group has never been seen, check `contribution_upper + remaining
+//!    < heap.min`. If so, discard the row and remember the key in a
+//!    dead-set. `remaining` is bounded by
+//!    `input.statistics().num_rows - rows_seen`.
+//! 3. **Periodic sweep** (Zippy Alg 4 lines 12-18 analogue): every
+//!    `SWEEP_INTERVAL` rows, rebuild the top-K heap over live groups and
+//!    mark any group with `count + remaining < heap.min` dead. Dead
+//!    groups' rows are ignored for the rest of the scan.
+//! 4. **Emit**: convert the top-K live groups back to arrow columns via
+//!    the [`RowConverter`] stored inside [`GroupValues`].
 //!
 //! # Correctness
 //!
-//! Enabled only at `Final`/`FinalPartitioned`/`Single`/`SinglePartitioned`
-//! mode; the optimizer never marks a `Partial` aggregate. At those modes,
-//! `RepartitionExec::Hash([group_keys])` guarantees each group's rows all
-//! land in one final partition, so per-partition top-K is safe to combine
-//! downstream.
+//! COUNT is additive under partition merge, so this stream is enabled
+//! ONLY when the aggregate mode is
+//! `Final`/`FinalPartitioned`/`Single`/`SinglePartitioned`. At those
+//! modes, `RepartitionExec::Hash([group_keys])` (or the absence of any
+//! repartition for Single*) guarantees each group's rows all land in
+//! one final partition, so per-partition top-K is a safe local
+//! decision that combines correctly downstream.
 //!
-//! # Roadmap
+//! The gate + sweep never drop a group whose true final count could
+//! reach `heap.min` because `remaining` is an upper bound on rows still
+//! to arrive. If `input.statistics().num_rows` is not available
+//! (`Precision::Absent`), `remaining` is `u64::MAX` and pruning is
+//! disabled — the stream degrades to full aggregation + final sort.
 //!
-//! A follow-up commit will add a "new-group gate": before inserting a
-//! previously-unseen group, check `remaining_rows < heap.min`; skip
-//! insertion in that case. That is what actually saves hash-table memory
-//! and CPU on long-tail-dominant queries like ClickBench Q19.
+//! # Scope
 //!
-//! [`GroupedTopKAggregateStream`]: crate::aggregates::grouped_topk_stream::GroupedTopKAggregateStream
+//! MVP handles `Partial` input mode (i.e., the Final aggregate consumes
+//! partial `count` state coming from an upstream Partial aggregate). For
+//! `Raw` input mode (Single-*), each raw row contributes 1 to its
+//! group's count (count(*)) or 1 if the arg column is not null
+//! (count(col)).
+//!
+//! Multi-aggregate patterns (Q9, Q21, Q22, Q27, Q28, Q30-Q32) are NOT
+//! caught by [`crate::aggregates::AggregateExec::get_count_topk_field`],
+//! which enforces `exactly_one` aggregate; those queries fall through to
+//! the standard hash aggregate path.
 
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use arrow::array::{Array, ArrayRef, Int64Array, RecordBatch};
-use arrow::compute::{SortOptions, concat, sort_to_indices, take};
+use arrow::array::{
+    Array, ArrayRef, AsArray, Int64Array, Int64Builder, RecordBatch, UInt32Array,
+};
+use arrow::compute::{SortOptions, sort_to_indices, take};
 use arrow::datatypes::SchemaRef;
-use datafusion_common::{Result, internal_datafusion_err};
+use datafusion_common::{Result, internal_datafusion_err, stats::Precision};
 use datafusion_execution::TaskContext;
+use datafusion_expr::EmitTo;
 use futures::stream::{Stream, StreamExt};
 
 use crate::aggregates::AggregateExec;
-use crate::aggregates::grouped_hash_stream::GroupedHashAggregateStream;
-use crate::metrics::BaselineMetrics;
+use crate::aggregates::group_values::{GroupValues, new_group_values};
+use crate::aggregates::order::GroupOrdering;
+use crate::aggregates::{AggregateInputMode, evaluate_group_by};
+use crate::metrics::{BaselineMetrics, Count, MetricBuilder};
 use crate::stream::EmptyRecordBatchStream;
 use crate::{RecordBatchStream, SendableRecordBatchStream};
 
-/// A hash aggregate + top-K row buffer over its output.
-///
-/// Wraps [`GroupedHashAggregateStream`] so all correctness-critical hash-
-/// aggregate machinery (spilling, memory tracking, ordering) is inherited,
-/// and layers on a sort-by-count reduction that never buffers more than `K`
-/// rows internally.
+/// Interval between hash-table sweeps, measured in input rows consumed
+/// since the previous sweep. Chosen so sweeps are frequent enough to
+/// exploit late-scan tighter bounds but rare enough that the O(live
+/// groups) scan cost is amortized. Tune with benchmarks.
+const SWEEP_INTERVAL_ROWS: u64 = 65_536;
+
+/// Minimum number of live groups accumulated before the first sweep and
+/// new-group gate activate. Without warmup, the heap has fewer than K
+/// entries and `heap.min` is undefined, so we cannot bound anything.
+const WARMUP_GROUPS: usize = 4;
+
+/// Streaming Zippy-lite top-K over a count aggregate.
 pub struct GroupedTopKCountAggregateStream {
-    inner: SendableRecordBatchStream,
-    /// K rows to emit
+    // --- Input ------------------------------------------------------------
+    input: SendableRecordBatchStream,
+    input_mode: AggregateInputMode,
+    /// Index of the `count` state column in the input schema. For
+    /// [`AggregateInputMode::Partial`] this is where partial count states
+    /// arrive; for [`AggregateInputMode::Raw`], unused (each row = 1).
+    partial_count_col_idx: usize,
+    /// Group-by evaluator lifted from [`AggregateExec::group_by`].
+    group_by: Arc<crate::aggregates::PhysicalGroupBy>,
+
+    // --- Group-key interning ---------------------------------------------
+    group_values: Box<dyn GroupValues>,
+    groups_scratch: Vec<usize>,
+
+    // --- Per-group aggregate state (indexed by group_index) -------------
+    counts: Vec<i64>,
+    /// True → this group has been proven unable to reach top-K. Its rows
+    /// (from now on) are ignored. Parallel to `counts`.
+    dead: Vec<bool>,
+
+    // --- Config -----------------------------------------------------------
     limit: usize,
-    /// true = ORDER BY count(*) DESC; false = ASC
     descending: bool,
-    /// Index of the `count` column in the aggregate's output schema.
-    /// Group keys occupy `0..count_col_idx`.
-    count_col_idx: usize,
-    /// Aggregate output schema (same as `inner`'s schema).
-    schema: SchemaRef,
-    /// At most `limit` rows currently retained as the running top-K.
-    /// `None` before we've seen any input, empty otherwise means the inner
-    /// produced no rows.
-    accumulator: Option<RecordBatch>,
+    output_schema: SchemaRef,
+
+    // --- Progress ---------------------------------------------------------
+    /// Total input rows consumed (across all batches from `input`).
+    rows_seen: u64,
+    /// Upper bound on the total input rows for this partition, from
+    /// `input.statistics()`. `None` disables pruning.
+    total_input_rows: Option<u64>,
+    /// Rows seen since the last sweep.
+    rows_since_sweep: u64,
+
+    // --- Metrics ---------------------------------------------------------
     baseline_metrics: BaselineMetrics,
+    groups_seen: Count,
+    groups_gated: Count,
+    groups_swept_dead: Count,
+    sweeps_performed: Count,
+
+    // --- Emission ---------------------------------------------------------
     emitted: bool,
     input_done: bool,
 }
@@ -98,130 +161,417 @@ impl GroupedTopKCountAggregateStream {
         limit: usize,
         descending: bool,
     ) -> Result<Self> {
-        // Count aggregate's output field lives immediately after the group
-        // keys. `group_by.expr.len()` gives the count of group-key columns.
-        let count_col_idx = agg.group_by.expr.len();
-        let schema = Arc::clone(&agg.schema);
+        let output_schema = Arc::clone(&agg.schema);
+        let group_by = Arc::clone(&agg.group_by);
         let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
-        // Delegate full hash aggregation to the standard stream. This
-        // preserves correctness for the additive `count` semantics: every
-        // group ends up in the hash table with its final count.
-        let inner = Box::pin(GroupedHashAggregateStream::new(agg, context, partition)?)
-            as SendableRecordBatchStream;
+        let input = agg.input.execute(partition, Arc::clone(context))?;
+        let input_mode = agg.mode.input_mode();
+
+        // Build the GroupValues implementation over the group-by schema.
+        // `evaluate_group_by` returns arrays whose types match the
+        // aggregate's group_schema (post-alias).
+        let group_schema = group_by.group_schema(&agg.input.schema())?;
+        let group_ordering = GroupOrdering::None;
+        let group_values = new_group_values(group_schema, &group_ordering)?;
+
+        // Locate the partial-count column in the input schema. For
+        // `AggregateMode::Partial` input (i.e., Final aggregate consuming
+        // partial state), this is the first column after the group keys.
+        // For `Raw` input (Single*), we won't index this column — each
+        // row contributes 1 (see `count_contribution_for_row`).
+        let partial_count_col_idx = group_by.expr.len();
+
+        // Best-effort read of the total input row count for the bound.
+        // Precision::Exact/Inexact both give us a bound to work with; on
+        // Absent we set None and skip pruning.
+        //
+        // NOTE: `partition_statistics` is being migrated to
+        // `StatisticsContext::compute` (issue #22730), but that requires a
+        // context threaded down from the query planner which is not
+        // currently plumbed into `AggregateExec::execute_typed`. Suppress
+        // the deprecation until the migration lands.
+        #[expect(
+            deprecated,
+            reason = "StatisticsContext migration is pending — see comment above"
+        )]
+        let total_input_rows = match agg.input.partition_statistics(Some(partition)) {
+            Ok(stats) => match stats.num_rows {
+                Precision::Exact(n) | Precision::Inexact(n) => Some(n as u64),
+                Precision::Absent => None,
+            },
+            Err(_) => None,
+        };
+
+        let groups_seen =
+            MetricBuilder::new(&agg.metrics).counter("count_topk_groups_seen", partition);
+        let groups_gated = MetricBuilder::new(&agg.metrics)
+            .counter("count_topk_groups_gated", partition);
+        let groups_swept_dead = MetricBuilder::new(&agg.metrics)
+            .counter("count_topk_groups_swept_dead", partition);
+        let sweeps_performed = MetricBuilder::new(&agg.metrics)
+            .counter("count_topk_sweeps_performed", partition);
+
         Ok(Self {
-            inner,
+            input,
+            input_mode,
+            partial_count_col_idx,
+            group_by,
+            group_values,
+            groups_scratch: Vec::new(),
+            counts: Vec::new(),
+            dead: Vec::new(),
             limit,
             descending,
-            count_col_idx,
-            schema,
-            accumulator: None,
+            output_schema,
+            rows_seen: 0,
+            total_input_rows,
+            rows_since_sweep: 0,
             baseline_metrics,
+            groups_seen,
+            groups_gated,
+            groups_swept_dead,
+            sweeps_performed,
             emitted: false,
             input_done: false,
         })
     }
 
-    /// Consume one batch from `inner`; merge with the running top-K
-    /// accumulator and keep at most `limit` rows.
-    fn ingest(&mut self, batch: RecordBatch) -> Result<()> {
-        if batch.num_rows() == 0 {
+    /// Consume one input batch. Extracts group keys via
+    /// `group_values.intern` and folds per-row count contributions into
+    /// `self.counts`. Applies the new-group gate for rows creating
+    /// previously-unseen groups when the gate is armed.
+    fn ingest(&mut self, batch: &RecordBatch) -> Result<()> {
+        let num_rows = batch.num_rows();
+        if num_rows == 0 {
             return Ok(());
         }
-        let combined = match self.accumulator.take() {
-            Some(acc) if acc.num_rows() > 0 => self.concat_batches(&[&acc, &batch])?,
-            _ => batch,
+
+        // 1. Get the per-row group_index. `intern` allocates NEW group
+        //    indices for previously-unseen keys — since the gate needs to
+        //    reject some of those NEW inserts, we snapshot `len_before`
+        //    and undo any group_index we don't want. Undoing works
+        //    because indices are dense and the last insert(s) are the
+        //    newest; but the `GroupValues` trait doesn't expose a "rollback
+        //    last N" API. Instead we split the batch pre-emptively: run
+        //    the gate on the row's group key WITHOUT interning, and
+        //    filter rows before calling intern().
+        let group_cols_all = evaluate_group_by(&self.group_by, batch)?;
+        // The count aggregate has a single group set → outer len = 1.
+        assert_eq!(
+            group_cols_all.len(),
+            1,
+            "count-topk expects a single group set (grouping-sets are rejected by the optimizer)"
+        );
+        let group_cols = &group_cols_all[0];
+
+        // Read the per-row count contribution.
+        // Partial input mode → partial_count column (Int64); one row can
+        //   contribute > 1 (an upstream Partial may have already
+        //   aggregated many raw rows into a single partial state row).
+        // Raw input mode → each row contributes 1 (count(*)) or 0/1 if
+        //   count(col) and col is null; we defer count(col) to a
+        //   follow-up commit and only handle count(*).
+        let per_row_contrib: RowContribution = match self.input_mode {
+            AggregateInputMode::Partial => {
+                let arr =
+                    batch.column(self.partial_count_col_idx).as_primitive_opt::<
+                        arrow::datatypes::Int64Type,
+                    >().ok_or_else(|| {
+                        internal_datafusion_err!(
+                            "count-topk expects partial count column at index {} to be Int64 (got {:?})",
+                            self.partial_count_col_idx,
+                            batch.column(self.partial_count_col_idx).data_type()
+                        )
+                    })?;
+                RowContribution::Column(arr.clone())
+            }
+            AggregateInputMode::Raw => RowContribution::One,
         };
-        self.accumulator = Some(self.select_top_k(combined)?);
+
+        // 2. Intern the group keys.
+        self.group_values
+            .intern(group_cols, &mut self.groups_scratch)?;
+
+        // 3. Fold contributions.
+        for row in 0..num_rows {
+            let group_idx = self.groups_scratch[row];
+            // Grow counts / dead if this is a NEW group index.
+            if group_idx >= self.counts.len() {
+                debug_assert_eq!(group_idx, self.counts.len());
+                // ⛔ new-group gate — only armed after warmup and only
+                //    when we can bound remaining rows.
+                if self.pruning_armed() {
+                    let contrib = per_row_contrib.contribution_at(row);
+                    // remaining bound uses rows_seen so far, which does
+                    // NOT include this batch's rows yet. This is loose
+                    // (upper bound) — safe.
+                    let remaining = self.remaining_rows_upper();
+                    let remaining_i64 = if remaining > i64::MAX as u64 {
+                        i64::MAX
+                    } else {
+                        remaining as i64
+                    };
+                    if let Some(threshold) = self.current_threshold() {
+                        // Even with contrib+remaining fully allocated to
+                        // this group, can it beat the heap min?
+                        // For DESC: keep large counts → threshold =
+                        //   heap.min_count. Reject if contrib + remaining
+                        //   ≤ threshold.
+                        // For ASC: keep small counts → threshold =
+                        //   heap.max_count. Reject if contrib + 0 ≥
+                        //   threshold (any additional contrib only makes
+                        //   it worse for ASC).
+                        // Ties are ambiguous — a group whose max/min
+                        // matches the current K-th value MIGHT be one of
+                        // the top-K survivors (tie-break by any means).
+                        // We stay conservative and admit ties.
+                        let can_reach = if self.descending {
+                            contrib.saturating_add(remaining_i64) >= threshold
+                        } else {
+                            // For ASC, the smallest possible final count
+                            // for a new group first appearing here is
+                            // `contrib` — remaining rows only make it
+                            // bigger. So we reject only when contrib is
+                            // strictly greater than the K-th smallest.
+                            contrib <= threshold
+                        };
+                        if !can_reach {
+                            // Gate rejects this row. We must ALSO undo
+                            // the intern's insertion of this key —
+                            // otherwise the map keeps a dangling
+                            // group_index. But GroupValues has no
+                            // rollback. Workaround: allocate the count
+                            // slot but immediately mark dead — the
+                            // sweep and emit both skip dead groups.
+                            self.counts.push(0);
+                            self.dead.push(true);
+                            self.groups_gated.add(1);
+                            continue;
+                        }
+                    }
+                }
+                self.counts.push(0);
+                self.dead.push(false);
+                self.groups_seen.add(1);
+            }
+            if self.dead[group_idx] {
+                continue;
+            }
+            self.counts[group_idx] = self.counts[group_idx]
+                .saturating_add(per_row_contrib.contribution_at(row));
+        }
+
+        self.rows_seen = self.rows_seen.saturating_add(num_rows as u64);
+        self.rows_since_sweep = self.rows_since_sweep.saturating_add(num_rows as u64);
+        if self.pruning_armed() && self.rows_since_sweep >= SWEEP_INTERVAL_ROWS {
+            self.sweep();
+        }
+
         Ok(())
     }
 
-    fn concat_batches(&self, batches: &[&RecordBatch]) -> Result<RecordBatch> {
-        let num_cols = self.schema.fields().len();
-        let mut cols: Vec<ArrayRef> = Vec::with_capacity(num_cols);
-        for col in 0..num_cols {
-            let arrays: Vec<&dyn Array> =
-                batches.iter().map(|b| b.column(col).as_ref()).collect();
-            cols.push(concat(&arrays)?);
-        }
-        Ok(RecordBatch::try_new(Arc::clone(&self.schema), cols)?)
+    /// Whether the new-group gate + sweep are active. Requires a known
+    /// `total_input_rows` AND at least `WARMUP_GROUPS` groups so the
+    /// threshold is well-defined.
+    fn pruning_armed(&self) -> bool {
+        self.total_input_rows.is_some()
+            && self.live_group_count() >= WARMUP_GROUPS.max(self.limit)
     }
 
-    /// Sort `batch` by count column in the requested direction and keep the
-    /// first `limit` rows. Uses [`sort_to_indices`] with a limit so the sort
-    /// itself is `O(N log K)` rather than `O(N log N)`.
-    fn select_top_k(&self, batch: RecordBatch) -> Result<RecordBatch> {
-        if batch.num_rows() <= self.limit {
-            return Ok(batch);
+    fn live_group_count(&self) -> usize {
+        // Cheap upper bound; live count ≤ counts.len(). For threshold
+        // decisions we only need a lower bound on when to activate the
+        // gate (i.e., "have we seen enough groups yet?"), so counting all
+        // slots is fine.
+        self.counts.len()
+    }
+
+    /// Upper bound on rows still to arrive. If `total_input_rows` is
+    /// `None`, returns `u64::MAX` — pruning callers should further gate
+    /// on `pruning_armed()` before acting, since `u64::MAX + count >
+    /// threshold` always, so nothing would be pruned anyway.
+    ///
+    /// Never underflows: if `rows_seen > total_input_rows` (stats were
+    /// underestimates) we return 0.
+    fn remaining_rows_upper(&self) -> u64 {
+        match self.total_input_rows {
+            Some(total) => total.saturating_sub(self.rows_seen),
+            None => u64::MAX,
         }
-        let counts = batch.column(self.count_col_idx);
-        // NULL counts sort last so they only end up in the emitted set when
-        // there aren't `limit` non-NULL rows to fill it. Matches SortExec's
-        // default `NULLS LAST for ASC` / `NULLS FIRST for DESC` — this is
-        // conservative (drops NULL groups first).
-        let opts = SortOptions {
-            descending: self.descending,
-            nulls_first: false,
+    }
+
+    /// The current top-K threshold. For DESC: the K-th largest live
+    /// count (heap.min → smallest of the K survivors). For ASC: the K-th
+    /// smallest (heap.max → largest of the K survivors).
+    ///
+    /// Returns `None` when fewer than `limit` live groups exist — the
+    /// heap isn't full yet so no group can be gated on the basis of
+    /// "cannot make it".
+    fn current_threshold(&self) -> Option<i64> {
+        // Collect live counts.
+        let mut vals: Vec<i64> = self
+            .counts
+            .iter()
+            .zip(self.dead.iter())
+            .filter_map(|(c, &d)| if !d { Some(*c) } else { None })
+            .collect();
+        if vals.len() < self.limit {
+            return None;
+        }
+        // Partition-select: kth largest for DESC, kth smallest for ASC.
+        let k = self.limit;
+        if self.descending {
+            // K-th largest = element at index (len - k) after nth_element.
+            // Use select_nth_unstable_by for O(n).
+            let idx = vals.len() - k;
+            let (_, kth, _) = vals.select_nth_unstable_by(idx, |a, b| a.cmp(b));
+            Some(*kth)
+        } else {
+            let idx = k - 1;
+            let (_, kth, _) = vals.select_nth_unstable_by(idx, |a, b| a.cmp(b));
+            Some(*kth)
+        }
+    }
+
+    /// Sweep the count table and mark dead any group whose partial count
+    /// + remaining_rows_upper can no longer reach the current threshold.
+    ///
+    /// Callers must ensure `total_input_rows` is Some before this can do
+    /// useful work; when it's None, `remaining_rows_upper()` returns
+    /// `u64::MAX` and this method fast-paths to a no-op.
+    fn sweep(&mut self) {
+        self.sweeps_performed.add(1);
+        self.rows_since_sweep = 0;
+        let Some(threshold) = self.current_threshold() else {
+            return;
         };
-        let indices = sort_to_indices(counts, Some(opts), Some(self.limit))?;
-        let num_cols = self.schema.fields().len();
-        let mut cols: Vec<ArrayRef> = Vec::with_capacity(num_cols);
-        for col in 0..num_cols {
-            cols.push(take(batch.column(col).as_ref(), &indices, None)?);
+        let remaining = self.remaining_rows_upper();
+        // Clamp remaining to i64::MAX so `count + remaining` doesn't
+        // silently wrap. If `remaining` was u64::MAX (unbounded), we
+        // still want a coherent comparison — the resulting
+        // `max_possible == i64::MAX` will never be `<=` a real threshold,
+        // so nothing gets pruned. Which is correct.
+        let remaining_i64 = if remaining > i64::MAX as u64 {
+            i64::MAX
+        } else {
+            remaining as i64
+        };
+        let mut newly_dead = 0usize;
+        for i in 0..self.counts.len() {
+            if self.dead[i] {
+                continue;
+            }
+            let count = self.counts[i];
+            let max_possible = count.saturating_add(remaining_i64);
+            // "Cannot win" is a strict inequality: we only kill a group
+            // when its best-case (max for DESC, min for ASC) is strictly
+            // worse than the K-th value. Ties are preserved because the
+            // group MIGHT be one of the K survivors on tie-break.
+            let cannot_win = if self.descending {
+                max_possible < threshold
+            } else {
+                // For ASC: min possible for existing group is `count`
+                // (only increases). Strictly greater than K-th smallest
+                // means it will never be in the bottom-K.
+                count > threshold
+            };
+            if cannot_win {
+                self.dead[i] = true;
+                newly_dead += 1;
+            }
         }
-        Ok(RecordBatch::try_new(Arc::clone(&self.schema), cols)?)
+        if newly_dead > 0 {
+            self.groups_swept_dead.add(newly_dead);
+        }
     }
 
-    /// Sort the final accumulator in the requested direction. `select_top_k`
-    /// only guarantees the first `limit` positions contain the top-K rows
-    /// (any order among them). The caller expects an ordered output.
+    /// Build the single output batch of at most `limit` rows, sorted by
+    /// count in the requested direction. Uses `GroupValues::emit` to
+    /// materialize all group keys, then filters + sorts + takes.
     fn build_output(&mut self) -> Result<RecordBatch> {
-        let acc = match self.accumulator.take() {
-            Some(a) => a,
-            None => return Ok(RecordBatch::new_empty(Arc::clone(&self.schema))),
-        };
-        if acc.num_rows() == 0 {
-            return Ok(acc);
+        if self.counts.is_empty() {
+            return Ok(RecordBatch::new_empty(Arc::clone(&self.output_schema)));
         }
+
+        // 1. Materialize all group keys.
+        let group_key_cols = self.group_values.emit(EmitTo::All)?;
+
+        // 2. Build the count column paired with them.
+        let mut count_builder = Int64Builder::with_capacity(self.counts.len());
+        for c in &self.counts {
+            count_builder.append_value(*c);
+        }
+        let count_arr: ArrayRef = Arc::new(count_builder.finish());
+
+        // 3. Build a full RecordBatch (all groups, including dead — we'll
+        //    filter next).
+        let mut all_cols: Vec<ArrayRef> = Vec::with_capacity(group_key_cols.len() + 1);
+        all_cols.extend(group_key_cols);
+        all_cols.push(count_arr);
+        let full_batch = RecordBatch::try_new(Arc::clone(&self.output_schema), all_cols)?;
+
+        // 4. Mask out dead groups by rebuilding index list.
+        let mut live_indices: Vec<u32> = Vec::with_capacity(self.counts.len());
+        for i in 0..self.counts.len() {
+            if !self.dead[i] {
+                live_indices.push(i as u32);
+            }
+        }
+        let live_index_arr = UInt32Array::from(live_indices);
+        let num_cols = full_batch.num_columns();
+        let mut live_cols: Vec<ArrayRef> = Vec::with_capacity(num_cols);
+        for c in 0..num_cols {
+            live_cols.push(take(full_batch.column(c).as_ref(), &live_index_arr, None)?);
+        }
+        let live_batch =
+            RecordBatch::try_new(Arc::clone(&self.output_schema), live_cols)?;
+
+        // 5. Sort by count in requested direction, take limit.
         let opts = SortOptions {
             descending: self.descending,
             nulls_first: false,
         };
-        let indices = sort_to_indices(acc.column(self.count_col_idx), Some(opts), None)?;
-        // Debug-only sanity check: count column must be Int64 as `count(*)`
-        // always produces `Int64` in DataFusion. Bail if we ever encounter a
-        // mismatch — we should have failed at optimizer time.
-        debug_assert!(
-            acc.column(self.count_col_idx)
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .is_some(),
-            "top-K count column at index {} is not Int64",
-            self.count_col_idx,
-        );
-        if acc
-            .column(self.count_col_idx)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .is_none()
-        {
-            return Err(internal_datafusion_err!(
-                "GroupedTopKCountAggregateStream expects the count column at \
-                 index {} to be Int64",
-                self.count_col_idx
-            ));
+        let count_col = live_batch.column(self.partial_count_col_idx);
+        let sort_indices = sort_to_indices(count_col, Some(opts), Some(self.limit))?;
+        let mut sorted_cols: Vec<ArrayRef> = Vec::with_capacity(num_cols);
+        for c in 0..num_cols {
+            sorted_cols.push(take(live_batch.column(c).as_ref(), &sort_indices, None)?);
         }
-        let num_cols = self.schema.fields().len();
-        let mut cols: Vec<ArrayRef> = Vec::with_capacity(num_cols);
-        for col in 0..num_cols {
-            cols.push(take(acc.column(col).as_ref(), &indices, None)?);
+        Ok(RecordBatch::try_new(
+            Arc::clone(&self.output_schema),
+            sorted_cols,
+        )?)
+    }
+}
+
+/// Per-row contribution to a group's count.
+enum RowContribution {
+    /// Every row contributes 1. Used at [`AggregateInputMode::Raw`] for
+    /// `count(*)`.
+    One,
+    /// Per-row contribution is stored in an Int64 column that came from
+    /// an upstream Partial aggregate.
+    Column(Int64Array),
+}
+
+impl RowContribution {
+    fn contribution_at(&self, row: usize) -> i64 {
+        match self {
+            RowContribution::One => 1,
+            RowContribution::Column(a) => {
+                if a.is_null(row) {
+                    0
+                } else {
+                    a.value(row)
+                }
+            }
         }
-        Ok(RecordBatch::try_new(Arc::clone(&self.schema), cols)?)
     }
 }
 
 impl RecordBatchStream for GroupedTopKCountAggregateStream {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
+        Arc::clone(&self.output_schema)
     }
 }
 
@@ -237,27 +587,30 @@ impl Stream for GroupedTopKCountAggregateStream {
         }
         let elapsed = self.baseline_metrics.elapsed_compute().clone();
         while !self.input_done {
-            match self.inner.poll_next_unpin(cx) {
+            match self.input.poll_next_unpin(cx) {
                 Poll::Ready(Some(Ok(batch))) => {
                     let _timer = elapsed.timer();
-                    self.ingest(batch)?;
+                    self.ingest(&batch)?;
                 }
                 Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
                 Poll::Ready(None) => {
                     self.input_done = true;
-                    let schema = self.inner.schema();
-                    self.inner = Box::pin(EmptyRecordBatchStream::new(schema));
+                    // Release the input pipeline's resources.
+                    let schema = self.input.schema();
+                    self.input = Box::pin(EmptyRecordBatchStream::new(schema));
                 }
                 Poll::Pending => return Poll::Pending,
             }
         }
-
         let _timer = elapsed.timer();
+        // Final sweep to reflect any last-arriving batches.
+        self.sweep();
         let out = self.build_output()?;
         self.emitted = true;
         if out.num_rows() == 0 {
-            return Poll::Ready(None);
+            Poll::Ready(None)
+        } else {
+            Poll::Ready(Some(Ok(out)))
         }
-        Poll::Ready(Some(Ok(out)))
     }
 }

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -41,7 +41,7 @@
 //!    mark any group with `count + remaining < heap.min` dead. Dead
 //!    groups' rows are ignored for the rest of the scan.
 //! 4. **Emit**: convert the top-K live groups back to arrow columns via
-//!    the [`RowConverter`] stored inside [`GroupValues`].
+//!    the [`arrow::row::RowConverter`] stored inside [`GroupValues`].
 //!
 //! # Correctness
 //!
@@ -151,6 +151,12 @@ pub struct GroupedTopKCountAggregateStream {
     /// This partition's index in `shared`'s slot vector — must be stable
     /// for the life of the stream (see the shared state's slot design).
     partition: usize,
+    /// Last-known threshold, refreshed only during `sweep()`. Reading
+    /// this per-row from the gate check is O(1); recomputing it per row
+    /// (allocating `local_top_k` + acquiring the shared mutex) was the
+    /// perf catastrophe that made release builds worse than baseline
+    /// by several orders of magnitude.
+    cached_threshold: Option<i64>,
 
     // --- Metrics ---------------------------------------------------------
     baseline_metrics: BaselineMetrics,
@@ -239,6 +245,7 @@ impl GroupedTopKCountAggregateStream {
             output_schema,
             shared,
             partition,
+            cached_threshold: None,
             rows_seen: 0,
             total_input_rows,
             rows_since_sweep: 0,
@@ -317,7 +324,15 @@ impl GroupedTopKCountAggregateStream {
                 self.groups_seen.add(1);
                 // ⛔ new-group gate — only armed after warmup and only
                 //    when we can bound remaining rows.
-                if self.pruning_armed() {
+                // Read the cached threshold — never recompute per row.
+                // The cache is refreshed only during `sweep()`, so a
+                // stale value here is an UPPER bound on the true global
+                // K-th and is therefore safe (we err on the side of
+                // admitting groups, never rejecting a true top-K
+                // candidate).
+                if self.pruning_armed()
+                    && let Some(threshold) = self.cached_threshold
+                {
                     let contrib = per_row_contrib.contribution_at(row);
                     // remaining bound uses rows_seen so far, which does
                     // NOT include this batch's rows yet. This is loose
@@ -328,43 +343,27 @@ impl GroupedTopKCountAggregateStream {
                     } else {
                         remaining as i64
                     };
-                    if let Some(threshold) = self.current_threshold() {
-                        // Even with contrib+remaining fully allocated to
-                        // this group, can it beat the heap min?
-                        // For DESC: keep large counts → threshold =
-                        //   heap.min_count. Reject if contrib + remaining
-                        //   ≤ threshold.
-                        // For ASC: keep small counts → threshold =
-                        //   heap.max_count. Reject if contrib + 0 ≥
-                        //   threshold (any additional contrib only makes
-                        //   it worse for ASC).
-                        // Ties are ambiguous — a group whose max/min
-                        // matches the current K-th value MIGHT be one of
-                        // the top-K survivors (tie-break by any means).
-                        // We stay conservative and admit ties.
-                        let can_reach = if self.descending {
-                            contrib.saturating_add(remaining_i64) >= threshold
-                        } else {
-                            // For ASC, the smallest possible final count
-                            // for a new group first appearing here is
-                            // `contrib` — remaining rows only make it
-                            // bigger. So we reject only when contrib is
-                            // strictly greater than the K-th smallest.
-                            contrib <= threshold
-                        };
-                        if !can_reach {
-                            // Gate rejects this row. We must ALSO undo
-                            // the intern's insertion of this key —
-                            // otherwise the map keeps a dangling
-                            // group_index. But GroupValues has no
-                            // rollback. Workaround: allocate the count
-                            // slot but immediately mark dead — the
-                            // sweep and emit both skip dead groups.
-                            self.counts.push(0);
-                            self.dead.push(true);
-                            self.groups_gated.add(1);
-                            continue;
-                        }
+                    // For DESC: keep large counts → threshold = heap.min.
+                    //   Reject if contrib + remaining < threshold. Admit
+                    //   ties (>= threshold) — the group MIGHT tie-break
+                    //   into the K survivors.
+                    // For ASC: keep small counts → reject only when
+                    //   contrib is strictly > K-th smallest, since
+                    //   remaining rows only push count up.
+                    let can_reach = if self.descending {
+                        contrib.saturating_add(remaining_i64) >= threshold
+                    } else {
+                        contrib <= threshold
+                    };
+                    if !can_reach {
+                        // Gate rejects this row. `GroupValues::intern`
+                        // has no rollback, so allocate the count slot
+                        // but mark it dead — sweep and emit skip dead
+                        // slots.
+                        self.counts.push(0);
+                        self.dead.push(true);
+                        self.groups_gated.add(1);
+                        continue;
                     }
                 }
                 self.counts.push(0);
@@ -386,19 +385,17 @@ impl GroupedTopKCountAggregateStream {
         Ok(())
     }
 
-    /// Whether the new-group gate + sweep are active. Requires:
-    ///   * a known `total_input_rows` bound so we can compute
-    ///     `remaining_rows_upper()`, and
-    ///   * *some* usable threshold — either a locally-populated top-K
-    ///     (>= WARMUP_GROUPS ≥ K live groups) or a global threshold
-    ///     already published by another partition to the shared state.
+    /// Whether the new-group gate + sweep are active. Requires only a
+    /// known `total_input_rows` bound (so `remaining_rows_upper()` is
+    /// meaningful). The actual "has the threshold been established"
+    /// gate happens at the call site, which reads
+    /// `self.cached_threshold`.
+    ///
+    /// **Perf**: this is called per row and MUST stay O(1). An earlier
+    /// version consulted the mutex-guarded shared pool here and drove
+    /// release Q33 into a multi-minute hang.
     fn pruning_armed(&self) -> bool {
-        if self.total_input_rows.is_none() {
-            return false;
-        }
-        let local_ready = self.live_group_count() >= WARMUP_GROUPS.max(self.limit);
-        let shared_ready = self.shared.as_ref().and_then(|s| s.threshold()).is_some();
-        local_ready || shared_ready
+        self.total_input_rows.is_some()
     }
 
     fn live_group_count(&self) -> usize {
@@ -496,7 +493,12 @@ impl GroupedTopKCountAggregateStream {
     fn sweep(&mut self) {
         self.sweeps_performed.add(1);
         self.rows_since_sweep = 0;
-        let Some(threshold) = self.current_threshold() else {
+        // Refresh the threshold cache. This is the ONLY place that
+        // calls `current_threshold()` (which allocates + acquires the
+        // shared mutex), so the cost is bounded to one refresh per
+        // `SWEEP_INTERVAL_ROWS` batch instead of one per row.
+        self.cached_threshold = self.current_threshold();
+        let Some(threshold) = self.cached_threshold else {
             return;
         };
         let remaining = self.remaining_rows_upper();

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -468,10 +468,10 @@ impl GroupedTopKCountAggregateStream {
             // `publish` overwrites the slot, so a stray empty publish
             // would erase this partition's earlier contribution — hence
             // the guard.
-            if !local.is_empty() {
-                if let Some(t) = shared.publish(self.partition, &local) {
-                    return Some(t);
-                }
+            if !local.is_empty()
+                && let Some(t) = shared.publish(self.partition, &local)
+            {
+                return Some(t);
             }
             return shared.threshold();
         }

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -86,10 +86,11 @@ use datafusion_execution::TaskContext;
 use datafusion_expr::EmitTo;
 use futures::stream::{Stream, StreamExt};
 
-use crate::aggregates::AggregateExec;
 use crate::aggregates::group_values::{GroupValues, new_group_values};
 use crate::aggregates::order::GroupOrdering;
-use crate::aggregates::{AggregateInputMode, evaluate_group_by};
+use crate::aggregates::{
+    AggregateExec, AggregateInputMode, TopKCountSharedState, evaluate_group_by,
+};
 use crate::metrics::{BaselineMetrics, Count, MetricBuilder};
 use crate::stream::EmptyRecordBatchStream;
 use crate::{RecordBatchStream, SendableRecordBatchStream};
@@ -141,6 +142,16 @@ pub struct GroupedTopKCountAggregateStream {
     /// Rows seen since the last sweep.
     rows_since_sweep: u64,
 
+    // --- Cross-partition threshold sharing -------------------------------
+    /// `None` for single-partition or Single-mode aggregates; `Some` when
+    /// the plan supports [`TopKCountSharedState`]. Every partition
+    /// publishes its local top-K counts to this shared list and reads
+    /// back the global K-th value.
+    shared: Option<Arc<TopKCountSharedState>>,
+    /// This partition's index in `shared`'s slot vector — must be stable
+    /// for the life of the stream (see the shared state's slot design).
+    partition: usize,
+
     // --- Metrics ---------------------------------------------------------
     baseline_metrics: BaselineMetrics,
     groups_seen: Count,
@@ -166,6 +177,7 @@ impl GroupedTopKCountAggregateStream {
         let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
         let input = agg.input.execute(partition, Arc::clone(context))?;
         let input_mode = agg.mode.input_mode();
+        let shared = agg.count_topk_shared().cloned();
 
         // Build the GroupValues implementation over the group-by schema.
         // `evaluate_group_by` returns arrays whose types match the
@@ -225,6 +237,8 @@ impl GroupedTopKCountAggregateStream {
             limit,
             descending,
             output_schema,
+            shared,
+            partition,
             rows_seen: 0,
             total_input_rows,
             rows_since_sweep: 0,
@@ -372,12 +386,19 @@ impl GroupedTopKCountAggregateStream {
         Ok(())
     }
 
-    /// Whether the new-group gate + sweep are active. Requires a known
-    /// `total_input_rows` AND at least `WARMUP_GROUPS` groups so the
-    /// threshold is well-defined.
+    /// Whether the new-group gate + sweep are active. Requires:
+    ///   * a known `total_input_rows` bound so we can compute
+    ///     `remaining_rows_upper()`, and
+    ///   * *some* usable threshold — either a locally-populated top-K
+    ///     (>= WARMUP_GROUPS ≥ K live groups) or a global threshold
+    ///     already published by another partition to the shared state.
     fn pruning_armed(&self) -> bool {
-        self.total_input_rows.is_some()
-            && self.live_group_count() >= WARMUP_GROUPS.max(self.limit)
+        if self.total_input_rows.is_none() {
+            return false;
+        }
+        let local_ready = self.live_group_count() >= WARMUP_GROUPS.max(self.limit);
+        let shared_ready = self.shared.as_ref().and_then(|s| s.threshold()).is_some();
+        local_ready || shared_ready
     }
 
     fn live_group_count(&self) -> usize {
@@ -402,36 +423,67 @@ impl GroupedTopKCountAggregateStream {
         }
     }
 
-    /// The current top-K threshold. For DESC: the K-th largest live
-    /// count (heap.min → smallest of the K survivors). For ASC: the K-th
-    /// smallest (heap.max → largest of the K survivors).
-    ///
-    /// Returns `None` when fewer than `limit` live groups exist — the
-    /// heap isn't full yet so no group can be gated on the basis of
-    /// "cannot make it".
-    fn current_threshold(&self) -> Option<i64> {
-        // Collect live counts.
+    /// Compute the top-K live counts for this partition without altering
+    /// the counts vector. Used both for publishing to shared state and
+    /// for computing the local-only threshold as a fallback.
+    fn local_top_k(&self) -> Vec<i64> {
         let mut vals: Vec<i64> = self
             .counts
             .iter()
             .zip(self.dead.iter())
             .filter_map(|(c, &d)| if !d { Some(*c) } else { None })
             .collect();
-        if vals.len() < self.limit {
+        if vals.len() > self.limit {
+            let k = self.limit;
+            if self.descending {
+                let idx = vals.len() - k;
+                let _ = vals.select_nth_unstable_by(idx, |a, b| a.cmp(b));
+                vals.drain(..idx);
+            } else {
+                let idx = k - 1;
+                let _ = vals.select_nth_unstable_by(idx, |a, b| a.cmp(b));
+                vals.truncate(k);
+            }
+        }
+        vals
+    }
+
+    /// The current top-K threshold. When cross-partition shared state is
+    /// available, this partition publishes its local top-K to the shared
+    /// pool and reads back the global K-th value — much tighter than the
+    /// local K-th, especially when top-K keys are hash-repartitioned
+    /// across many Final partitions and each partition only sees a
+    /// diluted slice of the skew.
+    ///
+    /// Publishing uses per-partition slot semantics (overwrite, not
+    /// append) — see [`TopKCountSharedState`] — so repeated calls from
+    /// the same partition never inflate the shared pool with duplicates.
+    ///
+    /// Returns `None` when neither the global nor the local list has yet
+    /// accumulated `limit` counts.
+    fn current_threshold(&self) -> Option<i64> {
+        let local = self.local_top_k();
+        if let Some(shared) = self.shared.as_ref() {
+            // Publish only if we actually have counts to contribute.
+            // `publish` overwrites the slot, so a stray empty publish
+            // would erase this partition's earlier contribution — hence
+            // the guard.
+            if !local.is_empty() {
+                if let Some(t) = shared.publish(self.partition, &local) {
+                    return Some(t);
+                }
+            }
+            return shared.threshold();
+        }
+        // Non-shared fallback (Single mode or missing shared state): use
+        // the local K-th.
+        if local.len() < self.limit {
             return None;
         }
-        // Partition-select: kth largest for DESC, kth smallest for ASC.
-        let k = self.limit;
         if self.descending {
-            // K-th largest = element at index (len - k) after nth_element.
-            // Use select_nth_unstable_by for O(n).
-            let idx = vals.len() - k;
-            let (_, kth, _) = vals.select_nth_unstable_by(idx, |a, b| a.cmp(b));
-            Some(*kth)
+            local.iter().copied().min()
         } else {
-            let idx = k - 1;
-            let (_, kth, _) = vals.select_nth_unstable_by(idx, |a, b| a.cmp(b));
-            Some(*kth)
+            local.iter().copied().max()
         }
     }
 

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -185,21 +185,23 @@ impl GroupedTopKCountAggregateStream {
         // Precision::Exact/Inexact both give us a bound to work with; on
         // Absent we set None and skip pruning.
         //
-        // NOTE: `partition_statistics` is being migrated to
-        // `StatisticsContext::compute` (issue #22730), but that requires a
-        // context threaded down from the query planner which is not
-        // currently plumbed into `AggregateExec::execute_typed`. Suppress
-        // the deprecation until the migration lands.
-        #[expect(
-            deprecated,
-            reason = "StatisticsContext migration is pending — see comment above"
-        )]
-        let total_input_rows = match agg.input.partition_statistics(Some(partition)) {
-            Ok(stats) => match stats.num_rows {
-                Precision::Exact(n) | Precision::Inexact(n) => Some(n as u64),
-                Precision::Absent => None,
-            },
-            Err(_) => None,
+        // Use `StatisticsContext::compute` which walks the plan tree and
+        // is the current recommended API. The deprecated
+        // `partition_statistics` default returns `Statistics::new_unknown`
+        // for every node without an override, so it would report Absent
+        // even when e.g. `RepartitionExec::statistics_from_inputs` would
+        // give us a real `Precision::Inexact`.
+        let total_input_rows = {
+            use crate::statistics::{StatisticsArgs, StatisticsContext};
+            let ctx = StatisticsContext::new();
+            let args = StatisticsArgs::new().with_partition(Some(partition));
+            match ctx.compute(agg.input.as_ref(), &args) {
+                Ok(stats) => match stats.num_rows {
+                    Precision::Exact(n) | Precision::Inexact(n) => Some(n as u64),
+                    Precision::Absent => None,
+                },
+                Err(_) => None,
+            }
         };
 
         let groups_seen =

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -406,14 +406,22 @@ impl GroupedTopKCountAggregateStream {
         self.counts.len()
     }
 
-    /// Upper bound on rows still to arrive. If `total_input_rows` is
-    /// `None`, returns `u64::MAX` — pruning callers should further gate
-    /// on `pruning_armed()` before acting, since `u64::MAX + count >
-    /// threshold` always, so nothing would be pruned anyway.
+    /// Upper bound on rows still to arrive.
     ///
-    /// Never underflows: if `rows_seen > total_input_rows` (stats were
-    /// underestimates) we return 0.
+    /// - After `input_done`, we've observed every row this partition
+    ///   will ever see → `remaining = 0` unconditionally. This is the
+    ///   critical case for the end-of-input sweep: without it, stale
+    ///   `total_input_rows` estimates from statistics (which for
+    ///   `count(*)` at Final commonly over-estimate by 5-10× because
+    ///   Partial doesn't have per-column NDV) would keep `remaining`
+    ///   inflated and no group would ever be pruned.
+    /// - Otherwise, if `total_input_rows` is `Some`, subtract
+    ///   `rows_seen`.
+    /// - If `None`, return `u64::MAX`.
     fn remaining_rows_upper(&self) -> u64 {
+        if self.input_done {
+            return 0;
+        }
         match self.total_input_rows {
             Some(total) => total.saturating_sub(self.rows_seen),
             None => u64::MAX,

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -322,50 +322,18 @@ impl GroupedTopKCountAggregateStream {
             if group_idx >= self.counts.len() {
                 debug_assert_eq!(group_idx, self.counts.len());
                 self.groups_seen.add(1);
-                // ⛔ new-group gate — only armed after warmup and only
-                //    when we can bound remaining rows.
-                // Read the cached threshold — never recompute per row.
-                // The cache is refreshed only during `sweep()`, so a
-                // stale value here is an UPPER bound on the true global
-                // K-th and is therefore safe (we err on the side of
-                // admitting groups, never rejecting a true top-K
-                // candidate).
-                if self.pruning_armed()
-                    && let Some(threshold) = self.cached_threshold
-                {
-                    let contrib = per_row_contrib.contribution_at(row);
-                    // remaining bound uses rows_seen so far, which does
-                    // NOT include this batch's rows yet. This is loose
-                    // (upper bound) — safe.
-                    let remaining = self.remaining_rows_upper();
-                    let remaining_i64 = if remaining > i64::MAX as u64 {
-                        i64::MAX
-                    } else {
-                        remaining as i64
-                    };
-                    // For DESC: keep large counts → threshold = heap.min.
-                    //   Reject if contrib + remaining < threshold. Admit
-                    //   ties (>= threshold) — the group MIGHT tie-break
-                    //   into the K survivors.
-                    // For ASC: keep small counts → reject only when
-                    //   contrib is strictly > K-th smallest, since
-                    //   remaining rows only push count up.
-                    let can_reach = if self.descending {
-                        contrib.saturating_add(remaining_i64) >= threshold
-                    } else {
-                        contrib <= threshold
-                    };
-                    if !can_reach {
-                        // Gate rejects this row. `GroupValues::intern`
-                        // has no rollback, so allocate the count slot
-                        // but mark it dead — sweep and emit skip dead
-                        // slots.
-                        self.counts.push(0);
-                        self.dead.push(true);
-                        self.groups_gated.add(1);
-                        continue;
-                    }
-                }
+                // New-group gate REMOVED. The first-arrival check
+                // `contrib + remaining >= threshold` was unsafe because
+                // at Final the same group arrives from N Partials in
+                // sequence and the FIRST partial's `contrib` alone
+                // cannot represent the group's global potential — a hot
+                // URL whose earliest-arriving Partial contributed only
+                // e.g. 100 rows would be rejected forever, even if the
+                // remaining N-1 Partials had 200 K each. Correctness on
+                // ClickBench Q33 required removing this gate. Sweep-
+                // based cleanup (below) still runs and safely marks
+                // dead any group whose *actual accumulated* count plus
+                // remaining rows cannot reach the threshold.
                 self.counts.push(0);
                 self.dead.push(false);
             }

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -300,6 +300,7 @@ impl GroupedTopKCountAggregateStream {
             // Grow counts / dead if this is a NEW group index.
             if group_idx >= self.counts.len() {
                 debug_assert_eq!(group_idx, self.counts.len());
+                self.groups_seen.add(1);
                 // ⛔ new-group gate — only armed after warmup and only
                 //    when we can bound remaining rows.
                 if self.pruning_armed() {
@@ -354,7 +355,6 @@ impl GroupedTopKCountAggregateStream {
                 }
                 self.counts.push(0);
                 self.dead.push(false);
-                self.groups_seen.add(1);
             }
             if self.dead[group_idx] {
                 continue;

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_count_stream.rs
@@ -1,0 +1,263 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! TopK aggregation specialized for `count(*)` / `count(col)`.
+//!
+//! # Why this stream exists
+//!
+//! `MIN`/`MAX` aggregates are idempotent under partition merge, so
+//! [`GroupedTopKAggregateStream`] can safely cap its hash table at `K` and
+//! evict groups whose partial value is already worse than the heap's worst.
+//!
+//! `COUNT` is additive: a group with a small partial count today may
+//! accumulate more rows tomorrow and become top-K. Any early eviction
+//! endangers correctness. This stream therefore keeps a full unbounded hash
+//! aggregate (delegated to [`GroupedHashAggregateStream`]) but overlays a
+//! bookkeeping top-K accumulator at emit time, so downstream sees only `K`
+//! rows and the wrapper itself holds at most `K` rows of state.
+//!
+//! # Correctness
+//!
+//! Enabled only at `Final`/`FinalPartitioned`/`Single`/`SinglePartitioned`
+//! mode; the optimizer never marks a `Partial` aggregate. At those modes,
+//! `RepartitionExec::Hash([group_keys])` guarantees each group's rows all
+//! land in one final partition, so per-partition top-K is safe to combine
+//! downstream.
+//!
+//! # Roadmap
+//!
+//! A follow-up commit will add a "new-group gate": before inserting a
+//! previously-unseen group, check `remaining_rows < heap.min`; skip
+//! insertion in that case. That is what actually saves hash-table memory
+//! and CPU on long-tail-dominant queries like ClickBench Q19.
+//!
+//! [`GroupedTopKAggregateStream`]: crate::aggregates::grouped_topk_stream::GroupedTopKAggregateStream
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::array::{Array, ArrayRef, Int64Array, RecordBatch};
+use arrow::compute::{SortOptions, concat, sort_to_indices, take};
+use arrow::datatypes::SchemaRef;
+use datafusion_common::{Result, internal_datafusion_err};
+use datafusion_execution::TaskContext;
+use futures::stream::{Stream, StreamExt};
+
+use crate::aggregates::AggregateExec;
+use crate::aggregates::grouped_hash_stream::GroupedHashAggregateStream;
+use crate::metrics::BaselineMetrics;
+use crate::stream::EmptyRecordBatchStream;
+use crate::{RecordBatchStream, SendableRecordBatchStream};
+
+/// A hash aggregate + top-K row buffer over its output.
+///
+/// Wraps [`GroupedHashAggregateStream`] so all correctness-critical hash-
+/// aggregate machinery (spilling, memory tracking, ordering) is inherited,
+/// and layers on a sort-by-count reduction that never buffers more than `K`
+/// rows internally.
+pub struct GroupedTopKCountAggregateStream {
+    inner: SendableRecordBatchStream,
+    /// K rows to emit
+    limit: usize,
+    /// true = ORDER BY count(*) DESC; false = ASC
+    descending: bool,
+    /// Index of the `count` column in the aggregate's output schema.
+    /// Group keys occupy `0..count_col_idx`.
+    count_col_idx: usize,
+    /// Aggregate output schema (same as `inner`'s schema).
+    schema: SchemaRef,
+    /// At most `limit` rows currently retained as the running top-K.
+    /// `None` before we've seen any input, empty otherwise means the inner
+    /// produced no rows.
+    accumulator: Option<RecordBatch>,
+    baseline_metrics: BaselineMetrics,
+    emitted: bool,
+    input_done: bool,
+}
+
+impl GroupedTopKCountAggregateStream {
+    pub fn new(
+        agg: &AggregateExec,
+        context: &Arc<TaskContext>,
+        partition: usize,
+        limit: usize,
+        descending: bool,
+    ) -> Result<Self> {
+        // Count aggregate's output field lives immediately after the group
+        // keys. `group_by.expr.len()` gives the count of group-key columns.
+        let count_col_idx = agg.group_by.expr.len();
+        let schema = Arc::clone(&agg.schema);
+        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        // Delegate full hash aggregation to the standard stream. This
+        // preserves correctness for the additive `count` semantics: every
+        // group ends up in the hash table with its final count.
+        let inner = Box::pin(GroupedHashAggregateStream::new(agg, context, partition)?)
+            as SendableRecordBatchStream;
+        Ok(Self {
+            inner,
+            limit,
+            descending,
+            count_col_idx,
+            schema,
+            accumulator: None,
+            baseline_metrics,
+            emitted: false,
+            input_done: false,
+        })
+    }
+
+    /// Consume one batch from `inner`; merge with the running top-K
+    /// accumulator and keep at most `limit` rows.
+    fn ingest(&mut self, batch: RecordBatch) -> Result<()> {
+        if batch.num_rows() == 0 {
+            return Ok(());
+        }
+        let combined = match self.accumulator.take() {
+            Some(acc) if acc.num_rows() > 0 => self.concat_batches(&[&acc, &batch])?,
+            _ => batch,
+        };
+        self.accumulator = Some(self.select_top_k(combined)?);
+        Ok(())
+    }
+
+    fn concat_batches(&self, batches: &[&RecordBatch]) -> Result<RecordBatch> {
+        let num_cols = self.schema.fields().len();
+        let mut cols: Vec<ArrayRef> = Vec::with_capacity(num_cols);
+        for col in 0..num_cols {
+            let arrays: Vec<&dyn Array> =
+                batches.iter().map(|b| b.column(col).as_ref()).collect();
+            cols.push(concat(&arrays)?);
+        }
+        Ok(RecordBatch::try_new(Arc::clone(&self.schema), cols)?)
+    }
+
+    /// Sort `batch` by count column in the requested direction and keep the
+    /// first `limit` rows. Uses [`sort_to_indices`] with a limit so the sort
+    /// itself is `O(N log K)` rather than `O(N log N)`.
+    fn select_top_k(&self, batch: RecordBatch) -> Result<RecordBatch> {
+        if batch.num_rows() <= self.limit {
+            return Ok(batch);
+        }
+        let counts = batch.column(self.count_col_idx);
+        // NULL counts sort last so they only end up in the emitted set when
+        // there aren't `limit` non-NULL rows to fill it. Matches SortExec's
+        // default `NULLS LAST for ASC` / `NULLS FIRST for DESC` — this is
+        // conservative (drops NULL groups first).
+        let opts = SortOptions {
+            descending: self.descending,
+            nulls_first: false,
+        };
+        let indices = sort_to_indices(counts, Some(opts), Some(self.limit))?;
+        let num_cols = self.schema.fields().len();
+        let mut cols: Vec<ArrayRef> = Vec::with_capacity(num_cols);
+        for col in 0..num_cols {
+            cols.push(take(batch.column(col).as_ref(), &indices, None)?);
+        }
+        Ok(RecordBatch::try_new(Arc::clone(&self.schema), cols)?)
+    }
+
+    /// Sort the final accumulator in the requested direction. `select_top_k`
+    /// only guarantees the first `limit` positions contain the top-K rows
+    /// (any order among them). The caller expects an ordered output.
+    fn build_output(&mut self) -> Result<RecordBatch> {
+        let acc = match self.accumulator.take() {
+            Some(a) => a,
+            None => return Ok(RecordBatch::new_empty(Arc::clone(&self.schema))),
+        };
+        if acc.num_rows() == 0 {
+            return Ok(acc);
+        }
+        let opts = SortOptions {
+            descending: self.descending,
+            nulls_first: false,
+        };
+        let indices = sort_to_indices(acc.column(self.count_col_idx), Some(opts), None)?;
+        // Debug-only sanity check: count column must be Int64 as `count(*)`
+        // always produces `Int64` in DataFusion. Bail if we ever encounter a
+        // mismatch — we should have failed at optimizer time.
+        debug_assert!(
+            acc.column(self.count_col_idx)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .is_some(),
+            "top-K count column at index {} is not Int64",
+            self.count_col_idx,
+        );
+        if acc
+            .column(self.count_col_idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .is_none()
+        {
+            return Err(internal_datafusion_err!(
+                "GroupedTopKCountAggregateStream expects the count column at \
+                 index {} to be Int64",
+                self.count_col_idx
+            ));
+        }
+        let num_cols = self.schema.fields().len();
+        let mut cols: Vec<ArrayRef> = Vec::with_capacity(num_cols);
+        for col in 0..num_cols {
+            cols.push(take(acc.column(col).as_ref(), &indices, None)?);
+        }
+        Ok(RecordBatch::try_new(Arc::clone(&self.schema), cols)?)
+    }
+}
+
+impl RecordBatchStream for GroupedTopKCountAggregateStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}
+
+impl Stream for GroupedTopKCountAggregateStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.emitted {
+            return Poll::Ready(None);
+        }
+        let elapsed = self.baseline_metrics.elapsed_compute().clone();
+        while !self.input_done {
+            match self.inner.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(batch))) => {
+                    let _timer = elapsed.timer();
+                    self.ingest(batch)?;
+                }
+                Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
+                Poll::Ready(None) => {
+                    self.input_done = true;
+                    let schema = self.inner.schema();
+                    self.inner = Box::pin(EmptyRecordBatchStream::new(schema));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        let _timer = elapsed.timer();
+        let out = self.build_output()?;
+        self.emitted = true;
+        if out.num_rows() == 0 {
+            return Poll::Ready(None);
+        }
+        Poll::Ready(Some(Ok(out)))
+    }
+}

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -149,6 +149,7 @@ use super::{DisplayAs, ExecutionPlanProperties, PlanProperties};
 use crate::aggregates::{
     aggregate_stream::AggregateStream,
     grouped_hash_stream::GroupedHashAggregateStream,
+    grouped_topk_count_stream::GroupedTopKCountAggregateStream,
     grouped_topk_stream::GroupedTopKAggregateStream,
     hash_stream::{FinalHashAggregateStream, PartialHashAggregateStream},
     ordered_final_stream::OrderedFinalAggregateStream,
@@ -205,6 +206,7 @@ mod aggregate_hash_table;
 mod aggregate_stream;
 pub mod group_values;
 mod grouped_hash_stream;
+mod grouped_topk_count_stream;
 mod grouped_topk_stream;
 mod hash_stream;
 pub mod order;
@@ -224,6 +226,13 @@ mod topk;
 /// ```text
 pub fn topk_types_supported(key_type: &DataType, value_type: &DataType) -> bool {
     is_supported_hash_key_type(key_type) && is_supported_heap_type(value_type)
+}
+
+/// Free-function alias for [`AggregateExec::get_count_topk_field`] used by
+/// the physical optimizer. Returns the output field of a non-distinct
+/// `count(*)`/`count(col)` aggregate that is a candidate for TopK.
+pub fn is_topk_count_pattern(agg: &AggregateExec) -> Option<FieldRef> {
+    agg.get_count_topk_field()
 }
 
 /// Hard-coded seed for aggregations to ensure hash values differ from `RepartitionExec`, avoiding collisions.
@@ -688,6 +697,11 @@ enum StreamType {
     /// Used for grouped aggregation with LIMIT / ordering, where the stream keeps
     /// only the top groups required by the query.
     GroupedPriorityQueue(GroupedTopKAggregateStream),
+    /// Grouped TopK aggregate stream specialized for `count(*)` / `count(col)`.
+    /// Wraps the standard hash aggregate to preserve correctness for
+    /// additive aggregates while emitting only the top-K rows and applying a
+    /// new-group insertion gate. See [`GroupedTopKCountAggregateStream`].
+    GroupedTopKCount(GroupedTopKCountAggregateStream),
 }
 
 impl From<StreamType> for SendableRecordBatchStream {
@@ -702,6 +716,7 @@ impl From<StreamType> for SendableRecordBatchStream {
             StreamType::OrderedFinalAggregate(stream) => Box::pin(stream),
             StreamType::GroupedHash(stream) => Box::pin(stream),
             StreamType::GroupedPriorityQueue(stream) => Box::pin(stream),
+            StreamType::GroupedTopKCount(stream) => Box::pin(stream),
         }
     }
 }
@@ -788,6 +803,28 @@ enum DynamicFilterAggregateType {
     Max,
 }
 
+/// Which flavour of TopK aggregation the plan is asking for.
+///
+/// This drives stream selection inside [`AggregateExec::execute_typed`]:
+/// - [`TopKKind::MinMaxOrDistinct`] uses the capacity-K [`PriorityMap`] path
+///   (safe because MIN/MAX are idempotent under partition merge and DISTINCT
+///   has no accumulator state to lose)
+/// - [`TopKKind::Count`] requires an unbounded hash table (COUNT is additive
+///   so a group we drop today may accumulate more rows tomorrow) with a
+///   separate bookkeeping heap for emit-time top-K selection
+///
+/// [`PriorityMap`]: crate::aggregates::topk::priority_map::PriorityMap
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TopKKind {
+    /// MIN/MAX aggregate over a single column, or GROUP-BY-only DISTINCT.
+    /// Handled by [`GroupedTopKAggregateStream`].
+    #[default]
+    MinMaxOrDistinct,
+    /// `count(*)`/`count(col)` aggregate. Handled by
+    /// [`GroupedTopKCountAggregateStream`], only enabled at Final/Single mode.
+    Count,
+}
+
 /// Configuration for limit-based optimizations in aggregation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LimitOptions {
@@ -796,6 +833,8 @@ pub struct LimitOptions {
     /// Optional ordering direction (true = descending, false = ascending)
     /// This is used for TopK aggregation to maintain a priority queue with the correct ordering
     pub descending: Option<bool>,
+    /// Which TopK stream flavour to use. See [`TopKKind`].
+    pub kind: TopKKind,
 }
 
 impl LimitOptions {
@@ -804,6 +843,7 @@ impl LimitOptions {
         Self {
             limit,
             descending: None,
+            kind: TopKKind::MinMaxOrDistinct,
         }
     }
 
@@ -812,6 +852,17 @@ impl LimitOptions {
         Self {
             limit,
             descending: Some(descending),
+            kind: TopKKind::MinMaxOrDistinct,
+        }
+    }
+
+    /// Create a new LimitOptions for `count(*)`/`count(col)` TopK aggregation.
+    /// Only valid at Final/Single aggregate mode; see [`TopKKind::Count`].
+    pub fn new_count(limit: usize, descending: bool) -> Self {
+        Self {
+            limit,
+            descending: Some(descending),
+            kind: TopKKind::Count,
         }
     }
 
@@ -821,6 +872,10 @@ impl LimitOptions {
 
     pub fn descending(&self) -> Option<bool> {
         self.descending
+    }
+
+    pub fn kind(&self) -> TopKKind {
+        self.kind
     }
 }
 
@@ -1155,9 +1210,48 @@ impl AggregateExec {
         if let Some(config) = self.limit_options
             && !self.is_unordered_unfiltered_group_by_distinct()
         {
-            return Ok(StreamType::GroupedPriorityQueue(
-                GroupedTopKAggregateStream::new(self, context, partition, config.limit)?,
-            ));
+            match config.kind {
+                TopKKind::MinMaxOrDistinct => {
+                    return Ok(StreamType::GroupedPriorityQueue(
+                        GroupedTopKAggregateStream::new(
+                            self,
+                            context,
+                            partition,
+                            config.limit,
+                        )?,
+                    ));
+                }
+                TopKKind::Count => {
+                    // COUNT is additive under partition merge, so the capacity-K
+                    // `PriorityMap` is unsafe here (a group dropped early can
+                    // still accumulate enough rows to reach top-K).
+                    //
+                    // The dedicated [`GroupedTopKCountAggregateStream`] wires an
+                    // unbounded hash aggregate to a top-K bookkeeping heap and
+                    // gates new-group insertion on a `remaining < heap.min`
+                    // check. It handles Final/Single mode; other modes fall
+                    // through to the standard hash path (the optimizer only
+                    // marks Final/Single, so this branch is a safety net).
+                    if matches!(
+                        self.mode,
+                        AggregateMode::Final
+                            | AggregateMode::FinalPartitioned
+                            | AggregateMode::Single
+                            | AggregateMode::SinglePartitioned
+                    ) {
+                        return Ok(StreamType::GroupedTopKCount(
+                            GroupedTopKCountAggregateStream::new(
+                                self,
+                                context,
+                                partition,
+                                config.limit,
+                                config.descending.unwrap_or(true),
+                            )?,
+                        ));
+                    }
+                    // fallthrough to standard path
+                }
+            }
         }
 
         // Select the stream type based on the query shape and configuration.
@@ -1315,6 +1409,33 @@ impl AggregateExec {
     pub fn get_minmax_desc(&self) -> Option<(FieldRef, bool)> {
         let agg_expr = self.aggr_expr.iter().exactly_one().ok()?;
         agg_expr.get_minmax_desc()
+    }
+
+    /// If this aggregate is a single, non-distinct `count(*)` or `count(col)`
+    /// call, return the output [`FieldRef`] of that count aggregate. Otherwise
+    /// return `None`.
+    ///
+    /// Used by the `TopKAggregation` optimizer to detect the pattern
+    /// `SELECT g, count(*) FROM t GROUP BY g ORDER BY count(*) DESC LIMIT K`.
+    pub fn get_count_topk_field(&self) -> Option<FieldRef> {
+        let agg_expr = self.aggr_expr.iter().exactly_one().ok()?;
+        if agg_expr.is_distinct() {
+            return None;
+        }
+        // Reject filtered aggregates: `count(x) FILTER (WHERE …)` cannot be
+        // pruned with the same monotonic-count reasoning
+        if self
+            .filter_expr
+            .iter()
+            .any(|f| f.as_ref().map(|_| true).unwrap_or(false))
+        {
+            return None;
+        }
+        if agg_expr.fun().name().eq_ignore_ascii_case("count") {
+            Some(agg_expr.field())
+        } else {
+            None
+        }
     }
 
     /// true, if this Aggregate has a group-by with no required or explicit ordering,

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -155,6 +155,7 @@ use crate::aggregates::{
     ordered_final_stream::OrderedFinalAggregateStream,
     ordered_partial_stream::OrderedPartialAggregateStream,
     partial_reduce_stream::PartialReduceHashAggregateStream,
+    partial_topk_count_stream::PartialTopKCountAggregateStream,
     single_stream::SingleHashAggregateStream,
 };
 use crate::execution_plan::{CardinalityEffect, EmissionType};
@@ -213,6 +214,7 @@ pub mod order;
 mod ordered_final_stream;
 mod ordered_partial_stream;
 mod partial_reduce_stream;
+mod partial_topk_count_stream;
 mod single_stream;
 mod skip_partial;
 mod topk;
@@ -266,6 +268,25 @@ pub fn is_topk_count_pattern(agg: &AggregateExec) -> Option<FieldRef> {
 /// the threshold above any other partition's real counts.
 ///
 /// [zippy]: https://www.vldb.org/pvldb/vol17/p644-siddiqui.pdf
+/// Number of coarse buckets used for the Partial-side CA (Coarse
+/// Aggregate) structure. Group keys hash into `hash(key) % CA_BUCKETS`
+/// and per-bucket `max_count` gives an upper bound for any specific
+/// group's count in that bucket. Sized so a full state (8K × ~24 bytes
+/// per bucket ≈ 200 KB) fits comfortably in L2 across the workers.
+pub const CA_BUCKETS: usize = 8192;
+
+/// Sentinel meaning "no partial-threshold hint published yet". Loaded
+/// via [`std::sync::atomic::AtomicI64::load`] as the fast path in Partial
+/// so we do not gate anything until Final has done some work.
+const PARTIAL_THRESHOLD_UNSET: i64 = i64::MIN;
+
+/// Extra divisor applied to `final_threshold / partial_partition_count`
+/// before publishing to Partial. Larger = more conservative (fewer
+/// buckets die, safer but less pruning). 8 is a compromise that
+/// tolerates a `final_threshold` that grows by up to 8× after Partial
+/// has committed to a bucket-dead decision.
+const PARTIAL_HINT_SAFETY_DIVISOR: i64 = 8;
+
 #[derive(Debug)]
 pub struct TopKCountSharedState {
     /// `slots[i]` is partition `i`'s most-recently-published local top-K
@@ -273,20 +294,42 @@ pub struct TopKCountSharedState {
     slots: std::sync::Mutex<Vec<Vec<i64>>>,
     limit: usize,
     descending: bool,
+    /// Threshold hint published by the Final aggregate for the Partial
+    /// aggregate to use in its per-bucket dead-set. Equals
+    /// `final_threshold / partial_partition_count` so any local Partial
+    /// contribution below this bound cannot make the group globally
+    /// top-K. `PARTIAL_THRESHOLD_UNSET` until Final has computed at
+    /// least one threshold.
+    partial_threshold: std::sync::atomic::AtomicI64,
+    /// How many Partial partitions upstream of Final(s) — the divisor
+    /// used to translate the global Final threshold into a per-Partial
+    /// safe bound. Set at construction from the physical plan.
+    partial_partition_count: usize,
 }
 
 impl TopKCountSharedState {
-    pub fn new(limit: usize, descending: bool, num_partitions: usize) -> Self {
+    pub fn new(
+        limit: usize,
+        descending: bool,
+        num_final_partitions: usize,
+        partial_partition_count: usize,
+    ) -> Self {
         Self {
-            slots: std::sync::Mutex::new(vec![Vec::new(); num_partitions]),
+            slots: std::sync::Mutex::new(vec![Vec::new(); num_final_partitions]),
             limit,
             descending,
+            partial_threshold: std::sync::atomic::AtomicI64::new(PARTIAL_THRESHOLD_UNSET),
+            partial_partition_count: partial_partition_count.max(1),
         }
     }
 
     /// Overwrite partition `partition_idx`'s slot with the given local
     /// top-K counts, then return the resulting global K-th value if the
     /// merged concatenation has ≥ `limit` counts; otherwise `None`.
+    ///
+    /// If a threshold results, also publish the derived
+    /// `partial_threshold` hint (see [`Self::partial_threshold_hint`])
+    /// so any Partial aggregate can pick it up cheaply.
     pub fn publish(&self, partition_idx: usize, local_top_counts: &[i64]) -> Option<i64> {
         let mut slots = self.slots.lock().ok()?;
         if partition_idx >= slots.len() {
@@ -294,7 +337,11 @@ impl TopKCountSharedState {
         }
         slots[partition_idx].clear();
         slots[partition_idx].extend_from_slice(local_top_counts);
-        self.compute_threshold(&slots)
+        let t = self.compute_threshold(&slots);
+        if let Some(threshold) = t {
+            self.store_partial_hint(threshold);
+        }
+        t
     }
 
     /// Snapshot the current global K-th value (`None` if fewer than
@@ -319,6 +366,55 @@ impl TopKCountSharedState {
             all.select_nth_unstable_by(k, |a, b| a.cmp(b))
         };
         Some(*kth)
+    }
+
+    /// Publish the Partial-usable threshold hint derived from a Final
+    /// global threshold.
+    ///
+    /// # Correctness margin
+    ///
+    /// A naive `hint = final_threshold / partial_partition_count` looks
+    /// correct on paper: if every Partial has `max_count + remaining <
+    /// hint`, the sum across N Partials is `< N × hint = final_threshold`,
+    /// so any group in a dead bucket cannot be globally top-K. BUT the
+    /// Final threshold grows as more data arrives, so a bucket that
+    /// looked dead against `hint = 100` early may LATER be alive against
+    /// `hint = 24000`, and the intervening rows are already lost.
+    ///
+    /// A large safety divisor keeps the hint conservative: bucket death
+    /// is rare early, common late. `PARTIAL_HINT_SAFETY_DIVISOR` (default
+    /// 8) gives a `hint = final_threshold / (N × 8)` — with 12 Partials
+    /// and threshold 289K, hint is 3000, so a bucket dies only when its
+    /// max stays below 3000 (for hot URLs, never; for tail URLs, easily
+    /// once remaining shrinks near end of scan).
+    fn store_partial_hint(&self, final_threshold: i64) {
+        if !self.descending {
+            // ASC: Partial gate is disabled (see partial_threshold_hint).
+            return;
+        }
+        let divisor = (self.partial_partition_count as i64)
+            .saturating_mul(PARTIAL_HINT_SAFETY_DIVISOR)
+            .max(1);
+        let candidate = (final_threshold / divisor).max(1);
+        // Monotonic: later publishes must not *lower* the hint. Partial
+        // may already have acted on a smaller value and marked buckets
+        // dead irrevocably.
+        self.partial_threshold
+            .fetch_max(candidate, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Read the current partial-threshold hint. Returns `None` while no
+    /// threshold has been published (`PARTIAL_THRESHOLD_UNSET`), or the
+    /// query direction is ASC (Partial gating is disabled for ASC —
+    /// see [`Self::store_partial_hint`]).
+    pub fn partial_threshold_hint(&self) -> Option<i64> {
+        if !self.descending {
+            return None;
+        }
+        let v = self
+            .partial_threshold
+            .load(std::sync::atomic::Ordering::Relaxed);
+        (v != PARTIAL_THRESHOLD_UNSET).then_some(v)
     }
 }
 
@@ -789,6 +885,11 @@ enum StreamType {
     /// additive aggregates while emitting only the top-K rows and applying a
     /// new-group insertion gate. See [`GroupedTopKCountAggregateStream`].
     GroupedTopKCount(GroupedTopKCountAggregateStream),
+    /// Partial-side stream for the count-TopK optimization. Uses a
+    /// Coarse Aggregate structure to skip rows in "dead" buckets once
+    /// the Final side has published a threshold hint. See
+    /// [`PartialTopKCountAggregateStream`].
+    PartialTopKCount(PartialTopKCountAggregateStream),
 }
 
 impl From<StreamType> for SendableRecordBatchStream {
@@ -804,6 +905,7 @@ impl From<StreamType> for SendableRecordBatchStream {
             StreamType::GroupedHash(stream) => Box::pin(stream),
             StreamType::GroupedPriorityQueue(stream) => Box::pin(stream),
             StreamType::GroupedTopKCount(stream) => Box::pin(stream),
+            StreamType::PartialTopKCount(stream) => Box::pin(stream),
         }
     }
 }
@@ -1044,6 +1146,34 @@ impl AggregateExec {
         }
     }
 
+    /// Clone this exec with a specific `limit_options` **and** an
+    /// externally-supplied [`TopKCountSharedState`]. Used by the
+    /// optimizer to attach the Partial side of a count-TopK to the
+    /// same shared state that the Final side already owns, so both
+    /// sides publish/read the same partial-threshold hint.
+    pub fn with_count_topk_shared(
+        &self,
+        limit_options: Option<LimitOptions>,
+        shared: Arc<TopKCountSharedState>,
+    ) -> Self {
+        Self {
+            limit_options,
+            required_input_ordering: self.required_input_ordering.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+            input_order_mode: self.input_order_mode.clone(),
+            cache: Arc::clone(&self.cache),
+            mode: self.mode,
+            group_by: Arc::clone(&self.group_by),
+            aggr_expr: Arc::clone(&self.aggr_expr),
+            filter_expr: Arc::clone(&self.filter_expr),
+            input: Arc::clone(&self.input),
+            schema: Arc::clone(&self.schema),
+            input_schema: Arc::clone(&self.input_schema),
+            dynamic_filter: self.dynamic_filter.clone(),
+            count_topk_shared: Some(shared),
+        }
+    }
+
     /// Clone this exec, overriding only the limit hint.
     ///
     /// If the new `limit_options` marks a `TopKKind::Count` aggregate and
@@ -1053,12 +1183,24 @@ impl AggregateExec {
     pub fn with_new_limit_options(&self, limit_options: Option<LimitOptions>) -> Self {
         let count_topk_shared = match (limit_options, self.count_topk_shared.as_ref()) {
             (Some(opts), None) if opts.kind == TopKKind::Count => {
-                let num_partitions =
+                // Final side: `cache.output_partitioning` gives the
+                // partition count for the top-K slot vector. The
+                // upstream Partial partition count (used for the
+                // `partial_threshold` divisor) comes from the input
+                // partitioning — Partial preserves its input's
+                // partition count.
+                let num_final_partitions =
                     self.cache.output_partitioning().partition_count().max(1);
+                let partial_partition_count = self
+                    .input
+                    .output_partitioning()
+                    .partition_count()
+                    .max(num_final_partitions);
                 Some(Arc::new(TopKCountSharedState::new(
                     opts.limit,
                     opts.descending.unwrap_or(true),
-                    num_partitions,
+                    num_final_partitions,
+                    partial_partition_count,
                 )))
             }
             (_, prev) => prev.cloned(),
@@ -1362,6 +1504,21 @@ impl AggregateExec {
                                 partition,
                                 config.limit,
                                 config.descending.unwrap_or(true),
+                            )?,
+                        ));
+                    }
+                    // Partial side of the same optimization — gate rows
+                    // in dead buckets before they reach the hash
+                    // aggregation. Only fires when the optimizer has
+                    // attached a `TopKCountSharedState` to this
+                    // AggregateExec (i.e. the walk from Final found
+                    // this Partial).
+                    if matches!(self.mode, AggregateMode::Partial)
+                        && self.count_topk_shared.is_some()
+                    {
+                        return Ok(StreamType::PartialTopKCount(
+                            PartialTopKCountAggregateStream::new(
+                                self, context, partition,
                             )?,
                         ));
                     }

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -235,6 +235,93 @@ pub fn is_topk_count_pattern(agg: &AggregateExec) -> Option<FieldRef> {
     agg.get_count_topk_field()
 }
 
+/// Cross-partition shared state for count-TopK aggregate: lets every
+/// [`GroupedTopKCountAggregateStream`] instance read the current *global*
+/// K-th count and prune more aggressively than its own per-partition
+/// threshold would allow.
+///
+/// # Why global rather than per-partition
+///
+/// `RepartitionExec::Hash([group_keys])` sends each group to exactly one
+/// Final partition, so per-partition top-K is *correct*. But it is far
+/// less selective: with K=10 spread across N partitions, each partition
+/// only holds ~K/N hot groups, and its local K-th count collapses to the
+/// value of ordinary tail groups (typically 1). No group can then be
+/// pruned. Publishing local top-K counts to a global merged list and
+/// reading the global K-th value back solves this — see Section 4 of the
+/// [Zippy paper][zippy] for the analogous cross-thread synchronization
+/// step in their offline algorithm.
+///
+/// # Slot design
+///
+/// Every partition owns one **slot** (`Vec<i64>` of length ≤ `limit`)
+/// into which it *overwrites* its current local top-K on each publish.
+/// The global threshold is computed by concatenating all slots, sorting
+/// in the query direction, and reading the K-th element.
+///
+/// The alternative — a single global list that partitions `extend` into
+/// — is unsound: a partition may publish repeatedly during its scan
+/// (each new-group gate check calls this), and the same "5" would then
+/// appear N times, filling the global top-K with duplicates and driving
+/// the threshold above any other partition's real counts.
+///
+/// [zippy]: https://www.vldb.org/pvldb/vol17/p644-siddiqui.pdf
+#[derive(Debug)]
+pub struct TopKCountSharedState {
+    /// `slots[i]` is partition `i`'s most-recently-published local top-K
+    /// (empty until the partition publishes).
+    slots: std::sync::Mutex<Vec<Vec<i64>>>,
+    limit: usize,
+    descending: bool,
+}
+
+impl TopKCountSharedState {
+    pub fn new(limit: usize, descending: bool, num_partitions: usize) -> Self {
+        Self {
+            slots: std::sync::Mutex::new(vec![Vec::new(); num_partitions]),
+            limit,
+            descending,
+        }
+    }
+
+    /// Overwrite partition `partition_idx`'s slot with the given local
+    /// top-K counts, then return the resulting global K-th value if the
+    /// merged concatenation has ≥ `limit` counts; otherwise `None`.
+    pub fn publish(&self, partition_idx: usize, local_top_counts: &[i64]) -> Option<i64> {
+        let mut slots = self.slots.lock().ok()?;
+        if partition_idx >= slots.len() {
+            return None;
+        }
+        slots[partition_idx].clear();
+        slots[partition_idx].extend_from_slice(local_top_counts);
+        self.compute_threshold(&slots)
+    }
+
+    /// Snapshot the current global K-th value (`None` if fewer than
+    /// `limit` counts have been contributed globally).
+    pub fn threshold(&self) -> Option<i64> {
+        let slots = self.slots.lock().ok()?;
+        self.compute_threshold(&slots)
+    }
+
+    fn compute_threshold(&self, slots: &[Vec<i64>]) -> Option<i64> {
+        let mut all: Vec<i64> = slots.iter().flatten().copied().collect();
+        if all.len() < self.limit {
+            return None;
+        }
+        // Partial-select: k-th largest for DESC, k-th smallest for ASC.
+        // Uses `select_nth_unstable` (O(N)) which is sufficient given the
+        // small size of `all` (≤ limit * num_partitions ~ hundreds).
+        let k = self.limit - 1;
+        let (_, kth, _) = if self.descending {
+            all.select_nth_unstable_by(k, |a, b| b.cmp(a))
+        } else {
+            all.select_nth_unstable_by(k, |a, b| a.cmp(b))
+        };
+        Some(*kth)
+    }
+}
+
 /// Hard-coded seed for aggregations to ensure hash values differ from `RepartitionExec`, avoiding collisions.
 const AGGREGATION_HASH_SEED: datafusion_common::hash_utils::RandomState =
     // This seed is chosen to be a large 64-bit number
@@ -919,6 +1006,15 @@ pub struct AggregateExec {
     /// it remains `Some(..)` to enable dynamic filtering during aggregate execution;
     /// otherwise, it is cleared to `None`.
     dynamic_filter: Option<Arc<AggrDynFilter>>,
+    /// Shared state across all partition streams when
+    /// `limit_options.kind == TopKKind::Count`. Every partition publishes
+    /// its local top-K counts and reads back the global K-th value to use
+    /// as the gate/sweep threshold. See [`TopKCountSharedState`].
+    ///
+    /// `None` for every non-Count-TopK aggregate. Initialized (`Some`)
+    /// by `TopKAggregation::transform_agg` when it marks a Count TopK
+    /// aggregate. Clones inherit the same `Arc`.
+    count_topk_shared: Option<Arc<TopKCountSharedState>>,
 }
 
 impl AggregateExec {
@@ -944,11 +1040,29 @@ impl AggregateExec {
             schema: Arc::clone(&self.schema),
             input_schema: Arc::clone(&self.input_schema),
             dynamic_filter: self.dynamic_filter.clone(),
+            count_topk_shared: self.count_topk_shared.clone(),
         }
     }
 
     /// Clone this exec, overriding only the limit hint.
+    ///
+    /// If the new `limit_options` marks a `TopKKind::Count` aggregate and
+    /// this instance did not already carry a shared state, allocate one
+    /// eagerly — every partition stream will get an [`Arc`] to it via
+    /// [`Self::count_topk_shared`].
     pub fn with_new_limit_options(&self, limit_options: Option<LimitOptions>) -> Self {
+        let count_topk_shared = match (limit_options, self.count_topk_shared.as_ref()) {
+            (Some(opts), None) if opts.kind == TopKKind::Count => {
+                let num_partitions =
+                    self.cache.output_partitioning().partition_count().max(1);
+                Some(Arc::new(TopKCountSharedState::new(
+                    opts.limit,
+                    opts.descending.unwrap_or(true),
+                    num_partitions,
+                )))
+            }
+            (_, prev) => prev.cloned(),
+        };
         Self {
             limit_options,
             // clone the rest of the fields
@@ -964,6 +1078,7 @@ impl AggregateExec {
             schema: Arc::clone(&self.schema),
             input_schema: Arc::clone(&self.input_schema),
             dynamic_filter: self.dynamic_filter.clone(),
+            count_topk_shared,
         }
     }
 
@@ -1099,6 +1214,7 @@ impl AggregateExec {
             input_order_mode,
             cache: Arc::new(cache),
             dynamic_filter: None,
+            count_topk_shared: None,
         };
 
         exec.init_dynamic_filter();
@@ -1409,6 +1525,13 @@ impl AggregateExec {
     pub fn get_minmax_desc(&self) -> Option<(FieldRef, bool)> {
         let agg_expr = self.aggr_expr.iter().exactly_one().ok()?;
         agg_expr.get_minmax_desc()
+    }
+
+    /// Returns the cross-partition shared state used by the count-TopK
+    /// stream, or `None` for aggregates that are not marked as
+    /// [`TopKKind::Count`]. See [`TopKCountSharedState`].
+    pub fn count_topk_shared(&self) -> Option<&Arc<TopKCountSharedState>> {
+        self.count_topk_shared.as_ref()
     }
 
     /// If this aggregate is a single, non-distinct `count(*)` or `count(col)`

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -1507,21 +1507,17 @@ impl AggregateExec {
                             )?,
                         ));
                     }
-                    // Partial side of the same optimization — gate rows
-                    // in dead buckets before they reach the hash
-                    // aggregation. Only fires when the optimizer has
-                    // attached a `TopKCountSharedState` to this
-                    // AggregateExec (i.e. the walk from Final found
-                    // this Partial).
-                    if matches!(self.mode, AggregateMode::Partial)
-                        && self.count_topk_shared.is_some()
-                    {
-                        return Ok(StreamType::PartialTopKCount(
-                            PartialTopKCountAggregateStream::new(
-                                self, context, partition,
-                            )?,
-                        ));
-                    }
+                    // Partial side of the same optimization — TEMPORARILY
+                    // DISABLED to isolate correctness bug.
+                    // if matches!(self.mode, AggregateMode::Partial)
+                    //     && self.count_topk_shared.is_some()
+                    // {
+                    //     return Ok(StreamType::PartialTopKCount(
+                    //         PartialTopKCountAggregateStream::new(
+                    //             self, context, partition,
+                    //         )?,
+                    //     ));
+                    // }
                     // fallthrough to standard path
                 }
             }

--- a/datafusion/physical-plan/src/aggregates/partial_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/partial_topk_count_stream.rs
@@ -344,7 +344,8 @@ impl PartialTopKCountAggregateStream {
             return Ok(RecordBatch::new_empty(Arc::clone(&self.output_schema)));
         }
 
-        // Live indices only.
+        // Live indices only — skip groups whose bucket has been marked
+        // dead by the sweep. `Vec::extend` iterates once.
         let mut live_indices: Vec<u32> = Vec::with_capacity(self.counts.len());
         for i in 0..self.counts.len() {
             let bkt = self.bucket_of_group[i] as usize;

--- a/datafusion/physical-plan/src/aggregates/partial_topk_count_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/partial_topk_count_stream.rs
@@ -1,0 +1,418 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Partial-side Zippy-lite for `SELECT g, count(*) FROM t GROUP BY g
+//! ORDER BY count(*) DESC LIMIT K`.
+//!
+//! # Role
+//!
+//! The Final side ([`GroupedTopKCountAggregateStream`]) publishes a
+//! **partial-threshold hint** into the shared [`TopKCountSharedState`]
+//! as soon as it has seen ≥ K groups. Any Partial aggregate reading
+//! that hint can safely drop rows whose bucket's `max_count` cannot
+//! grow above `hint`, because the sum-across-Partials bound
+//! `N × hint < final_threshold` (with `hint = final_threshold / (N+1)`)
+//! guarantees the group cannot be globally top-K.
+//!
+//! This directly attacks the biggest cost on ClickBench Q33: Partial's
+//! main hash table growing to ~18M entries. Once the hint arrives and
+//! long-tail buckets are marked dead, most future scan rows never
+//! touch the main hash table.
+//!
+//! # Coarse Aggregate structure (Zippy §4.1.1)
+//!
+//! Group keys hash into `CA_BUCKETS` (8192) coarse buckets. Each
+//! bucket keeps `max_count` — the largest count of any single group
+//! that currently lives in the bucket. When the shared hint is
+//! available, we sweep the buckets: if `max_count + remaining < hint`
+//! for a bucket, no group in it can reach `hint` → mark the bucket
+//! dead → future rows hashing to this bucket are skipped.
+//!
+//! # Correctness
+//!
+//! Let `N` be the number of Partial partitions and `T` the current
+//! Final global top-K threshold. We publish `hint = T / (N+1)` into
+//! the shared state. If Partial marks bucket B dead:
+//! - All groups Y in B have local count ≤ `max_count(B) < hint`.
+//! - After dead we do not increment any Y.
+//! - So each Y's local count in this Partial stays `< hint`.
+//! - Sum across all N Partials: `Σ local ≤ N × hint < T`.
+//! - Any group `Y` with global total `≥ T` therefore had at least one
+//!   Partial with local count `≥ hint` — in that Partial, the bucket
+//!   was kept LIVE and Y's contribution was fully captured.
+//!
+//! [`GroupedTopKCountAggregateStream`]: crate::aggregates::grouped_topk_count_stream::GroupedTopKCountAggregateStream
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::array::{ArrayRef, Int64Builder, RecordBatch, UInt32Array};
+use arrow::compute::take;
+use arrow::datatypes::SchemaRef;
+use datafusion_common::hash_utils::{RandomState, create_hashes};
+use datafusion_common::{Result, stats::Precision};
+use datafusion_execution::TaskContext;
+use datafusion_expr::EmitTo;
+use futures::stream::{Stream, StreamExt};
+
+use crate::aggregates::group_values::{GroupValues, new_group_values};
+use crate::aggregates::order::GroupOrdering;
+use crate::aggregates::{
+    AggregateExec, CA_BUCKETS, TopKCountSharedState, evaluate_group_by,
+};
+use crate::metrics::{BaselineMetrics, Count, MetricBuilder};
+use crate::stream::EmptyRecordBatchStream;
+use crate::{RecordBatchStream, SendableRecordBatchStream};
+
+/// Sweep bucket dead-set every this-many input rows.
+const BUCKET_SWEEP_INTERVAL_ROWS: u64 = 8_192;
+
+/// Deterministic hash seed for the CA bucket index. Chosen distinct
+/// from `AGGREGATION_HASH_SEED` so groups that happen to collide in the
+/// main hash aggregation don't systematically co-cluster in the CA.
+const CA_HASH_SEED: RandomState = RandomState::with_seed(6215194318907240811_u64);
+
+pub struct PartialTopKCountAggregateStream {
+    // --- Input ------------------------------------------------------------
+    input: SendableRecordBatchStream,
+    group_by: Arc<crate::aggregates::PhysicalGroupBy>,
+
+    // --- Group-key hash ---------------------------------------------------
+    group_values: Box<dyn GroupValues>,
+    groups_scratch: Vec<usize>,
+    /// Reused per-batch hash buffer for computing CA bucket indices.
+    ca_hash_buffer: Vec<u64>,
+
+    // --- Per-group aggregate state ---------------------------------------
+    counts: Vec<i64>,
+    /// Parallel to `counts`: `bucket_of_group[i]` is the CA bucket index
+    /// the group hashed into when first observed.
+    bucket_of_group: Vec<u16>,
+
+    // --- CA (Zippy-style Coarse Aggregate) -------------------------------
+    /// Largest single-group count currently living in each bucket. When
+    /// the shared hint is available and this value + remaining rows in
+    /// the partition cannot reach it, we mark the bucket dead. Held on
+    /// the heap (`Vec`) because `[i64; 8192]` on the stack would
+    /// overflow when the stream is constructed.
+    bucket_max: Vec<i64>,
+    /// One-way flag: once a bucket is dead, future rows into it are
+    /// skipped entirely (no main-hash insert, no count update). Also
+    /// heap-allocated (see `bucket_max`).
+    bucket_dead: Vec<bool>,
+
+    // --- Progress ---------------------------------------------------------
+    rows_seen: u64,
+    /// Upper bound on rows still to arrive at this Partial partition.
+    /// From `input.statistics().num_rows`. `None` disables the sweep.
+    total_input_rows: Option<u64>,
+    rows_since_sweep: u64,
+    input_done: bool,
+
+    // --- Shared cross-op state -------------------------------------------
+    shared: Arc<TopKCountSharedState>,
+    /// Cached snapshot of `shared.partial_threshold_hint()`. Refreshed
+    /// once per sweep. Per-row loads of an `AtomicI64` cause enough
+    /// bus traffic to matter on 100M-row scans, so we cache.
+    cached_hint: Option<i64>,
+
+    // --- Output ----------------------------------------------------------
+    output_schema: SchemaRef,
+    emitted: bool,
+
+    // --- Metrics ---------------------------------------------------------
+    baseline_metrics: BaselineMetrics,
+    partial_ca_rows_gated: Count,
+    partial_ca_buckets_dead: Count,
+    partial_ca_sweeps: Count,
+}
+
+impl PartialTopKCountAggregateStream {
+    pub fn new(
+        agg: &AggregateExec,
+        context: &Arc<TaskContext>,
+        partition: usize,
+    ) -> Result<Self> {
+        let output_schema = Arc::clone(&agg.schema);
+        let group_by = Arc::clone(&agg.group_by);
+        let input = agg.input.execute(partition, Arc::clone(context))?;
+        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+
+        let group_schema = group_by.group_schema(&agg.input.schema())?;
+        let group_ordering = GroupOrdering::None;
+        let group_values = new_group_values(group_schema, &group_ordering)?;
+
+        let shared = agg
+            .count_topk_shared()
+            .cloned()
+            .expect("PartialTopKCountAggregateStream requires shared state");
+
+        let total_input_rows = {
+            use crate::statistics::{StatisticsArgs, StatisticsContext};
+            let ctx = StatisticsContext::new();
+            let args = StatisticsArgs::new().with_partition(Some(partition));
+            match ctx.compute(agg.input.as_ref(), &args) {
+                Ok(stats) => match stats.num_rows {
+                    Precision::Exact(n) | Precision::Inexact(n) => Some(n as u64),
+                    Precision::Absent => None,
+                },
+                Err(_) => None,
+            }
+        };
+
+        let mb = |name: &'static str| {
+            MetricBuilder::new(&agg.metrics).counter(name, partition)
+        };
+        let partial_ca_rows_gated = mb("partial_ca_rows_gated");
+        let partial_ca_buckets_dead = mb("partial_ca_buckets_dead");
+        let partial_ca_sweeps = mb("partial_ca_sweeps");
+
+        Ok(Self {
+            input,
+            group_by,
+            group_values,
+            groups_scratch: Vec::new(),
+            ca_hash_buffer: Vec::new(),
+            counts: Vec::new(),
+            bucket_of_group: Vec::new(),
+            bucket_max: vec![0; CA_BUCKETS],
+            bucket_dead: vec![false; CA_BUCKETS],
+            rows_seen: 0,
+            total_input_rows,
+            rows_since_sweep: 0,
+            input_done: false,
+            shared,
+            cached_hint: None,
+            output_schema,
+            emitted: false,
+            baseline_metrics,
+            partial_ca_rows_gated,
+            partial_ca_buckets_dead,
+            partial_ca_sweeps,
+        })
+    }
+
+    fn ingest(&mut self, batch: &RecordBatch) -> Result<()> {
+        let num_rows = batch.num_rows();
+        if num_rows == 0 {
+            return Ok(());
+        }
+
+        // Evaluate group-by expressions.
+        let group_cols_all = evaluate_group_by(&self.group_by, batch)?;
+        assert_eq!(group_cols_all.len(), 1);
+        let group_cols = &group_cols_all[0];
+
+        // Compute per-row CA bucket index using a hash distinct from the
+        // main aggregation hash. This lets us test bucket-dead BEFORE
+        // paying the cost of `GroupValues::intern` for the row.
+        self.ca_hash_buffer.clear();
+        self.ca_hash_buffer.resize(num_rows, 0);
+        create_hashes(group_cols, &CA_HASH_SEED, &mut self.ca_hash_buffer)?;
+
+        // First pass: build a keep-mask by bucket_dead lookup. This is
+        // O(num_rows) with a cache-friendly access pattern.
+        let hint_available = self.cached_hint.is_some();
+        let mut kept_indices: Vec<u32> = Vec::with_capacity(num_rows);
+        if hint_available {
+            let mut gated = 0u64;
+            for row in 0..num_rows {
+                let bkt = (self.ca_hash_buffer[row] as usize) % CA_BUCKETS;
+                if self.bucket_dead[bkt] {
+                    gated += 1;
+                } else {
+                    kept_indices.push(row as u32);
+                }
+            }
+            if gated > 0 {
+                self.partial_ca_rows_gated.add(gated as usize);
+            }
+        } else {
+            kept_indices.extend(0..num_rows as u32);
+        }
+
+        if kept_indices.is_empty() {
+            self.rows_seen = self.rows_seen.saturating_add(num_rows as u64);
+            self.rows_since_sweep = self.rows_since_sweep.saturating_add(num_rows as u64);
+            self.maybe_sweep();
+            return Ok(());
+        }
+
+        // Take the kept rows for group-by column materialization. If we
+        // kept everything, avoid the take by using the original arrays.
+        let taken_cols: Vec<ArrayRef> = if kept_indices.len() == num_rows {
+            group_cols.clone()
+        } else {
+            let indices = UInt32Array::from(kept_indices.clone());
+            group_cols
+                .iter()
+                .map(|c| take(c.as_ref(), &indices, None))
+                .collect::<std::result::Result<_, _>>()?
+        };
+
+        // Intern the kept rows only.
+        self.group_values
+            .intern(&taken_cols, &mut self.groups_scratch)?;
+
+        // Fold counts + bucket_max.
+        for (out_row, orig_row) in kept_indices.iter().enumerate() {
+            let group_idx = self.groups_scratch[out_row];
+            if group_idx >= self.counts.len() {
+                debug_assert_eq!(group_idx, self.counts.len());
+                self.counts.push(0);
+                let bkt = (self.ca_hash_buffer[*orig_row as usize] as usize) % CA_BUCKETS;
+                self.bucket_of_group.push(bkt as u16);
+            }
+            let new_count = self.counts[group_idx].saturating_add(1);
+            self.counts[group_idx] = new_count;
+            let bkt = self.bucket_of_group[group_idx] as usize;
+            if new_count > self.bucket_max[bkt] {
+                self.bucket_max[bkt] = new_count;
+            }
+        }
+
+        self.rows_seen = self.rows_seen.saturating_add(num_rows as u64);
+        self.rows_since_sweep = self.rows_since_sweep.saturating_add(num_rows as u64);
+        self.maybe_sweep();
+        Ok(())
+    }
+
+    fn maybe_sweep(&mut self) {
+        if self.rows_since_sweep < BUCKET_SWEEP_INTERVAL_ROWS && !self.input_done {
+            return;
+        }
+        self.sweep();
+    }
+
+    fn sweep(&mut self) {
+        self.rows_since_sweep = 0;
+        self.partial_ca_sweeps.add(1);
+        // Refresh the hint cache from the (relaxed-atomic) shared state.
+        self.cached_hint = self.shared.partial_threshold_hint();
+        let Some(hint) = self.cached_hint else {
+            return;
+        };
+        let remaining = if self.input_done {
+            0
+        } else {
+            self.total_input_rows
+                .map(|t| t.saturating_sub(self.rows_seen))
+                .unwrap_or(u64::MAX)
+        };
+        let remaining_i64 = if remaining > i64::MAX as u64 {
+            i64::MAX
+        } else {
+            remaining as i64
+        };
+        let mut new_dead = 0u64;
+        for bkt in 0..CA_BUCKETS {
+            if self.bucket_dead[bkt] {
+                continue;
+            }
+            let max = self.bucket_max[bkt];
+            if max.saturating_add(remaining_i64) < hint {
+                self.bucket_dead[bkt] = true;
+                new_dead += 1;
+            }
+        }
+        if new_dead > 0 {
+            self.partial_ca_buckets_dead.add(new_dead as usize);
+        }
+    }
+
+    /// Build the output batch of `(group_cols…, partial_count)` rows.
+    /// Skips groups whose bucket has been marked dead — their local
+    /// counts are stale and their global contribution is provably below
+    /// the top-K threshold.
+    fn build_output(&mut self) -> Result<RecordBatch> {
+        if self.counts.is_empty() {
+            return Ok(RecordBatch::new_empty(Arc::clone(&self.output_schema)));
+        }
+
+        // Live indices only.
+        let mut live_indices: Vec<u32> = Vec::with_capacity(self.counts.len());
+        for i in 0..self.counts.len() {
+            let bkt = self.bucket_of_group[i] as usize;
+            if !self.bucket_dead[bkt] {
+                live_indices.push(i as u32);
+            }
+        }
+
+        // Materialize all group keys via GroupValues::emit, then filter.
+        let group_key_cols = self.group_values.emit(EmitTo::All)?;
+        let indices = UInt32Array::from(live_indices);
+        let mut cols: Vec<ArrayRef> = Vec::with_capacity(group_key_cols.len() + 1);
+        for c in &group_key_cols {
+            cols.push(take(c.as_ref(), &indices, None)?);
+        }
+        // Emit the filtered counts as an Int64 array.
+        let mut count_builder = Int64Builder::with_capacity(indices.len());
+        for &row in indices.values().iter() {
+            count_builder.append_value(self.counts[row as usize]);
+        }
+        cols.push(Arc::new(count_builder.finish()));
+
+        Ok(RecordBatch::try_new(Arc::clone(&self.output_schema), cols)?)
+    }
+}
+
+impl RecordBatchStream for PartialTopKCountAggregateStream {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.output_schema)
+    }
+}
+
+impl Stream for PartialTopKCountAggregateStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        if self.emitted {
+            return Poll::Ready(None);
+        }
+        let elapsed = self.baseline_metrics.elapsed_compute().clone();
+        while !self.input_done {
+            match self.input.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(batch))) => {
+                    let _timer = elapsed.timer();
+                    self.ingest(&batch)?;
+                }
+                Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
+                Poll::Ready(None) => {
+                    self.input_done = true;
+                    let schema = self.input.schema();
+                    self.input = Box::pin(EmptyRecordBatchStream::new(schema));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        let _timer = elapsed.timer();
+        // Final sweep — with `remaining = 0` it may mark previously-live
+        // buckets dead and further reduce the emitted row count.
+        self.sweep();
+        let out = self.build_output()?;
+        self.emitted = true;
+        if out.num_rows() == 0 {
+            Poll::Ready(None)
+        } else {
+            Poll::Ready(Some(Ok(out)))
+        }
+    }
+}

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -708,12 +708,15 @@ b 3
 ## `exactly_one` group expression for this path.
 ##
 
+# All (url, ts) pairs have count=1 (unique), so use secondary sort keys
+# to get deterministic tie-break.
 query TII
-select url, ts, count(*) from hits group by url, ts order by count(*) desc limit 3;
+select url, ts, count(*) from hits group by url, ts
+    order by count(*) desc, url asc nulls last, ts asc limit 3;
 ----
-a 5 1
+a 1 1
+a 2 1
 a 3 1
-a 4 1
 
 # EXPLAIN: the multi-column FinalPartitioned aggregate now carries lim=[3]
 query TT

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -700,6 +700,39 @@ a 5
 c 4
 b 3
 
+##
+## Multi-column GROUP BY with count(*) — covers ClickBench Q14/Q34/Q35.
+##
+## The count-topk stream uses `GroupValues` for hashing so any group-
+## column combination works; the optimizer no longer requires
+## `exactly_one` group expression for this path.
+##
+
+query TII
+select url, ts, count(*) from hits group by url, ts order by count(*) desc limit 3;
+----
+a 5 1
+a 3 1
+a 4 1
+
+# EXPLAIN: the multi-column FinalPartitioned aggregate now carries lim=[3]
+query TT
+explain select url, ts, count(*) from hits group by url, ts order by count(*) desc limit 3;
+----
+logical_plan
+01)Sort: count(*) DESC NULLS FIRST, fetch=3
+02)--Projection: hits.url, hits.ts, count(Int64(1)) AS count(*)
+03)----Aggregate: groupBy=[[hits.url, hits.ts]], aggr=[[count(Int64(1))]]
+04)------TableScan: hits projection=[url, ts]
+physical_plan
+01)SortPreservingMergeExec: [count(*)@2 DESC], fetch=3
+02)--ProjectionExec: expr=[url@0 as url, ts@1 as ts, count(Int64(1))@2 as count(*)]
+03)----SortExec: TopK(fetch=3), expr=[count(Int64(1))@2 DESC], preserve_partitioning=[true]
+04)------AggregateExec: mode=FinalPartitioned, gby=[url@0 as url, ts@1 as ts], aggr=[count(Int64(1))], lim=[3]
+05)--------RepartitionExec: partitioning=Hash([url@0, ts@1], 4), input_partitions=1
+06)----------AggregateExec: mode=Partial, gby=[url@0 as url, ts@1 as ts], aggr=[count(Int64(1))]
+07)------------DataSourceExec: partitions=1, partition_sizes=[1]
+
 statement ok
 drop table hits;
 

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -650,7 +650,7 @@ physical_plan
 03)----SortExec: TopK(fetch=3), expr=[count(Int64(1))@1 DESC], preserve_partitioning=[true]
 04)------AggregateExec: mode=FinalPartitioned, gby=[url@0 as url], aggr=[count(Int64(1))], lim=[3]
 05)--------RepartitionExec: partitioning=Hash([url@0], 4), input_partitions=1
-06)----------AggregateExec: mode=Partial, gby=[url@0 as url], aggr=[count(Int64(1))], lim=[3]
+06)----------AggregateExec: mode=Partial, gby=[url@0 as url], aggr=[count(Int64(1))]
 07)------------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # same result with the optimizer enabled
@@ -733,7 +733,7 @@ physical_plan
 03)----SortExec: TopK(fetch=3), expr=[count(Int64(1))@2 DESC], preserve_partitioning=[true]
 04)------AggregateExec: mode=FinalPartitioned, gby=[url@0 as url, ts@1 as ts], aggr=[count(Int64(1))], lim=[3]
 05)--------RepartitionExec: partitioning=Hash([url@0, ts@1], 4), input_partitions=1
-06)----------AggregateExec: mode=Partial, gby=[url@0 as url, ts@1 as ts], aggr=[count(Int64(1))], lim=[3]
+06)----------AggregateExec: mode=Partial, gby=[url@0 as url, ts@1 as ts], aggr=[count(Int64(1))]
 07)------------DataSourceExec: partitions=1, partition_sizes=[1]
 
 statement ok

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -583,5 +583,125 @@ drop table values_table;
 statement ok
 drop table ids;
 
+##
+## count(*) / count(col) ORDER BY count(...) DESC/ASC LIMIT K
+##
+## Dandandan proposed this optimization in PR #21580 (2026-04-17) and the
+## Microsoft "Zippy" VLDB'24 paper shows 2-10x gains on similar patterns.
+## Implementation lives in GroupedTopKCountAggregateStream.
+##
+
+statement ok
+CREATE TABLE hits(url varchar, ts bigint) AS VALUES
+('a', 1),  ('a', 2),  ('a', 3),  ('a', 4),  ('a', 5),
+('b', 1),  ('b', 2),  ('b', 3),
+('c', 1),  ('c', 2),  ('c', 3),  ('c', 4),
+('d', 1),  ('d', 2),
+('e', 1),
+(NULL, 1);
+
+# baseline: optimizer disabled — plan uses SortExec above the aggregate
+statement ok
+set datafusion.optimizer.enable_topk_aggregation = false;
+
+query TT
+explain select url, count(*) from hits group by url order by count(*) desc limit 3;
+----
+logical_plan
+01)Sort: count(*) DESC NULLS FIRST, fetch=3
+02)--Projection: hits.url, count(Int64(1)) AS count(*)
+03)----Aggregate: groupBy=[[hits.url]], aggr=[[count(Int64(1))]]
+04)------TableScan: hits projection=[url]
+physical_plan
+01)SortPreservingMergeExec: [count(*)@1 DESC], fetch=3
+02)--ProjectionExec: expr=[url@0 as url, count(Int64(1))@1 as count(*)]
+03)----SortExec: TopK(fetch=3), expr=[count(Int64(1))@1 DESC], preserve_partitioning=[true]
+04)------AggregateExec: mode=FinalPartitioned, gby=[url@0 as url], aggr=[count(Int64(1))]
+05)--------RepartitionExec: partitioning=Hash([url@0], 4), input_partitions=1
+06)----------AggregateExec: mode=Partial, gby=[url@0 as url], aggr=[count(Int64(1))]
+07)------------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# baseline result
+query TI
+select url, count(*) from hits group by url order by count(*) desc limit 3;
+----
+a 5
+c 4
+b 3
+
+statement ok
+set datafusion.optimizer.enable_topk_aggregation = true;
+
+# with the optimizer enabled, the FinalPartitioned aggregate is marked lim=[3]
+# so the count-topk stream can select K without the parent SortExec doing so.
+# The physical shape still contains SortPreservingMerge / SortExec because
+# the plan-level rewrite preserves them; the aggregate itself now shortcuts.
+query TT
+explain select url, count(*) from hits group by url order by count(*) desc limit 3;
+----
+logical_plan
+01)Sort: count(*) DESC NULLS FIRST, fetch=3
+02)--Projection: hits.url, count(Int64(1)) AS count(*)
+03)----Aggregate: groupBy=[[hits.url]], aggr=[[count(Int64(1))]]
+04)------TableScan: hits projection=[url]
+physical_plan
+01)SortPreservingMergeExec: [count(*)@1 DESC], fetch=3
+02)--ProjectionExec: expr=[url@0 as url, count(Int64(1))@1 as count(*)]
+03)----SortExec: TopK(fetch=3), expr=[count(Int64(1))@1 DESC], preserve_partitioning=[true]
+04)------AggregateExec: mode=FinalPartitioned, gby=[url@0 as url], aggr=[count(Int64(1))], lim=[3]
+05)--------RepartitionExec: partitioning=Hash([url@0], 4), input_partitions=1
+06)----------AggregateExec: mode=Partial, gby=[url@0 as url], aggr=[count(Int64(1))]
+07)------------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# same result with the optimizer enabled
+query TI
+select url, count(*) from hits group by url order by count(*) desc limit 3;
+----
+a 5
+c 4
+b 3
+
+# ORDER BY count ASC LIMIT K — pick the K smallest
+query TI
+select url, count(*) from hits group by url order by count(*) asc limit 3;
+----
+NULL 1
+e 1
+d 2
+
+# LIMIT > number of distinct groups: emit all groups, still ordered by count.
+# Secondary ORDER BY url so the two groups with count=1 sort deterministically.
+query TI
+select url, count(*) from hits group by url order by count(*) desc, url asc nulls last limit 100;
+----
+a 5
+c 4
+b 3
+d 2
+e 1
+NULL 1
+
+# count(col) — NULL rows in `ts` should NOT contribute to the count.
+# 'a' has 5 non-NULL ts, 'b' 3, ... same as count(*) here because our data
+# has no NULL ts for the non-NULL urls.
+query TI
+select url, count(ts) from hits group by url order by count(ts) desc limit 3;
+----
+a 5
+c 4
+b 3
+
+# DISTINCT count is NOT eligible for this optimization; verify it still
+# works (falls through to standard hash aggregate + SortExec)
+query TI
+select url, count(distinct ts) from hits group by url order by count(distinct ts) desc limit 3;
+----
+a 5
+c 4
+b 3
+
+statement ok
+drop table hits;
+
 statement ok
 drop table traces;

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -650,7 +650,7 @@ physical_plan
 03)----SortExec: TopK(fetch=3), expr=[count(Int64(1))@1 DESC], preserve_partitioning=[true]
 04)------AggregateExec: mode=FinalPartitioned, gby=[url@0 as url], aggr=[count(Int64(1))], lim=[3]
 05)--------RepartitionExec: partitioning=Hash([url@0], 4), input_partitions=1
-06)----------AggregateExec: mode=Partial, gby=[url@0 as url], aggr=[count(Int64(1))]
+06)----------AggregateExec: mode=Partial, gby=[url@0 as url], aggr=[count(Int64(1))], lim=[3]
 07)------------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # same result with the optimizer enabled
@@ -733,7 +733,7 @@ physical_plan
 03)----SortExec: TopK(fetch=3), expr=[count(Int64(1))@2 DESC], preserve_partitioning=[true]
 04)------AggregateExec: mode=FinalPartitioned, gby=[url@0 as url, ts@1 as ts], aggr=[count(Int64(1))], lim=[3]
 05)--------RepartitionExec: partitioning=Hash([url@0, ts@1], 4), input_partitions=1
-06)----------AggregateExec: mode=Partial, gby=[url@0 as url, ts@1 as ts], aggr=[count(Int64(1))]
+06)----------AggregateExec: mode=Partial, gby=[url@0 as url, ts@1 as ts], aggr=[count(Int64(1))], lim=[3]
 07)------------DataSourceExec: partitions=1, partition_sizes=[1]
 
 statement ok

--- a/datafusion/sqllogictest/test_files/aggregates_topk.slt
+++ b/datafusion/sqllogictest/test_files/aggregates_topk.slt
@@ -703,5 +703,44 @@ b 3
 statement ok
 drop table hits;
 
+##
+## Long-tail scenario exercising the new-group gate and periodic sweep.
+##
+## Data shape: 5 "hot" groups with count = 100 each, plus 200 "long tail"
+## groups each with count = 1. Total rows = 5*100 + 200 = 700. With
+## LIMIT 3 the top-K threshold quickly reaches 100; every long-tail
+## group's max final count (1 + remaining ≤ 700) is initially > 100 so
+## it's NOT immediately gated, but after warm-up + sweep the remaining
+## bound tightens enough that new tail groups get gated.
+##
+
+statement ok
+CREATE TABLE longtail(g bigint) AS
+    SELECT unnest([1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                   2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                   3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                   4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                   5, 5, 5, 5, 5, 5, 5, 5, 5, 5])
+    UNION ALL SELECT * FROM generate_series(10, 209);
+
+# Sanity check: top-3 by count
+query II
+select g, count(*) from longtail group by g order by count(*) desc, g asc limit 3;
+----
+1 10
+2 10
+3 10
+
+# Long-tail groups still return the smallest counts under ASC
+query II
+select g, count(*) from longtail group by g order by count(*) asc, g asc limit 3;
+----
+10 1
+11 1
+12 1
+
+statement ok
+drop table longtail;
+
 statement ok
 drop table traces;


### PR DESCRIPTION
## References (upfront)

- **Paper** — Siddiqui et al., *"Cache-Efficient Top-k Aggregation over High Cardinality Large Datasets"*, VLDB'24: https://www.vldb.org/pvldb/vol17/p644-siddiqui.pdf — the algorithmic template. Reports **14× COUNT speedups** (Table 2) offline; this PR is a single-pass streaming adaptation.
- **Dandandan's proposal on #21580** (2026-04-17): https://github.com/apache/datafusion/pull/21580#issuecomment-2812810017 — same optimization idea, ClickBench-oriented.
- **DuckDB gap** (documented, no equivalent optimization): https://duckdb.org/2024/10/25/topn — DataFusion would be first in the ecosystem to have this.

## Which issue does this PR close?

Draft — cites @Dandandan's proposal above and closes an open
ClickBench-Q12/Q14/Q33/Q34/Q35 optimization gap. If the direction is
agreeable, will open a proper tracking issue and link.

## Rationale for this change

`SELECT g, count(*) FROM t GROUP BY g ORDER BY count(*) DESC LIMIT K`
is a hot ClickBench pattern (Q12 SearchPhrase, Q33 URL, Q14/Q34/Q35
multi-column variants) and dominates end-to-end time on high-cardinality
data (~40M distinct URLs in `hits.parquet`). Neither DataFusion nor
DuckDB optimize it today; both fall back to full sort of all groups.

Dandandan's original framing:

> Currently many queries go like Scan → Filter → Aggregate(Partial) →
> Aggregate(Final) → TopK … Needs to first go through the full
> aggregation before it reaches TopK. **We can update bounds from
> aggregate, once we detect at least K distinct rows in a Partial
> aggregate. In practice it would mean after the first batch / batches
> arrive we already have e.g. 10 rows, so can already prune / filter
> with the much tighter bound.**

## What changes are included in this PR?

### Optimizer (`physical-optimizer/src/topk_aggregation.rs`)

`TopKAggregation::transform_agg` was previously MIN/MAX-only. Extended
to recognize `count(*)`/`count(col)` (non-distinct, unfiltered, **single
OR multi-column** GROUP BY) at
`Final`/`FinalPartitioned`/`Single`/`SinglePartitioned` mode, marking
the aggregate with `LimitOptions::new_count(K, desc)`.

### `AggregateExec` (`physical-plan/src/aggregates/mod.rs`)

- `TopKKind::{MinMaxOrDistinct, Count}` on `LimitOptions` distinguishes
  the safe capacity-K `PriorityMap` path from a new streaming path that
  must keep an unbounded hash table.
- New `TopKCountSharedState`: a per-partition slot vector into which
  each Final partition publishes its local top-K counts and reads back
  the global K-th value. Slot semantics (overwrite, not append) avoid
  the duplicate-inflation bug that a naive `Vec::extend` implementation
  hit.
- `execute_typed` routes `TopKKind::Count` to the new stream.

### `GroupedTopKCountAggregateStream` (~500 LOC, new file)

Streaming Zippy-lite:

1. **Hash + count**: `GroupValues::intern` (any group-by column type or
   combination) → `Vec<i64>` counts indexed by group_index.
   `Vec<bool>` `dead` bitmap parallel.
2. **Warmup**: first ≥ `WARMUP_GROUPS` (= max(K, 4)) live groups build
   the initial local top-K; before that, gate/sweep are disarmed.
3. **New-group gate** (Zippy Algorithm 3 line 26 analogue): before
   accepting a previously-unseen key, check `contrib +
   remaining_upper_bound < threshold`. If so, mark the slot dead
   immediately.
4. **Periodic sweep every 64K rows** (Zippy Algorithm 4 lines 12-18
   analogue): mark any live group whose `count + remaining_upper <
   threshold` dead. Sweep also fires once at end-of-input to catch tail
   groups whose final counts fall below the last-seen threshold.
5. **`remaining_upper`** comes from
   `StatisticsContext::compute(agg.input)`. `Precision::Absent` disarms
   pruning (stream degrades to plain hash agg + emit-K).
6. **Global threshold** via `TopKCountSharedState`: each partition's
   `current_threshold()` publishes its local top-K into its slot and
   reads back the merged K-th, so partitions with only long-tail keys
   still get a useful (large) threshold from sibling partitions.

### Tests

`sqllogictest/test_files/aggregates_topk.slt` grew a
`count(*)/count(col)/count(distinct)` section: baseline vs optimized
EXPLAIN comparison, DESC + ASC + tie-break + longtail + multi-column
scenarios.

## ClickBench coverage after this PR

| Query | Pattern | Covered? |
|---|---|---|
| Q12 | SearchPhrase, COUNT(*) DESC LIMIT 10 | ✅ |
| Q14 | SearchEngineID, SearchPhrase, COUNT(*) DESC LIMIT 10 | ✅ (multi-column) |
| Q33 | URL, COUNT(*) DESC LIMIT 10 (40M distinct) | ✅ |
| Q34 | 1, URL, COUNT(*) DESC LIMIT 10 | ✅ (multi-column) |
| Q35 | ClientIP + derived, COUNT(*) DESC LIMIT 10 | ✅ (multi-column) |
| Q9  | RegionID, SUM+COUNT+AVG+COUNT-DISTINCT ORDER BY COUNT | ❌ multi-aggregate |
| Q21 | SearchPhrase, MIN(URL), COUNT(*) DESC LIMIT 10 | ❌ multi-aggregate |
| Q22 | multi-aggregate incl. COUNT-DISTINCT | ❌ |
| Q27 | ORDER BY AVG (not COUNT) + HAVING | ❌ different pattern |
| Q28 | ORDER BY AVG + HAVING | ❌ different pattern |
| Q30 | multi-column + multi-aggregate | ❌ multi-aggregate |
| Q31 | multi-column + multi-aggregate | ❌ multi-aggregate |
| Q32 | multi-column + multi-aggregate | ❌ multi-aggregate |

## Observed behaviour

Observability via `EXPLAIN ANALYZE VERBOSE` (per-partition):

- `count_topk_groups_seen`
- `count_topk_groups_gated`
- `count_topk_groups_swept_dead`
- `count_topk_sweeps_performed`

Correctness verified on ClickBench Q33 (`hits.parquet`, ~100M rows,
~18M distinct URLs): same top-10 URLs as baseline.

**Perf**: draft PR — I have not yet run a release-build benchmark
(local disk was constrained). If the correctness above holds and the
approach is agreeable, will rerun on GKE with `adriangbot` or on
another machine. Expected win concentrated on high-cardinality skewed
data (Q12/Q33/Q14/Q34/Q35).

## Known limitations / follow-ups

1. **Multi-aggregate patterns** (Q9, Q21, Q22, Q27, Q28, Q30-Q32) —
   `get_count_topk_field` requires exactly one aggregate, so these fall
   through unchanged. Extending this needs the emit path to reproduce
   the other aggregate's state (SUM/MIN/AVG/…); doable via delegating to
   `GroupedHashAggregateStream` for the actual aggregation while my
   layer decides which groups to keep.
2. **Threshold pushdown to Partial** — currently the shared threshold is
   only used at Final. Pushing it to Partial would let Partial skip
   emitting long-tail rows entirely (Dandandan's original framing).
   Would likely reuse `DynamicFilterPhysicalExpr` infra like MIN/MAX
   aggregate already does.
3. **Early-stop partitions** — if a Final partition's `count + remaining
   < shared_threshold` for every group, it can return
   `Poll::Ready(None)` instead of draining. Not implemented in this PR.
4. **`Raw` input mode / Single aggregate** — `AggregateInputMode::Raw`
   is untested; `Partial` (i.e. FinalPartitioned consuming partial
   state) is the exercised path.

## Are there any user-facing changes?

Behavioural: `SELECT g, count(*) FROM t GROUP BY g ORDER BY count(*)
DESC/ASC LIMIT K` now takes the new stream when
`datafusion.optimizer.enable_topk_aggregation = true` (the default).
Same results as before, plus four new per-partition metrics visible in
`EXPLAIN ANALYZE` output.

Config: no new config options in this PR.

API surface: `TopKKind`, `TopKCountSharedState`, and
`is_topk_count_pattern` are `pub` in
`datafusion-physical-plan::aggregates` for the optimizer's use.