### PR TITLE
docs: update Polygon.io reference to Massive.com

### DIFF
--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -123,7 +123,7 @@ Here are some active projects using DataFusion:
 - [OpenObserve] Distributed cloud native observability platform
 - [ParadeDB](https://github.com/paradedb/paradedb) PostgreSQL for Search & Analytics
 - [Parseable] Log storage and observability platform
-- [Polygon.io](https://polygon.io/) Stock Market API
+- [Massive.com](https://massive.com/) Stock Market API
 - [qv] Quickly view your data
 - [R2 Query Engine](https://blog.cloudflare.com/r2-sql-deep-dive/) Cloudflare's distributed engine for querying data in Iceberg Catalogs
 - [rerun.io](https://rerun.io/) Visualize and query robotics logs and transform them into training data.


### PR DESCRIPTION
## Which issue does this PR close?

N/A.

## Rationale for this change

Polygon.io has rebranded as Massive.com, so the user guide should use the current company name and website.

## What changes are included in this PR?

Updates the project listing from Polygon.io to Massive.com and replaces the old URL with https://massive.com/.

## Are these changes tested?

Yes. The following required checks passed:

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./ci/scripts/doc_prettier_check.sh --write --allow-dirty`

## Are there any user-facing changes?

Yes. The user guide now displays the current Massive.com branding and website.