### PR TITLE
fix: output_bytes metric in hash aggregation

### DIFF
--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -179,6 +179,11 @@ impl RecordBatchMemoryCounter {
         total_size
     }
 
+    /// Increase the memory usage by n
+    pub fn add(&mut self, n: usize) {
+        self.memory_usage += n;
+    }
+
     /// Total memory of the unique buffers of all batches counted so far.
     pub fn memory_usage(&self) -> usize {
         self.memory_usage

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -214,6 +214,11 @@ impl RecordBatchMemoryCounter {
         total_size
     }
 
+    /// Increase the memory usage by n
+    pub fn add(&mut self, n: usize) {
+        self.memory_usage += n;
+    }
+
     /// Total memory of all counted allocations.
     pub fn memory_usage(&self) -> usize {
         self.memory_usage

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -937,6 +937,77 @@ mod record_batch_tests {
         assert_eq!(counter.memory_usage(), get_record_batch_memory_size(&batch));
     }
 
+    /// Counts 1000 same-shaped batches with one `RecordBatchMemoryCounter`,
+    /// returning `(undercounted_batches, charged_total, expected_total)`.
+    ///
+    /// With `retain == true` every batch is kept alive until the end, so no
+    /// buffer can be freed and no address recycled while the counter is used.
+    /// With `retain == false` each batch is dropped after being counted, as a
+    /// streaming consumer would, letting the allocator hand the same address
+    /// to the next batch.
+    fn count_fresh_batches(retain: bool) -> (usize, usize, usize) {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ints",
+            DataType::Int32,
+            false,
+        )]));
+        let make_batch = |seed: i32| {
+            let values: Vec<i32> = (seed..seed + 1024).collect();
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from(values))],
+            )
+            .unwrap()
+        };
+
+        let mut counter = RecordBatchMemoryCounter::new();
+        let mut retained = Vec::new();
+        let mut undercounted_batches = 0usize;
+        let mut expected_total = 0usize;
+
+        for seed in 0..1000 {
+            let batch = make_batch(seed);
+            let expected = get_record_batch_memory_size(&batch);
+            let charged = counter.count_batch(&batch);
+            expected_total += expected;
+            if charged < expected {
+                undercounted_batches += 1;
+            }
+            if retain {
+                retained.push(batch);
+            }
+            // Otherwise `batch` is dropped here, freeing its buffer.
+        }
+
+        (undercounted_batches, counter.memory_usage(), expected_total)
+    }
+
+    /// While every counted batch stays alive, an address seen twice is a
+    /// genuinely shared buffer, so the counter is exact.
+    #[test]
+    fn test_record_batch_memory_counter_exact_while_batches_retained() {
+        let (undercounted, charged, expected) = count_fresh_batches(true);
+        assert_eq!(undercounted, 0);
+        assert_eq!(charged, expected);
+    }
+
+    /// Every batch here is new memory, so an exact counter charges all of
+    /// them. `RecordBatchMemoryCounter` identifies buffers by address, and
+    /// once a counted batch is dropped the allocator recycles its allocation
+    /// for the next same-sized batch, which the counter then skips as already
+    /// seen. Allocators bin by size class and prefer recently freed blocks, so
+    /// counting same-shaped batches in a loop hits this readily.
+    #[test]
+    fn test_record_batch_memory_counter_undercounts_after_address_reuse() {
+        let (undercounted, charged, expected) = count_fresh_batches(false);
+        println!("undercounted={undercounted} charged={charged} expected={expected}");
+        assert_eq!(
+            undercounted, 0,
+            "counter skipped {undercounted} fresh batches whose addresses were recycled"
+        );
+        assert_eq!(charged, expected);
+    }
+
     #[test]
     fn test_record_batch_memory_counter_promotes_buffer_set() {
         let fields = (0..=INLINE_BUFFER_IDS)

--- a/datafusion/ffi/src/physical_expr/metrics.rs
+++ b/datafusion/ffi/src/physical_expr/metrics.rs
@@ -37,8 +37,8 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use datafusion_common::format::{MetricCategory, MetricType};
 use datafusion_physical_expr_common::metrics::{
-    Count, CustomMetricValue, Gauge, MetricValue, MetricsSet, PruningMetrics,
-    RatioMergeStrategy, RatioMetrics, Time, Timestamp,
+    Count, CustomMetricValue, Gauge, MetricValue, MetricsSet, OutputBytesCount,
+    PruningMetrics, RatioMergeStrategy, RatioMetrics, Time, Timestamp,
 };
 use datafusion_physical_expr_common::metrics::{Label, Metric};
 use stabby::string::String as SString;
@@ -396,6 +396,12 @@ fn count_from_value(v: u64) -> Count {
     c
 }
 
+fn output_bytes_count_from_value(v: u64) -> OutputBytesCount {
+    let c = OutputBytesCount::new();
+    c.add(v as usize);
+    c
+}
+
 fn gauge_from_value(v: u64) -> Gauge {
     let g = Gauge::new();
     g.add(v as usize);
@@ -478,7 +484,9 @@ impl From<FFI_MetricValue> for MetricValue {
             }
             FFI_MetricValue::SpillCount(n) => Self::SpillCount(count_from_value(n)),
             FFI_MetricValue::SpilledBytes(n) => Self::SpilledBytes(count_from_value(n)),
-            FFI_MetricValue::OutputBytes(n) => Self::OutputBytes(count_from_value(n)),
+            FFI_MetricValue::OutputBytes(n) => {
+                Self::OutputBytes(output_bytes_count_from_value(n))
+            }
             FFI_MetricValue::OutputBatches(n) => Self::OutputBatches(count_from_value(n)),
             FFI_MetricValue::SpilledRows(n) => Self::SpilledRows(count_from_value(n)),
             FFI_MetricValue::CurrentMemoryUsage(n) => {
@@ -610,9 +618,11 @@ mod tests {
         assert_value_roundtrip(MetricValue::OutputRows(c.clone()));
         assert_value_roundtrip(MetricValue::SpillCount(c.clone()));
         assert_value_roundtrip(MetricValue::SpilledBytes(c.clone()));
-        assert_value_roundtrip(MetricValue::OutputBytes(c.clone()));
         assert_value_roundtrip(MetricValue::OutputBatches(c.clone()));
         assert_value_roundtrip(MetricValue::SpilledRows(c.clone()));
+
+        let obc = OutputBytesCount::new();
+        assert_value_roundtrip(MetricValue::OutputBytes(obc.clone()));
 
         let g = Gauge::new();
         g.add(123);

--- a/datafusion/ffi/src/physical_expr/metrics.rs
+++ b/datafusion/ffi/src/physical_expr/metrics.rs
@@ -397,7 +397,7 @@ fn count_from_value(v: u64) -> Count {
 }
 
 fn output_bytes_count_from_value(v: u64) -> OutputBytesCount {
-    let c = OutputBytesCount::new();
+    let c = OutputBytesCount::default();
     c.add(v as usize);
     c
 }
@@ -621,7 +621,7 @@ mod tests {
         assert_value_roundtrip(MetricValue::OutputBatches(c.clone()));
         assert_value_roundtrip(MetricValue::SpilledRows(c.clone()));
 
-        let obc = OutputBytesCount::new();
+        let obc = OutputBytesCount::default();
         assert_value_roundtrip(MetricValue::OutputBytes(obc.clone()));
 
         let g = Gauge::new();

--- a/datafusion/physical-expr-common/src/metrics/baseline.rs
+++ b/datafusion/physical-expr-common/src/metrics/baseline.rs
@@ -20,10 +20,11 @@
 use std::{borrow::Cow, collections::BTreeMap, sync::Arc, task::Poll};
 
 use arrow::record_batch::RecordBatch;
-use datafusion_common::{Result, utils::memory::get_record_batch_memory_size};
+use datafusion_common::Result;
 
 use super::{
-    Count, ExecutionPlanMetricsSet, Metric, MetricBuilder, MetricsSet, Time, Timestamp,
+    Count, ExecutionPlanMetricsSet, Metric, MetricBuilder, MetricsSet, OutputBytesCount,
+    Time, Timestamp,
 };
 
 const OUTPUT_ROWS_SKEW_METRIC_NAME: &str = "output_rows_skew";
@@ -66,7 +67,7 @@ pub struct BaselineMetrics {
     /// instances share underlying memory buffers, their sizes will be counted
     /// multiple times.
     /// Issue: <https://github.com/apache/datafusion/issues/16841>
-    output_bytes: Count,
+    output_bytes: OutputBytesCount,
 
     /// output batches: the total output batch count
     output_batches: Count,
@@ -331,8 +332,7 @@ impl RecordOutput for usize {
 impl RecordOutput for RecordBatch {
     fn record_output(self, bm: &BaselineMetrics) -> Self {
         bm.record_output(self.num_rows());
-        let n_bytes = get_record_batch_memory_size(&self);
-        bm.output_bytes.add(n_bytes);
+        bm.output_bytes.count_batch(&self);
         bm.output_batches.add(1);
         self
     }
@@ -341,8 +341,7 @@ impl RecordOutput for RecordBatch {
 impl RecordOutput for &RecordBatch {
     fn record_output(self, bm: &BaselineMetrics) -> Self {
         bm.record_output(self.num_rows());
-        let n_bytes = get_record_batch_memory_size(self);
-        bm.output_bytes.add(n_bytes);
+        bm.output_bytes.count_batch(self);
         bm.output_batches.add(1);
         self
     }

--- a/datafusion/physical-expr-common/src/metrics/baseline.rs
+++ b/datafusion/physical-expr-common/src/metrics/baseline.rs
@@ -100,6 +100,34 @@ impl BaselineMetrics {
         }
     }
 
+    /// Create a new BaselineMetric structure, and set `start_time` to now
+    pub fn new_with_deduplicated_output_bytes(
+        metrics: &ExecutionPlanMetricsSet,
+        partition: usize,
+    ) -> Self {
+        let start_time = MetricBuilder::new(metrics).start_timestamp(partition);
+        start_time.record();
+
+        Self {
+            end_time: MetricBuilder::new(metrics)
+                .with_type(super::MetricType::Summary)
+                .end_timestamp(partition),
+            elapsed_compute: MetricBuilder::new(metrics)
+                .with_type(super::MetricType::Summary)
+                .elapsed_compute(partition),
+            output_rows: MetricBuilder::new(metrics)
+                .with_type(super::MetricType::Summary)
+                .output_rows(partition),
+            output_bytes: MetricBuilder::new(metrics)
+                .with_type(super::MetricType::Summary)
+                .with_deduplicated_output_bytes(true)
+                .output_bytes(partition),
+            output_batches: MetricBuilder::new(metrics)
+                .with_type(super::MetricType::Dev)
+                .output_batches(partition),
+        }
+    }
+
     /// Returns a [`BaselineMetrics`] that updates the same `elapsed_compute` ignoring
     /// all other metrics
     ///
@@ -110,7 +138,7 @@ impl BaselineMetrics {
             end_time: Default::default(),
             elapsed_compute: self.elapsed_compute.clone(),
             output_rows: Default::default(),
-            output_bytes: Default::default(),
+            output_bytes: OutputBytesCount::new(self.output_bytes.is_deduped()),
             output_batches: Default::default(),
         }
     }

--- a/datafusion/physical-expr-common/src/metrics/builder.rs
+++ b/datafusion/physical-expr-common/src/metrics/builder.rs
@@ -25,8 +25,8 @@ use crate::metrics::{
 };
 
 use super::{
-    Count, ExecutionPlanMetricsSet, Gauge, Label, LabelValue, Metric, MetricValue, Time,
-    Timestamp,
+    Count, ExecutionPlanMetricsSet, Gauge, Label, LabelValue, Metric, MetricValue,
+    OutputBytesCount, Time, Timestamp,
 };
 
 /// Structure for constructing metrics, counters, timers, etc.
@@ -181,8 +181,8 @@ impl<'a> MetricBuilder<'a> {
     }
 
     /// Consume self and create a new counter for recording total output bytes
-    pub fn output_bytes(self, partition: usize) -> Count {
-        let count = Count::new();
+    pub fn output_bytes(self, partition: usize) -> OutputBytesCount {
+        let count = OutputBytesCount::new();
         self.with_category(MetricCategory::Bytes)
             .with_partition(partition)
             .build(MetricValue::OutputBytes(count.clone()));

--- a/datafusion/physical-expr-common/src/metrics/builder.rs
+++ b/datafusion/physical-expr-common/src/metrics/builder.rs
@@ -67,6 +67,9 @@ pub struct MetricBuilder<'a> {
     /// Semantic category (rows / bytes / timing).
     /// `None` means "always include" (the default for custom metrics).
     metric_category: Option<MetricCategory>,
+
+    /// Whether to deduplicate the output bytes between the record batches
+    deduped_output_bytes: bool,
 }
 
 impl<'a> MetricBuilder<'a> {
@@ -81,6 +84,7 @@ impl<'a> MetricBuilder<'a> {
             labels: vec![],
             metric_type: MetricType::Dev,
             metric_category: None,
+            deduped_output_bytes: false,
         }
     }
 
@@ -93,6 +97,12 @@ impl<'a> MetricBuilder<'a> {
     /// Set the metric type to the metric being constructed
     pub fn with_type(mut self, metric_type: MetricType) -> Self {
         self.metric_type = metric_type;
+        self
+    }
+
+    /// Set the deduplicated output bytes to the metric being constructed
+    pub fn with_deduplicated_output_bytes(mut self, deduped: bool) -> Self {
+        self.deduped_output_bytes = deduped;
         self
     }
 
@@ -132,6 +142,7 @@ impl<'a> MetricBuilder<'a> {
             metrics,
             metric_type,
             metric_category,
+            ..
         } = self;
         let mut metric =
             Metric::new_with_labels(value, partition, labels).with_type(metric_type);
@@ -182,7 +193,7 @@ impl<'a> MetricBuilder<'a> {
 
     /// Consume self and create a new counter for recording total output bytes
     pub fn output_bytes(self, partition: usize) -> OutputBytesCount {
-        let count = OutputBytesCount::new();
+        let count = OutputBytesCount::new(self.deduped_output_bytes);
         self.with_category(MetricCategory::Bytes)
             .with_partition(partition)
             .build(MetricValue::OutputBytes(count.clone()));

--- a/datafusion/physical-expr-common/src/metrics/mod.rs
+++ b/datafusion/physical-expr-common/src/metrics/mod.rs
@@ -43,8 +43,8 @@ pub use custom::CustomMetricValue;
 pub use elapsed_compute::{ElapsedComputeFuture, ElapsedComputeFutureExt};
 pub use expression::ExpressionEvaluatorMetrics;
 pub use value::{
-    Count, Gauge, MetricValue, PruningMetrics, RatioMergeStrategy, RatioMetrics,
-    ScopedTimerGuard, Time, Timestamp,
+    Count, Gauge, MetricValue, OutputBytesCount, PruningMetrics, RatioMergeStrategy,
+    RatioMetrics, ScopedTimerGuard, Time, Timestamp,
 };
 
 /// Something that tracks a value of interest (metric) during execution.

--- a/datafusion/physical-expr-common/src/metrics/mod.rs
+++ b/datafusion/physical-expr-common/src/metrics/mod.rs
@@ -44,8 +44,8 @@ pub use custom::CustomMetricValue;
 pub use elapsed_compute::{ElapsedComputeFuture, ElapsedComputeFutureExt};
 pub use expression::ExpressionEvaluatorMetrics;
 pub use value::{
-    Count, Gauge, MetricValue, PruningMetrics, RatioMergeStrategy, RatioMetrics,
-    ScopedTimerGuard, Time, Timestamp,
+    Count, Gauge, MetricValue, OutputBytesCount, PruningMetrics, RatioMergeStrategy,
+    RatioMetrics, ScopedTimerGuard, Time, Timestamp,
 };
 
 /// Something that tracks a value of interest (metric) during execution.

--- a/datafusion/physical-expr-common/src/metrics/value.rs
+++ b/datafusion/physical-expr-common/src/metrics/value.rs
@@ -18,9 +18,11 @@
 //! Value representation of metrics
 
 use super::CustomMetricValue;
+use arrow::record_batch::RecordBatch;
 use chrono::{DateTime, Utc};
 use datafusion_common::{
     human_readable_count, human_readable_duration, human_readable_size, instant::Instant,
+    utils::memory::RecordBatchMemoryCounter,
 };
 use parking_lot::Mutex;
 use std::{
@@ -32,6 +34,52 @@ use std::{
     },
     time::Duration,
 };
+
+/// A counter to record deduplicated RecordBatch output bytes
+/// see [`RecordBatchMemoryCounter`] for details
+#[derive(Debug, Clone)]
+pub struct OutputBytesCount {
+    /// value of the metric counter
+    value: Arc<Mutex<RecordBatchMemoryCounter>>,
+}
+
+impl Default for OutputBytesCount {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for OutputBytesCount {
+    fn eq(&self, other: &Self) -> bool {
+        self.value().eq(&other.value())
+    }
+}
+
+impl OutputBytesCount {
+    /// create a new counter
+    pub fn new() -> Self {
+        Self {
+            value: Arc::new(Mutex::new(RecordBatchMemoryCounter::new())),
+        }
+    }
+
+    /// Count the RecordBatch's memory
+    pub fn count_batch(&self, record_batch: &RecordBatch) {
+        let mut val = self.value.lock();
+        (*val).count_batch(record_batch);
+    }
+
+    /// Add `n` to the metric's value
+    pub fn add(&self, n: usize) {
+        let mut val = self.value.lock();
+        (*val).add(n);
+    }
+
+    /// Get the current value
+    pub fn value(&self) -> usize {
+        self.value.lock().memory_usage()
+    }
+}
 
 /// A counter to record things such as number of input or output rows
 ///
@@ -651,7 +699,7 @@ pub enum MetricValue {
     /// Total size of spilled bytes produced: "spilled_bytes" metric
     SpilledBytes(Count),
     /// Total size of output bytes produced: "output_bytes" metric
-    OutputBytes(Count),
+    OutputBytes(OutputBytesCount),
     /// Total number of output batches produced: "output_batches" metric
     OutputBatches(Count),
     /// Total size of spilled rows produced: "spilled_rows" metric
@@ -880,7 +928,7 @@ impl MetricValue {
             Self::OutputRows(_) => Self::OutputRows(Count::new()),
             Self::SpillCount(_) => Self::SpillCount(Count::new()),
             Self::SpilledBytes(_) => Self::SpilledBytes(Count::new()),
-            Self::OutputBytes(_) => Self::OutputBytes(Count::new()),
+            Self::OutputBytes(_) => Self::OutputBytes(OutputBytesCount::new()),
             Self::OutputBatches(_) => Self::OutputBatches(Count::new()),
             Self::SpilledRows(_) => Self::SpilledRows(Count::new()),
             Self::CurrentMemoryUsage(_) => Self::CurrentMemoryUsage(Gauge::new()),
@@ -940,7 +988,6 @@ impl MetricValue {
             (Self::OutputRows(count), Self::OutputRows(other_count))
             | (Self::SpillCount(count), Self::SpillCount(other_count))
             | (Self::SpilledBytes(count), Self::SpilledBytes(other_count))
-            | (Self::OutputBytes(count), Self::OutputBytes(other_count))
             | (Self::OutputBatches(count), Self::OutputBatches(other_count))
             | (Self::SpilledRows(count), Self::SpilledRows(other_count))
             | (
@@ -949,6 +996,9 @@ impl MetricValue {
                     count: other_count, ..
                 },
             ) => count.add(other_count.value()),
+            (Self::OutputBytes(count), Self::OutputBytes(other_count)) => {
+                count.add(other_count.value())
+            }
             (Self::CurrentMemoryUsage(gauge), Self::CurrentMemoryUsage(other_gauge))
             | (
                 Self::Gauge { gauge, .. },
@@ -1084,7 +1134,11 @@ impl Display for MetricValue {
             | Self::Count { count, .. } => {
                 write!(f, "{count}")
             }
-            Self::SpilledBytes(count) | Self::OutputBytes(count) => {
+            Self::SpilledBytes(count) => {
+                let readable_count = human_readable_size(count.value());
+                write!(f, "{readable_count}")
+            }
+            Self::OutputBytes(count) => {
                 let readable_count = human_readable_size(count.value());
                 write!(f, "{readable_count}")
             }

--- a/datafusion/physical-expr-common/src/metrics/value.rs
+++ b/datafusion/physical-expr-common/src/metrics/value.rs
@@ -21,8 +21,9 @@ use super::CustomMetricValue;
 use arrow::record_batch::RecordBatch;
 use chrono::{DateTime, Utc};
 use datafusion_common::{
-    human_readable_count, human_readable_duration, human_readable_size, instant::Instant,
-    utils::memory::RecordBatchMemoryCounter,
+    human_readable_count, human_readable_duration, human_readable_size,
+    instant::Instant,
+    utils::memory::{RecordBatchMemoryCounter, get_record_batch_memory_size},
 };
 use parking_lot::Mutex;
 use std::{
@@ -38,14 +39,15 @@ use std::{
 /// A counter to record deduplicated RecordBatch output bytes
 /// see [`RecordBatchMemoryCounter`] for details
 #[derive(Debug, Clone)]
-pub struct OutputBytesCount {
+pub enum OutputBytesCount {
     /// value of the metric counter
-    value: Arc<Mutex<RecordBatchMemoryCounter>>,
+    Deduped(Arc<Mutex<RecordBatchMemoryCounter>>),
+    Plain(Count),
 }
 
 impl Default for OutputBytesCount {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
@@ -57,27 +59,49 @@ impl PartialEq for OutputBytesCount {
 
 impl OutputBytesCount {
     /// create a new counter
-    pub fn new() -> Self {
-        Self {
-            value: Arc::new(Mutex::new(RecordBatchMemoryCounter::new())),
+    pub fn new(deduped: bool) -> Self {
+        if deduped {
+            Self::Deduped(Arc::new(Mutex::new(RecordBatchMemoryCounter::new())))
+        } else {
+            Self::Plain(Count::new())
         }
+    }
+
+    pub fn is_deduped(&self) -> bool {
+        matches!(&self, &OutputBytesCount::Deduped(_))
     }
 
     /// Count the RecordBatch's memory
     pub fn count_batch(&self, record_batch: &RecordBatch) {
-        let mut val = self.value.lock();
-        (*val).count_batch(record_batch);
+        match &self {
+            Self::Deduped(val) => {
+                let mut val = val.lock();
+                (*val).count_batch(record_batch);
+            }
+            Self::Plain(val) => {
+                let n_bytes = get_record_batch_memory_size(record_batch);
+                val.add(n_bytes);
+            }
+        }
     }
 
     /// Add `n` to the metric's value
     pub fn add(&self, n: usize) {
-        let mut val = self.value.lock();
-        (*val).add(n);
+        match &self {
+            Self::Deduped(val) => {
+                let mut val = val.lock();
+                (*val).add(n);
+            }
+            Self::Plain(val) => val.add(n),
+        }
     }
 
     /// Get the current value
     pub fn value(&self) -> usize {
-        self.value.lock().memory_usage()
+        match self {
+            Self::Deduped(val) => val.lock().memory_usage(),
+            Self::Plain(val) => val.value(),
+        }
     }
 }
 
@@ -928,7 +952,9 @@ impl MetricValue {
             Self::OutputRows(_) => Self::OutputRows(Count::new()),
             Self::SpillCount(_) => Self::SpillCount(Count::new()),
             Self::SpilledBytes(_) => Self::SpilledBytes(Count::new()),
-            Self::OutputBytes(_) => Self::OutputBytes(OutputBytesCount::new()),
+            Self::OutputBytes(val) => {
+                Self::OutputBytes(OutputBytesCount::new(val.is_deduped()))
+            }
             Self::OutputBatches(_) => Self::OutputBatches(Count::new()),
             Self::SpilledRows(_) => Self::SpilledRows(Count::new()),
             Self::CurrentMemoryUsage(_) => Self::CurrentMemoryUsage(Gauge::new()),

--- a/datafusion/physical-plan/src/aggregates/aggregate_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/aggregate_stream.rs
@@ -296,7 +296,8 @@ impl AggregateStream {
         let agg_schema = Arc::clone(&agg.schema);
         let agg_filter_expr = Arc::clone(&agg.filter_expr);
 
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
         let input = agg.input.execute(partition, Arc::clone(context))?;
 
         let aggregate_expressions = aggregate_expressions(&agg.aggr_expr, &agg.mode, 0)?;

--- a/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs
@@ -401,7 +401,8 @@ impl GroupedHashAggregateStream {
 
         let batch_size = context.session_config().batch_size();
         let input = agg.input.execute(partition, Arc::clone(context))?;
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
         let group_by_metrics = GroupByMetrics::new(&agg.metrics, partition);
         let aggregate_labels = agg
             .aggr_expr

--- a/datafusion/physical-plan/src/aggregates/grouped_topk_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_topk_stream.rs
@@ -73,7 +73,8 @@ impl GroupedTopKAggregateStream {
         let agg_schema = Arc::clone(&aggr.schema);
         let group_by = Arc::clone(&aggr.group_by);
         let input = aggr.input.execute(partition, Arc::clone(context))?;
-        let baseline_metrics = BaselineMetrics::new(&aggr.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&aggr.metrics, partition);
         let group_by_metrics = GroupByMetrics::new(&aggr.metrics, partition);
         let aggregate_argument_metrics = AggregateArgumentMetrics::new(
             &aggr.metrics,

--- a/datafusion/physical-plan/src/aggregates/hash_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/hash_stream.rs
@@ -387,7 +387,8 @@ impl PartialHashAggregateStream {
         let schema = Arc::clone(&agg.schema);
         let input = agg.input.execute(partition, Arc::clone(context))?;
         let batch_size = context.session_config().batch_size();
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
 
         // Preserve the existing aggregate metric surface for this plan node.
         let _spill_metrics = SpillMetrics::new(&agg.metrics, partition);
@@ -705,7 +706,8 @@ impl FinalHashAggregateStream {
         let input = agg.input.execute(partition, Arc::clone(context))?;
         let input_schema = input.schema();
         let batch_size = context.session_config().batch_size();
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
         let spill_metrics = SpillMetrics::new(&agg.metrics, partition);
 
         let hash_table = AggregateHashTable::<FinalMarker>::new(

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -8467,4 +8467,154 @@ mod tests {
         assert!(agg.set_dynamic_filter(df).is_err());
         Ok(())
     }
+
+    /// Reproduces `output_bytes` undercounting caused by buffer address reuse.
+    ///
+    /// The deduplicating `output_bytes` counter identifies buffers by address
+    /// for the lifetime of the stream. A streaming aggregate hands each output
+    /// batch downstream and forgets it; once the consumer drops it, the
+    /// allocator may hand the same address to the next emitted batch, which the
+    /// counter then treats as already counted.
+    ///
+    /// Sorted partial aggregation emits a fresh materialization per completed
+    /// group range, so it produces many independently allocated output batches
+    /// with no shared buffers between them. Each is smaller than `batch_size`,
+    /// so none is sliced and measuring each batch on its own is exact.
+    #[tokio::test]
+    async fn output_bytes_metric_undercounts_when_buffer_addresses_are_reused()
+    -> Result<()> {
+        use datafusion_common::utils::memory::{
+            RecordBatchMemoryCounter, get_record_batch_memory_size,
+        };
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("value", DataType::Int64, false),
+        ]));
+
+        // 200 input batches, each with 512 distinct, strictly increasing keys.
+        let keys_per_batch = 512;
+        let input_batches = (0..200i32)
+            .map(|i| {
+                let start = i * keys_per_batch;
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![
+                        Arc::new(Int32Array::from(
+                            (start..start + keys_per_batch).collect::<Vec<_>>(),
+                        )),
+                        Arc::new(Int64Array::from(vec![1i64; keys_per_batch as usize])),
+                    ],
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let ordering = LexOrdering::new([PhysicalSortExpr::new_default(Arc::new(
+            Column::new("key", 0),
+        ))])
+        .unwrap();
+        let input = TestMemoryExec::try_new(&[input_batches], Arc::clone(&schema), None)?
+            .try_with_sort_information(vec![ordering])?;
+        let input = Arc::new(TestMemoryExec::update_cache(&Arc::new(input)));
+
+        let group_by =
+            PhysicalGroupBy::new_single(vec![(col("key", &schema)?, "key".to_string())]);
+        let aggr_expr = vec![Arc::new(
+            AggregateExprBuilder::new(count_udaf(), vec![col("value", &schema)?])
+                .schema(Arc::clone(&schema))
+                .alias("COUNT(value)")
+                .build()?,
+        )];
+        let aggregate = Arc::new(AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by,
+            aggr_expr,
+            vec![None],
+            input,
+            Arc::clone(&schema),
+        )?);
+        assert_eq!(aggregate.input_order_mode(), &InputOrderMode::Sorted);
+
+        // batch_size larger than any emitted batch so nothing is sliced.
+        let task_ctx = Arc::new(
+            TaskContext::default()
+                .with_session_config(SessionConfig::new().with_batch_size(8192)),
+        );
+
+        // Pass 1: ground truth. Retain every output batch so no buffer can be
+        // freed and no address recycled. Any address match between batches is
+        // then a genuine shared buffer. If the deduplicated total over all
+        // retained batches equals the per-batch sum, the emits share nothing
+        // and the per-batch sum is the exact expected value.
+        let retained = collect(aggregate.execute(0, Arc::clone(&task_ctx))?).await?;
+        let output_batches = retained.len();
+        assert!(output_batches > 1, "test needs many separate emits");
+        let per_batch_sum: usize = retained
+            .iter()
+            .map(|batch| {
+                assert!(batch.num_rows() <= 8192, "batch was sliced");
+                get_record_batch_memory_size(batch)
+            })
+            .sum();
+        let mut ground_truth = RecordBatchMemoryCounter::new();
+        for batch in &retained {
+            ground_truth.count_batch(batch);
+        }
+        let expected_bytes = ground_truth.memory_usage();
+        assert_eq!(
+            expected_bytes, per_batch_sum,
+            "emitted batches share buffers; per-batch sum is not a valid expectation"
+        );
+        // Pass 1 also fed the metric while every batch was alive, so it must
+        // agree with the ground truth. This confirms the counter is exact when
+        // its retention requirement holds.
+        let metrics_while_retained = aggregate.metrics().unwrap();
+        let reported_while_retained = metrics_while_retained
+            .sum(|m| matches!(m.value(), MetricValue::OutputBytes(_)))
+            .unwrap()
+            .as_usize();
+        assert_eq!(reported_while_retained, expected_bytes);
+        drop(retained);
+
+        // Pass 2: consume like a real downstream operator, measure then drop.
+        // Use a fresh AggregateExec so its metrics are not mixed with pass 1.
+        let aggregate = Arc::new(AggregateExec::try_new(
+            AggregateMode::Partial,
+            aggregate.group_expr().clone(),
+            aggregate.aggr_expr().to_vec(),
+            aggregate.filter_expr().to_vec(),
+            Arc::clone(aggregate.input()),
+            Arc::clone(&schema),
+        )?);
+        let mut stream = aggregate.execute(0, task_ctx)?;
+        let mut dropped_batches = 0usize;
+        while let Some(batch) = stream.next().await {
+            let batch = batch?;
+            assert!(batch.num_rows() <= 8192, "batch was sliced");
+            dropped_batches += 1;
+        }
+        assert_eq!(dropped_batches, output_batches);
+
+        let metrics = aggregate.metrics().unwrap();
+        let reported_bytes = metrics
+            .sum(|m| matches!(m.value(), MetricValue::OutputBytes(_)))
+            .unwrap()
+            .as_usize();
+        let reported_batches = metrics
+            .sum(|m| matches!(m.value(), MetricValue::OutputBatches(_)))
+            .unwrap()
+            .as_usize();
+        assert_eq!(reported_batches, output_batches);
+
+        println!(
+            "output_batches={output_batches} reported_bytes={reported_bytes} \
+             expected_bytes={expected_bytes}"
+        );
+        assert_eq!(
+            reported_bytes, expected_bytes,
+            "output_bytes undercounts: {reported_bytes} reported vs {expected_bytes} \
+             actually emitted across {output_batches} batches"
+        );
+        Ok(())
+    }
 }

--- a/datafusion/physical-plan/src/aggregates/ordered_final_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/ordered_final_stream.rs
@@ -282,7 +282,8 @@ impl OrderedFinalAggregateStream {
         input: SendableRecordBatchStream,
         input_order_mode: &InputOrderMode,
     ) -> Result<Self> {
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
         let metrics = OrderedAggregateTableMetrics::new(agg, partition);
         let spill_metrics = SpillMetrics::new(&agg.metrics, partition);
         let reservation =

--- a/datafusion/physical-plan/src/aggregates/ordered_partial_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/ordered_partial_stream.rs
@@ -131,7 +131,8 @@ impl OrderedPartialAggregateStream {
         let schema = Arc::clone(&agg.schema);
         let input = agg.input.execute(partition, Arc::clone(context))?;
         let batch_size = context.session_config().batch_size();
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
 
         // Preserve the existing aggregate metric surface for this plan node.
         let _spill_metrics = SpillMetrics::new(&agg.metrics, partition);

--- a/datafusion/physical-plan/src/aggregates/ordered_single_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/ordered_single_stream.rs
@@ -335,7 +335,8 @@ impl OrderedSingleAggregateStream {
         let input = agg.input.execute(partition, Arc::clone(context))?;
         let input_schema = input.schema();
         let batch_size = context.session_config().batch_size();
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
         let spill_metrics = SpillMetrics::new(&agg.metrics, partition);
         let state_schema = Arc::new(create_schema(
             input_schema.as_ref(),

--- a/datafusion/physical-plan/src/aggregates/partial_reduce_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/partial_reduce_stream.rs
@@ -189,7 +189,8 @@ impl PartialReduceHashAggregateStream {
         let schema = Arc::clone(&agg.schema);
         let input = agg.input.execute(partition, Arc::clone(context))?;
         let batch_size = context.session_config().batch_size();
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
 
         // Preserve the existing aggregate metric surface for this plan node.
         let _spill_metrics = SpillMetrics::new(&agg.metrics, partition);

--- a/datafusion/physical-plan/src/aggregates/single_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/single_stream.rs
@@ -334,7 +334,8 @@ impl SingleHashAggregateStream {
         let input = agg.input.execute(partition, Arc::clone(context))?;
         let input_schema = input.schema();
         let batch_size = context.session_config().batch_size();
-        let baseline_metrics = BaselineMetrics::new(&agg.metrics, partition);
+        let baseline_metrics =
+            BaselineMetrics::new_with_deduplicated_output_bytes(&agg.metrics, partition);
         let spill_metrics = SpillMetrics::new(&agg.metrics, partition);
         let state_schema = Arc::new(create_schema(
             input_schema.as_ref(),

--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -800,9 +800,8 @@ impl PgJsonExecutionPlanVisitor<'_> {
             MetricValue::SpillCount(c)
             | MetricValue::OutputBatches(c)
             | MetricValue::SpilledRows(c) => serde_json::Value::from(c.value()),
-            MetricValue::SpilledBytes(c) | MetricValue::OutputBytes(c) => {
-                serde_json::Value::from(c.value())
-            }
+            MetricValue::SpilledBytes(c) => serde_json::Value::from(c.value()),
+            MetricValue::OutputBytes(c) => serde_json::Value::from(c.value()),
             MetricValue::CurrentMemoryUsage(g) => serde_json::Value::from(g.value()),
             MetricValue::ElapsedCompute(t) => {
                 // Emit as float milliseconds to align with PG's

--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -808,9 +808,8 @@ impl PgJsonExecutionPlanVisitor<'_> {
             MetricValue::SpillCount(c)
             | MetricValue::OutputBatches(c)
             | MetricValue::SpilledRows(c) => serde_json::Value::from(c.value()),
-            MetricValue::SpilledBytes(c) | MetricValue::OutputBytes(c) => {
-                serde_json::Value::from(c.value())
-            }
+            MetricValue::SpilledBytes(c) => serde_json::Value::from(c.value()),
+            MetricValue::OutputBytes(c) => serde_json::Value::from(c.value()),
             MetricValue::CurrentMemoryUsage(g) => serde_json::Value::from(g.value()),
             MetricValue::ElapsedCompute(t) => {
                 // Emit as float milliseconds to align with PG's

--- a/datafusion/sqllogictest/test_files/aggregate_output_bytes.slt
+++ b/datafusion/sqllogictest/test_files/aggregate_output_bytes.slt
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# --------------------------------------------
+# Regression test for the hash aggregation `output_bytes` metric.
+#
+# The hash aggregate's grouping table materializes its emitted output as a
+# single RecordBatch and then slices it into `batch_size`-sized chunks across
+# successive `poll_next` calls. Those slices share the same underlying
+# buffers (Arrow `.slice()` is zero-copy), so each buffer must only be
+# counted once in `output_bytes`, no matter how many slices reference it.
+#
+# Using `RecordBatch::record_output` (as the streams used to) recomputes
+# memory usage from scratch on every slice, with no memory of buffers
+# already counted -- so all N slices of one materialization each count the
+# shared buffers again, inflating `output_bytes` by ~Nx. `RecordBatchMemoryMetrics`
+# fixes this by tracking already-counted buffers across all the slices of one
+# materialization, so a shared buffer is only counted on the first slice
+# that references it.
+#
+# The two `output_bytes` values below (1264.0 B vs 1344.0 B) are close but
+# not bit-for-bit equal -- `batch_size` also affects how `DataSourceExec`
+# chunks the *input* to the aggregator, independently of how the aggregate's
+# own output gets sliced, which shifts the exact materialized size by a few
+# bytes. That's expected and not what this test checks. What matters is that
+# `output_bytes` does not scale with the number of output batches: it must
+# stay at `1344.0 B` when sliced into 3 batches, not jump to ~3x that value.
+# --------------------------------------------
+
+statement ok
+set datafusion.execution.target_partitions = 1;
+
+statement ok
+set datafusion.explain.analyze_level = dev;
+
+statement ok
+CREATE TABLE agg_output_bytes_src AS
+SELECT value AS group_col, 1::BIGINT AS value_col
+FROM generate_series(0, 29) AS t(value);
+
+# batch_size = 100: the 30-row emit fits in one output batch, no slicing.
+statement ok
+set datafusion.execution.batch_size = 100;
+
+query TT
+EXPLAIN ANALYZE
+SELECT group_col, COUNT(value_col) FROM agg_output_bytes_src GROUP BY group_col;
+----
+Plan with Metrics
+01)AggregateExec: mode=Single, gby=[group_col@0 as group_col], aggr=[count(agg_output_bytes_src.value_col)], metrics=[output_rows=30, elapsed_compute=<slt:ignore>, output_bytes=1264.0 B, output_batches=1, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, aggregate_arguments_time=<slt:ignore>, aggregation_time=<slt:ignore>, emitting_time=<slt:ignore>, time_calculating_group_ids=<slt:ignore>]
+02)--DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+# batch_size = 10: the same 30-row emit is sliced into 3 output batches, all
+# sharing buffers with the same underlying materialized batch. output_bytes
+# must stay at 1344.0 B, not be inflated to ~3x that (see header comment).
+statement ok
+set datafusion.execution.batch_size = 10;
+
+query TT
+EXPLAIN ANALYZE
+SELECT group_col, COUNT(value_col) FROM agg_output_bytes_src GROUP BY group_col;
+----
+Plan with Metrics
+01)AggregateExec: mode=Single, gby=[group_col@0 as group_col], aggr=[count(agg_output_bytes_src.value_col)], metrics=[output_rows=30, elapsed_compute=<slt:ignore>, output_bytes=1344.0 B, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, aggregate_arguments_time=<slt:ignore>, aggregation_time=<slt:ignore>, emitting_time=<slt:ignore>, time_calculating_group_ids=<slt:ignore>]
+02)--DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
+
+statement ok
+DROP TABLE agg_output_bytes_src;
+
+statement ok
+reset datafusion.execution.batch_size;
+
+statement ok
+reset datafusion.explain.analyze_level;
+
+statement ok
+set datafusion.execution.target_partitions = 4;

--- a/datafusion/sqllogictest/test_files/aggregate_output_bytes.slt
+++ b/datafusion/sqllogictest/test_files/aggregate_output_bytes.slt
@@ -61,7 +61,7 @@ EXPLAIN ANALYZE
 SELECT group_col, COUNT(value_col) FROM agg_output_bytes_src GROUP BY group_col;
 ----
 Plan with Metrics
-01)AggregateExec: mode=Single, gby=[group_col@0 as group_col], aggr=[count(agg_output_bytes_src.value_col)], metrics=[output_rows=30, elapsed_compute=<slt:ignore>, output_bytes=1264.0 B, output_batches=1, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, aggregate_arguments_time=<slt:ignore>, aggregation_time=<slt:ignore>, emitting_time=<slt:ignore>, time_calculating_group_ids=<slt:ignore>]
+01)AggregateExec: mode=Single, gby=[group_col@0 as group_col], aggr=[count(agg_output_bytes_src.value_col)], metrics=[output_rows=30, elapsed_compute=<slt:ignore>, output_bytes=1264.0 B, output_batches=1, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, agg_expr_0_arguments_time=<slt:ignore>, agg_expr_0_evaluate_time=<slt:ignore>, agg_expr_0_merge_time=<slt:ignore>, agg_expr_0_state_time=<slt:ignore>, agg_expr_0_update_time=<slt:ignore>, aggregate_arguments_time=<slt:ignore>, aggregation_time=<slt:ignore>, emitting_time=<slt:ignore>, time_calculating_group_ids=<slt:ignore>]
 02)--DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
 
 # batch_size = 10: the same 30-row emit is sliced into 3 output batches, all
@@ -75,7 +75,7 @@ EXPLAIN ANALYZE
 SELECT group_col, COUNT(value_col) FROM agg_output_bytes_src GROUP BY group_col;
 ----
 Plan with Metrics
-01)AggregateExec: mode=Single, gby=[group_col@0 as group_col], aggr=[count(agg_output_bytes_src.value_col)], metrics=[output_rows=30, elapsed_compute=<slt:ignore>, output_bytes=1344.0 B, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, aggregate_arguments_time=<slt:ignore>, aggregation_time=<slt:ignore>, emitting_time=<slt:ignore>, time_calculating_group_ids=<slt:ignore>]
+01)AggregateExec: mode=Single, gby=[group_col@0 as group_col], aggr=[count(agg_output_bytes_src.value_col)], metrics=[output_rows=30, elapsed_compute=<slt:ignore>, output_bytes=1344.0 B, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, agg_expr_0_arguments_time=<slt:ignore>, agg_expr_0_evaluate_time=<slt:ignore>, agg_expr_0_merge_time=<slt:ignore>, agg_expr_0_state_time=<slt:ignore>, agg_expr_0_update_time=<slt:ignore>, aggregate_arguments_time=<slt:ignore>, aggregation_time=<slt:ignore>, emitting_time=<slt:ignore>, time_calculating_group_ids=<slt:ignore>]
 02)--DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
 
 statement ok

--- a/datafusion/sqllogictest/test_files/explain_analyze.slt
+++ b/datafusion/sqllogictest/test_files/explain_analyze.slt
@@ -383,7 +383,7 @@ FROM t1
 CROSS JOIN t2;
 ----
 Plan with Metrics
-01)CrossJoinExec, metrics=[output_bytes=96.0 B, build_mem_used=128.0 B]
+01)CrossJoinExec, metrics=[output_bytes=64.0 B, build_mem_used=128.0 B]
 02)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
 03)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
 04)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]

--- a/datafusion/sqllogictest/test_files/explain_analyze.slt
+++ b/datafusion/sqllogictest/test_files/explain_analyze.slt
@@ -383,7 +383,7 @@ FROM t1
 CROSS JOIN t2;
 ----
 Plan with Metrics
-01)CrossJoinExec, metrics=[output_bytes=64.0 B, build_mem_used=128.0 B]
+01)CrossJoinExec, metrics=[output_bytes=96.0 B, build_mem_used=128.0 B]
 02)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]
 03)----DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]
 04)--ProjectionExec: expr=[column1@0 as k], metrics=[output_bytes=32.0 B]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23776.

## Rationale for this change
Summing together the produced sliced RecordBatches in hash aggregation leads to inflated output_bytes metric

## What changes are included in this PR?


## Are these changes tested?
Yes

## Are there any user-facing changes?
If the metrics are user-facing, then yes.