### PR TITLE
Migrate ExplainExec and AnalyzeExec protobuf serde

### DIFF
--- a/datafusion/physical-plan/src/analyze.rs
+++ b/datafusion/physical-plan/src/analyze.rs
@@ -303,6 +303,102 @@ impl ExecutionPlan for AnalyzeExec {
             futures::stream::once(output),
         )))
     }
+
+    #[cfg(feature = "proto")]
+    fn try_to_proto(
+        &self,
+        ctx: &crate::proto::ExecutionPlanEncodeCtx<'_>,
+    ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalPlanNode>> {
+        use datafusion_proto_models::protobuf;
+
+        let input = ctx.encode_child(self.input())?;
+        let (has_metric_categories, metric_categories) = match self.metric_categories() {
+            Some(categories) => {
+                (true, categories.iter().map(ToString::to_string).collect())
+            }
+            None => (false, vec![]),
+        };
+        let format = match self.format() {
+            ExplainFormat::Indent => protobuf::ExplainFormat::Indent,
+            ExplainFormat::Tree => protobuf::ExplainFormat::Tree,
+            ExplainFormat::PostgresJSON => protobuf::ExplainFormat::Pgjson,
+            ExplainFormat::Graphviz => protobuf::ExplainFormat::Graphviz,
+        } as i32;
+        Ok(Some(protobuf::PhysicalPlanNode {
+            physical_plan_type: Some(
+                protobuf::physical_plan_node::PhysicalPlanType::Analyze(Box::new(
+                    protobuf::AnalyzeExecNode {
+                        verbose: self.verbose(),
+                        show_statistics: self.show_statistics(),
+                        input: Some(Box::new(input)),
+                        schema: Some(self.schema().as_ref().try_into()?),
+                        has_metric_categories,
+                        metric_categories,
+                        format,
+                    },
+                )),
+            ),
+        }))
+    }
+}
+
+#[cfg(feature = "proto")]
+impl AnalyzeExec {
+    /// Reconstruct an [`AnalyzeExec`] from its protobuf representation.
+    pub fn try_from_proto(
+        node: &datafusion_proto_models::protobuf::PhysicalPlanNode,
+        ctx: &crate::proto::ExecutionPlanDecodeCtx<'_>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        use datafusion_proto_models::protobuf;
+
+        let analyze = crate::expect_plan_variant!(
+            node,
+            protobuf::physical_plan_node::PhysicalPlanType::Analyze,
+            "AnalyzeExec",
+        );
+        let input =
+            ctx.decode_required_child(analyze.input.as_deref(), "AnalyzeExec", "input")?;
+        let metric_categories = if analyze.has_metric_categories {
+            Some(
+                analyze
+                    .metric_categories
+                    .iter()
+                    .map(|category| category.parse::<MetricCategory>())
+                    .collect::<Result<Vec<_>>>()?,
+            )
+        } else {
+            None
+        };
+        let proto_format =
+            protobuf::ExplainFormat::try_from(analyze.format).map_err(|_| {
+                DataFusionError::Internal(format!(
+                    "Received an AnalyzeExecNode message with unknown ExplainFormat {}",
+                    analyze.format
+                ))
+            })?;
+        let format = match proto_format {
+            protobuf::ExplainFormat::Indent => ExplainFormat::Indent,
+            protobuf::ExplainFormat::Tree => ExplainFormat::Tree,
+            protobuf::ExplainFormat::Pgjson => ExplainFormat::PostgresJSON,
+            protobuf::ExplainFormat::Graphviz => ExplainFormat::Graphviz,
+        };
+        let schema = analyze.schema.as_ref().ok_or_else(|| {
+            datafusion_common::internal_datafusion_err!(
+                "AnalyzeExec is missing required field 'schema'"
+            )
+        })?;
+        Ok(Arc::new(
+            AnalyzeExec::builder(
+                analyze.verbose,
+                analyze.show_statistics,
+                input,
+                Arc::new(arrow::datatypes::Schema::try_from(schema)?),
+            )
+            .with_metric_categories(metric_categories)
+            .with_format(format)
+            .build(),
+        ))
+    }
 }
 
 /// Creates the output of AnalyzeExec as a RecordBatch

