### PR TITLE
fix: preserve input ordering required by limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ profile.json.gz
 
 # Claude Code personal settings
 .claude/settings.local.json
+
+.codex/config.toml

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 
 use super::*;
+use datafusion::assert_batches_eq;
 use datafusion_common::{ParamValues, ScalarValue, metadata::ScalarAndMetadata};
 use insta::assert_snapshot;
 
@@ -491,5 +492,41 @@ async fn test_recursive_cte_batch_schema_stable_with_order_by_limit() -> Result<
             "batch {i} schema field names leaked from recursive branch"
         );
     }
+    Ok(())
+}
+
+#[tokio::test]
+async fn ordered_offset_subquery_preserves_selected_row() -> Result<()> {
+    let ctx = SessionContext::new_with_config(
+        SessionConfig::new().set_usize("datafusion.optimizer.max_passes", 1),
+    );
+    let results = ctx
+        .sql(
+            "SELECT grp, COUNT(*) AS n
+             FROM (
+               SELECT grp, sort_key
+               FROM (
+                 VALUES ('physical_second', 2), ('sorted_first', 1)
+               ) AS t(grp, sort_key)
+               ORDER BY sort_key ASC NULLS LAST
+               OFFSET 1
+             ) q
+             GROUP BY grp
+             ORDER BY grp",
+        )
+        .await?
+        .collect()
+        .await?;
+
+    assert_batches_eq!(
+        [
+            "+-----------------+---+",
+            "| grp             | n |",
+            "+-----------------+---+",
+            "| physical_second | 1 |",
+            "+-----------------+---+",
+        ],
+        &results
+    );
     Ok(())
 }

--- a/datafusion/physical-optimizer/src/ensure_requirements/enforce_sorting/mod.rs
+++ b/datafusion/physical-optimizer/src/ensure_requirements/enforce_sorting/mod.rs
@@ -444,7 +444,11 @@ pub fn ensure_sorting(
                 );
                 child = update_sort_ctx_children_data(child, true)?;
             }
-        } else if physical_ordering.is_none() || !plan.maintains_input_order()[idx] {
+        } else if !is_limit(plan)
+            && (physical_ordering.is_none() || !plan.maintains_input_order()[idx])
+        {
+            // Limit is excluded because it consumes the input sequence, so
+            // removing a linked sort can change which rows it skips or returns.
             // We have a `SortExec` whose effect may be neutralized by another
             // order-imposing operator, remove this sort:
             child = update_child_to_remove_unnecessary_sort(idx, child, plan)?;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23534.

## Rationale for this change

EnsureRequirements may remove a descendant SortExec when the child has no visible output ordering.

This is incorrect at a LIMIT boundary because LIMIT and OFFSET depend on the input sequence to determine which    rows are returned. When an intervening ProjectionExec removes the sort key, its output_ordering() becomes None, even though it still preserves the row sequence. The optimizer then incorrectly removes the sort below the projection, producing incorrect results.

## What changes are included in this PR?

- Prevent EnsureRequirements from removing a linked SortExec at a limit boundary.

- Add a SQL regression test that verifies the correct row is selected by an ordered subquery with OFFSET.

- Configure the regression test with one logical optimizer pass to ensure correctness does not depend on a later logical rewrite.

No public API changes are included.

## Are these changes tested?

Yes. The regression test fails without the fix, returning sorted_first instead of physical_second.

The following checks were run:

```shell
cargo test -p datafusion --test core_integration \
  ordered_offset_subquery_preserves_selected_row -- --nocapture

cargo fmt --all

cargo clippy --all-targets --all-features -- -D warnings

RUST_BACKTRACE=1 cargo test --profile ci \
  --exclude datafusion-examples \
  --exclude datafusion-benchmarks \
  --exclude datafusion-cli \
  --workspace --lib --tests --bins \
  --features
  avro,json,backtrace,extended_tests,recursive_protection,parquet_
  encryption
```

## Are there any user-facing changes?

Yes. Ordered subqueries followed by LIMIT or OFFSET now preserve the sort needed to select the correct rows when an intervening projection hides the sort key.

There are no public API or documentation changes.