### PR TITLE
fix: support Dictionary arrays in regex_match_dyn (#23709)

### DIFF
--- a/datafusion/physical-expr/src/expressions/binary/kernels.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels.rs
@@ -31,7 +31,7 @@ use datafusion_common::{exec_err, internal_err, plan_err};
 
 use std::sync::Arc;
 
-/// Downcasts $LEFT and $RIGHT to $ARRAY_TYPE and then calls $KERNEL($LEFT, $RIGHT)
+
 macro_rules! call_kernel {
     ($LEFT:expr, $RIGHT:expr, $KERNEL:expr, $ARRAY_TYPE:ident) => {{
         let left = $LEFT.as_any().downcast_ref::<$ARRAY_TYPE>().unwrap();
@@ -41,8 +41,6 @@ macro_rules! call_kernel {
     }};
 }
 
-/// Creates a $FUNC(left: ArrayRef, right: ArrayRef) that
-/// downcasts left / right to the appropriate integral type and calls the kernel
 macro_rules! create_left_integral_dyn_kernel {
     ($FUNC:ident, $KERNEL:ident) => {
         pub(crate) fn $FUNC(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
@@ -87,7 +85,7 @@ create_left_integral_dyn_kernel!(bitwise_and_dyn, bitwise_and);
 create_left_integral_dyn_kernel!(bitwise_shift_right_dyn, bitwise_shift_right);
 create_left_integral_dyn_kernel!(bitwise_shift_left_dyn, bitwise_shift_left);
 
-/// Downcasts $LEFT as $ARRAY_TYPE and $RIGHT as TYPE and calls $KERNEL($LEFT, $RIGHT)
+
 macro_rules! call_scalar_kernel {
     ($LEFT:expr, $RIGHT:expr, $KERNEL:ident, $ARRAY_TYPE:ident, $TYPE:ty) => {{
         let len = $LEFT.len();
@@ -103,8 +101,6 @@ macro_rules! call_scalar_kernel {
     }};
 }
 
-/// Creates a $FUNC(left: ArrayRef, right: ScalarValue) that
-/// downcasts left / right to the appropriate integral type and calls the kernel
 macro_rules! create_left_integral_dyn_scalar_kernel {
     ($FUNC:ident, $KERNEL:ident) => {
         pub(crate) fn $FUNC(
@@ -212,6 +208,15 @@ pub(crate) fn regex_match_dyn(
         }
         DataType::LargeUtf8 => {
             regexp_is_match_flag!(left, right, LargeStringArray, not_match, flag)
+        }
+        DataType::Dictionary(_, _) => {
+            let dict = left.as_any_dictionary();
+            let unpacked_left = arrow::compute::kernels::take::take(
+                dict.values().as_ref(),
+                dict.keys(),
+                None,
+            )?;
+            regex_match_dyn(&unpacked_left, right, not_match, flag)
         }
         other => internal_err!(
             "Data type {} not supported for regex_match_dyn on string array",

--- a/datafusion/physical-expr/src/expressions/binary/kernels.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels.rs
@@ -25,13 +25,14 @@ use arrow::compute::kernels::bitwise::{
 };
 use arrow::compute::kernels::boolean::not;
 use arrow::compute::kernels::comparison::{regexp_is_match, regexp_is_match_scalar};
+use arrow::compute::kernels::take::take;
 use arrow::datatypes::DataType;
 use datafusion_common::{Result, ScalarValue};
 use datafusion_common::{exec_err, internal_err, plan_err};
 
 use std::sync::Arc;
 
-
+/// Downcasts $LEFT and $RIGHT to $ARRAY_TYPE and then calls $KERNEL($LEFT, $RIGHT)
 macro_rules! call_kernel {
     ($LEFT:expr, $RIGHT:expr, $KERNEL:expr, $ARRAY_TYPE:ident) => {{
         let left = $LEFT.as_any().downcast_ref::<$ARRAY_TYPE>().unwrap();
@@ -41,6 +42,8 @@ macro_rules! call_kernel {
     }};
 }
 
+/// Creates a $FUNC(left: ArrayRef, right: ArrayRef) that
+/// downcasts left / right to the appropriate integral type and calls the kernel
 macro_rules! create_left_integral_dyn_kernel {
     ($FUNC:ident, $KERNEL:ident) => {
         pub(crate) fn $FUNC(left: ArrayRef, right: ArrayRef) -> Result<ArrayRef> {
@@ -85,7 +88,7 @@ create_left_integral_dyn_kernel!(bitwise_and_dyn, bitwise_and);
 create_left_integral_dyn_kernel!(bitwise_shift_right_dyn, bitwise_shift_right);
 create_left_integral_dyn_kernel!(bitwise_shift_left_dyn, bitwise_shift_left);
 
-
+/// Downcasts $LEFT as $ARRAY_TYPE and $RIGHT as TYPE and calls $KERNEL($LEFT, $RIGHT)
 macro_rules! call_scalar_kernel {
     ($LEFT:expr, $RIGHT:expr, $KERNEL:ident, $ARRAY_TYPE:ident, $TYPE:ty) => {{
         let len = $LEFT.len();
@@ -101,6 +104,8 @@ macro_rules! call_scalar_kernel {
     }};
 }
 
+/// Creates a $FUNC(left: ArrayRef, right: ScalarValue) that
+/// downcasts left / right to the appropriate integral type and calls the kernel
 macro_rules! create_left_integral_dyn_scalar_kernel {
     ($FUNC:ident, $KERNEL:ident) => {
         pub(crate) fn $FUNC(
@@ -211,11 +216,7 @@ pub(crate) fn regex_match_dyn(
         }
         DataType::Dictionary(_, _) => {
             let dict = left.as_any_dictionary();
-            let unpacked_left = arrow::compute::kernels::take::take(
-                dict.values().as_ref(),
-                dict.keys(),
-                None,
-            )?;
+            let unpacked_left = take(dict.values().as_ref(), dict.keys(), None)?;
             regex_match_dyn(&unpacked_left, right, not_match, flag)
         }
         other => internal_err!(
@@ -302,4 +303,24 @@ pub(crate) fn regex_match_dyn_scalar(
         ),
     };
     Some(result)
+}
+
+#[test]
+fn test_regex_match_dyn_dictionary() -> Result<()> {
+    let values = StringArray::from(vec![Some("user auth failed"), Some("anonymous")]);
+    let keys = Int32Array::from(vec![Some(0), Some(1), None, Some(0)]);
+    let left: ArrayRef = Arc::new(DictionaryArray::new(keys, Arc::new(values)));
+    let right: ArrayRef = Arc::new(StringArray::from(vec![
+        Some("(auth|login)"),
+        Some("^anon"),
+        Some("x"),
+        Some("nope"),
+    ]));
+
+    let result = regex_match_dyn(&left, &right, false, false)?;
+    assert_eq!(
+        result.as_any().downcast_ref::<BooleanArray>().unwrap(),
+        &BooleanArray::from(vec![Some(true), Some(true), None, Some(false)])
+    );
+    Ok(())
 }

--- a/datafusion/physical-expr/src/expressions/binary/kernels.rs
+++ b/datafusion/physical-expr/src/expressions/binary/kernels.rs
@@ -25,7 +25,7 @@ use arrow::compute::kernels::bitwise::{
 };
 use arrow::compute::kernels::boolean::not;
 use arrow::compute::kernels::comparison::{regexp_is_match, regexp_is_match_scalar};
-use arrow::compute::kernels::take::take;
+use arrow::compute::take;
 use arrow::datatypes::DataType;
 use datafusion_common::{Result, ScalarValue};
 use datafusion_common::{exec_err, internal_err, plan_err};

--- a/datafusion/sqllogictest/test_files/regexp/regexp_match.slt
+++ b/datafusion/sqllogictest/test_files/regexp/regexp_match.slt
@@ -199,3 +199,22 @@ query B
 select null !~* 'abc';
 ----
 NULL
+
+
+# Test for Issue 23709: regex_match_dyn with Dictionary encoded patterns
+statement ok
+CREATE TABLE dict_regex_t AS SELECT * FROM (VALUES ('user auth failed')) v(s);
+
+statement ok
+CREATE TABLE dict_regex_p AS SELECT * FROM (VALUES ('(auth|login)')) v(pat);
+
+query B
+SELECT arrow_cast(dict_regex_t.s, 'Dictionary(Int32, Utf8)') SIMILAR TO dict_regex_p.pat FROM dict_regex_t CROSS JOIN dict_regex_p;
+----
+true
+
+statement ok
+DROP TABLE dict_regex_t;
+
+statement ok
+DROP TABLE dict_regex_p;

--- a/datafusion/sqllogictest/test_files/regexp/regexp_match.slt
+++ b/datafusion/sqllogictest/test_files/regexp/regexp_match.slt
@@ -201,7 +201,7 @@ select null !~* 'abc';
 NULL
 
 
-# Test for Issue 23709: regex_match_dyn with Dictionary encoded patterns
+# Test for Issue 23709: regex_match_dyn with Dictionary encoded value side
 statement ok
 CREATE TABLE dict_regex_t AS SELECT * FROM (VALUES ('user auth failed')) v(s);
 
@@ -218,3 +218,4 @@ DROP TABLE dict_regex_t;
 
 statement ok
 DROP TABLE dict_regex_p;
+


### PR DESCRIPTION
## Which issue does this PR close?

This PR fixes the internal error thrown when SIMILAR TO is used with a dictionary-encoded value and a non-scalar array pattern, as described in #23709.
-->
- Closes #23709 .



## What changes are included in this PR?

1.Added a DataType::Dictionary match arm to regex_match_dyn in kernels.rs that mirrors the scalar path.
2.Unpacks the dictionary using the take kernel and routes it back into the standard string matching paths.
3.Added an sqllogictest to regexp_match.slt to verify the fix against the failing query.

## Are these changes tested?

<!--
Yes.
Added a new sqllogictest to datafusion/sqllogictest/test_files/regexp/regexp_match.slt. This test specifically covers the reproducer from #23709, verifying that regex_match_dyn successfully evaluates a Dictionary(Int32, Utf8) encoded array against a non-scalar array pattern without throwing an internal error.
-->


