### PR TITLE
fix: preserve global limit for multi-partition fetch

### DIFF
--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -15,30 +15,38 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Formatter;
 use std::sync::Arc;
 
 use crate::physical_optimizer::test_utils::{
-    coalesce_partitions_exec, global_limit_exec, hash_join_exec, local_limit_exec,
-    sort_exec, sort_preserving_merge_exec, stream_exec,
+    TestScan, coalesce_partitions_exec, global_limit_exec, hash_join_exec,
+    local_limit_exec, sort_exec, sort_preserving_merge_exec, stream_exec,
 };
 
 use arrow::compute::SortOptions;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion_common::Statistics;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
+use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::{JoinType, Operator};
-use datafusion_physical_expr::Partitioning;
 use datafusion_physical_expr::expressions::{BinaryExpr, col, lit};
+use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion_physical_expr_common::physical_expr::PhysicalExprRef;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion_physical_optimizer::PhysicalOptimizerRule;
 use datafusion_physical_optimizer::limit_pushdown::LimitPushdown;
 use datafusion_physical_plan::empty::EmptyExec;
+use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion_physical_plan::filter::FilterExec;
 use datafusion_physical_plan::joins::NestedLoopJoinExec;
 use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::repartition::RepartitionExec;
-use datafusion_physical_plan::{ExecutionPlan, get_plan_string};
+use datafusion_physical_plan::union::UnionExec;
+use datafusion_physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, StatisticsArgs,
+    get_plan_string,
+};
 
 fn create_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
@@ -103,6 +111,75 @@ fn format_plan(plan: &Arc<dyn ExecutionPlan>) -> String {
     get_plan_string(plan).join("\n")
 }
 
