### PR TITLE
feat: allow configuring datafusion-cli history file location

### DIFF
--- a/datafusion-cli/examples/cli-session-context.rs
+++ b/datafusion-cli/examples/cli-session-context.rs
@@ -94,5 +94,7 @@ pub async fn main() {
         instrumented_registry: Arc::new(InstrumentedObjectStoreRegistry::new()),
     };
 
-    exec_from_repl(&my_ctx, &mut print_options).await.unwrap();
+    exec_from_repl(&my_ctx, &mut print_options, None)
+        .await
+        .unwrap();
 }

--- a/datafusion-cli/examples/cli-session-context.rs
+++ b/datafusion-cli/examples/cli-session-context.rs
@@ -94,7 +94,8 @@ pub async fn main() {
         instrumented_registry: Arc::new(InstrumentedObjectStoreRegistry::new()),
     };
 
-    exec_from_repl(&my_ctx, &mut print_options, None)
+    let repl_options = Default::default();
+    exec_from_repl(&my_ctx, &mut print_options, &repl_options)
         .await
         .unwrap();
 }

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -48,6 +48,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::prelude::*;
+use std::path::Path;
 use tokio::signal;
 
 /// run and execute SQL statements and commands, against a context with the given print options
@@ -129,13 +130,15 @@ pub async fn exec_from_files(
 pub async fn exec_from_repl(
     ctx: &dyn CliSessionContext,
     print_options: &mut PrintOptions,
+    history_file: Option<&Path>,
 ) -> rustyline::Result<()> {
+    let history_file = history_file.unwrap_or_else(|| Path::new(".history"));
     let mut rl = Editor::new()?;
     rl.set_helper(Some(CliHelper::new(
         &ctx.task_ctx().session_config().options().sql_parser.dialect,
         print_options.color,
     )));
-    rl.load_history(".history").ok();
+    rl.load_history(history_file).ok();
 
     loop {
         match rl.readline("> ") {
@@ -210,7 +213,7 @@ pub async fn exec_from_repl(
         }
     }
 
-    rl.save_history(".history")
+    rl.save_history(history_file)
 }
 
 pub(super) async fn exec_and_print(

--- a/datafusion-cli/src/exec.rs
+++ b/datafusion-cli/src/exec.rs
@@ -20,6 +20,7 @@
 use crate::cli_context::CliSessionContext;
 use crate::helper::split_from_semicolon;
 use crate::print_format::PrintFormat;
+use crate::repl_options::ReplOptions;
 use crate::{
     command::{Command, OutputFormat},
     helper::CliHelper,
@@ -48,7 +49,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::prelude::*;
-use std::path::Path;
 use tokio::signal;
 
 /// run and execute SQL statements and commands, against a context with the given print options
@@ -130,15 +130,14 @@ pub async fn exec_from_files(
 pub async fn exec_from_repl(
     ctx: &dyn CliSessionContext,
     print_options: &mut PrintOptions,
-    history_file: Option<&Path>,
+    repl_options: &ReplOptions,
 ) -> rustyline::Result<()> {
-    let history_file = history_file.unwrap_or_else(|| Path::new(".history"));
     let mut rl = Editor::new()?;
     rl.set_helper(Some(CliHelper::new(
         &ctx.task_ctx().session_config().options().sql_parser.dialect,
         print_options.color,
     )));
-    rl.load_history(history_file).ok();
+    rl.load_history(&repl_options.history_file).ok();
 
     loop {
         match rl.readline("> ") {
@@ -213,7 +212,7 @@ pub async fn exec_from_repl(
         }
     }
 
-    rl.save_history(history_file)
+    rl.save_history(&repl_options.history_file)
 }
 
 pub(super) async fn exec_and_print(

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -18,7 +18,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::num::NonZeroUsize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::{Arc, LazyLock};
 
@@ -108,6 +108,13 @@ struct Args {
         conflicts_with = "file"
     )]
     rc: Option<Vec<String>>,
+
+    #[clap(
+        long,
+        help = "Path to the file used to persist interactive shell history. Overrides DATAFUSION_HISTORY_FILE if set, default to .history",
+        value_parser(parse_valid_history_file)
+    )]
+    history_file: Option<String>,
 
     #[clap(long, value_enum, default_value_t = PrintFormat::Automatic)]
     format: PrintFormat,
@@ -304,12 +311,17 @@ async fn main_inner() -> Result<()> {
         }
     };
 
+    let history_file = args
+        .history_file
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("DATAFUSION_HISTORY_FILE").map(PathBuf::from));
+
     if repl_mode {
         if !rc.is_empty() {
             exec::exec_from_files(&ctx, rc, &print_options).await?;
         }
         // TODO maybe we can have thiserror for cli but for now let's keep it simple
-        return exec::exec_from_repl(&ctx, &mut print_options)
+        return exec::exec_from_repl(&ctx, &mut print_options, history_file.as_deref())
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)));
     }
@@ -376,6 +388,25 @@ fn parse_valid_data_dir(dir: &str) -> Result<String, String> {
         Ok(dir.to_string())
     } else {
         Err(format!("Invalid data directory '{dir}'"))
+    }
+}
+
+fn parse_valid_history_file(path: &str) -> Result<String, String> {
+    let path = Path::new(path);
+    if path.is_dir() {
+        return Err(format!(
+            "Invalid history file '{}': is a directory",
+            path.display()
+        ));
+    }
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() && !parent.is_dir() => {
+            Err(format!(
+                "Invalid history file '{}': parent directory does not exist",
+                path.display()
+            ))
+        }
+        _ => Ok(path.to_string_lossy().into_owned()),
     }
 }
 

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -43,6 +43,7 @@ use datafusion_cli::{
     pool_type::PoolType,
     print_format::PrintFormat,
     print_options::{MaxRows, PrintOptions},
+    repl_options::ReplOptions,
 };
 
 use clap::Parser;