--- a/datafusion/physical-plan/src/explain.rs
+++ b/datafusion/physical-plan/src/explain.rs
@@ -185,6 +185,188 @@ impl ExecutionPlan for ExplainExec {
             futures::stream::iter(vec![Ok(record_batch)]),
         )))
     }
+
+    #[cfg(feature = "proto")]
+    fn try_to_proto(
+        &self,
+        _ctx: &crate::proto::ExecutionPlanEncodeCtx<'_>,
+    ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalPlanNode>> {
+        use datafusion_proto_models::protobuf;
+
+        Ok(Some(protobuf::PhysicalPlanNode {
+            physical_plan_type: Some(
+                protobuf::physical_plan_node::PhysicalPlanType::Explain(
+                    protobuf::ExplainExecNode {
+                        schema: Some(self.schema().as_ref().try_into()?),
+                        stringified_plans: self
+                            .stringified_plans()
+                            .iter()
+                            .map(stringified_plan_to_proto)
+                            .collect(),
+                        verbose: self.verbose(),
+                    },
+                ),
+            ),
+        }))
+    }
+}
+
+#[cfg(feature = "proto")]
+impl ExplainExec {
+    /// Reconstruct an [`ExplainExec`] from its protobuf representation.
+    pub fn try_from_proto(
+        node: &datafusion_proto_models::protobuf::PhysicalPlanNode,
+        _ctx: &crate::proto::ExecutionPlanDecodeCtx<'_>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        use datafusion_proto_models::protobuf;
+
+        let explain = crate::expect_plan_variant!(
+            node,
+            protobuf::physical_plan_node::PhysicalPlanType::Explain,
+            "ExplainExec",
+        );
+        let schema = explain.schema.as_ref().ok_or_else(|| {
+            datafusion_common::internal_datafusion_err!(
+                "ExplainExec is missing required field 'schema'"
+            )
+        })?;
+        Ok(Arc::new(ExplainExec::new(
+            Arc::new(arrow::datatypes::Schema::try_from(schema)?),
+            explain
+                .stringified_plans
+                .iter()
+                .map(stringified_plan_from_proto)
+                .collect(),
+            explain.verbose,
+        )))
+    }
+}
+
+#[cfg(feature = "proto")]
+fn stringified_plan_to_proto(
+    stringified_plan: &StringifiedPlan,
+) -> datafusion_proto_models::protobuf::StringifiedPlan {
+    use datafusion_common::display::PlanType;
+    use datafusion_proto_models::datafusion_common::EmptyMessage;
+    use datafusion_proto_models::protobuf;
+    use protobuf::plan_type::PlanTypeEnum::{
+        AnalyzedLogicalPlan, FinalAnalyzedLogicalPlan, FinalLogicalPlan,
+        FinalPhysicalPlan, FinalPhysicalPlanWithSchema, FinalPhysicalPlanWithStats,
+        InitialLogicalPlan, InitialPhysicalPlan, InitialPhysicalPlanWithSchema,
+        InitialPhysicalPlanWithStats, OptimizedLogicalPlan, OptimizedPhysicalPlan,
+        PhysicalPlanError,
+    };
+
+    protobuf::StringifiedPlan {
+        plan_type: match stringified_plan.clone().plan_type {
+            PlanType::InitialLogicalPlan => Some(protobuf::PlanType {
+                plan_type_enum: Some(InitialLogicalPlan(EmptyMessage {})),
+            }),
+            PlanType::AnalyzedLogicalPlan { analyzer_name } => Some(protobuf::PlanType {
+                plan_type_enum: Some(AnalyzedLogicalPlan(
+                    protobuf::AnalyzedLogicalPlanType { analyzer_name },
+                )),
+            }),
+            PlanType::FinalAnalyzedLogicalPlan => Some(protobuf::PlanType {
+                plan_type_enum: Some(FinalAnalyzedLogicalPlan(EmptyMessage {})),
+            }),
+            PlanType::OptimizedLogicalPlan { optimizer_name } => {
+                Some(protobuf::PlanType {
+                    plan_type_enum: Some(OptimizedLogicalPlan(
+                        protobuf::OptimizedLogicalPlanType { optimizer_name },
+                    )),
+                })
+            }
+            PlanType::FinalLogicalPlan => Some(protobuf::PlanType {
+                plan_type_enum: Some(FinalLogicalPlan(EmptyMessage {})),
+            }),
+            PlanType::InitialPhysicalPlan => Some(protobuf::PlanType {
+                plan_type_enum: Some(InitialPhysicalPlan(EmptyMessage {})),
+            }),
+            PlanType::OptimizedPhysicalPlan { optimizer_name } => {
+                Some(protobuf::PlanType {
+                    plan_type_enum: Some(OptimizedPhysicalPlan(
+                        protobuf::OptimizedPhysicalPlanType { optimizer_name },
+                    )),
+                })
+            }
+            PlanType::FinalPhysicalPlan => Some(protobuf::PlanType {
+                plan_type_enum: Some(FinalPhysicalPlan(EmptyMessage {})),
+            }),
+            PlanType::InitialPhysicalPlanWithStats => Some(protobuf::PlanType {
+                plan_type_enum: Some(InitialPhysicalPlanWithStats(EmptyMessage {})),
+            }),
+            PlanType::InitialPhysicalPlanWithSchema => Some(protobuf::PlanType {
+                plan_type_enum: Some(InitialPhysicalPlanWithSchema(EmptyMessage {})),
+            }),
+            PlanType::FinalPhysicalPlanWithStats => Some(protobuf::PlanType {
+                plan_type_enum: Some(FinalPhysicalPlanWithStats(EmptyMessage {})),
+            }),
+            PlanType::FinalPhysicalPlanWithSchema => Some(protobuf::PlanType {
+                plan_type_enum: Some(FinalPhysicalPlanWithSchema(EmptyMessage {})),
+            }),
+            PlanType::PhysicalPlanError => Some(protobuf::PlanType {
+                plan_type_enum: Some(PhysicalPlanError(EmptyMessage {})),
+            }),
+        },
+        plan: stringified_plan.plan.to_string(),
+    }
+}
+
+#[cfg(feature = "proto")]
+fn stringified_plan_from_proto(
+    stringified_plan: &datafusion_proto_models::protobuf::StringifiedPlan,
+) -> StringifiedPlan {
+    use datafusion_common::display::PlanType;
+    use datafusion_proto_models::protobuf::plan_type::PlanTypeEnum::{
+        AnalyzedLogicalPlan, FinalAnalyzedLogicalPlan, FinalLogicalPlan,
+        FinalPhysicalPlan, FinalPhysicalPlanWithSchema, FinalPhysicalPlanWithStats,
+        InitialLogicalPlan, InitialPhysicalPlan, InitialPhysicalPlanWithSchema,
+        InitialPhysicalPlanWithStats, OptimizedLogicalPlan, OptimizedPhysicalPlan,
+        PhysicalPlanError,
+    };
+    use datafusion_proto_models::protobuf::{
+        AnalyzedLogicalPlanType, OptimizedLogicalPlanType, OptimizedPhysicalPlanType,
+    };
+
+    StringifiedPlan {
+        plan_type: match stringified_plan
+            .plan_type
+            .as_ref()
+            .and_then(|plan_type| plan_type.plan_type_enum.as_ref())
+            .unwrap_or_else(|| {
+                panic!(
+                    "Cannot create protobuf::StringifiedPlan from {stringified_plan:?}"
+                )
+            }) {
+            InitialLogicalPlan(_) => PlanType::InitialLogicalPlan,
+            AnalyzedLogicalPlan(AnalyzedLogicalPlanType { analyzer_name }) => {
+                PlanType::AnalyzedLogicalPlan {
+                    analyzer_name: analyzer_name.clone(),
+                }
+            }
+            FinalAnalyzedLogicalPlan(_) => PlanType::FinalAnalyzedLogicalPlan,
+            OptimizedLogicalPlan(OptimizedLogicalPlanType { optimizer_name }) => {
+                PlanType::OptimizedLogicalPlan {
+                    optimizer_name: optimizer_name.clone(),
+                }
+            }
+            FinalLogicalPlan(_) => PlanType::FinalLogicalPlan,
+            InitialPhysicalPlan(_) => PlanType::InitialPhysicalPlan,
+            InitialPhysicalPlanWithStats(_) => PlanType::InitialPhysicalPlanWithStats,
+            InitialPhysicalPlanWithSchema(_) => PlanType::InitialPhysicalPlanWithSchema,
+            OptimizedPhysicalPlan(OptimizedPhysicalPlanType { optimizer_name }) => {
+                PlanType::OptimizedPhysicalPlan {
+                    optimizer_name: optimizer_name.clone(),
+                }
+            }
+            FinalPhysicalPlan(_) => PlanType::FinalPhysicalPlan,
+            FinalPhysicalPlanWithStats(_) => PlanType::FinalPhysicalPlanWithStats,
+            FinalPhysicalPlanWithSchema(_) => PlanType::FinalPhysicalPlanWithSchema,
+            PhysicalPlanError(_) => PlanType::PhysicalPlanError,
+        },
+        plan: Arc::new(stringified_plan.plan.clone()),
+    }
 }
 
 /// If this plan should be shown, given the previous plan that was

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use arrow::datatypes::{IntervalMonthDayNanoType, Schema, SchemaRef};
 use datafusion_catalog::memory::MemorySourceConfig;
 use datafusion_common::config::CsvOptions;