+#[derive(Debug)]
+struct TestCombinerExec {
+    input: Arc<dyn ExecutionPlan>,
+    properties: Arc<PlanProperties>,
+}
+
+impl TestCombinerExec {
+    fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(input.schema()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        Self {
+            input,
+            properties: Arc::new(properties),
+        }
+    }
+}
+
+impl DisplayAs for TestCombinerExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "TestCombinerExec")
+    }
+}
+
+impl ExecutionPlan for TestCombinerExec {
+    fn name(&self) -> &str {
+        "TestCombinerExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(children.len(), 1);
+        Ok(Arc::new(Self::new(children[0].clone())))
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        unreachable!("TestCombinerExec is only used by optimizer tests")
+    }
+
+    fn statistics_from_inputs(
+        &self,
+        _input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        Ok(Arc::new(Statistics::new_unknown(self.schema().as_ref())))
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+}
+
 #[test]
 fn transforms_streaming_table_exec_into_fetching_version_when_skip_is_zero() -> Result<()>
 {
@@ -162,6 +239,343 @@ fn transforms_streaming_table_exec_into_fetching_version_and_keeps_the_global_li
     Ok(())
 }
 
+#[test]
+fn keeps_global_limit_above_fetch_capable_multi_partition_scan() -> Result<()> {
+    let schema = create_schema();
+    let scan = Arc::new(
+        TestScan::new(schema, vec![])
+            .with_supports_fetch(true)
+            .with_partition_count(2),
+    );
+    let global_limit = global_limit_exec(scan, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    CoalescePartitionsExec: fetch=5
+      TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn keeps_global_offset_limit_above_fetch_capable_multi_partition_scan() -> Result<()> {
+    let schema = create_schema();
+    let scan = Arc::new(
+        TestScan::new(schema, vec![])
+            .with_supports_fetch(true)
+            .with_partition_count(2),
+    );
+    let global_limit = global_limit_exec(scan, 2, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=2, fetch=5
+      CoalescePartitionsExec: fetch=7
+        TestScan: fetch=7
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn preserves_existing_per_partition_fetch_under_global_limit() -> Result<()> {
+    let schema = create_schema();
+    let scan = Arc::new(
+        TestScan::new(schema, vec![])
+            .with_supports_fetch(true)
+            .with_partition_count(2),
+    );
+    let scan = scan.with_fetch(Some(3)).unwrap();
+    let global_limit = global_limit_exec(scan, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    CoalescePartitionsExec: fetch=5
+      TestScan: fetch=3
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn adds_global_boundary_above_unfetchable_multi_partition_scan() -> Result<()> {
+    let schema = create_schema();
+    let scan = Arc::new(TestScan::new(schema, vec![]).with_partition_count(2));
+    let global_limit = global_limit_exec(scan, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    CoalescePartitionsExec: fetch=5
+      TestScan
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn materializes_global_boundary_before_pushing_into_union_children() -> Result<()> {
+    let schema = create_schema();
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let union = UnionExec::try_new(vec![left, right])?;
+    let global_limit = global_limit_exec(union, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    CoalescePartitionsExec: fetch=5
+      UnionExec
+        TestScan: fetch=5
+        TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn materializes_global_boundary_for_offset_only_multi_partition_scan() -> Result<()> {
+    let schema = create_schema();
+    let scan = Arc::new(TestScan::new(schema, vec![]).with_partition_count(2));
+    let global_limit = global_limit_exec(scan, 2, None);
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=2, fetch=None
+      CoalescePartitionsExec
+        TestScan
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn removes_noop_global_limit_without_materializing_boundary() -> Result<()> {
+    let schema = create_schema();
+    let scan = Arc::new(TestScan::new(schema, vec![]));
+    let noop_global_limit = global_limit_exec(scan, 0, None);
+
+    let optimized =
+        LimitPushdown::new().optimize(noop_global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @"TestScan"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn preserves_outer_global_limit_across_nested_global_limit() -> Result<()> {
+    let schema = create_schema();
+    let scan = Arc::new(
+        TestScan::new(schema, vec![])
+            .with_supports_fetch(true)
+            .with_partition_count(2),
+    );
+    let inner = global_limit_exec(scan, 0, Some(10));
+    let outer = global_limit_exec(inner, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(outer, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    CoalescePartitionsExec: fetch=5
+      TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn preserves_outer_global_limit_across_noop_global_limit() -> Result<()> {
+    let schema = create_schema();
+    let scan = Arc::new(
+        TestScan::new(schema, vec![])
+            .with_supports_fetch(true)
+            .with_partition_count(2),
+    );
+    let noop = global_limit_exec(scan, 0, None);
+    let outer = global_limit_exec(noop, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(outer, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    CoalescePartitionsExec: fetch=5
+      TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn materializes_pending_global_limit_below_extension_combiner() -> Result<()> {
+    let schema = create_schema();
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let union = UnionExec::try_new(vec![left, right])?;
+    let combiner = Arc::new(TestCombinerExec::new(union));
+    let global_limit = global_limit_exec(combiner, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    TestCombinerExec
+      CoalescePartitionsExec: fetch=5
+        UnionExec
+          TestScan: fetch=5
+          TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn upgrades_pending_local_limit_before_extension_combiner() -> Result<()> {
+    let schema = create_schema();
+    let inner_left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let inner_right =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let inner_union = UnionExec::try_new(vec![inner_left, inner_right])?;
+    let combiner = Arc::new(TestCombinerExec::new(inner_union));
+    let outer_child = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let outer_union = UnionExec::try_new(vec![combiner, outer_child])?;
+    let local_limit = local_limit_exec(outer_union, 5);
+
+    let optimized = LimitPushdown::new().optimize(local_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    UnionExec
+      TestCombinerExec
+        CoalescePartitionsExec: fetch=5
+          UnionExec
+            TestScan: fetch=5
+            TestScan: fetch=5
+      TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn upgrades_pending_local_limit_before_noop_global_wrapper() -> Result<()> {
+    let schema = create_schema();
+    let inner_left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let inner_right =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let inner_union = UnionExec::try_new(vec![inner_left, inner_right])?;
+    let noop_global = global_limit_exec(inner_union, 0, None);
+    let outer_child = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let outer_union = UnionExec::try_new(vec![noop_global, outer_child])?;
+    let local_limit = local_limit_exec(outer_union, 5);
+
+    let optimized = LimitPushdown::new().optimize(local_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    UnionExec
+      CoalescePartitionsExec: fetch=5
+        UnionExec
+          TestScan: fetch=5
+          TestScan: fetch=5
+      TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn keeps_global_limit_above_local_limit_on_multi_partition_union() -> Result<()> {
+    let schema = create_schema();
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let union = UnionExec::try_new(vec![left, right])?;
+    let local_limit = local_limit_exec(union, 3);
+    let global_limit = global_limit_exec(local_limit, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    CoalescePartitionsExec: fetch=5
+      UnionExec
+        TestScan: fetch=3
+        TestScan: fetch=3
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn keeps_global_offset_limit_above_local_limit_on_multi_partition_union() -> Result<()> {
+    let schema = create_schema();
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let union = UnionExec::try_new(vec![left, right])?;
+    let local_limit = local_limit_exec(union, 3);
+    let global_limit = global_limit_exec(local_limit, 2, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=2, fetch=5
+      CoalescePartitionsExec: fetch=7
+        UnionExec
+          TestScan: fetch=3
+          TestScan: fetch=3
+    "
+    );
+
+    Ok(())
+}
+
 fn join_on_columns(
     left_col: &str,
     right_col: &str,
@@ -180,8 +594,9 @@ fn join_on_columns(
 fn absorbs_limit_into_hash_join_inner() -> Result<()> {
     // HashJoinExec with Inner join should absorb limit via with_fetch
     let schema = create_schema();
-    let left = empty_exec(Arc::clone(&schema));
-    let right = empty_exec(Arc::clone(&schema));
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
     let on = join_on_columns("c1", "c1");
     let hash_join = hash_join_exec(left, right, on, None, &JoinType::Inner)?;
     let global_limit = global_limit_exec(hash_join, 0, Some(5));
@@ -192,8 +607,8 @@ fn absorbs_limit_into_hash_join_inner() -> Result<()> {
         @r"
     GlobalLimitExec: skip=0, fetch=5
       HashJoinExec: mode=Partitioned, join_type=Inner, on=[(c1@0, c1@0)]
-        EmptyExec
-        EmptyExec
+        TestScan
+        TestScan
     "
     );
 
@@ -205,8 +620,8 @@ fn absorbs_limit_into_hash_join_inner() -> Result<()> {
         optimized,
         @r"
     HashJoinExec: mode=Partitioned, join_type=Inner, on=[(c1@0, c1@0)], fetch=5
-      EmptyExec
-      EmptyExec
+      TestScan
+      TestScan
     "
     );
 
@@ -217,8 +632,9 @@ fn absorbs_limit_into_hash_join_inner() -> Result<()> {
 fn absorbs_limit_into_hash_join_right() -> Result<()> {
     // HashJoinExec with Right join should absorb limit via with_fetch
     let schema = create_schema();
-    let left = empty_exec(Arc::clone(&schema));
-    let right = empty_exec(Arc::clone(&schema));
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
     let on = join_on_columns("c1", "c1");
     let hash_join = hash_join_exec(left, right, on, None, &JoinType::Right)?;
     let global_limit = global_limit_exec(hash_join, 0, Some(10));
@@ -229,8 +645,8 @@ fn absorbs_limit_into_hash_join_right() -> Result<()> {
         @r"
     GlobalLimitExec: skip=0, fetch=10
       HashJoinExec: mode=Partitioned, join_type=Right, on=[(c1@0, c1@0)]
-        EmptyExec
-        EmptyExec
+        TestScan
+        TestScan
     "
     );
 
@@ -242,8 +658,8 @@ fn absorbs_limit_into_hash_join_right() -> Result<()> {
         optimized,
         @r"
     HashJoinExec: mode=Partitioned, join_type=Right, on=[(c1@0, c1@0)], fetch=10
-      EmptyExec
-      EmptyExec
+      TestScan
+      TestScan
     "
     );
 
@@ -254,8 +670,9 @@ fn absorbs_limit_into_hash_join_right() -> Result<()> {
 fn absorbs_limit_into_hash_join_left() -> Result<()> {
     // during probing, then unmatched rows at the end, stopping when limit is reached
     let schema = create_schema();
-    let left = empty_exec(Arc::clone(&schema));
-    let right = empty_exec(Arc::clone(&schema));
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
     let on = join_on_columns("c1", "c1");
     let hash_join = hash_join_exec(left, right, on, None, &JoinType::Left)?;
     let global_limit = global_limit_exec(hash_join, 0, Some(5));
@@ -266,8 +683,8 @@ fn absorbs_limit_into_hash_join_left() -> Result<()> {
         @r"
     GlobalLimitExec: skip=0, fetch=5
       HashJoinExec: mode=Partitioned, join_type=Left, on=[(c1@0, c1@0)]
-        EmptyExec
-        EmptyExec
+        TestScan
+        TestScan
     "
     );
 
@@ -279,8 +696,8 @@ fn absorbs_limit_into_hash_join_left() -> Result<()> {
         optimized,
         @r"
     HashJoinExec: mode=Partitioned, join_type=Left, on=[(c1@0, c1@0)], fetch=5
-      EmptyExec
-      EmptyExec
+      TestScan
+      TestScan
     "
     );
 

--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -289,6 +289,115 @@ impl ExecutionPlan for TestFetchOnlyExec {
     }
 }
 
+/// Test multi-child plan with a single output partition that allows limit
+/// pushdown. Optionally absorbs a fetch via `with_fetch`.
+#[derive(Debug, Clone)]
+struct TestMultiChildExec {
+    inputs: Vec<Arc<dyn ExecutionPlan>>,
+    properties: Arc<PlanProperties>,
+    supports_fetch: bool,
+    fetch: Option<usize>,
+}
+
+impl TestMultiChildExec {
+    fn new(inputs: Vec<Arc<dyn ExecutionPlan>>) -> Self {
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(inputs[0].schema()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        Self {
+            inputs,
+            properties: Arc::new(properties),
+            supports_fetch: false,
+            fetch: None,
+        }
+    }
+
+    /// Set whether `with_fetch()` returns `Some` (true) or `None` (false).
+    fn with_supports_fetch(mut self, supports: bool) -> Self {
+        self.supports_fetch = supports;
+        self
+    }
+}
+
+impl DisplayAs for TestMultiChildExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "TestMultiChildExec")?;
+        if let Some(fetch) = self.fetch {
+            write!(f, ": fetch={fetch}")?;
+        }
+        Ok(())
+    }
+}
+
+impl ExecutionPlan for TestMultiChildExec {
+    fn name(&self) -> &str {
+        "TestMultiChildExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        self.inputs.iter().collect()
+    }
+
+    fn apply_expressions(
+        &self,
+        _f: &mut dyn FnMut(&PhysicalExprRef) -> Result<TreeNodeRecursion>,
+    ) -> Result<TreeNodeRecursion> {
+        // `TestMultiChildExec` owns no `PhysicalExpr`s.
+        Ok(TreeNodeRecursion::Continue)
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(children.len(), self.inputs.len());
+        let mut new_plan = Self::new(children).with_supports_fetch(self.supports_fetch);
+        new_plan.fetch = self.fetch;
+        Ok(Arc::new(new_plan))
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        unreachable!("TestMultiChildExec is only used by optimizer tests")
+    }
+
+    fn statistics_from_inputs(
+        &self,
+        _input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        Ok(Arc::new(Statistics::new_unknown(self.schema().as_ref())))
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn with_fetch(&self, fetch: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        if self.supports_fetch {
+            let mut new_plan = self.clone();
+            new_plan.fetch = fetch;
+            Some(Arc::new(new_plan))
+        } else {
+            None
+        }
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.fetch
+    }
+}
+
 #[test]
 fn transforms_streaming_table_exec_into_fetching_version_when_skip_is_zero() -> Result<()>
 {
@@ -567,6 +676,111 @@ fn materializes_pending_global_limit_below_extension_combiner() -> Result<()> {
         UnionExec
           TestScan: fetch=5
           TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn materializes_global_limit_before_multi_child_extension() -> Result<()> {
+    // Regression test: a pending global limit used to be cloned to every
+    // child of a multi-child node, so each child applied the full LIMIT and
+    // the merged output exceeded it. The limit must stay above the node.
+    let schema = create_schema();
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let custom = Arc::new(TestMultiChildExec::new(vec![left, right]));
+    let global_limit = global_limit_exec(custom, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=0, fetch=5
+      TestMultiChildExec
+        TestScan: fetch=5
+        TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn materializes_global_offset_limit_before_multi_child_extension() -> Result<()> {
+    // The offset stays in the GlobalLimitExec; children only get a fetch hint
+    // of skip + fetch for early stopping.
+    let schema = create_schema();
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let custom = Arc::new(TestMultiChildExec::new(vec![left, right]));
+    let global_limit = global_limit_exec(custom, 2, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=2, fetch=5
+      TestMultiChildExec
+        TestScan: fetch=7
+        TestScan: fetch=7
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn multi_child_extension_absorbs_global_limit_and_hints_children() -> Result<()> {
+    // When the multi-child node absorbs the fetch itself, no extra limit is
+    // needed; children still receive the same fetch for early stopping.
+    let schema = create_schema();
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let custom =
+        Arc::new(TestMultiChildExec::new(vec![left, right]).with_supports_fetch(true));
+    let global_limit = global_limit_exec(custom, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    TestMultiChildExec: fetch=5
+      TestScan: fetch=5
+      TestScan: fetch=5
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn materializes_local_limit_before_multi_child_extension() -> Result<()> {
+    // A local limit also cannot be replicated to every child of a multi-child
+    // node with a single output partition.
+    let schema = create_schema();
+    let left =
+        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
+    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let custom = Arc::new(TestMultiChildExec::new(vec![left, right]));
+    let local_limit = local_limit_exec(custom, 5);
+
+    let optimized = LimitPushdown::new().optimize(local_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=0, fetch=5
+      TestMultiChildExec
+        TestScan: fetch=5
+        TestScan: fetch=5
     "
     );
 

--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -189,14 +189,8 @@ impl ExecutionPlan for TestCombinerExec {
     }
 }
 
-/// A test [`ExecutionPlan`] that reports an existing `fetch` bound on its own
-/// output but cannot absorb a new fetch: `with_fetch` uses the trait default
-/// and returns `None`. `supports_limit_pushdown` defaults to the trait default
-/// (`false`) and can be enabled via
-/// [`Self::with_supports_limit_pushdown`]. This simulates an operator whose
-/// trait-level fetch cannot be tightened, so a still-pending global limit must
-/// be enforced explicitly (either above the operator or, when pushdown is
-/// supported, at the seam between the operator and its child).
+/// Test plan that reports a fixed `fetch` but cannot change it through
+/// `with_fetch`. It can optionally allow limits to be pushed to its child.
 #[derive(Debug)]
 struct TestFetchOnlyExec {
     input: Arc<dyn ExecutionPlan>,
@@ -221,8 +215,7 @@ impl TestFetchOnlyExec {
         }
     }
 
-    /// Set whether `supports_limit_pushdown()` reports `true`, allowing a
-    /// pending limit to pass through this operator to its child.
+    /// Set whether limits may be pushed through this operator to its child.
     fn with_supports_limit_pushdown(mut self, supports: bool) -> Self {
         self.supports_limit_pushdown = supports;
         self
@@ -1370,11 +1363,8 @@ fn outer_offset_with_same_sort_key_still_pushes_limit() -> Result<()> {
 
 #[test]
 fn keeps_global_limit_when_existing_fetch_is_looser_than_owed() -> Result<()> {
-    // Regression test: an existing `fetch=10` on an operator that cannot
-    // absorb a tighter fetch (`with_fetch` returns `None`) does not satisfy an
-    // owed `fetch=5`. Before the fix, the pending global requirement was
-    // cleared solely because `skip == 0` and `fetch().is_some()`, so the
-    // `GlobalLimitExec` was removed entirely and the global `LIMIT` was lost.
+    // This operator's `fetch=10` is weaker than `LIMIT 5` and cannot be lowered.
+    // Keep `GlobalLimitExec` so the query still returns at most five rows.
     let schema = create_schema();
     let scan = Arc::new(TestScan::new(schema, vec![]));
     let fetch_only = Arc::new(TestFetchOnlyExec::new(scan, Some(10)));
@@ -1397,17 +1387,9 @@ fn keeps_global_limit_when_existing_fetch_is_looser_than_owed() -> Result<()> {
 #[test]
 fn pushes_owed_limit_below_fetch_only_unary_when_limit_pushdown_supported() -> Result<()>
 {
-    // Regression test for the `supports_limit_pushdown() == true` variant of
-    // `keeps_global_limit_when_existing_fetch_is_looser_than_owed`: the unary
-    // reports `supports_limit_pushdown() == true` so the rule takes the
-    // push-down-continue branch (no `GlobalLimitExec` above the unary), while
-    // `with_fetch` keeps the trait default (`None`) so the looser existing
-    // `fetch=10` cannot be tightened to the owed `fetch=5`. The owed global
-    // requirement must therefore survive the unary and be enforced at the seam
-    // between the unary and its child — the child also cannot absorb the limit
-    // (`TestScan::with_fetch` returns `None` by default), so the
-    // `GlobalLimitExec` must be materialized directly above the child instead
-    // of being dropped.
+    // This operator allows limit pushdown but cannot lower its own `fetch` from
+    // 10 to 5. Its child cannot accept a fetch either, so keep
+    // `GlobalLimitExec(fetch=5)` between them.
     let schema = create_schema();
     let scan = Arc::new(TestScan::new(schema, vec![]));
     let fetch_only = Arc::new(
@@ -1432,9 +1414,7 @@ fn pushes_owed_limit_below_fetch_only_unary_when_limit_pushdown_supported() -> R
 #[test]
 fn does_not_add_redundant_wrapper_when_existing_fetch_is_tighter_than_owed() -> Result<()>
 {
-    // An existing `fetch=3` on a single-partition operator is at least as
-    // tight as the owed `fetch=5`, so the pending requirement is satisfied
-    // without inserting a redundant `GlobalLimitExec`.
+    // `fetch=3` is stricter than `LIMIT 5`, so no additional limit is needed.
     let schema = create_schema();
     let scan = Arc::new(TestScan::new(schema, vec![]));
     let fetch_only = Arc::new(TestFetchOnlyExec::new(scan, Some(3)));
@@ -1455,9 +1435,8 @@ fn does_not_add_redundant_wrapper_when_existing_fetch_is_tighter_than_owed() -> 
 
 #[test]
 fn tightens_existing_sort_fetch_to_owed_limit() -> Result<()> {
-    // When an existing `fetch=10` is looser than the owed `fetch=5` and the
-    // operator can absorb a tighter fetch (`SortExec::with_fetch`), the fetch
-    // is tightened to the owed value instead of keeping the loose bound.
+    // `SortExec` can lower its `fetch` from 10 to 5, so the separate
+    // `GlobalLimitExec` is unnecessary.
     let schema = create_schema();
     let scan = Arc::new(TestScan::new(schema.clone(), vec![]));
     let ordering: LexOrdering = [PhysicalSortExpr {
@@ -1483,9 +1462,8 @@ fn tightens_existing_sort_fetch_to_owed_limit() -> Result<()> {
 
 #[test]
 fn keeps_global_offset_limit_when_existing_fetch_is_looser() -> Result<()> {
-    // An existing `fetch=10` cannot satisfy an owed `skip=2, fetch=5`: an
-    // existing fetch alone must never satisfy the offset part of a
-    // requirement, so the `GlobalLimitExec` must be preserved.
+    // An operator `fetch` cannot apply `OFFSET 2`; keep `GlobalLimitExec` to
+    // enforce both the offset and `LIMIT 5`.
     let schema = create_schema();
     let scan = Arc::new(TestScan::new(schema, vec![]));
     let fetch_only = Arc::new(TestFetchOnlyExec::new(scan, Some(10)));

--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -112,83 +112,6 @@ fn format_plan(plan: &Arc<dyn ExecutionPlan>) -> String {
     get_plan_string(plan).join("\n")
 }
 
-#[derive(Debug)]
-struct TestCombinerExec {
-    input: Arc<dyn ExecutionPlan>,
-    properties: Arc<PlanProperties>,
-}
-
-impl TestCombinerExec {
-    fn new(input: Arc<dyn ExecutionPlan>) -> Self {
-        let properties = PlanProperties::new(
-            EquivalenceProperties::new(input.schema()),
-            Partitioning::UnknownPartitioning(1),
-            EmissionType::Incremental,
-            Boundedness::Bounded,
-        );
-        Self {
-            input,
-            properties: Arc::new(properties),
-        }
-    }
-}
-
-impl DisplayAs for TestCombinerExec {
-    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "TestCombinerExec")
-    }
-}
-
-impl ExecutionPlan for TestCombinerExec {
-    fn name(&self) -> &str {
-        "TestCombinerExec"
-    }
-
-    fn properties(&self) -> &Arc<PlanProperties> {
-        &self.properties
-    }
-
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.input]
-    }
-
-    fn apply_expressions(
-        &self,
-        _f: &mut dyn FnMut(&PhysicalExprRef) -> Result<TreeNodeRecursion>,
-    ) -> Result<TreeNodeRecursion> {
-        // `TestCombinerExec` owns no `PhysicalExpr`s.
-        Ok(TreeNodeRecursion::Continue)
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(children.len(), 1);
-        Ok(Arc::new(Self::new(children[0].clone())))
-    }
-
-    fn execute(
-        &self,
-        _partition: usize,
-        _context: Arc<TaskContext>,
-    ) -> Result<SendableRecordBatchStream> {
-        unreachable!("TestCombinerExec is only used by optimizer tests")
-    }
-
-    fn statistics_from_inputs(
-        &self,
-        _input_stats: &[Arc<Statistics>],
-        _args: &StatisticsArgs,
-    ) -> Result<Arc<Statistics>> {
-        Ok(Arc::new(Statistics::new_unknown(self.schema().as_ref())))
-    }
-
-    fn supports_limit_pushdown(&self) -> bool {
-        true
-    }
-}
-
 /// Test plan that reports a fixed `fetch` but cannot change it through
 /// `with_fetch`. It can optionally allow limits to be pushed to its child.
 #[derive(Debug)]
@@ -572,6 +495,38 @@ fn materializes_global_boundary_before_pushing_into_union_children() -> Result<(
 }
 
 #[test]
+fn materializes_ordered_global_limit_with_sort_preserving_merge() -> Result<()> {
+    let schema = create_schema();
+    let ordering: LexOrdering = [PhysicalSortExpr {
+        expr: col("c1", &schema)?,
+        options: SortOptions::default(),
+    }]
+    .into();
+    let scan = Arc::new(
+        TestScan::with_ordering(Arc::clone(&schema), ordering.clone())
+            .with_supports_fetch(true)
+            .with_partition_count(2),
+    );
+    let mut global_limit =
+        datafusion_physical_plan::limit::GlobalLimitExec::new(scan, 2, Some(5));
+    global_limit.set_required_ordering(Some(ordering));
+    let global_limit = Arc::new(global_limit);
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=2, fetch=5
+      SortPreservingMergeExec: [c1@0 ASC], fetch=7
+        TestScan: output_ordering=[c1@0 ASC], fetch=7
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn materializes_global_boundary_for_offset_only_multi_partition_scan() -> Result<()> {
     let schema = create_schema();
     let scan = Arc::new(TestScan::new(schema, vec![]).with_partition_count(2));
@@ -594,16 +549,17 @@ fn materializes_global_boundary_for_offset_only_multi_partition_scan() -> Result
 #[test]
 fn removes_noop_global_limit_without_materializing_boundary() -> Result<()> {
     let schema = create_schema();
-    let scan = Arc::new(TestScan::new(schema, vec![]));
+    let scan = Arc::new(TestScan::new(schema, vec![]).with_partition_count(2));
     let noop_global_limit = global_limit_exec(scan, 0, None);
 
     let optimized =
         LimitPushdown::new().optimize(noop_global_limit, &ConfigOptions::new())?;
 
-    insta::assert_snapshot!(
-        format_plan(&optimized),
-        @"TestScan"
-    );
+    let plan = format_plan(&optimized);
+    assert!(!plan.contains("CoalescePartitionsExec"));
+    assert!(!plan.contains("SortPreservingMergeExec"));
+    assert!(!plan.contains("GlobalLimitExec"));
+    insta::assert_snapshot!(plan, @"TestScan");
 
     Ok(())
 }
@@ -663,7 +619,7 @@ fn materializes_pending_global_limit_below_extension_combiner() -> Result<()> {
         Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
     let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
     let union = UnionExec::try_new(vec![left, right])?;
-    let combiner = Arc::new(TestCombinerExec::new(union));
+    let combiner = Arc::new(TestMultiChildExec::new(vec![union]));
     let global_limit = global_limit_exec(combiner, 0, Some(5));
 
     let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
@@ -671,7 +627,7 @@ fn materializes_pending_global_limit_below_extension_combiner() -> Result<()> {
     insta::assert_snapshot!(
         format_plan(&optimized),
         @r"
-    TestCombinerExec
+    TestMultiChildExec
       CoalescePartitionsExec: fetch=5
         UnionExec
           TestScan: fetch=5
@@ -795,7 +751,7 @@ fn upgrades_pending_local_limit_before_extension_combiner() -> Result<()> {
     let inner_right =
         Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
     let inner_union = UnionExec::try_new(vec![inner_left, inner_right])?;
-    let combiner = Arc::new(TestCombinerExec::new(inner_union));
+    let combiner = Arc::new(TestMultiChildExec::new(vec![inner_union]));
     let outer_child = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
     let outer_union = UnionExec::try_new(vec![combiner, outer_child])?;
     let local_limit = local_limit_exec(outer_union, 5);
@@ -806,7 +762,7 @@ fn upgrades_pending_local_limit_before_extension_combiner() -> Result<()> {
         format_plan(&optimized),
         @r"
     UnionExec
-      TestCombinerExec
+      TestMultiChildExec
         CoalescePartitionsExec: fetch=5
           UnionExec
             TestScan: fetch=5
@@ -955,9 +911,8 @@ fn absorbs_limit_into_hash_join_inner() -> Result<()> {
 fn absorbs_limit_into_hash_join_right() -> Result<()> {
     // HashJoinExec with Right join should absorb limit via with_fetch
     let schema = create_schema();
-    let left =
-        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
-    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let left = empty_exec(Arc::clone(&schema));
+    let right = empty_exec(Arc::clone(&schema));
     let on = join_on_columns("c1", "c1");
     let hash_join = hash_join_exec(left, right, on, None, &JoinType::Right)?;
     let global_limit = global_limit_exec(hash_join, 0, Some(10));
@@ -968,8 +923,8 @@ fn absorbs_limit_into_hash_join_right() -> Result<()> {
         @r"
     GlobalLimitExec: skip=0, fetch=10
       HashJoinExec: mode=Partitioned, join_type=Right, on=[(c1@0, c1@0)]
-        TestScan
-        TestScan
+        EmptyExec
+        EmptyExec
     "
     );
 
@@ -981,8 +936,8 @@ fn absorbs_limit_into_hash_join_right() -> Result<()> {
         optimized,
         @r"
     HashJoinExec: mode=Partitioned, join_type=Right, on=[(c1@0, c1@0)], fetch=10
-      TestScan
-      TestScan
+      EmptyExec
+      EmptyExec
     "
     );
 
@@ -993,9 +948,8 @@ fn absorbs_limit_into_hash_join_right() -> Result<()> {
 fn absorbs_limit_into_hash_join_left() -> Result<()> {
     // during probing, then unmatched rows at the end, stopping when limit is reached
     let schema = create_schema();
-    let left =
-        Arc::new(TestScan::new(Arc::clone(&schema), vec![]).with_supports_fetch(true));
-    let right = Arc::new(TestScan::new(schema, vec![]).with_supports_fetch(true));
+    let left = empty_exec(Arc::clone(&schema));
+    let right = empty_exec(Arc::clone(&schema));
     let on = join_on_columns("c1", "c1");
     let hash_join = hash_join_exec(left, right, on, None, &JoinType::Left)?;
     let global_limit = global_limit_exec(hash_join, 0, Some(5));
@@ -1006,8 +960,8 @@ fn absorbs_limit_into_hash_join_left() -> Result<()> {
         @r"
     GlobalLimitExec: skip=0, fetch=5
       HashJoinExec: mode=Partitioned, join_type=Left, on=[(c1@0, c1@0)]
-        TestScan
-        TestScan
+        EmptyExec
+        EmptyExec
     "
     );
 
@@ -1019,8 +973,8 @@ fn absorbs_limit_into_hash_join_left() -> Result<()> {
         optimized,
         @r"
     HashJoinExec: mode=Partitioned, join_type=Left, on=[(c1@0, c1@0)], fetch=5
-      TestScan
-      TestScan
+      EmptyExec
+      EmptyExec
     "
     );
 

--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -28,6 +28,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion_common::Statistics;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
+use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::{JoinType, Operator};
 use datafusion_physical_expr::expressions::{BinaryExpr, col, lit};
@@ -151,6 +152,14 @@ impl ExecutionPlan for TestCombinerExec {
         vec![&self.input]
     }
 
+    fn apply_expressions(
+        &self,
+        _f: &mut dyn FnMut(&PhysicalExprRef) -> Result<TreeNodeRecursion>,
+    ) -> Result<TreeNodeRecursion> {
+        // `TestCombinerExec` owns no `PhysicalExpr`s.
+        Ok(TreeNodeRecursion::Continue)
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
@@ -241,6 +250,14 @@ impl ExecutionPlan for TestFetchOnlyExec {
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.input]
+    }
+
+    fn apply_expressions(
+        &self,
+        _f: &mut dyn FnMut(&PhysicalExprRef) -> Result<TreeNodeRecursion>,
+    ) -> Result<TreeNodeRecursion> {
+        // `TestFetchOnlyExec` owns no `PhysicalExpr`s.
+        Ok(TreeNodeRecursion::Continue)
     }
 
     fn with_new_children(

--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -180,6 +180,105 @@ impl ExecutionPlan for TestCombinerExec {
     }
 }
 
+/// A test [`ExecutionPlan`] that reports an existing `fetch` bound on its own
+/// output but cannot absorb a new fetch: `with_fetch` uses the trait default
+/// and returns `None`. `supports_limit_pushdown` defaults to the trait default
+/// (`false`) and can be enabled via
+/// [`Self::with_supports_limit_pushdown`]. This simulates an operator whose
+/// trait-level fetch cannot be tightened, so a still-pending global limit must
+/// be enforced explicitly (either above the operator or, when pushdown is
+/// supported, at the seam between the operator and its child).
+#[derive(Debug)]
+struct TestFetchOnlyExec {
+    input: Arc<dyn ExecutionPlan>,
+    fetch: Option<usize>,
+    supports_limit_pushdown: bool,
+    properties: Arc<PlanProperties>,
+}
+
+impl TestFetchOnlyExec {
+    fn new(input: Arc<dyn ExecutionPlan>, fetch: Option<usize>) -> Self {
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(input.schema()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        Self {
+            input,
+            fetch,
+            supports_limit_pushdown: false,
+            properties: Arc::new(properties),
+        }
+    }
+
+    /// Set whether `supports_limit_pushdown()` reports `true`, allowing a
+    /// pending limit to pass through this operator to its child.
+    fn with_supports_limit_pushdown(mut self, supports: bool) -> Self {
+        self.supports_limit_pushdown = supports;
+        self
+    }
+}
+
+impl DisplayAs for TestFetchOnlyExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "TestFetchOnlyExec")?;
+        if let Some(fetch) = self.fetch {
+            write!(f, ": fetch={fetch}")?;
+        }
+        Ok(())
+    }
+}
+
+impl ExecutionPlan for TestFetchOnlyExec {
+    fn name(&self) -> &str {
+        "TestFetchOnlyExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(children.len(), 1);
+        Ok(Arc::new(
+            Self::new(children[0].clone(), self.fetch)
+                .with_supports_limit_pushdown(self.supports_limit_pushdown),
+        ))
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        unreachable!("TestFetchOnlyExec is only used by optimizer tests")
+    }
+
+    fn statistics_from_inputs(
+        &self,
+        _input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        Ok(Arc::new(Statistics::new_unknown(self.schema().as_ref())))
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.fetch
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        self.supports_limit_pushdown
+    }
+}
+
 #[test]
 fn transforms_streaming_table_exec_into_fetching_version_when_skip_is_zero() -> Result<()>
 {
@@ -1246,6 +1345,143 @@ fn outer_offset_with_same_sort_key_still_pushes_limit() -> Result<()> {
       SortExec: expr=[c1@0 ASC], preserve_partitioning=[false]
         SortExec: TopK(fetch=8), expr=[c1@0 ASC], preserve_partitioning=[false]
           EmptyExec
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn keeps_global_limit_when_existing_fetch_is_looser_than_owed() -> Result<()> {
+    // Regression test: an existing `fetch=10` on an operator that cannot
+    // absorb a tighter fetch (`with_fetch` returns `None`) does not satisfy an
+    // owed `fetch=5`. Before the fix, the pending global requirement was
+    // cleared solely because `skip == 0` and `fetch().is_some()`, so the
+    // `GlobalLimitExec` was removed entirely and the global `LIMIT` was lost.
+    let schema = create_schema();
+    let scan = Arc::new(TestScan::new(schema, vec![]));
+    let fetch_only = Arc::new(TestFetchOnlyExec::new(scan, Some(10)));
+    let global_limit = global_limit_exec(fetch_only, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=0, fetch=5
+      TestFetchOnlyExec: fetch=10
+        TestScan
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pushes_owed_limit_below_fetch_only_unary_when_limit_pushdown_supported() -> Result<()>
+{
+    // Regression test for the `supports_limit_pushdown() == true` variant of
+    // `keeps_global_limit_when_existing_fetch_is_looser_than_owed`: the unary
+    // reports `supports_limit_pushdown() == true` so the rule takes the
+    // push-down-continue branch (no `GlobalLimitExec` above the unary), while
+    // `with_fetch` keeps the trait default (`None`) so the looser existing
+    // `fetch=10` cannot be tightened to the owed `fetch=5`. The owed global
+    // requirement must therefore survive the unary and be enforced at the seam
+    // between the unary and its child — the child also cannot absorb the limit
+    // (`TestScan::with_fetch` returns `None` by default), so the
+    // `GlobalLimitExec` must be materialized directly above the child instead
+    // of being dropped.
+    let schema = create_schema();
+    let scan = Arc::new(TestScan::new(schema, vec![]));
+    let fetch_only = Arc::new(
+        TestFetchOnlyExec::new(scan, Some(10)).with_supports_limit_pushdown(true),
+    );
+    let global_limit = global_limit_exec(fetch_only, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    TestFetchOnlyExec: fetch=10
+      GlobalLimitExec: skip=0, fetch=5
+        TestScan
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn does_not_add_redundant_wrapper_when_existing_fetch_is_tighter_than_owed() -> Result<()>
+{
+    // An existing `fetch=3` on a single-partition operator is at least as
+    // tight as the owed `fetch=5`, so the pending requirement is satisfied
+    // without inserting a redundant `GlobalLimitExec`.
+    let schema = create_schema();
+    let scan = Arc::new(TestScan::new(schema, vec![]));
+    let fetch_only = Arc::new(TestFetchOnlyExec::new(scan, Some(3)));
+    let global_limit = global_limit_exec(fetch_only, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    TestFetchOnlyExec: fetch=3
+      TestScan
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn tightens_existing_sort_fetch_to_owed_limit() -> Result<()> {
+    // When an existing `fetch=10` is looser than the owed `fetch=5` and the
+    // operator can absorb a tighter fetch (`SortExec::with_fetch`), the fetch
+    // is tightened to the owed value instead of keeping the loose bound.
+    let schema = create_schema();
+    let scan = Arc::new(TestScan::new(schema.clone(), vec![]));
+    let ordering: LexOrdering = [PhysicalSortExpr {
+        expr: col("c1", &schema)?,
+        options: SortOptions::default(),
+    }]
+    .into();
+    let sort = sort_exec(ordering, scan).with_fetch(Some(10)).unwrap();
+    let global_limit = global_limit_exec(sort, 0, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    SortExec: TopK(fetch=5), expr=[c1@0 ASC], preserve_partitioning=[false]
+      TestScan
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn keeps_global_offset_limit_when_existing_fetch_is_looser() -> Result<()> {
+    // An existing `fetch=10` cannot satisfy an owed `skip=2, fetch=5`: an
+    // existing fetch alone must never satisfy the offset part of a
+    // requirement, so the `GlobalLimitExec` must be preserved.
+    let schema = create_schema();
+    let scan = Arc::new(TestScan::new(schema, vec![]));
+    let fetch_only = Arc::new(TestFetchOnlyExec::new(scan, Some(10)));
+    let global_limit = global_limit_exec(fetch_only, 2, Some(5));
+
+    let optimized = LimitPushdown::new().optimize(global_limit, &ConfigOptions::new())?;
+
+    insta::assert_snapshot!(
+        format_plan(&optimized),
+        @r"
+    GlobalLimitExec: skip=2, fetch=5
+      TestFetchOnlyExec: fetch=10
+        TestScan
     "
     );
 

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -165,41 +165,15 @@ pub fn pushdown_limit_helper(
         global_state.pending = Some(LimitScope::Global);
     }
 
-    if let Some(global_limit) = pushdown_plan.downcast_ref::<GlobalLimitExec>()
-        && global_limit.skip() == 0
-        && global_limit.fetch().is_none()
-    {
-        // A `GlobalLimitExec` with no skip and no fetch enforces nothing, so
-        // remove it and keep the carried state unchanged. General limit handling
-        // would mark a global limit as pending even when none is needed. Keep the
-        // local-to-global promotion above: it remains valid because this node has
-        // one output partition.
-        return Ok((
-            Transformed {
-                data: Arc::clone(global_limit.input()),
-                transformed: true,
-                tnr: TreeNodeRecursion::Stop,
-            },
-            global_state,
-        ));
-    }
-
     if global_state.pending == Some(LimitScope::Global)
         && pushdown_plan.output_partitioning().partition_count() > 1
+        && (global_state.skip > 0 || global_state.fetch.is_some())
     {
         // Handle this before the generic `fetch` case: on a multi-partition plan,
         // `fetch` limits partitions separately and cannot limit their combined output.
         // Keep it for early stopping, then combine the partitions to enforce the
         // global limit.
         let hint = global_state.fetch.map(|fetch| fetch + global_state.skip);
-        if let Some(hint) = hint {
-            let hint = pushdown_plan.fetch().map_or(hint, |fetch| fetch.min(hint));
-            if pushdown_plan.fetch() != Some(hint)
-                && let Some(plan_with_fetch) = pushdown_plan.with_fetch(Some(hint))
-            {
-                pushdown_plan = plan_with_fetch;
-            }
-        }
 
         let plan = materialize_global_requirement(
             pushdown_plan,
@@ -217,11 +191,16 @@ pub fn pushdown_limit_helper(
         let input = Arc::clone(global_limit.input());
         let skip = global_limit.skip();
         let fetch = global_limit.fetch();
+        let has_requirement = skip > 0 || fetch.is_some();
 
         (global_state.skip, global_state.fetch) =
             combine_limit(global_state.skip, global_state.fetch, skip, fetch);
         global_state.preserve_order |= global_limit.required_ordering().is_some();
-        global_state.pending = Some(LimitScope::Global);
+        // A nested no-op GlobalLimit must preserve any outer pending scope;
+        // a real GlobalLimit establishes Global scope for its own requirement.
+        if has_requirement {
+            global_state.pending = Some(LimitScope::Global);
+        }
         if let Some(fetch) = global_state.fetch
             && limit_satisfied_by_input(&input, global_state.skip, fetch)?
         {
@@ -246,6 +225,8 @@ pub fn pushdown_limit_helper(
             Some(local_limit.fetch()),
         );
         global_state.preserve_order |= local_limit.required_ordering().is_some();
+        // LocalLimit is per-partition; with one input partition that is
+        // equivalent to a global limit, so choose the corresponding scope.
         global_state.pending = if input.output_partitioning().partition_count() == 1 {
             Some(LimitScope::Global)
         } else {
@@ -289,11 +270,17 @@ pub fn pushdown_limit_helper(
     let Some(global_fetch) = global_state.fetch else {
         // There's no valid fetch information, exit early:
         return if global_state.skip > 0 && global_state.pending.is_some() {
-            // There might be a case with only offset, if so add a global limit:
+            // Materialize OFFSET only while correctness is pending; once it is
+            // enforced, do not recreate it in descendants.
             let new_plan = add_global_limit(pushdown_plan, global_state.skip, None);
             global_state.pending = None;
             Ok((Transformed::yes(new_plan), global_state))
         } else {
+            // A no-op limit must not leave a pending requirement behind. Keep
+            // any outer requirement that still has an offset or fetch.
+            if global_state.skip == 0 && global_state.fetch.is_none() {
+                global_state.pending = None;
+            }
             // There's no info on offset or fetch, nothing to do:
             Ok((Transformed::no(pushdown_plan), global_state))
         };
@@ -327,8 +314,8 @@ pub fn pushdown_limit_helper(
             return Ok((Transformed::yes(new_plan), global_state));
         }
         if !combines_input_partitions(&pushdown_plan) {
-            // We have information in the global state and the plan pushes down,
-            // continue:
+            // Delegation is scope-safe here, and this node does not combine
+            // partitions, so enforcement may continue below without duplication.
             Ok((Transformed::no(pushdown_plan), global_state))
         } else if let Some(plan_with_fetch) = pushdown_plan.with_fetch(skip_and_fetch) {
             // This partition-combining operator accepted `fetch`, so the fetch now
@@ -356,7 +343,8 @@ pub fn pushdown_limit_helper(
         // This operator stops limit pushdown. If the limit is already enforced, try
         // only to add a fetch for early stopping; otherwise enforce the limit here.
 
-        // There's no push down, change fetch & skip to default values:
+        // A non-pushdown barrier must not leak correctness state into children;
+        // retain the local skip to decide whether an explicit limit must remain above it.
         let global_skip = global_state.skip;
         global_state.fetch = None;
         global_state.skip = 0;
@@ -501,8 +489,8 @@ fn combines_input_partitions(plan: &Arc<dyn ExecutionPlan>) -> bool {
     plan.is::<CoalescePartitionsExec>() || plan.is::<SortPreservingMergeExec>()
 }
 
-/// Adds a limit to the plan, chooses between global and local limits based on
-/// skip value and the number of partitions.
+/// Adds a limit to the plan. OFFSET requires Global scope; without OFFSET,
+/// Local scope works across partitions, while one partition makes both scopes equivalent.
 fn add_limit(
     pushdown_plan: Arc<dyn ExecutionPlan>,
     skip: usize,
@@ -524,11 +512,9 @@ fn materialize_global_requirement(
     fetch: Option<usize>,
     preserve_order: bool,
 ) -> Arc<dyn ExecutionPlan> {
-    if pushdown_plan.output_partitioning().partition_count() == 1 {
-        return add_global_limit(pushdown_plan, skip, fetch);
-    }
-
     let skip_and_fetch = fetch.map(|fetch| fetch + skip);
+    // Use SPM only when required order must be preserved and the input advertises
+    // ordering; otherwise Coalesce must not invent an ordering for the stream.
     let limited: Arc<dyn ExecutionPlan> = if preserve_order
         && let Some(ordering) = pushdown_plan.output_ordering().cloned()
     {
@@ -541,6 +527,8 @@ fn materialize_global_requirement(
     };
 
     if skip > 0 {
+        // The merge fetch (skip + fetch) enables early termination, but cannot
+        // discard the OFFSET rows; the outer GlobalLimit performs that step.
         add_global_limit(limited, skip, fetch)
     } else {
         limited

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -92,12 +92,21 @@ pub struct LimitPushdown {}
 /// For example: If the plan is satisfied with current fetch info, we decide to not add a LocalLimit
 ///
 /// [`LimitPushdown`]: crate::limit_pushdown::LimitPushdown
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct GlobalRequirements {
     fetch: Option<usize>,
     skip: usize,
-    satisfied: bool,
     preserve_order: bool,
+    status: LimitStatus,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum LimitStatus {
+    #[default]
+    None,
+    PendingLocal,
+    PendingGlobal,
+    Enforced,
 }
 
 impl LimitPushdown {
@@ -116,8 +125,8 @@ impl PhysicalOptimizerRule for LimitPushdown {
         let global_state = GlobalRequirements {
             fetch: None,
             skip: 0,
-            satisfied: false,
             preserve_order: false,
+            status: LimitStatus::None,
         };
         pushdown_limits(plan, global_state)
     }
@@ -131,13 +140,6 @@ impl PhysicalOptimizerRule for LimitPushdown {
     }
 }
 
-struct LimitInfo {
-    input: Arc<dyn ExecutionPlan>,
-    fetch: Option<usize>,
-    skip: usize,
-    preserve_order: bool,
-}
-
 /// This function is the main helper function of the `LimitPushDown` rule.
 /// The helper takes an `ExecutionPlan` and a global (algorithm) state which is
 /// an instance of `GlobalRequirements` and modifies these parameters while
@@ -149,46 +151,97 @@ pub fn pushdown_limit_helper(
     mut pushdown_plan: Arc<dyn ExecutionPlan>,
     mut global_state: GlobalRequirements,
 ) -> Result<(Transformed<Arc<dyn ExecutionPlan>>, GlobalRequirements)> {
-    // Extract limit, if exist, and return child inputs.
-    if let Some(limit_info) = extract_limit(&pushdown_plan) {
-        // If we have fetch/skip info in the global state already, we need to
-        // decide which one to continue with:
-        let (skip, fetch) = combine_limit(
-            global_state.skip,
-            global_state.fetch,
-            limit_info.skip,
-            limit_info.fetch,
-        );
-        global_state.skip = skip;
-        global_state.fetch = fetch;
-        global_state.preserve_order = limit_info.preserve_order;
-        global_state.satisfied = false;
+    if global_state.status == LimitStatus::PendingLocal
+        && pushdown_plan.output_partitioning().partition_count() == 1
+    {
+        global_state.status = LimitStatus::PendingGlobal;
+    }
 
-        if let Some(fetch) = fetch
-            && limit_satisfied_by_input(&limit_info.input, skip, fetch)?
-        {
-            // The input already produces at most `fetch` rows, so no new limit
-            // node is needed. Mark satisfied so downstream won't re-add one,
-            // but preserve skip/fetch so any nested limit nodes (e.g. an inner
-            // GlobalLimitExec) can still be merged with the outer constraint.
-            global_state.satisfied = true;
-
-            return Ok((
-                Transformed {
-                    data: limit_info.input,
-                    transformed: true,
-                    tnr: TreeNodeRecursion::Stop,
-                },
-                global_state,
-            ));
-        }
-
-        // Now the global state has the most recent information, we can remove
-        // the limit node. We will decide later if we should add it again or
-        // not.
+    if let Some(global_limit) = pushdown_plan.downcast_ref::<GlobalLimitExec>()
+        && global_limit.skip() == 0
+        && global_limit.fetch().is_none()
+    {
         return Ok((
             Transformed {
-                data: limit_info.input,
+                data: Arc::clone(global_limit.input()),
+                transformed: true,
+                tnr: TreeNodeRecursion::Stop,
+            },
+            global_state,
+        ));
+    }
+
+    if global_state.status == LimitStatus::PendingGlobal
+        && pushdown_plan.output_partitioning().partition_count() > 1
+    {
+        let hint = global_state.fetch.map(|fetch| fetch + global_state.skip);
+        if let Some(hint) = hint {
+            let hint = pushdown_plan.fetch().map_or(hint, |fetch| fetch.min(hint));
+            if pushdown_plan.fetch() != Some(hint)
+                && let Some(plan_with_fetch) = pushdown_plan.with_fetch(Some(hint))
+            {
+                pushdown_plan = plan_with_fetch;
+            }
+        }
+
+        let plan = materialize_global_requirement(
+            pushdown_plan,
+            global_state.skip,
+            global_state.fetch,
+            global_state.preserve_order,
+        );
+        global_state.fetch = hint;
+        global_state.skip = 0;
+        global_state.status = LimitStatus::Enforced;
+        return Ok((Transformed::yes(plan), global_state));
+    }
+
+    if let Some(global_limit) = pushdown_plan.downcast_ref::<GlobalLimitExec>() {
+        let input = Arc::clone(global_limit.input());
+        let skip = global_limit.skip();
+        let fetch = global_limit.fetch();
+
+        (global_state.skip, global_state.fetch) =
+            combine_limit(global_state.skip, global_state.fetch, skip, fetch);
+        global_state.preserve_order |= global_limit.required_ordering().is_some();
+        global_state.status = LimitStatus::PendingGlobal;
+        if let Some(fetch) = global_state.fetch
+            && limit_satisfied_by_input(&input, global_state.skip, fetch)?
+        {
+            global_state.status = LimitStatus::Enforced;
+        }
+        return Ok((
+            Transformed {
+                data: input,
+                transformed: true,
+                tnr: TreeNodeRecursion::Stop,
+            },
+            global_state,
+        ));
+    }
+
+    if let Some(local_limit) = pushdown_plan.downcast_ref::<LocalLimitExec>() {
+        let input = Arc::clone(local_limit.input());
+        (global_state.skip, global_state.fetch) = combine_limit(
+            global_state.skip,
+            global_state.fetch,
+            0,
+            Some(local_limit.fetch()),
+        );
+        global_state.preserve_order |= local_limit.required_ordering().is_some();
+        global_state.status = if input.output_partitioning().partition_count() == 1 {
+            LimitStatus::PendingGlobal
+        } else {
+            LimitStatus::PendingLocal
+        };
+        if let Some(fetch) = global_state.fetch
+            && limit_satisfied_by_input(&input, global_state.skip, fetch)?
+        {
+            global_state.status = LimitStatus::Enforced;
+        }
+        return Ok((
+            Transformed {
+                data: input,
                 transformed: true,
                 tnr: TreeNodeRecursion::Stop,
             },
@@ -200,7 +253,7 @@ pub fn pushdown_limit_helper(
     // state as necessary:
     if pushdown_plan.fetch().is_some() {
         if global_state.skip == 0 {
-            global_state.satisfied = true;
+            global_state.status = LimitStatus::Enforced;
         }
         (global_state.skip, global_state.fetch) = combine_limit(
             global_state.skip,
@@ -212,17 +265,11 @@ pub fn pushdown_limit_helper(
 
     let Some(global_fetch) = global_state.fetch else {
         // There's no valid fetch information, exit early:
-        return if global_state.skip > 0 && !global_state.satisfied {
+        return if global_state.skip > 0 && global_state.status != LimitStatus::Enforced {
             // There might be a case with only offset, if so add a global limit:
-            global_state.satisfied = true;
-            Ok((
-                Transformed::yes(add_global_limit(
-                    pushdown_plan,
-                    global_state.skip,
-                    None,
-                )),
-                global_state,
-            ))
+            let new_plan = add_global_limit(pushdown_plan, global_state.skip, None);
+            global_state.status = LimitStatus::Enforced;
+            Ok((Transformed::yes(new_plan), global_state))
         } else {
             // There's no info on offset or fetch, nothing to do:
             Ok((Transformed::no(pushdown_plan), global_state))
@@ -242,28 +289,22 @@ pub fn pushdown_limit_helper(
             // with the information from the global state.
             let mut new_plan = plan_with_fetch;
             // Execution plans can't (yet) handle skip, so if we have one,
-            // we still need to add a global limit
+            // we still need to add a global limit.
             if global_state.skip > 0 {
                 new_plan =
                     add_global_limit(new_plan, global_state.skip, global_state.fetch);
             }
             global_state.fetch = skip_and_fetch;
             global_state.skip = 0;
-            global_state.satisfied = true;
+            global_state.status = LimitStatus::Enforced;
             Ok((Transformed::yes(new_plan), global_state))
-        } else if global_state.satisfied {
+        } else if global_state.status == LimitStatus::Enforced {
             // If the plan is already satisfied, do not add a limit:
             Ok((Transformed::no(pushdown_plan), global_state))
         } else {
-            global_state.satisfied = true;
-            Ok((
-                Transformed::yes(add_limit(
-                    pushdown_plan,
-                    global_state.skip,
-                    global_fetch,
-                )),
-                global_state,
-            ))
+            let new_plan = add_limit(pushdown_plan, global_state.skip, global_fetch);
+            global_state.status = LimitStatus::Enforced;
+            Ok((Transformed::yes(new_plan), global_state))
         }
     } else {
         // The plan does not support push down and it is not a limit. We will need
@@ -276,7 +317,7 @@ pub fn pushdown_limit_helper(
         global_state.skip = 0;
 
         let maybe_fetchable = pushdown_plan.with_fetch(skip_and_fetch);
-        if global_state.satisfied {
+        if global_state.status == LimitStatus::Enforced {
             if let Some(plan_with_fetch) = maybe_fetchable {
                 let plan_with_preserve_order = plan_with_fetch
                     .with_preserve_order(global_state.preserve_order)
@@ -286,7 +327,6 @@ pub fn pushdown_limit_helper(
                 Ok((Transformed::no(pushdown_plan), global_state))
             }
         } else {
-            global_state.satisfied = true;
             pushdown_plan = if let Some(plan_with_fetch) = maybe_fetchable {
                 let plan_with_preserve_order = plan_with_fetch
                     .with_preserve_order(global_state.preserve_order)
@@ -304,6 +344,7 @@ pub fn pushdown_limit_helper(
             } else {
                 add_limit(pushdown_plan, global_skip, global_fetch)
             };
+            global_state.status = LimitStatus::Enforced;
             Ok((Transformed::yes(pushdown_plan), global_state))
         }
     }
@@ -383,7 +424,7 @@ pub(crate) fn pushdown_limits(
     // subtrees should not inherit its `skip`. Keep `fetch`, but clear
     // `skip` before recursing so child-local limits are not merged with
     // an `OFFSET` that has already been applied.
-    if global_state.satisfied {
+    if global_state.status == LimitStatus::Enforced {
         global_state.skip = 0;
     }
 
@@ -410,27 +451,6 @@ pub(crate) fn pushdown_limits(
     }
 }
 
-/// Extracts limit information from the [`ExecutionPlan`] if it is a
-/// [`GlobalLimitExec`] or a [`LocalLimitExec`].
-fn extract_limit(plan: &Arc<dyn ExecutionPlan>) -> Option<LimitInfo> {
-    if let Some(global_limit) = plan.downcast_ref::<GlobalLimitExec>() {
-        Some(LimitInfo {
-            input: Arc::clone(global_limit.input()),
-            fetch: global_limit.fetch(),
-            skip: global_limit.skip(),
-            preserve_order: global_limit.required_ordering().is_some(),
-        })
-    } else {
-        plan.downcast_ref::<LocalLimitExec>()
-            .map(|local_limit| LimitInfo {
-                input: Arc::clone(local_limit.input()),
-                fetch: Some(local_limit.fetch()),
-                skip: 0,
-                preserve_order: local_limit.required_ordering().is_some(),
-            })
-    }
-}
-
 /// Checks if the given plan combines input partitions.
 fn combines_input_partitions(plan: &Arc<dyn ExecutionPlan>) -> bool {
     plan.is::<CoalescePartitionsExec>() || plan.is::<SortPreservingMergeExec>()
@@ -447,6 +467,38 @@ fn add_limit(
         add_global_limit(pushdown_plan, skip, Some(fetch))
     } else {
         Arc::new(LocalLimitExec::new(pushdown_plan, fetch + skip)) as _
+    }
+}
+
+/// Materializes a global requirement at a single-partition boundary. A fetch
+/// on a multi-partition plan is only a per-partition hint, so it must be
+/// followed by a partition combiner before the requirement is satisfied.
+fn materialize_global_requirement(
+    pushdown_plan: Arc<dyn ExecutionPlan>,
+    skip: usize,
+    fetch: Option<usize>,
+    preserve_order: bool,
+) -> Arc<dyn ExecutionPlan> {
+    if pushdown_plan.output_partitioning().partition_count() == 1 {
+        return add_global_limit(pushdown_plan, skip, fetch);
+    }
+
+    let skip_and_fetch = fetch.map(|fetch| fetch + skip);
+    let limited: Arc<dyn ExecutionPlan> = if preserve_order
+        && let Some(ordering) = pushdown_plan.output_ordering().cloned()
+    {
+        Arc::new(
+            SortPreservingMergeExec::new(ordering, pushdown_plan)
+                .with_fetch(skip_and_fetch),
+        )
+    } else {
+        Arc::new(CoalescePartitionsExec::new(pushdown_plan).with_fetch(skip_and_fetch))
+    };
+
+    if skip > 0 {
+        add_global_limit(limited, skip, fetch)
+    } else {
+        limited
     }
 }
 

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -101,22 +101,16 @@ pub struct GlobalRequirements {
     pending: Option<LimitScope>,
 }
 
-/// Scope of a semantic cap that remains pending independently of its numeric
-/// `skip` and `fetch` payload.
-///
-/// Mirrors the two physical limit operators: [`LimitScope::Local`] corresponds
-/// to a [`LocalLimitExec`] (a cap on each output partition), and
-/// [`LimitScope::Global`] corresponds to a [`GlobalLimitExec`] (a cap on the
-/// merged output across all partitions of the subtree).
+/// The scope of a row limit: what the limited row count applies to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LimitScope {
-    /// A per-output-partition cap is still owed, as with a [`LocalLimitExec`]:
-    /// each output partition may emit at most the owed number of rows,
-    /// independently of the other partitions.
+    /// The limit caps each output partition independently, as enforced by
+    /// [`LocalLimitExec`].
     Local,
-    /// A subtree-wide cap is still owed, as with a [`GlobalLimitExec`]: the
-    /// cap applies to the merged output across all partitions of the subtree
-    /// (e.g., at a `CoalescePartitionsExec` or `SortPreservingMergeExec`).
+    /// The limit caps the combined output of all partitions, as enforced by
+    /// [`GlobalLimitExec`] over a single-partition input. A fetch on a
+    /// multi-partition operator cannot satisfy this scope; the partitions
+    /// must first be merged into one stream.
     Global,
 }
 

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -93,7 +93,7 @@ pub struct LimitPushdown {}
 /// outstanding; a retained `fetch` is a descendant early-stop hint only.
 ///
 /// [`LimitPushdown`]: crate::limit_pushdown::LimitPushdown
-#[derive(Clone, Debug, Default)]
+#[derive(Default, Clone, Debug)]
 pub struct GlobalRequirements {
     fetch: Option<usize>,
     skip: usize,

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -87,27 +87,36 @@ pub struct LimitPushdown {}
 /// State carried through [`LimitPushdown`] while it pushes limits down the plan.
 ///
 /// `pending` keeps the semantic requirement's scope separate from its numeric
-/// payload. `Some(PendingScope::Local)` means a per-output-partition cap is
-/// still owed, and `Some(PendingScope::Global)` means a subtree-wide cap is
+/// payload. `Some(LimitScope::Local)` means a per-output-partition cap is
+/// still owed, and `Some(LimitScope::Global)` means a subtree-wide cap is
 /// still owed. When `pending` is `None`, no semantic enforcement remains
 /// outstanding; a retained `fetch` is a descendant early-stop hint only.
 ///
 /// [`LimitPushdown`]: crate::limit_pushdown::LimitPushdown
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct GlobalRequirements {
     fetch: Option<usize>,
     skip: usize,
     preserve_order: bool,
-    pending: Option<PendingScope>,
+    pending: Option<LimitScope>,
 }
 
 /// Scope of a semantic cap that remains pending independently of its numeric
 /// `skip` and `fetch` payload.
+///
+/// `LimitScope::Local` scopes the requirement to a single operator's own
+/// output partitions (its internal scope) with no cross-partition aggregation
+/// implied. `LimitScope::Global` carries the global `LIMIT`/`FETCH` semantics
+/// that must still be enforced when multiple partitions are merged (e.g., at
+/// a `CoalescePartitionsExec` or `SortPreservingMergeExec`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum PendingScope {
-    /// A per-output-partition cap is still owed.
+enum LimitScope {
+    /// The cap applies only within this operator's internal scope: a
+    /// per-output-partition cap is still owed, with no cross-partition
+    /// aggregation implied.
     Local,
-    /// A subtree-wide cap is still owed.
+    /// A subtree-wide cap is still owed: the global limit/fetch semantics
+    /// must still be enforced at a multi-partition merge point.
     Global,
 }
 
@@ -153,21 +162,37 @@ pub fn pushdown_limit_helper(
     mut pushdown_plan: Arc<dyn ExecutionPlan>,
     mut global_state: GlobalRequirements,
 ) -> Result<(Transformed<Arc<dyn ExecutionPlan>>, GlobalRequirements)> {
-    if global_state.pending == Some(PendingScope::Local)
+    if global_state.pending == Some(LimitScope::Local)
         && pushdown_plan.output_partitioning().partition_count() == 1
     {
         // Local and global scope are equivalent with one output partition, but
         // retain the global scope in case recursion later exposes multi-partition
         // children, including through extension combiners.
-        global_state.pending = Some(PendingScope::Global);
+        global_state.pending = Some(LimitScope::Global);
     }
 
     if let Some(global_limit) = pushdown_plan.downcast_ref::<GlobalLimitExec>()
         && global_limit.skip() == 0
         && global_limit.fetch().is_none()
     {
-        // Remove this no-op wrapper without clearing inherited state, which may
-        // have been promoted from local to global scope at a one-output boundary.
+        // A `GlobalLimitExec` with `skip == 0` and `fetch == None` is a pure
+        // pass-through: it skips no rows and emits every input row, so the node
+        // itself carries no semantics and removing it cannot change the result.
+        //
+        // The inherited `pending` state must be preserved, not cleared: the
+        // still-owed requirement (which may have been promoted from
+        // `LimitScope::Local` to `LimitScope::Global` at a one-output-partition
+        // boundary) must continue to be enforced further down. The point of this
+        // short-circuit is to keep peeling such wrappers while carrying that
+        // state unchanged.
+        //
+        // We deliberately do not fall through to the generic `GlobalLimitExec`
+        // handling below: that branch exists to absorb a real `skip`/`fetch`
+        // payload into the carried state, whereas this node has no payload to
+        // absorb. It would also unconditionally re-assert
+        // `pending = Some(LimitScope::Global)` (and fold in
+        // `required_ordering()`), which could turn an already-satisfied or
+        // absent requirement into a forced global materialization further down.
         return Ok((
             Transformed {
                 data: Arc::clone(global_limit.input()),
@@ -178,7 +203,7 @@ pub fn pushdown_limit_helper(
         ));
     }
 
-    if global_state.pending == Some(PendingScope::Global)
+    if global_state.pending == Some(LimitScope::Global)
         && pushdown_plan.output_partitioning().partition_count() > 1
     {
         // This must precede generic `plan.fetch()` handling: a fetch on multiple
@@ -215,7 +240,7 @@ pub fn pushdown_limit_helper(
         (global_state.skip, global_state.fetch) =
             combine_limit(global_state.skip, global_state.fetch, skip, fetch);
         global_state.preserve_order |= global_limit.required_ordering().is_some();
-        global_state.pending = Some(PendingScope::Global);
+        global_state.pending = Some(LimitScope::Global);
         if let Some(fetch) = global_state.fetch
             && limit_satisfied_by_input(&input, global_state.skip, fetch)?
         {
@@ -241,9 +266,9 @@ pub fn pushdown_limit_helper(
         );
         global_state.preserve_order |= local_limit.required_ordering().is_some();
         global_state.pending = if input.output_partitioning().partition_count() == 1 {
-            Some(PendingScope::Global)
+            Some(LimitScope::Global)
         } else {
-            Some(PendingScope::Local)
+            Some(LimitScope::Local)
         };
         if let Some(fetch) = global_state.fetch
             && limit_satisfied_by_input(&input, global_state.skip, fetch)?
@@ -261,15 +286,28 @@ pub fn pushdown_limit_helper(
     }
 
     // Merge a fetch already present on a non-limit operator into global state.
-    if pushdown_plan.fetch().is_some() {
-        if global_state.skip == 0 {
+    //
+    // A `fetch` on a non-limit operator is an early-stop bound on the
+    // operator's own output, and the `ExecutionPlan` trait exposes it without
+    // formally encoding scope, so it can only ever prove a per-partition cap.
+    // It can therefore satisfy a still-pending requirement only when no skip
+    // is owed and the existing bound is at least as tight as the owed fetch:
+    // an existing `fetch = 10` does not satisfy an owed `fetch = 5`, and if
+    // the operator cannot absorb a tighter fetch via `with_fetch`, dropping
+    // the pending requirement here would silently lose the global `LIMIT`.
+    // The numeric early-stop bound is still merged unconditionally below.
+    if let Some(existing_fetch) = pushdown_plan.fetch() {
+        if global_state.skip == 0
+            && let Some(required_fetch) = global_state.fetch
+            && existing_fetch <= required_fetch
+        {
             global_state.pending = None;
         }
         (global_state.skip, global_state.fetch) = combine_limit(
             global_state.skip,
             global_state.fetch,
             0,
-            pushdown_plan.fetch(),
+            Some(existing_fetch),
         );
     }
 

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -86,11 +86,10 @@ pub struct LimitPushdown {}
 
 /// State carried through [`LimitPushdown`] while it pushes limits down the plan.
 ///
-/// `pending` keeps the semantic requirement's scope separate from its numeric
-/// payload. `Some(LimitScope::Local)` means a per-output-partition cap is
-/// still owed, and `Some(LimitScope::Global)` means a subtree-wide cap is
-/// still owed. When `pending` is `None`, no semantic enforcement remains
-/// outstanding; a retained `fetch` is a descendant early-stop hint only.
+/// `fetch` and `skip` hold the limit currently being pushed down. `pending`
+/// says whether a local or global limit still has to be enforced. After it
+/// becomes `None`, `fetch` may still be copied to children to help them stop
+/// early, but it is no longer responsible for correctness.
 ///
 /// [`LimitPushdown`]: crate::limit_pushdown::LimitPushdown
 #[derive(Default, Clone, Debug)]
@@ -159,9 +158,9 @@ pub fn pushdown_limit_helper(
     if global_state.pending == Some(LimitScope::Local)
         && pushdown_plan.output_partitioning().partition_count() == 1
     {
-        // Local and global scope are equivalent with one output partition, but
-        // retain the global scope in case recursion later exposes multi-partition
-        // children, including through extension combiners.
+        // A local limit on one output partition also limits the total output.
+        // Treat it as global before descending because this node may have
+        // multi-partition children.
         global_state.pending = Some(LimitScope::Global);
     }
 
@@ -169,24 +168,11 @@ pub fn pushdown_limit_helper(
         && global_limit.skip() == 0
         && global_limit.fetch().is_none()
     {
-        // A `GlobalLimitExec` with `skip == 0` and `fetch == None` is a pure
-        // pass-through: it skips no rows and emits every input row, so the node
-        // itself carries no semantics and removing it cannot change the result.
-        //
-        // The inherited `pending` state must be preserved, not cleared: the
-        // still-owed requirement (which may have been promoted from
-        // `LimitScope::Local` to `LimitScope::Global` at a one-output-partition
-        // boundary) must continue to be enforced further down. The point of this
-        // short-circuit is to keep peeling such wrappers while carrying that
-        // state unchanged.
-        //
-        // We deliberately do not fall through to the generic `GlobalLimitExec`
-        // handling below: that branch exists to absorb a real `skip`/`fetch`
-        // payload into the carried state, whereas this node has no payload to
-        // absorb. It would also unconditionally re-assert
-        // `pending = Some(LimitScope::Global)` (and fold in
-        // `required_ordering()`), which could turn an already-satisfied or
-        // absent requirement into a forced global materialization further down.
+        // A `GlobalLimitExec` with no skip and no fetch enforces nothing, so
+        // remove it and keep the carried state unchanged. General limit handling
+        // would mark a global limit as pending even when none is needed. Keep the
+        // local-to-global promotion above: it remains valid because this node has
+        // one output partition.
         return Ok((
             Transformed {
                 data: Arc::clone(global_limit.input()),
@@ -200,10 +186,10 @@ pub fn pushdown_limit_helper(
     if global_state.pending == Some(LimitScope::Global)
         && pushdown_plan.output_partitioning().partition_count() > 1
     {
-        // This must precede generic `plan.fetch()` handling: a fetch on multiple
-        // outputs cannot by itself prove a global cap, because the `ExecutionPlan`
-        // trait does not formally encode scope. Retain it only as a per-partition
-        // hint; an existing smaller hint does not imply a smaller global cap.
+        // Handle this before the generic `fetch` case: on a multi-partition plan,
+        // `fetch` limits partitions separately and cannot limit their combined output.
+        // Keep it for early stopping, then combine the partitions to enforce the
+        // global limit.
         let hint = global_state.fetch.map(|fetch| fetch + global_state.skip);
         if let Some(hint) = hint {
             let hint = pushdown_plan.fetch().map_or(hint, |fetch| fetch.min(hint));
@@ -279,17 +265,11 @@ pub fn pushdown_limit_helper(
         ));
     }
 
-    // Merge a fetch already present on a non-limit operator into global state.
-    //
-    // A `fetch` on a non-limit operator is an early-stop bound on the
-    // operator's own output, and the `ExecutionPlan` trait exposes it without
-    // formally encoding scope, so it can only ever prove a per-partition cap.
-    // It can therefore satisfy a still-pending requirement only when no skip
-    // is owed and the existing bound is at least as tight as the owed fetch:
-    // an existing `fetch = 10` does not satisfy an owed `fetch = 5`, and if
-    // the operator cannot absorb a tighter fetch via `with_fetch`, dropping
-    // the pending requirement here would silently lose the global `LIMIT`.
-    // The numeric early-stop bound is still merged unconditionally below.
+    // An existing `fetch` satisfies the carried limit only if there is no
+    // offset and it is no larger than the requested fetch. For example,
+    // `fetch=10` does not enforce `LIMIT 5`; if the operator cannot be changed to
+    // `fetch=5`, the explicit limit must remain. Still combine the fetch values
+    // below so descendants can use the tighter value to stop early.
     if let Some(existing_fetch) = pushdown_plan.fetch() {
         if global_state.skip == 0
             && let Some(required_fetch) = global_state.fetch
@@ -326,8 +306,8 @@ pub fn pushdown_limit_helper(
             // continue:
             Ok((Transformed::no(pushdown_plan), global_state))
         } else if let Some(plan_with_fetch) = pushdown_plan.with_fetch(skip_and_fetch) {
-            // This operator combines input partitions. Apply the carried fetch when
-            // supported. If it cannot, only a pending requirement needs an explicit limit.
+            // This partition-combining operator accepted `fetch`, so the fetch now
+            // bounds its combined output.
             let mut new_plan = plan_with_fetch;
             // Execution plans can't (yet) handle skip, so if we have one,
             // we still need to add a global limit.
@@ -340,7 +320,7 @@ pub fn pushdown_limit_helper(
             global_state.pending = None;
             Ok((Transformed::yes(new_plan), global_state))
         } else if global_state.pending.is_none() {
-            // No semantic requirement remains pending, so do not add another limit.
+            // The required limit is already enforced, so do not add another one.
             Ok((Transformed::no(pushdown_plan), global_state))
         } else {
             let new_plan = add_limit(pushdown_plan, global_state.skip, global_fetch);
@@ -348,8 +328,8 @@ pub fn pushdown_limit_helper(
             Ok((Transformed::yes(new_plan), global_state))
         }
     } else {
-        // This operator blocks pushdown. If no semantic requirement remains pending,
-        // apply only an optional fetch hint; otherwise enforce the requirement here.
+        // This operator stops limit pushdown. If the limit is already enforced, try
+        // only to add a fetch for early stopping; otherwise enforce the limit here.
 
         // There's no push down, change fetch & skip to default values:
         let global_skip = global_state.skip;
@@ -460,9 +440,10 @@ pub(crate) fn pushdown_limits(
         (new_node, global_state) = pushdown_limit_helper(new_node.data, global_state)?;
     }
 
-    // No semantic enforcement remains pending for a child subtree. Descendants
-    // may inherit the `fetch` budget for early stopping, but `OFFSET` must not
-    // cross this point or combine with nested limits.
+    // Once the limit is enforced, clear `skip` before visiting children so it
+    // cannot combine with a nested limit and skip rows twice. Each child may
+    // receive the same `fetch` for early stopping; those values are not added
+    // together because the limit has already been enforced above.
     if global_state.pending.is_none() {
         global_state.skip = 0;
     }
@@ -509,10 +490,9 @@ fn add_limit(
     }
 }
 
-/// Materializes a global requirement at a single-partition boundary. A fetch on
-/// a multi-partition plan cannot by itself prove a global cap, because the
-/// `ExecutionPlan` trait does not formally encode scope. It is retained only as
-/// a per-partition hint, so a partition combiner must satisfy the requirement.
+/// Enforces one limit across all output partitions. Multiple partitions are
+/// merged first, preserving order when required, because a fetch on each
+/// partition cannot limit their combined output.
 fn materialize_global_requirement(
     pushdown_plan: Arc<dyn ExecutionPlan>,
     skip: usize,

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -104,19 +104,19 @@ pub struct GlobalRequirements {
 /// Scope of a semantic cap that remains pending independently of its numeric
 /// `skip` and `fetch` payload.
 ///
-/// `LimitScope::Local` scopes the requirement to a single operator's own
-/// output partitions (its internal scope) with no cross-partition aggregation
-/// implied. `LimitScope::Global` carries the global `LIMIT`/`FETCH` semantics
-/// that must still be enforced when multiple partitions are merged (e.g., at
-/// a `CoalescePartitionsExec` or `SortPreservingMergeExec`).
+/// Mirrors the two physical limit operators: [`LimitScope::Local`] corresponds
+/// to a [`LocalLimitExec`] (a cap on each output partition), and
+/// [`LimitScope::Global`] corresponds to a [`GlobalLimitExec`] (a cap on the
+/// merged output across all partitions of the subtree).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LimitScope {
-    /// The cap applies only within this operator's internal scope: a
-    /// per-output-partition cap is still owed, with no cross-partition
-    /// aggregation implied.
+    /// A per-output-partition cap is still owed, as with a [`LocalLimitExec`]:
+    /// each output partition may emit at most the owed number of rows,
+    /// independently of the other partitions.
     Local,
-    /// A subtree-wide cap is still owed: the global limit/fetch semantics
-    /// must still be enforced at a multi-partition merge point.
+    /// A subtree-wide cap is still owed, as with a [`GlobalLimitExec`]: the
+    /// cap applies to the merged output across all partitions of the subtree
+    /// (e.g., at a `CoalescePartitionsExec` or `SortPreservingMergeExec`).
     Global,
 }
 

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -84,12 +84,12 @@ use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 #[derive(Default, Debug)]
 pub struct LimitPushdown {}
 
-/// This is a "data class" we use within the [`LimitPushdown`] rule to push
-/// down limits in the plan. GlobalRequirements are hold as a rule-wide state
-/// and holds the fetch and skip information. The struct also has a field named
-/// satisfied which means if the "current" plan is valid in terms of limits or not.
+/// State carried through [`LimitPushdown`] while it pushes limits down the plan.
 ///
-/// For example: If the plan is satisfied with current fetch info, we decide to not add a LocalLimit
+/// While `status` is pending, `skip` and `fetch` are semantic requirements
+/// needing enforcement. Once no enforcement remains pending, a retained `fetch`
+/// is only an early-stop budget for descendant operators; it must not create
+/// another semantic limit.
 ///
 /// [`LimitPushdown`]: crate::limit_pushdown::LimitPushdown
 #[derive(Clone, Debug)]
@@ -100,12 +100,19 @@ pub struct GlobalRequirements {
     status: LimitStatus,
 }
 
+/// Tracks a requirement's scope and enforcement state, which cannot be inferred
+/// from a numeric operator `fetch` or the rewritten plan shape.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 enum LimitStatus {
+    /// No inherited semantic requirement or fetch budget.
     #[default]
     None,
+    /// One pending cap is required per output partition of the current branch.
     PendingLocal,
+    /// One pending cap is required across all output partitions of the current subtree.
     PendingGlobal,
+    /// The semantic obligation has been enforced, absorbed, or proven redundant
+    /// at or above this point; retained `fetch` is an early-stop hint only.
     Enforced,
 }
 
@@ -154,6 +161,9 @@ pub fn pushdown_limit_helper(
     if global_state.status == LimitStatus::PendingLocal
         && pushdown_plan.output_partitioning().partition_count() == 1
     {
+        // Local and global scope are equivalent with one output partition, but
+        // retain the global scope in case recursion later exposes multi-partition
+        // children, including through extension combiners.
         global_state.status = LimitStatus::PendingGlobal;
     }
 
@@ -161,6 +171,8 @@ pub fn pushdown_limit_helper(
         && global_limit.skip() == 0
         && global_limit.fetch().is_none()
     {
+        // Remove this no-op wrapper without clearing inherited state, which may
+        // have been promoted from local to global scope at a one-output boundary.
         return Ok((
             Transformed {
                 data: Arc::clone(global_limit.input()),
@@ -174,6 +186,10 @@ pub fn pushdown_limit_helper(
     if global_state.status == LimitStatus::PendingGlobal
         && pushdown_plan.output_partitioning().partition_count() > 1
     {
+        // This must precede generic `plan.fetch()` handling: a fetch on multiple
+        // outputs cannot by itself prove a global cap, because the `ExecutionPlan`
+        // trait does not formally encode scope. Retain it only as a per-partition
+        // hint; an existing smaller hint does not imply a smaller global cap.
         let hint = global_state.fetch.map(|fetch| fetch + global_state.skip);
         if let Some(hint) = hint {
             let hint = pushdown_plan.fetch().map_or(hint, |fetch| fetch.min(hint));
@@ -249,8 +265,7 @@ pub fn pushdown_limit_helper(
         ));
     }
 
-    // If we have a non-limit operator with fetch capability, update global
-    // state as necessary:
+    // Merge a fetch already present on a non-limit operator into global state.
     if pushdown_plan.fetch().is_some() {
         if global_state.skip == 0 {
             global_state.status = LimitStatus::Enforced;
@@ -420,10 +435,9 @@ pub(crate) fn pushdown_limits(
         (new_node, global_state) = pushdown_limit_helper(new_node.data, global_state)?;
     }
 
-    // Once a limit has been materialized above the current node, child
-    // subtrees should not inherit its `skip`. Keep `fetch`, but clear
-    // `skip` before recursing so child-local limits are not merged with
-    // an `OFFSET` that has already been applied.
+    // No semantic enforcement remains pending for a child subtree. Descendants
+    // may inherit the `fetch` budget for early stopping, but `OFFSET` must not
+    // cross this point or combine with nested limits.
     if global_state.status == LimitStatus::Enforced {
         global_state.skip = 0;
     }
@@ -470,9 +484,10 @@ fn add_limit(
     }
 }
 
-/// Materializes a global requirement at a single-partition boundary. A fetch
-/// on a multi-partition plan is only a per-partition hint, so it must be
-/// followed by a partition combiner before the requirement is satisfied.
+/// Materializes a global requirement at a single-partition boundary. A fetch on
+/// a multi-partition plan cannot by itself prove a global cap, because the
+/// `ExecutionPlan` trait does not formally encode scope. It is retained only as
+/// a per-partition hint, so a partition combiner must satisfy the requirement.
 fn materialize_global_requirement(
     pushdown_plan: Arc<dyn ExecutionPlan>,
     skip: usize,

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -78,6 +78,7 @@ use datafusion_physical_plan::placeholder_row::PlaceholderRowExec;
 use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion_physical_plan::statistics::{StatisticsArgs, StatisticsContext};
+use datafusion_physical_plan::union::UnionExec;
 use datafusion_physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 /// This rule inspects [`ExecutionPlan`]'s and pushes down the fetch limit from
 /// the parent to the child if applicable.
@@ -301,6 +302,30 @@ pub fn pushdown_limit_helper(
     let skip_and_fetch = Some(global_fetch + global_state.skip);
 
     if pushdown_plan.supports_limit_pushdown() {
+        // A pending limit cannot be replicated to every child of a multi-child
+        // node: each child would enforce it and their merged output could
+        // exceed it. Only a unary node can pass it through transparently, plus
+        // `UnionExec` with `Local` (each output partition comes from one child).
+        let can_delegate_pending = global_state.pending.is_none()
+            || pushdown_plan.children().len() <= 1
+            || (global_state.pending == Some(LimitScope::Local)
+                && pushdown_plan.is::<UnionExec>());
+        if !can_delegate_pending {
+            // Enforce the limit at this node's output, then let children stop
+            // early with the same fetch hint.
+            let new_plan = if global_state.skip > 0 {
+                add_limit(pushdown_plan, global_state.skip, global_fetch)
+            } else if let Some(plan_with_fetch) = pushdown_plan.with_fetch(skip_and_fetch)
+            {
+                plan_with_fetch
+            } else {
+                add_limit(pushdown_plan, 0, global_fetch)
+            };
+            global_state.fetch = skip_and_fetch;
+            global_state.skip = 0;
+            global_state.pending = None;
+            return Ok((Transformed::yes(new_plan), global_state));
+        }
         if !combines_input_partitions(&pushdown_plan) {
             // We have information in the global state and the plan pushes down,
             // continue:

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -86,10 +86,11 @@ pub struct LimitPushdown {}
 
 /// State carried through [`LimitPushdown`] while it pushes limits down the plan.
 ///
-/// While `status` is pending, `skip` and `fetch` are semantic requirements
-/// needing enforcement. Once no enforcement remains pending, a retained `fetch`
-/// is only an early-stop budget for descendant operators; it must not create
-/// another semantic limit.
+/// `pending` keeps the semantic requirement's scope separate from its numeric
+/// payload. `Some(PendingScope::Local)` means a per-output-partition cap is
+/// still owed, and `Some(PendingScope::Global)` means a subtree-wide cap is
+/// still owed. When `pending` is `None`, no semantic enforcement remains
+/// outstanding; a retained `fetch` is a descendant early-stop hint only.
 ///
 /// [`LimitPushdown`]: crate::limit_pushdown::LimitPushdown
 #[derive(Clone, Debug)]
@@ -97,23 +98,17 @@ pub struct GlobalRequirements {
     fetch: Option<usize>,
     skip: usize,
     preserve_order: bool,
-    status: LimitStatus,
+    pending: Option<PendingScope>,
 }
 
-/// Tracks a requirement's scope and enforcement state, which cannot be inferred
-/// from a numeric operator `fetch` or the rewritten plan shape.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-enum LimitStatus {
-    /// No inherited semantic requirement or fetch budget.
-    #[default]
-    None,
-    /// One pending cap is required per output partition of the current branch.
-    PendingLocal,
-    /// One pending cap is required across all output partitions of the current subtree.
-    PendingGlobal,
-    /// The semantic obligation has been enforced, absorbed, or proven redundant
-    /// at or above this point; retained `fetch` is an early-stop hint only.
-    Enforced,
+/// Scope of a semantic cap that remains pending independently of its numeric
+/// `skip` and `fetch` payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingScope {
+    /// A per-output-partition cap is still owed.
+    Local,
+    /// A subtree-wide cap is still owed.
+    Global,
 }
 
 impl LimitPushdown {
@@ -133,7 +128,7 @@ impl PhysicalOptimizerRule for LimitPushdown {
             fetch: None,
             skip: 0,
             preserve_order: false,
-            status: LimitStatus::None,
+            pending: None,
         };
         pushdown_limits(plan, global_state)
     }
@@ -158,13 +153,13 @@ pub fn pushdown_limit_helper(
     mut pushdown_plan: Arc<dyn ExecutionPlan>,
     mut global_state: GlobalRequirements,
 ) -> Result<(Transformed<Arc<dyn ExecutionPlan>>, GlobalRequirements)> {
-    if global_state.status == LimitStatus::PendingLocal
+    if global_state.pending == Some(PendingScope::Local)
         && pushdown_plan.output_partitioning().partition_count() == 1
     {
         // Local and global scope are equivalent with one output partition, but
         // retain the global scope in case recursion later exposes multi-partition
         // children, including through extension combiners.
-        global_state.status = LimitStatus::PendingGlobal;
+        global_state.pending = Some(PendingScope::Global);
     }
 
     if let Some(global_limit) = pushdown_plan.downcast_ref::<GlobalLimitExec>()
@@ -183,7 +178,7 @@ pub fn pushdown_limit_helper(
         ));
     }
 
-    if global_state.status == LimitStatus::PendingGlobal
+    if global_state.pending == Some(PendingScope::Global)
         && pushdown_plan.output_partitioning().partition_count() > 1
     {
         // This must precede generic `plan.fetch()` handling: a fetch on multiple
@@ -208,7 +203,7 @@ pub fn pushdown_limit_helper(
         );
         global_state.fetch = hint;
         global_state.skip = 0;
-        global_state.status = LimitStatus::Enforced;
+        global_state.pending = None;
         return Ok((Transformed::yes(plan), global_state));
     }
 
@@ -220,11 +215,11 @@ pub fn pushdown_limit_helper(
         (global_state.skip, global_state.fetch) =
             combine_limit(global_state.skip, global_state.fetch, skip, fetch);
         global_state.preserve_order |= global_limit.required_ordering().is_some();
-        global_state.status = LimitStatus::PendingGlobal;
+        global_state.pending = Some(PendingScope::Global);
         if let Some(fetch) = global_state.fetch
             && limit_satisfied_by_input(&input, global_state.skip, fetch)?
         {
-            global_state.status = LimitStatus::Enforced;
+            global_state.pending = None;
         }
         return Ok((
             Transformed {
@@ -245,15 +240,15 @@ pub fn pushdown_limit_helper(
             Some(local_limit.fetch()),
         );
         global_state.preserve_order |= local_limit.required_ordering().is_some();
-        global_state.status = if input.output_partitioning().partition_count() == 1 {
-            LimitStatus::PendingGlobal
+        global_state.pending = if input.output_partitioning().partition_count() == 1 {
+            Some(PendingScope::Global)
         } else {
-            LimitStatus::PendingLocal
+            Some(PendingScope::Local)
         };
         if let Some(fetch) = global_state.fetch
             && limit_satisfied_by_input(&input, global_state.skip, fetch)?
         {
-            global_state.status = LimitStatus::Enforced;
+            global_state.pending = None;
         }
         return Ok((
             Transformed {
@@ -268,7 +263,7 @@ pub fn pushdown_limit_helper(
     // Merge a fetch already present on a non-limit operator into global state.
     if pushdown_plan.fetch().is_some() {
         if global_state.skip == 0 {
-            global_state.status = LimitStatus::Enforced;
+            global_state.pending = None;
         }
         (global_state.skip, global_state.fetch) = combine_limit(
             global_state.skip,
@@ -280,10 +275,10 @@ pub fn pushdown_limit_helper(
 
     let Some(global_fetch) = global_state.fetch else {
         // There's no valid fetch information, exit early:
-        return if global_state.skip > 0 && global_state.status != LimitStatus::Enforced {
+        return if global_state.skip > 0 && global_state.pending.is_some() {
             // There might be a case with only offset, if so add a global limit:
             let new_plan = add_global_limit(pushdown_plan, global_state.skip, None);
-            global_state.status = LimitStatus::Enforced;
+            global_state.pending = None;
             Ok((Transformed::yes(new_plan), global_state))
         } else {
             // There's no info on offset or fetch, nothing to do:
@@ -299,9 +294,8 @@ pub fn pushdown_limit_helper(
             // continue:
             Ok((Transformed::no(pushdown_plan), global_state))
         } else if let Some(plan_with_fetch) = pushdown_plan.with_fetch(skip_and_fetch) {
-            // This plan is combining input partitions, so we need to add the
-            // fetch info to plan if possible. If not, we must add a limit node
-            // with the information from the global state.
+            // This operator combines input partitions. Apply the carried fetch when
+            // supported. If it cannot, only a pending requirement needs an explicit limit.
             let mut new_plan = plan_with_fetch;
             // Execution plans can't (yet) handle skip, so if we have one,
             // we still need to add a global limit.
@@ -311,20 +305,19 @@ pub fn pushdown_limit_helper(
             }
             global_state.fetch = skip_and_fetch;
             global_state.skip = 0;
-            global_state.status = LimitStatus::Enforced;
+            global_state.pending = None;
             Ok((Transformed::yes(new_plan), global_state))
-        } else if global_state.status == LimitStatus::Enforced {
-            // If the plan is already satisfied, do not add a limit:
+        } else if global_state.pending.is_none() {
+            // No semantic requirement remains pending, so do not add another limit.
             Ok((Transformed::no(pushdown_plan), global_state))
         } else {
             let new_plan = add_limit(pushdown_plan, global_state.skip, global_fetch);
-            global_state.status = LimitStatus::Enforced;
+            global_state.pending = None;
             Ok((Transformed::yes(new_plan), global_state))
         }
     } else {
-        // The plan does not support push down and it is not a limit. We will need
-        // to add a limit or a fetch. If the plan is already satisfied, we will try
-        // to add the fetch info and return the plan.
+        // This operator blocks pushdown. If no semantic requirement remains pending,
+        // apply only an optional fetch hint; otherwise enforce the requirement here.
 
         // There's no push down, change fetch & skip to default values:
         let global_skip = global_state.skip;
@@ -332,7 +325,7 @@ pub fn pushdown_limit_helper(
         global_state.skip = 0;
 
         let maybe_fetchable = pushdown_plan.with_fetch(skip_and_fetch);
-        if global_state.status == LimitStatus::Enforced {
+        if global_state.pending.is_none() {
             if let Some(plan_with_fetch) = maybe_fetchable {
                 let plan_with_preserve_order = plan_with_fetch
                     .with_preserve_order(global_state.preserve_order)
@@ -359,7 +352,7 @@ pub fn pushdown_limit_helper(
             } else {
                 add_limit(pushdown_plan, global_skip, global_fetch)
             };
-            global_state.status = LimitStatus::Enforced;
+            global_state.pending = None;
             Ok((Transformed::yes(pushdown_plan), global_state))
         }
     }
@@ -438,7 +431,7 @@ pub(crate) fn pushdown_limits(
     // No semantic enforcement remains pending for a child subtree. Descendants
     // may inherit the `fetch` budget for early stopping, but `OFFSET` must not
     // cross this point or combine with nested limits.
-    if global_state.status == LimitStatus::Enforced {
+    if global_state.pending.is_none() {
         global_state.skip = 0;
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23799.

## Rationale for this change

An operator-level `fetch` applies independently to each output partition, so it cannot always replace a query-wide limit. For example, pushing `LIMIT 5` into a two-partition scan as `fetch=5` can return up to 10 rows.

The per-partition fetch is still useful as an early-stop hint, but the optimizer must distinguish that hint from a limit that still needs to be enforced. This distinction also affects OFFSET, existing fetches, partition ordering, and operators with multiple children.

## What changes are included in this PR?

`LimitPushdown` now tracks both the limit values (`skip` and `fetch`) and whether a local or global limit is still pending:

| Pending state | Meaning |
| --- | --- |
| `Local` | Each output partition still needs its own limit. |
| `Global` | One limit still needs to be applied to the combined output. |
| None | The limit is already enforced; a retained fetch is only an early-stop hint. |

The rule handles the relevant cases as follows.

### Partition scope

- A pending global limit over multiple output partitions is enforced only after the partitions are combined.
- `CoalescePartitionsExec` is used when no ordering must be preserved.
- `SortPreservingMergeExec` is used when the limit requires the input ordering to remain intact.
- A local limit at a single-output operator is promoted to global before descending, because that operator may hide multiple input partitions.

### OFFSET and existing fetches

- A child may receive `skip + fetch` as an early-stop hint, but a fetch alone never implements OFFSET.
- An existing operator fetch satisfies a pending limit only when there is no OFFSET and `existing_fetch <= required_fetch`.
- A looser fetch is tightened through `with_fetch` when supported; otherwise an explicit limit remains.
- A tighter existing fetch is preserved rather than widened.
- A no-op `GlobalLimitExec` (`skip=0`, no fetch) is removed without creating a partition-combining boundary.

### Unary and custom operators

`supports_limit_pushdown` means that a limit may be delegated through an operator; `with_fetch` separately means that the operator can apply a fetch to its own output.

- An unknown operator uses the conservative defaults: it blocks pushdown, and an explicit limit is kept above it unless its `with_fetch` implementation can enforce the output bound.
- A unary operator that declares `supports_limit_pushdown` may pass a pending limit to its single child.
- If an operator accepts `with_fetch`, it can enforce the bound on its own output. With OFFSET, an explicit `GlobalLimitExec` is still required above it.

### Operators with multiple children

A pending limit is not copied independently to every child of an arbitrary multi-child operator, because their combined output could exceed the requested row count.

- The limit is first enforced on the multi-child operator's output, either through its `with_fetch` implementation or an explicit limit node.
- After that enforcement, `pending` is cleared and only a safe early-stop fetch is passed to the children.
- `UnionExec` is a narrow exception for local limits: each Union output partition comes from one child partition, so the same per-partition local limit can safely be delegated to its children.
- A global limit over Union is still enforced over the combined output before descending.

## What is the testing strategy for this PR?

The `physical_optimizer::limit_pushdown` integration tests cover 42 plan shapes, including:

- fetch-capable and unfetchable multi-partition inputs;
- ordered and unordered global materialization;
- LIMIT, OFFSET + LIMIT, and OFFSET-only plans;
- tighter, looser, and immutable existing fetches;
- unary operators that hide multi-partition children;
- arbitrary multi-child operators, with and without `with_fetch`;
- safe child hints after output enforcement;
- local and global limits over Union;
- nested limits and no-op global limits.

Verified on the latest rebased branch with:

```text
cargo fmt --all --check

cargo test -p datafusion --test core_integration \
  physical_optimizer::limit_pushdown::
# 42 passed; 0 failed

cargo test -p datafusion-physical-optimizer limit_pushdown
# 2 passed; 0 failed

cargo clippy -p datafusion -p datafusion-physical-optimizer \
  --all-targets --all-features -- -D warnings
# passed

git diff --check
# passed
```

## Are there any user-facing changes?

Yes. Affected plans now preserve query-wide LIMIT/OFFSET semantics instead of returning too many rows or applying an offset more than once. There are no public API or configuration changes.