@@ -311,17 +312,14 @@ async fn main_inner() -> Result<()> {
         }
     };
 
-    let history_file = args
-        .history_file
-        .map(PathBuf::from)
-        .or_else(|| env::var_os("DATAFUSION_HISTORY_FILE").map(PathBuf::from));
-
     if repl_mode {
         if !rc.is_empty() {
             exec::exec_from_files(&ctx, rc, &print_options).await?;
         }
+        let repl_options = get_repl_options(&args.history_file);
+
         // TODO maybe we can have thiserror for cli but for now let's keep it simple
-        return exec::exec_from_repl(&ctx, &mut print_options, history_file.as_deref())
+        return exec::exec_from_repl(&ctx, &mut print_options, &repl_options)
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)));
     }
@@ -422,6 +420,16 @@ fn parse_command(command: &str) -> Result<String, String> {
         Ok(command.to_string())
     } else {
         Err("-c flag expects only non empty commands".to_string())
+    }
+}
+
+fn get_repl_options(history_file: &Option<String>) -> ReplOptions {
+    if let Some(history_file) = history_file {
+        ReplOptions {
+            history_file: PathBuf::from(history_file),
+        }
+    } else {
+        Default::default()
     }
 }
 

--- a/datafusion-cli/src/repl_options.rs
+++ b/datafusion-cli/src/repl_options.rs
@@ -15,23 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/apache/datafusion/19fe44cf2f30cbdd63d4a4f52c74055163c6cc38/docs/logos/standalone_logo/logo_original.svg"
-)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc = include_str!("../README.md")]
-pub const DATAFUSION_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+use std::env;
+use std::path::PathBuf;
 
-pub mod catalog;
-pub mod cli_context;
-pub mod command;
-pub mod exec;
-pub mod functions;
-pub mod helper;
-pub mod highlighter;
-pub mod object_storage;
-pub mod pool_type;
-pub mod print_format;
-pub mod print_options;
-pub mod repl_options;
+#[derive(Debug, Clone)]
+pub struct ReplOptions {
+    pub history_file: PathBuf,
+}
+
+impl Default for ReplOptions {
+    fn default() -> Self {
+        let history_file = env::var_os("DATAFUSION_HISTORY_FILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(".history"));
+        Self { history_file }
+    }
+}

--- a/docs/source/user-guide/cli/usage.md
+++ b/docs/source/user-guide/cli/usage.md
@@ -39,6 +39,8 @@ Options:
           Execute commands from file(s), then exit
   -r, --rc [<RC>...]
           Run the provided files on startup instead of ~/.datafusionrc
+      --history-file <HISTORY_FILE>
+          Path to the file used to persist interactive shell history. Overrides DATAFUSION_HISTORY_FILE if set, default to .history
       --format <FORMAT>
           [default: automatic] [possible values: csv, tsv, table, json, nd-json, automatic]
   -q, --quiet


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23796.

## Rationale for this change

`datafusion-cli`'s interactive REPL hardcodes its rustyline history file as the relative path `.history`. Because the path is relative, the history file is created (and looked up) in whatever directory the CLI happens to be launched from, so every working directory silently accumulates its own hidden `.history` file with no way to point it somewhere else.

## What changes are included in this PR?

- Add a `--history-file <PATH>` CLI flag to `datafusion-cli`, validated at parse time (rejects a path that is an existing directory, or whose parent directory doesn't exist).
- Add a `DATAFUSION_HISTORY_FILE` environment variable as an alternative way to set it (e.g. for scripted/containerized setups). The `--history-file` flag takes precedence over the environment variable.
- The existing default behavior (`.history`, relative to the current directory) is unchanged when neither is set, so this is non-breaking.
- `exec_from_repl` now takes a `ReplOptions` struct (new `datafusion-cli/src/repl_options.rs` module, mirroring the existing `print_options` module) instead of hardcoding `.history` twice. `ReplOptions::default()` centralizes both the `.history` fallback and the `DATAFUSION_HISTORY_FILE` env var resolution in one place.
- Updated `datafusion-cli/examples/cli-session-context.rs` (the only other caller of `exec_from_repl`) and `docs/source/user-guide/cli/usage.md` accordingly.

## Are these changes tested?

This is a small, mostly mechanical CLI argument-plumbing change with no new branching logic worth unit-testing in isolation (the added validator mirrors the existing `parse_valid_file`/`parse_valid_data_dir` helpers, which aren't separately unit-tested either). I manually verified end-to-end via the built binary:

- Default (`.history` in cwd, unchanged behavior)
- `--history-file <path>` override
- `DATAFUSION_HISTORY_FILE=<path>` override
- `--history-file` taking precedence over `DATAFUSION_HISTORY_FILE` when both are set
- `--history-file` pointing at a non-existent parent directory fails fast with a clear error instead of a late rustyline error

Existing `datafusion-cli` unit tests pass (`cargo test -p datafusion-cli --lib --bins`).

## Are there any user-facing changes?

Yes: a new `--history-file` CLI flag and `DATAFUSION_HISTORY_FILE` environment variable, documented in `docs/source/user-guide/cli/usage.md`. No breaking changes; default behavior is unchanged.