-use datafusion_common::display::StringifiedPlan;
 use datafusion_common::format::ExplainFormat;
 use datafusion_common::{
     DataFusionError, Result, internal_datafusion_err, internal_err, not_impl_err,
@@ -744,8 +743,8 @@ pub trait PhysicalPlanNodeExt: Sized {
         };
         let decode_ctx = ExecutionPlanDecodeCtx::new(&plan_decoder);
         match plan {
-            PhysicalPlanType::Explain(explain) => {
-                self.try_into_explain_physical_plan(explain, ctx, proto_converter)
+            PhysicalPlanType::Explain(_) => {
+                ExplainExec::try_from_proto(self.node(), &decode_ctx)
             }
             PhysicalPlanType::Projection(_) => {
                 ProjectionExec::try_from_proto(self.node(), &decode_ctx)
@@ -894,10 +893,6 @@ pub trait PhysicalPlanNodeExt: Sized {
             return Ok(node);
         }
 
-        if let Some(exec) = plan.downcast_ref::<ExplainExec>() {
-            return protobuf::PhysicalPlanNode::try_from_explain_exec(exec, codec);
-        }
-
         if let Some(exec) = plan.downcast_ref::<AnalyzeExec>() {
             return protobuf::PhysicalPlanNode::try_from_analyze_exec(
                 exec,
@@ -993,21 +988,22 @@ pub trait PhysicalPlanNodeExt: Sized {
         }
     }
 
+    #[deprecated(
+        since = "55.0.0",
+        note = "unused by DataFusion; `ExplainExec` deserializes itself via `ExplainExec::try_from_proto`"
+    )]
     fn try_into_explain_physical_plan(
         &self,
-        explain: &protobuf::ExplainExecNode,
-        _ctx: &PhysicalPlanDecodeContext<'_>,
-        _proto_converter: &dyn PhysicalProtoConverterExtension,
+        _explain: &protobuf::ExplainExecNode,
+        ctx: &PhysicalPlanDecodeContext<'_>,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(ExplainExec::new(
-            Arc::new(explain.schema.as_ref().unwrap().try_into()?),
-            explain
-                .stringified_plans
-                .iter()
-                .map(StringifiedPlan::from_proto)
-                .collect(),
-            explain.verbose,
-        )))
+        let plan_decoder = ConverterPlanDecoder {
+            ctx,
+            proto_converter,
+        };
+        let decode_ctx = ExecutionPlanDecodeCtx::new(&plan_decoder);
+        ExplainExec::try_from_proto(self.node(), &decode_ctx)
     }
 
     #[deprecated(
