### PR TITLE
fix: accept LargeUtf8 and Utf8View patterns in SIMILAR TO planning

### DIFF
--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -1009,7 +1009,12 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
     ) -> Result<Expr> {
         let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
         let pattern_type = pattern.get_type(schema)?;
-        if pattern_type != DataType::Utf8 && pattern_type != DataType::Null {
+        // The analyzer coerces both operands to a common string type, so any
+        // string-typed (or untyped NULL) pattern is accepted here.
+        if !matches!(
+            pattern_type,
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View | DataType::Null
+        ) {
             return plan_err!("Invalid pattern in SIMILAR TO expression");
         }
         let escape_char = match escape_char.map(|v| v.value) {

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -1008,15 +1008,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         planner_context: &mut PlannerContext,
     ) -> Result<Expr> {
         let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
-        let pattern_type = pattern.get_type(schema)?;
-        // The analyzer coerces both operands to a common string type, so any
-        // string-typed (or untyped NULL) pattern is accepted here.
-        if !matches!(
-            pattern_type,
-            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View | DataType::Null
-        ) {
-            return plan_err!("Invalid pattern in SIMILAR TO expression");
-        }
         let escape_char = match escape_char.map(|v| v.value) {
             Some(Value::SingleQuotedString(char)) if char.len() == 1 => {
                 Some(char.chars().next().unwrap())

--- a/datafusion/sqllogictest/test_files/type_coercion.slt
+++ b/datafusion/sqllogictest/test_files/type_coercion.slt
@@ -366,6 +366,24 @@ SELECT t.s NOT SIMILAR TO arrow_cast(p.pat, 'Utf8View') FROM t CROSS JOIN p;
 ----
 false
 
+# NULL patterns (literal or Null-typed non-scalar) are accepted by the planner
+# and evaluate to NULL
+query B
+SELECT t.s SIMILAR TO NULL FROM t;
+----
+NULL
+
+statement ok
+CREATE TABLE pn AS SELECT NULL AS pat;
+
+query B
+SELECT t.s SIMILAR TO pn.pat FROM t CROSS JOIN pn;
+----
+NULL
+
+statement ok
+DROP TABLE pn;
+
 statement ok
 DROP TABLE t;
 

--- a/datafusion/sqllogictest/test_files/type_coercion.slt
+++ b/datafusion/sqllogictest/test_files/type_coercion.slt
@@ -349,6 +349,23 @@ SELECT arrow_cast(t.s, 'Dictionary(Int32, Utf8)') SIMILAR TO p.pat FROM t CROSS 
 ----
 true
 
+# non-scalar Utf8View / LargeUtf8 patterns are accepted by the SQL planner and
+# coerced by the analyzer (https://github.com/apache/datafusion/issues/23732)
+query B
+SELECT t.s SIMILAR TO arrow_cast(p.pat, 'Utf8View') FROM t CROSS JOIN p;
+----
+true
+
+query B
+SELECT t.s SIMILAR TO arrow_cast(p.pat, 'LargeUtf8') FROM t CROSS JOIN p;
+----
+true
+
+query B
+SELECT t.s NOT SIMILAR TO arrow_cast(p.pat, 'Utf8View') FROM t CROSS JOIN p;
+----
+false
+
 statement ok
 DROP TABLE t;
 

--- a/datafusion/sqllogictest/test_files/type_coercion.slt
+++ b/datafusion/sqllogictest/test_files/type_coercion.slt
@@ -304,7 +304,9 @@ query error does not support zero arguments
 SELECT * FROM (SELECT 1) WHERE TRY_CAST(STARTS_WITH() AS INT) = 1;
 
 ###################################################################
-## SIMILAR TO type coercion (https://github.com/apache/datafusion/issues/22886)
+## SIMILAR TO type coercion
+## https://github.com/apache/datafusion/issues/22886
+## https://github.com/apache/datafusion/issues/23732
 ###################################################################
 
 # NULL pattern is coerced to a typed NULL and evaluates to NULL instead of panicking
@@ -349,8 +351,7 @@ SELECT arrow_cast(t.s, 'Dictionary(Int32, Utf8)') SIMILAR TO p.pat FROM t CROSS 
 ----
 true
 
-# non-scalar Utf8View / LargeUtf8 patterns are accepted by the SQL planner and
-# coerced by the analyzer (https://github.com/apache/datafusion/issues/23732)
+# non-scalar string-like patterns are coerced by the analyzer
 query B
 SELECT t.s SIMILAR TO arrow_cast(p.pat, 'Utf8View') FROM t CROSS JOIN p;
 ----
@@ -366,8 +367,12 @@ SELECT t.s NOT SIMILAR TO arrow_cast(p.pat, 'Utf8View') FROM t CROSS JOIN p;
 ----
 false
 
-# NULL patterns (literal or Null-typed non-scalar) are accepted by the planner
-# and evaluate to NULL
+query B
+SELECT t.s SIMILAR TO arrow_cast(p.pat, 'Dictionary(Int32, Utf8)') FROM t CROSS JOIN p;
+----
+true
+
+# NULL patterns (literal or Null-typed non-scalar) evaluate to NULL
 query B
 SELECT t.s SIMILAR TO NULL FROM t;
 ----
@@ -394,6 +399,6 @@ DROP TABLE p;
 query error There isn't a common type to coerce Int64 and Utf8 in SIMILAR TO expression
 SELECT 1 SIMILAR TO 'a';
 
-# a non-string pattern is rejected even earlier, during SQL planning
-query error Invalid pattern in SIMILAR TO expression
+# a non-string pattern is rejected by the analyzer
+query error There isn't a common type to coerce Utf8 and Int64 in SIMILAR TO expression
 SELECT 'a' SIMILAR TO 1;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23732

## Rationale for this change

Follow-up to #23704, which made the `TypeCoercion` analyzer coerce `SIMILAR TO` operands to a common string type. The SQL planner still rejects `LargeUtf8` and `Utf8View` **patterns** before the analyzer ever runs:

```sql
SELECT s FROM test, patterns WHERE s SIMILAR TO arrow_cast(pat, 'Utf8View');
-- error: Invalid pattern in SIMILAR TO expression
```

Now that the analyzer coerces both operands, this planner restriction is unnecessary (and inconsistent with `LIKE`, whose planner path has no such check).

## What changes are included in this PR?

- `datafusion/sql/src/expr/mod.rs`: the pattern-type check in `sql_similarto_to_expr` now accepts `Utf8` / `LargeUtf8` / `Utf8View` / `Null` instead of only `Utf8` / `Null`.
- `datafusion/sqllogictest/test_files/type_coercion.slt`: regression tests with non-literal `Utf8View` and `LargeUtf8` patterns (plus a `NOT SIMILAR TO` case), next to the existing #22886 regression tests.

The planner relaxation and tests were originally part of #22887; this PR lands the remaining piece of it.

## Are these changes tested?

Yes — new sqllogictest cases in `type_coercion.slt`. The existing planner rejection of non-string patterns (`SELECT 'a' SIMILAR TO 1`) still errors as before.

## Are there any user-facing changes?

Yes: `SIMILAR TO` queries with non-literal `LargeUtf8` / `Utf8View` patterns that previously failed during SQL planning with `Invalid pattern in SIMILAR TO expression` now plan and execute successfully. No breaking API changes.