@@ -2313,22 +2309,22 @@ pub trait PhysicalPlanNodeExt: Sized {
         )))
     }
 
+    #[deprecated(
+        since = "55.0.0",
+        note = "unused by DataFusion; `ExplainExec` serializes itself via `ExecutionPlan::try_to_proto`"
+    )]
     fn try_from_explain_exec(
         exec: &ExplainExec,
-        _codec: &dyn PhysicalExtensionCodec,
+        codec: &dyn PhysicalExtensionCodec,
     ) -> Result<protobuf::PhysicalPlanNode> {
-        Ok(protobuf::PhysicalPlanNode {
-            physical_plan_type: Some(PhysicalPlanType::Explain(
-                protobuf::ExplainExecNode {
-                    schema: Some(exec.schema().as_ref().try_into()?),
-                    stringified_plans: exec
-                        .stringified_plans()
-                        .iter()
-                        .map(protobuf::StringifiedPlan::from_proto)
-                        .collect(),
-                    verbose: exec.verbose(),
-                },
-            )),
+        let proto_converter = DefaultPhysicalProtoConverter {};
+        let plan_encoder = ConverterPlanEncoder {
+            codec,
+            proto_converter: &proto_converter,
+        };
+        let encode_ctx = ExecutionPlanEncodeCtx::new(&plan_encoder);
+        exec.try_to_proto(&encode_ctx)?.ok_or_else(|| {
+            internal_datafusion_err!("ExplainExec did not serialize itself")
         })
     }
 

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use arrow::datatypes::{IntervalMonthDayNanoType, Schema, SchemaRef};
 use datafusion_catalog::memory::MemorySourceConfig;
 use datafusion_common::config::CsvOptions;
-use datafusion_common::format::ExplainFormat;
 use datafusion_common::{
     DataFusionError, Result, internal_datafusion_err, internal_err, not_impl_err,
 };
@@ -83,7 +82,6 @@ use datafusion_physical_plan::joins::{
 };
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion_physical_plan::memory::LazyMemoryExec;
-use datafusion_physical_plan::metrics::MetricCategory;
 use datafusion_physical_plan::placeholder_row::PlaceholderRowExec;
 use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::proto::{
@@ -102,7 +100,7 @@ use prost::Message;
 use prost::bytes::BufMut;
 
 use crate::common::{byte_to_string, str_to_byte};
-use crate::convert::{FromProto, TryFromProto};
+use crate::convert::TryFromProto;
 use crate::convert_required;
 use crate::physical_plan::from_proto::{
     parse_physical_expr_with_converter, parse_physical_sort_expr,
@@ -828,8 +826,8 @@ pub trait PhysicalPlanNodeExt: Sized {
             PhysicalPlanType::NestedLoopJoin(_) => {
                 NestedLoopJoinExec::try_from_proto(self.node(), &decode_ctx)
             }
-            PhysicalPlanType::Analyze(analyze) => {
-                self.try_into_analyze_physical_plan(analyze, ctx, proto_converter)
+            PhysicalPlanType::Analyze(_) => {
+                AnalyzeExec::try_from_proto(self.node(), &decode_ctx)
             }
             PhysicalPlanType::JsonSink(sink) => {
                 self.try_into_json_sink_physical_plan(sink, ctx, proto_converter)
@@ -891,14 +889,6 @@ pub trait PhysicalPlanNodeExt: Sized {
         let encode_ctx = ExecutionPlanEncodeCtx::new(&encoder);
         if let Some(node) = plan.try_to_proto(&encode_ctx)? {
             return Ok(node);
-        }
-
-        if let Some(exec) = plan.downcast_ref::<AnalyzeExec>() {
-            return protobuf::PhysicalPlanNode::try_from_analyze_exec(
-                exec,
-                codec,
-                proto_converter,
-            );
         }
 
         if let Some(exec) = plan.downcast_ref::<AggregateExec>() {
@@ -1924,48 +1914,22 @@ pub trait PhysicalPlanNodeExt: Sized {
         NestedLoopJoinExec::try_from_proto(&node, &decode_ctx)
     }
 
+    #[deprecated(
+        since = "55.0.0",
+        note = "unused by DataFusion; `AnalyzeExec` deserializes itself via `AnalyzeExec::try_from_proto`"
+    )]
     fn try_into_analyze_physical_plan(
         &self,
-        analyze: &protobuf::AnalyzeExecNode,
+        _analyze: &protobuf::AnalyzeExecNode,
         ctx: &PhysicalPlanDecodeContext<'_>,
         proto_converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let input: Arc<dyn ExecutionPlan> =
-            into_physical_plan(&analyze.input, ctx, proto_converter)?;
-        let metric_categories = if analyze.has_metric_categories {
-            let cats: Result<Vec<MetricCategory>> = analyze
-                .metric_categories
-                .iter()
-                .map(|s| s.parse::<MetricCategory>())
-                .collect();
-            Some(cats?)
-        } else {
-            None
+        let plan_decoder = ConverterPlanDecoder {
+            ctx,
+            proto_converter,
         };
-        let pb_format =
-            protobuf::ExplainFormat::try_from(analyze.format).map_err(|_| {
-                DataFusionError::Internal(format!(
-                    "Received an AnalyzeExecNode message with unknown ExplainFormat {}",
-                    analyze.format
-                ))
-            })?;
-        let format = match pb_format {
-            protobuf::ExplainFormat::Indent => ExplainFormat::Indent,
-            protobuf::ExplainFormat::Tree => ExplainFormat::Tree,
-            protobuf::ExplainFormat::Pgjson => ExplainFormat::PostgresJSON,
-            protobuf::ExplainFormat::Graphviz => ExplainFormat::Graphviz,
-        };
-        Ok(Arc::new(
-            AnalyzeExec::builder(
-                analyze.verbose,
-                analyze.show_statistics,
-                input,
-                Arc::new(convert_required!(analyze.schema)?),
-            )
-            .with_metric_categories(metric_categories)
-            .with_format(format)
-            .build(),
-        ))
+        let decode_ctx = ExecutionPlanDecodeCtx::new(&plan_decoder);
+        AnalyzeExec::try_from_proto(self.node(), &decode_ctx)
     }
 
     fn try_into_json_sink_physical_plan(
@@ -2347,38 +2311,22 @@ pub trait PhysicalPlanNodeExt: Sized {
         })
     }
 
+    #[deprecated(
+        since = "55.0.0",
+        note = "unused by DataFusion; `AnalyzeExec` serializes itself via `ExecutionPlan::try_to_proto`"
+    )]
     fn try_from_analyze_exec(
         exec: &AnalyzeExec,
         codec: &dyn PhysicalExtensionCodec,
         proto_converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<protobuf::PhysicalPlanNode> {
-        let input = protobuf::PhysicalPlanNode::try_from_physical_plan_with_converter(
-            exec.input().to_owned(),
+        let plan_encoder = ConverterPlanEncoder {
             codec,
             proto_converter,
-        )?;
-        let (has_metric_categories, metric_categories) = match exec.metric_categories() {
-            Some(cats) => (true, cats.iter().map(|c| c.to_string()).collect()),
-            None => (false, vec![]),
         };
-        let format = match exec.format() {
-            ExplainFormat::Indent => protobuf::ExplainFormat::Indent,
-            ExplainFormat::Tree => protobuf::ExplainFormat::Tree,
-            ExplainFormat::PostgresJSON => protobuf::ExplainFormat::Pgjson,
-            ExplainFormat::Graphviz => protobuf::ExplainFormat::Graphviz,
-        } as i32;
-        Ok(protobuf::PhysicalPlanNode {
-            physical_plan_type: Some(PhysicalPlanType::Analyze(Box::new(
-                protobuf::AnalyzeExecNode {
-                    verbose: exec.verbose(),
-                    show_statistics: exec.show_statistics(),
-                    input: Some(Box::new(input)),
-                    schema: Some(exec.schema().as_ref().try_into()?),
-                    has_metric_categories,
-                    metric_categories,
-                    format,
-                },
-            ))),
+        let encode_ctx = ExecutionPlanEncodeCtx::new(&plan_encoder);
+        exec.try_to_proto(&encode_ctx)?.ok_or_else(|| {
+            internal_datafusion_err!("AnalyzeExec did not serialize itself")
         })
     }
 

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -66,6 +66,7 @@ use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::coop::CooperativeExec;
 use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::explain::ExplainExec;
 use datafusion::physical_plan::expressions::{
     BinaryExpr, Column, DynamicFilterPhysicalExpr, NotExpr, PhysicalSortExpr, binary,
     cast, col, in_list, like, lit,
@@ -98,6 +99,7 @@ use datafusion::physical_plan::{
 use datafusion::prelude::{ParquetReadOptions, SessionContext};
 use datafusion::scalar::ScalarValue;
 use datafusion_common::config::{ConfigOptions, TableParquetOptions};
+use datafusion_common::display::{PlanType, StringifiedPlan};
 use datafusion_common::file_options::csv_writer::CsvWriterOptions;
 use datafusion_common::file_options::json_writer::JsonWriterOptions;
 use datafusion_common::parsers::CompressionTypeVariant;
@@ -1955,6 +1957,75 @@ fn roundtrip_analyze() -> Result<()> {
     roundtrip_test(Arc::new(
         AnalyzeExec::builder(false, false, input, Arc::new(schema)).build(),
     ))
+}
+
+#[test]
+fn roundtrip_explain() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("plan_type", DataType::Utf8, false),
+        Field::new("plan", DataType::Utf8, false),
+    ]));
+    let stringified_plans = vec![
+        StringifiedPlan::new(PlanType::InitialLogicalPlan, "initial logical"),
+        StringifiedPlan::new(
+            PlanType::AnalyzedLogicalPlan {
+                analyzer_name: "analyzer".to_string(),
+            },
+            "analyzed logical",
+        ),
+        StringifiedPlan::new(PlanType::FinalAnalyzedLogicalPlan, "final analyzed"),
+        StringifiedPlan::new(
+            PlanType::OptimizedLogicalPlan {
+                optimizer_name: "logical optimizer".to_string(),
+            },
+            "optimized logical",
+        ),
+        StringifiedPlan::new(PlanType::FinalLogicalPlan, "final logical"),
+        StringifiedPlan::new(PlanType::InitialPhysicalPlan, "initial physical"),
+        StringifiedPlan::new(
+            PlanType::InitialPhysicalPlanWithStats,
+            "initial physical with stats",
+        ),
+        StringifiedPlan::new(
+            PlanType::InitialPhysicalPlanWithSchema,
+            "initial physical with schema",
+        ),
+        StringifiedPlan::new(
+            PlanType::OptimizedPhysicalPlan {
+                optimizer_name: "physical optimizer".to_string(),
+            },
+            "optimized physical",
+        ),
+        StringifiedPlan::new(PlanType::FinalPhysicalPlan, "final physical"),
+        StringifiedPlan::new(
+            PlanType::FinalPhysicalPlanWithStats,
+            "final physical with stats",
+        ),
+        StringifiedPlan::new(
+            PlanType::FinalPhysicalPlanWithSchema,
+            "final physical with schema",
+        ),
+        StringifiedPlan::new(PlanType::PhysicalPlanError, "physical plan error"),
+    ];
+    let explain = Arc::new(ExplainExec::new(
+        Arc::clone(&schema),
+        stringified_plans.clone(),
+        true,
+    ));
+
+    let ctx = SessionContext::new();
+    let roundtripped = roundtrip_test_and_return(
+        explain,
+        &ctx,
+        &DefaultPhysicalExtensionCodec {},
+        &DefaultPhysicalProtoConverter {},
+    )?;
+    let roundtripped = roundtripped.downcast_ref::<ExplainExec>().unwrap();
+
+    assert_eq!(roundtripped.schema(), schema);
+    assert_eq!(roundtripped.stringified_plans(), stringified_plans);
+    assert!(roundtripped.verbose());
+    Ok(())
 }
 
 #[tokio::test]

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -78,6 +78,7 @@ use datafusion::physical_plan::joins::{
     StreamJoinPartitionMode, SymmetricHashJoinExec,
 };
 use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
+use datafusion::physical_plan::metrics::MetricCategory;
 use datafusion::physical_plan::placeholder_row::PlaceholderRowExec;
 use datafusion::physical_plan::projection::{ProjectionExec, ProjectionExpr};
 use datafusion::physical_plan::repartition::RepartitionExec;
@@ -102,6 +103,7 @@ use datafusion_common::config::{ConfigOptions, TableParquetOptions};
 use datafusion_common::display::{PlanType, StringifiedPlan};
 use datafusion_common::file_options::csv_writer::CsvWriterOptions;
 use datafusion_common::file_options::json_writer::JsonWriterOptions;
+use datafusion_common::format::ExplainFormat;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::stats::Precision;
 use datafusion_common::{
@@ -1949,14 +1951,43 @@ fn roundtrip_like() -> Result<()> {
 
 #[test]
 fn roundtrip_analyze() -> Result<()> {
-    let field_a = Field::new("plan_type", DataType::Utf8, false);
-    let field_b = Field::new("plan", DataType::Utf8, false);
-    let schema = Schema::new(vec![field_a, field_b]);
-    let input = Arc::new(PlaceholderRowExec::new(Arc::new(schema.clone())));
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("plan_type", DataType::Utf8, false),
+        Field::new("plan", DataType::Utf8, false),
+    ]));
+    let input = Arc::new(PlaceholderRowExec::new(Arc::clone(&schema)));
+    let metric_categories = vec![MetricCategory::Rows, MetricCategory::Timing];
+    let analyze = Arc::new(
+        AnalyzeExec::builder(true, true, input, Arc::clone(&schema))
+            .with_metric_categories(Some(metric_categories.clone()))
+            .with_format(ExplainFormat::Tree)
+            .build(),
+    );
 
-    roundtrip_test(Arc::new(
-        AnalyzeExec::builder(false, false, input, Arc::new(schema)).build(),
-    ))
+    let ctx = SessionContext::new();
+    let roundtripped = roundtrip_test_and_return(
+        analyze,
+        &ctx,
+        &DefaultPhysicalExtensionCodec {},
+        &DefaultPhysicalProtoConverter {},
+    )?;
+    let roundtripped = roundtripped.downcast_ref::<AnalyzeExec>().unwrap();
+
+    assert_eq!(roundtripped.schema(), schema);
+    assert!(roundtripped.verbose());
+    assert!(roundtripped.show_statistics());
+    assert_eq!(
+        roundtripped.metric_categories(),
+        Some(metric_categories.as_slice())
+    );
+    assert_eq!(roundtripped.format(), &ExplainFormat::Tree);
+    assert!(
+        roundtripped
+            .input()
+            .downcast_ref::<PlaceholderRowExec>()
+            .is_some()
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23511.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Physical plan protobuf serialization is being moved from the central
dispatch module into each `ExecutionPlan` implementation. Co-locating
this logic with the corresponding execution plan makes the serialization
code easier to maintain and incrementally reduces the central downcast
chain.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Implement plan-local protobuf serialization and deserialization for
  `ExplainExec`.
- Implement plan-local protobuf serialization and deserialization for
  `AnalyzeExec`.
- Remove both plans from the live central serialization dispatch.
- Retain the deprecated compatibility methods as delegates to the new
  implementations.
- Preserve the existing protobuf wire format.
- Strengthen roundtrip tests to cover all stored fields, including every
  `StringifiedPlan` variant, metric categories, and explain formats.

Each execution plan migration is kept in a separate commit.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. The following checks pass:

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Full extended workspace test suite
- `cargo test -p datafusion-proto --test proto_integration`

The proto integration suite passes all 209 tests after rebasing onto the
latest `main`.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No. This is an internal refactor and does not change the protobuf wire
format or user-facing behavior.
