### PR TITLE
feat(functions-aggregate): make approx_distinct HLL precision configurable

### DIFF
--- a/datafusion/functions-aggregate/benches/approx_distinct.rs
+++ b/datafusion/functions-aggregate/benches/approx_distinct.rs
@@ -421,6 +421,29 @@ fn approx_distinct_benchmark(c: &mut Criterion) {
     }
 }
 
+fn prepare_accumulator_with_precision(
+    data_type: DataType,
+    p: usize,
+) -> Box<dyn Accumulator> {
+    let schema = Arc::new(Schema::new(vec![Field::new("f", data_type, true)]));
+    let expr = col("f", &schema).unwrap();
+    let accumulator_args = AccumulatorArgs {
+        return_field: Field::new("f", DataType::UInt64, true).into(),
+        schema: &schema,
+        expr_fields: &[expr.return_field(&schema).unwrap()],
+        ignore_nulls: false,
+        order_bys: &[],
+        is_reversed: false,
+        name: "approx_distinct(f)",
+        is_distinct: false,
+        exprs: &[expr],
+    };
+    ApproxDistinct::with_hll_precision(p)
+        .unwrap()
+        .accumulator(accumulator_args)
+        .unwrap()
+}
+
 /// Build a `GroupsAccumulator` the same way the aggregate operator does: use the
 /// specialized one if the function supports it, otherwise fall back to wrapping
 /// the per-group `Accumulator` in a `GroupsAccumulatorAdapter`.
@@ -428,6 +451,32 @@ fn prepare_groups_accumulator(data_type: DataType) -> Box<dyn GroupsAccumulator>
     let schema = Arc::new(Schema::new(vec![Field::new("f", data_type, true)]));
     let expr = col("f", &schema).unwrap();
     let udf = Arc::new(AggregateUDF::from(ApproxDistinct::new()));
+    let agg = Arc::new(
+        AggregateExprBuilder::new(udf, vec![expr])
+            .schema(schema)
+            .alias("approx_distinct(f)")
+            .build()
+            .unwrap(),
+    );
+
+    if agg.groups_accumulator_supported() {
+        agg.create_groups_accumulator().unwrap()
+    } else {
+        let agg = Arc::clone(&agg);
+        let factory = move || agg.create_accumulator();
+        Box::new(GroupsAccumulatorAdapter::new(factory))
+    }
+}
+
+fn prepare_groups_accumulator_with_precision(
+    data_type: DataType,
+    p: usize,
+) -> Box<dyn GroupsAccumulator> {
+    let schema = Arc::new(Schema::new(vec![Field::new("f", data_type, true)]));
+    let expr = col("f", &schema).unwrap();
+    let udf = Arc::new(AggregateUDF::from(
+        ApproxDistinct::with_hll_precision(p).unwrap(),
+    ));
     let agg = Arc::new(
         AggregateExprBuilder::new(udf, vec![expr])
             .schema(schema)
@@ -583,9 +632,104 @@ fn approx_distinct_grouped_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark `approx_distinct` at varying HLL precisions (p ∈ {8, 10, 12, 14}).
+///
+/// Lower `p` means fewer registers (1/64th as many at p=8 vs p=14), so p=8
+/// should be noticeably faster than p=14 — this confirms the feature works.
+fn approx_distinct_precision_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("approx_distinct_precision");
+
+    let n_distinct_99 = BATCH_SIZE * 99 / 100;
+
+    // Pre-build input arrays once (outside the benched loop).
+    let i64_values = Arc::new(create_i64_array(n_distinct_99)) as ArrayRef;
+    let short_pool = create_string_pool(n_distinct_99, SHORT_STRING_LENGTH);
+    let utf8_values = Arc::new(create_string_array(&short_pool)) as ArrayRef;
+    let decimal128_values = Arc::new(create_decimal128_array(200)) as ArrayRef;
+
+    for p in [14usize, 12, 10, 8] {
+        // i64 at 99% distinct — measure update_batch + evaluate so the
+        // register scan (O(2^p)) is included. p=8 has 1/64th the registers
+        // to scan vs p=14 and should be noticeably faster on evaluate().
+        {
+            let values = Arc::clone(&i64_values);
+            group.bench_function(&format!("p={p} i64 99% distinct"), |b| {
+                b.iter(|| {
+                    let mut acc = prepare_accumulator_with_precision(DataType::Int64, p);
+                    acc.update_batch(std::slice::from_ref(&values)).unwrap();
+                    black_box(acc.evaluate().unwrap())
+                })
+            });
+        }
+
+        // utf8 short at 99% distinct
+        {
+            let values = Arc::clone(&utf8_values);
+            group.bench_function(&format!("p={p} utf8 short 99% distinct"), |b| {
+                b.iter(|| {
+                    let mut acc = prepare_accumulator_with_precision(DataType::Utf8, p);
+                    acc.update_batch(std::slice::from_ref(&values)).unwrap();
+                    black_box(acc.evaluate().unwrap())
+                })
+            });
+        }
+
+        // Decimal128 at fixed 200 distinct
+        {
+            let values = Arc::clone(&decimal128_values);
+            group.bench_function(&format!("p={p} decimal128 200 distinct"), |b| {
+                b.iter(|| {
+                    let mut acc = prepare_accumulator_with_precision(
+                        DataType::Decimal128(DECIMAL128_PRECISION, DECIMAL_SCALE),
+                        p,
+                    );
+                    acc.update_batch(std::slice::from_ref(&values)).unwrap();
+                    black_box(acc.evaluate().unwrap())
+                })
+            });
+        }
+    }
+
+    group.finish();
+}
+
+/// Benchmark grouped `approx_distinct` at varying HLL precisions.
+fn approx_distinct_grouped_precision_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("approx_distinct_grouped_precision");
+    group.sample_size(10);
+
+    for data_type in [DataType::Int64, DataType::Utf8] {
+        let batches = build_grouped_batches(&data_type);
+        for p in [14usize, 12, 10, 8] {
+            let label = format!("p={p} {data_type:?} {N_GROUPS} groups");
+            let batches = batches.clone();
+            group.bench_function(&label, |b| {
+                b.iter(|| {
+                    let mut acc =
+                        prepare_groups_accumulator_with_precision(data_type.clone(), p);
+                    for (values, group_indices) in &batches {
+                        acc.update_batch(
+                            std::slice::from_ref(values),
+                            group_indices,
+                            None,
+                            N_GROUPS,
+                        )
+                        .unwrap();
+                    }
+                    black_box(acc.evaluate(EmitTo::All).unwrap());
+                })
+            });
+        }
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     approx_distinct_benchmark,
-    approx_distinct_grouped_benchmark
+    approx_distinct_grouped_benchmark,
+    approx_distinct_precision_benchmark,
+    approx_distinct_grouped_precision_benchmark
 );
 criterion_main!(benches);

--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -575,7 +575,8 @@ impl GroupsAccumulator for HllGroupsAccumulator {
             }
             Some(nulls) => {
                 for row in nulls.valid_indices() {
-                    delta += self.groups[group_indices[row]].add_hash(self.hashes[row], p);
+                    delta +=
+                        self.groups[group_indices[row]].add_hash(self.hashes[row], p);
                 }
             }
         }
@@ -837,20 +838,36 @@ impl AggregateUDFImpl for ApproxDistinct {
             | DataType::Int16 => {
                 return get_fixed_domain_approx_accumulator(data_type);
             }
-            DataType::UInt32 => Box::new(NumericHLLAccumulator::<UInt32Type>::with_precision(p)),
-            DataType::UInt64 => Box::new(NumericHLLAccumulator::<UInt64Type>::with_precision(p)),
-            DataType::Int32 => Box::new(NumericHLLAccumulator::<Int32Type>::with_precision(p)),
-            DataType::Int64 => Box::new(NumericHLLAccumulator::<Int64Type>::with_precision(p)),
-            DataType::Date32 => Box::new(NumericHLLAccumulator::<Date32Type>::with_precision(p)),
-            DataType::Date64 => Box::new(NumericHLLAccumulator::<Date64Type>::with_precision(p)),
+            DataType::UInt32 => {
+                Box::new(NumericHLLAccumulator::<UInt32Type>::with_precision(p))
+            }
+            DataType::UInt64 => {
+                Box::new(NumericHLLAccumulator::<UInt64Type>::with_precision(p))
+            }
+            DataType::Int32 => {
+                Box::new(NumericHLLAccumulator::<Int32Type>::with_precision(p))
+            }
+            DataType::Int64 => {
+                Box::new(NumericHLLAccumulator::<Int64Type>::with_precision(p))
+            }
+            DataType::Date32 => {
+                Box::new(NumericHLLAccumulator::<Date32Type>::with_precision(p))
+            }
+            DataType::Date64 => {
+                Box::new(NumericHLLAccumulator::<Date64Type>::with_precision(p))
+            }
             DataType::Time32(TimeUnit::Second) => {
                 Box::new(NumericHLLAccumulator::<Time32SecondType>::with_precision(p))
             }
             DataType::Time32(TimeUnit::Millisecond) => {
-                Box::new(NumericHLLAccumulator::<Time32MillisecondType>::with_precision(p))
+                Box::new(
+                    NumericHLLAccumulator::<Time32MillisecondType>::with_precision(p),
+                )
             }
             DataType::Time64(TimeUnit::Microsecond) => {
-                Box::new(NumericHLLAccumulator::<Time64MicrosecondType>::with_precision(p))
+                Box::new(
+                    NumericHLLAccumulator::<Time64MicrosecondType>::with_precision(p),
+                )
             }
             DataType::Time64(TimeUnit::Nanosecond) => {
                 Box::new(NumericHLLAccumulator::<Time64NanosecondType>::with_precision(p))
@@ -858,24 +875,24 @@ impl AggregateUDFImpl for ApproxDistinct {
             DataType::Timestamp(TimeUnit::Second, _) => {
                 Box::new(NumericHLLAccumulator::<TimestampSecondType>::with_precision(p))
             }
-            DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                Box::new(NumericHLLAccumulator::<TimestampMillisecondType>::with_precision(p))
-            }
-            DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                Box::new(NumericHLLAccumulator::<TimestampMicrosecondType>::with_precision(p))
-            }
-            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                Box::new(NumericHLLAccumulator::<TimestampNanosecondType>::with_precision(p))
-            }
-            DataType::Interval(IntervalUnit::YearMonth) => {
-                Box::new(NumericHLLAccumulator::<IntervalYearMonthType>::with_precision(p))
-            }
+            DataType::Timestamp(TimeUnit::Millisecond, _) => Box::new(
+                NumericHLLAccumulator::<TimestampMillisecondType>::with_precision(p),
+            ),
+            DataType::Timestamp(TimeUnit::Microsecond, _) => Box::new(
+                NumericHLLAccumulator::<TimestampMicrosecondType>::with_precision(p),
+            ),
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => Box::new(
+                NumericHLLAccumulator::<TimestampNanosecondType>::with_precision(p),
+            ),
+            DataType::Interval(IntervalUnit::YearMonth) => Box::new(
+                NumericHLLAccumulator::<IntervalYearMonthType>::with_precision(p),
+            ),
             DataType::Interval(IntervalUnit::DayTime) => {
                 Box::new(NumericHLLAccumulator::<IntervalDayTimeType>::with_precision(p))
             }
-            DataType::Interval(IntervalUnit::MonthDayNano) => {
-                Box::new(NumericHLLAccumulator::<IntervalMonthDayNanoType>::with_precision(p))
-            }
+            DataType::Interval(IntervalUnit::MonthDayNano) => Box::new(
+                NumericHLLAccumulator::<IntervalMonthDayNanoType>::with_precision(p),
+            ),
             DataType::Decimal32(_, _) => {
                 Box::new(NumericHLLAccumulator::<Decimal32Type>::with_precision(p))
             }
@@ -889,17 +906,19 @@ impl AggregateUDFImpl for ApproxDistinct {
                 Box::new(NumericHLLAccumulator::<Decimal256Type>::with_precision(p))
             }
             DataType::Duration(TimeUnit::Second) => {
-                Box::new(NumericHLLAccumulator::<DurationSecondType>::with_precision(p))
+                Box::new(NumericHLLAccumulator::<DurationSecondType>::with_precision(
+                    p,
+                ))
             }
-            DataType::Duration(TimeUnit::Millisecond) => {
-                Box::new(NumericHLLAccumulator::<DurationMillisecondType>::with_precision(p))
-            }
-            DataType::Duration(TimeUnit::Microsecond) => {
-                Box::new(NumericHLLAccumulator::<DurationMicrosecondType>::with_precision(p))
-            }
-            DataType::Duration(TimeUnit::Nanosecond) => {
-                Box::new(NumericHLLAccumulator::<DurationNanosecondType>::with_precision(p))
-            }
+            DataType::Duration(TimeUnit::Millisecond) => Box::new(
+                NumericHLLAccumulator::<DurationMillisecondType>::with_precision(p),
+            ),
+            DataType::Duration(TimeUnit::Microsecond) => Box::new(
+                NumericHLLAccumulator::<DurationMicrosecondType>::with_precision(p),
+            ),
+            DataType::Duration(TimeUnit::Nanosecond) => Box::new(
+                NumericHLLAccumulator::<DurationNanosecondType>::with_precision(p),
+            ),
             DataType::Utf8
             | DataType::LargeUtf8
             | DataType::Utf8View
@@ -937,7 +956,9 @@ impl AggregateUDFImpl for ApproxDistinct {
     ) -> Result<Box<dyn GroupsAccumulator>> {
         let data_type = args.expr_fields[0].data_type();
         if is_hll_groups_type(data_type) {
-            Ok(Box::new(HllGroupsAccumulator::with_precision(self.hll_precision)))
+            Ok(Box::new(HllGroupsAccumulator::with_precision(
+                self.hll_precision,
+            )))
         } else {
             not_impl_err!(
                 "GroupsAccumulator for 'approx_distinct' is not implemented for data type {data_type}"
@@ -1597,9 +1618,12 @@ mod tests {
 
     // --- ApproxDistinct with non-default precision ---
 
+    #[cfg(not(feature = "force_hash_collisions"))]
     use arrow::datatypes::{Schema, UnionFields, UnionMode};
+    #[cfg(not(feature = "force_hash_collisions"))]
     use std::sync::Arc;
 
+    #[cfg(not(feature = "force_hash_collisions"))]
     fn make_acc_args<'a>(
         schema: &'a Schema,
         return_field: &'a FieldRef,
@@ -1625,11 +1649,9 @@ mod tests {
 
         let func = ApproxDistinct::with_hll_precision(12).unwrap();
         let values: ArrayRef = Arc::new(Int64Array::from_iter_values(0..1000i64));
-        let expr_field: FieldRef =
-            Arc::new(Field::new("v", DataType::Int64, false));
+        let expr_field: FieldRef = Arc::new(Field::new("v", DataType::Int64, false));
         let schema = Schema::new(vec![(*expr_field).clone()]);
-        let return_field: FieldRef =
-            Arc::new(Field::new("r", DataType::UInt64, false));
+        let return_field: FieldRef = Arc::new(Field::new("r", DataType::UInt64, false));
         let acc_args = make_acc_args(&schema, &return_field, &expr_field);
         let mut acc = func.accumulator(acc_args).unwrap();
         acc.update_batch(&[values]).unwrap();
@@ -1658,11 +1680,9 @@ mod tests {
             UnionMode::Dense,
         );
         let func = ApproxDistinct::new();
-        let expr_field: FieldRef =
-            Arc::new(Field::new("v", union_type.clone(), false));
+        let expr_field: FieldRef = Arc::new(Field::new("v", union_type.clone(), false));
         let schema = Schema::new(vec![(*expr_field).clone()]);
-        let return_field: FieldRef =
-            Arc::new(Field::new("r", DataType::UInt64, false));
+        let return_field: FieldRef = Arc::new(Field::new("r", DataType::UInt64, false));
         let acc_args = make_acc_args(&schema, &return_field, &expr_field);
         let mut acc = func.accumulator(acc_args).unwrap();
         let result = acc.evaluate().unwrap();
@@ -1724,7 +1744,11 @@ mod tests {
             .unwrap();
 
         let result = final_acc.evaluate(EmitTo::All).unwrap();
-        let count = result.as_any().downcast_ref::<UInt64Array>().unwrap().value(0);
+        let count = result
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap()
+            .value(0);
         // p=12 → ~1.6% error; allow 10% margin
         assert!(count > 180 && count < 220, "count {count} out of range");
     }

--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -17,7 +17,9 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
-use crate::hyperloglog::{HLL_HASH_STATE, HyperLogLog, NUM_REGISTERS, count_from_hashes};
+use crate::hyperloglog::{
+    DEFAULT_HLL_P, HLL_HASH_STATE, HLL_P_MAX, HLL_P_MIN, HyperLogLog, count_from_hashes,
+};
 use arrow::array::{
     Array, ArrayRef, BinaryArray, BinaryBuilder, BooleanArray, PrimitiveArray,
     UInt64Array,
@@ -75,10 +77,23 @@ impl<T: Hash + ?Sized> From<&HyperLogLog<T>> for ScalarValue {
 impl<T: Hash + ?Sized> TryFrom<&[u8]> for HyperLogLog<T> {
     type Error = DataFusionError;
     fn try_from(v: &[u8]) -> Result<HyperLogLog<T>> {
-        let arr: [u8; 16384] = v.try_into().map_err(|_| {
-            internal_datafusion_err!("Impossibly got invalid binary array from states")
-        })?;
-        Ok(HyperLogLog::<T>::new_with_registers(arr))
+        if v.is_empty() || !v.len().is_power_of_two() {
+            return internal_err!(
+                "approx_distinct: invalid HLL state length {} (must be a power of two)",
+                v.len()
+            );
+        }
+        let p = v.len().ilog2() as usize;
+        if !(HLL_P_MIN..=HLL_P_MAX).contains(&p) {
+            return internal_err!(
+                "approx_distinct: HLL state length {} implies precision {} outside {}..={}",
+                v.len(),
+                p,
+                HLL_P_MIN,
+                HLL_P_MAX
+            );
+        }
+        Ok(HyperLogLog::<T>::from_registers(v.to_vec()))
     }
 }
 
@@ -131,10 +146,16 @@ struct HLLAccumulator {
     hashes: Vec<u64>,
 }
 
+impl Default for HLLAccumulator {
+    fn default() -> Self {
+        Self::with_precision(DEFAULT_HLL_P)
+    }
+}
+
 impl HLLAccumulator {
-    pub fn new() -> Self {
+    pub fn with_precision(p: usize) -> Self {
         Self {
-            hll: HyperLogLog::new(),
+            hll: HyperLogLog::with_precision(p),
             hashes: Vec::new(),
         }
     }
@@ -201,14 +222,24 @@ where
     hll: HyperLogLog<T::Native>,
 }
 
+impl<T> Default for NumericHLLAccumulator<T>
+where
+    T: ArrowPrimitiveType,
+    T::Native: Hash,
+{
+    fn default() -> Self {
+        Self::with_precision(DEFAULT_HLL_P)
+    }
+}
+
 impl<T> NumericHLLAccumulator<T>
 where
     T: ArrowPrimitiveType,
     T::Native: Hash,
 {
-    pub fn new() -> Self {
+    pub fn with_precision(p: usize) -> Self {
         Self {
-            hll: HyperLogLog::new(),
+            hll: HyperLogLog::with_precision(p),
         }
     }
 }
@@ -254,7 +285,7 @@ where
 /// Maximum number of distinct hashes kept in the sparse representation of a
 /// per-group sketch before it is promoted to a dense [`HyperLogLog`].
 ///
-/// A dense sketch always occupies [`NUM_REGISTERS`] (16 KiB) regardless of how
+/// A dense sketch occupies `2^p` bytes regardless of how
 /// many values it has seen. The vast majority of groups in a high-cardinality
 /// `GROUP BY` only observe a handful of distinct values, so keeping their state
 /// as a small list of hashes saves a huge amount of memory (both while
@@ -276,15 +307,10 @@ enum GroupHll {
     Dense(Box<HyperLogLog<u8>>),
 }
 
-impl Default for GroupHll {
-    fn default() -> Self {
-        GroupHll::Sparse(Vec::new())
-    }
-}
-
-/// Fold a slice of pre-computed hashes into a fresh [`HyperLogLog`] sketch.
-fn fold_sparse_to_hll(hashes: &[u64]) -> HyperLogLog<u8> {
-    let mut hll = HyperLogLog::<u8>::new();
+/// Fold a slice of pre-computed hashes into a fresh [`HyperLogLog`] sketch with
+/// the given precision.
+fn fold_sparse_to_hll(hashes: &[u64], p: usize) -> HyperLogLog<u8> {
+    let mut hll = HyperLogLog::<u8>::with_precision(p);
     for &h in hashes {
         hll.add_hashed(h);
     }
@@ -292,10 +318,14 @@ fn fold_sparse_to_hll(hashes: &[u64]) -> HyperLogLog<u8> {
 }
 
 impl GroupHll {
+    fn new_sparse() -> Self {
+        GroupHll::Sparse(Vec::new())
+    }
+
     /// Add a pre-computed hash, returning the change in heap-allocated bytes so
     /// the accumulator can track its memory usage incrementally.
     #[inline]
-    fn add_hash(&mut self, hash: u64) -> isize {
+    fn add_hash(&mut self, hash: u64, p: usize) -> isize {
         match self {
             GroupHll::Dense(hll) => {
                 hll.add_hashed(hash);
@@ -305,7 +335,7 @@ impl GroupHll {
                 let cap_before = v.capacity();
                 v.push(hash);
                 if v.len() >= 2 * SPARSE_LIMIT {
-                    return self.compact_or_promote(cap_before);
+                    return self.compact_or_promote(cap_before, p);
                 }
                 ((v.capacity() - cap_before) * size_of::<u64>()) as isize
             }
@@ -315,18 +345,19 @@ impl GroupHll {
     /// Deduplicate the sparse hash list and, if it still exceeds
     /// [`SPARSE_LIMIT`] distinct values, promote it to a dense sketch.
     #[cold]
-    fn compact_or_promote(&mut self, cap_before: usize) -> isize {
+    fn compact_or_promote(&mut self, cap_before: usize, p: usize) -> isize {
         let GroupHll::Sparse(v) = self else {
             return 0;
         };
         v.sort_unstable();
         v.dedup();
         if v.len() > SPARSE_LIMIT {
+            let num_registers = 1_usize << p;
             // cap_before is the capacity already reflected in allocated_bytes.
             // Any reallocation caused by the triggering push was never counted and
             // is also freed here, so the two cancel out.
-            *self = GroupHll::Dense(Box::new(fold_sparse_to_hll(v)));
-            (NUM_REGISTERS as isize) - ((cap_before * size_of::<u64>()) as isize)
+            *self = GroupHll::Dense(Box::new(fold_sparse_to_hll(v, p)));
+            (num_registers as isize) - ((cap_before * size_of::<u64>()) as isize)
         } else {
             // Account for any Vec growth caused by the triggering push.
             // sort/dedup do not reallocate, so v.capacity() is the post-push capacity.
@@ -336,13 +367,14 @@ impl GroupHll {
 
     /// Merge a serialized state (produced by [`Self::serialize`] or by the
     /// per-group [`Accumulator`]) into this sketch.
-    fn merge_serialized(&mut self, bytes: &[u8]) -> Result<isize> {
+    fn merge_serialized(&mut self, bytes: &[u8], p: usize) -> Result<isize> {
         if bytes.is_empty() {
             return Ok(0);
         }
-        if bytes.len() == NUM_REGISTERS {
+        let num_registers = 1_usize << p;
+        if bytes.len() == num_registers {
             let other: HyperLogLog<u8> = bytes.try_into()?;
-            Ok(self.merge_dense(&other))
+            Ok(self.merge_dense(&other, p))
         } else {
             if !bytes.len().is_multiple_of(size_of::<u64>()) {
                 return internal_err!(
@@ -361,14 +393,14 @@ impl GroupHll {
             let mut delta = 0;
             for chunk in bytes.chunks_exact(size_of::<u64>()) {
                 let h = u64::from_le_bytes(chunk.try_into().unwrap());
-                delta += self.add_hash(h);
+                delta += self.add_hash(h, p);
             }
             Ok(delta)
         }
     }
 
     /// Merge a dense sketch into this one, promoting to dense if necessary.
-    fn merge_dense(&mut self, other: &HyperLogLog<u8>) -> isize {
+    fn merge_dense(&mut self, other: &HyperLogLog<u8>, p: usize) -> isize {
         match self {
             GroupHll::Dense(hll) => {
                 hll.merge(other);
@@ -380,20 +412,21 @@ impl GroupHll {
                 for &h in v.iter() {
                     hll.add_hashed(h);
                 }
+                let num_registers = 1_usize << p;
                 *self = GroupHll::Dense(Box::new(hll));
-                (NUM_REGISTERS as isize) - ((cap_before * size_of::<u64>()) as isize)
+                (num_registers as isize) - ((cap_before * size_of::<u64>()) as isize)
             }
         }
     }
 
     /// The approximate number of distinct values seen by this group.
-    fn count(&self) -> u64 {
+    fn count(&self, p: usize) -> u64 {
         match self {
             GroupHll::Dense(hll) => hll.count() as u64,
             // Estimate directly from the stored hashes; this produces exactly the
             // same value as folding them into a dense sketch but avoids
-            // allocating and scanning a 16 KiB register array for every group.
-            GroupHll::Sparse(v) => count_from_hashes(v) as u64,
+            // allocating and scanning a register array for every group.
+            GroupHll::Sparse(v) => count_from_hashes(v, p) as u64,
         }
     }
 
@@ -403,17 +436,17 @@ impl GroupHll {
     fn heap_bytes(&self) -> usize {
         match self {
             GroupHll::Sparse(v) => v.capacity() * size_of::<u64>(),
-            GroupHll::Dense(_) => NUM_REGISTERS,
+            GroupHll::Dense(hll) => 1 << hll.precision(),
         }
     }
 
     /// Serialize the sketch into `scratch` (which is cleared first). A dense
-    /// sketch is written as its raw [`NUM_REGISTERS`] registers (wire-compatible
-    /// with the per-group [`Accumulator`]); a sparse sketch is written as its
-    /// distinct hashes in little-endian order unless it has crossed
-    /// [`SPARSE_LIMIT`], in which case it is emitted as dense state so the final
-    /// merge path accepts it.
-    fn serialize(&mut self, scratch: &mut Vec<u8>) {
+    /// sketch is written as its raw register bytes (wire-compatible with the
+    /// per-group [`Accumulator`]); a sparse sketch is written as its distinct
+    /// hashes in little-endian order unless it has crossed [`SPARSE_LIMIT`],
+    /// in which case it is emitted as dense state so the final merge path
+    /// accepts it.
+    fn serialize(&mut self, scratch: &mut Vec<u8>, p: usize) {
         scratch.clear();
         match self {
             GroupHll::Dense(hll) => {
@@ -424,7 +457,7 @@ impl GroupHll {
                 v.sort_unstable();
                 v.dedup();
                 if v.len() > SPARSE_LIMIT {
-                    scratch.extend_from_slice(fold_sparse_to_hll(v).as_ref());
+                    scratch.extend_from_slice(fold_sparse_to_hll(v, p).as_ref());
                 } else {
                     for &h in v.iter() {
                         scratch.extend_from_slice(&h.to_le_bytes());
@@ -464,8 +497,7 @@ impl GroupHll {
 ///
 /// Group `b` has crossed the sparse limit, so its hashes have already been
 /// replayed into a dense sketch. New values for `b` update the dense registers
-/// directly, and serialized state is the raw [`NUM_REGISTERS`]-byte register
-/// array.
+/// directly, and serialized state is the raw register bytes.
 struct HllGroupsAccumulator {
     /// Per-group sketches, indexed by `group_index`.
     groups: Vec<GroupHll>,
@@ -473,21 +505,31 @@ struct HllGroupsAccumulator {
     allocated_bytes: usize,
     /// Reused workspace for vectorized value hashing.
     hashes: Vec<u64>,
+    /// HLL precision used by every group in this accumulator.
+    p: usize,
+}
+
+impl Default for HllGroupsAccumulator {
+    fn default() -> Self {
+        Self::with_precision(DEFAULT_HLL_P)
+    }
 }
 
 impl HllGroupsAccumulator {
-    fn new() -> Self {
+    fn with_precision(p: usize) -> Self {
         Self {
             groups: Vec::new(),
             allocated_bytes: 0,
             hashes: Vec::new(),
+            p,
         }
     }
 
     #[inline]
     fn ensure_groups(&mut self, total_num_groups: usize) {
         if total_num_groups > self.groups.len() {
-            self.groups.resize_with(total_num_groups, GroupHll::default);
+            self.groups
+                .resize_with(total_num_groups, GroupHll::new_sparse);
         }
     }
 
@@ -512,6 +554,7 @@ impl GroupsAccumulator for HllGroupsAccumulator {
         self.hashes.resize(array.len(), 0);
         create_hashes([array], &HLL_HASH_STATE, &mut self.hashes)?;
 
+        let p = self.p;
         let mut delta: isize = 0;
         // Pre-combine value-nulls and filter into one mask so the update loop
         // only visits rows that should affect the sketch.
@@ -522,12 +565,12 @@ impl GroupsAccumulator for HllGroupsAccumulator {
         match combined_nulls {
             None => {
                 for (row, &hash) in self.hashes.iter().enumerate() {
-                    delta += self.groups[group_indices[row]].add_hash(hash);
+                    delta += self.groups[group_indices[row]].add_hash(hash, p);
                 }
             }
             Some(nulls) => {
                 for row in nulls.valid_indices() {
-                    delta += self.groups[group_indices[row]].add_hash(self.hashes[row]);
+                    delta += self.groups[group_indices[row]].add_hash(self.hashes[row], p);
                 }
             }
         }
@@ -543,10 +586,12 @@ impl GroupsAccumulator for HllGroupsAccumulator {
     ) -> Result<()> {
         self.ensure_groups(total_num_groups);
         let states = downcast_value!(values[0], BinaryArray);
+        let p = self.p;
         let mut delta: isize = 0;
         for (row, &group_index) in group_indices.iter().enumerate() {
             if states.is_valid(row) {
-                delta += self.groups[group_index].merge_serialized(states.value(row))?;
+                delta +=
+                    self.groups[group_index].merge_serialized(states.value(row), p)?;
             }
         }
         self.apply_delta(delta);
@@ -555,12 +600,13 @@ impl GroupsAccumulator for HllGroupsAccumulator {
 
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
         let groups = emit_to.take_needed(&mut self.groups);
+        let p = self.p;
         let mut freed = 0;
         let counts: UInt64Array = groups
             .iter()
             .map(|g| {
                 freed += g.heap_bytes();
-                Some(g.count())
+                Some(g.count(p))
             })
             .collect();
         // The emitted groups have been removed; reclaim their tracked bytes.
@@ -570,12 +616,13 @@ impl GroupsAccumulator for HllGroupsAccumulator {
 
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         let mut groups = emit_to.take_needed(&mut self.groups);
+        let p = self.p;
         let mut builder = BinaryBuilder::new();
         let mut scratch: Vec<u8> = Vec::new();
         let mut freed = 0;
         for g in groups.iter_mut() {
             freed += g.heap_bytes();
-            g.serialize(&mut scratch);
+            g.serialize(&mut scratch, p);
             builder.append_value(&scratch);
         }
         // The emitted groups have been removed; reclaim their tracked bytes.
@@ -654,12 +701,29 @@ impl Default for ApproxDistinct {
 #[derive(PartialEq, Eq, Hash)]
 pub struct ApproxDistinct {
     signature: Signature,
+    /// HLL register precision. Only used for types that take the HLL code path
+    /// (i.e. not Boolean / small-int types, which use exact bitmap counting).
+    hll_precision: usize,
 }
 
 impl ApproxDistinct {
     pub fn new() -> Self {
+        Self::with_hll_precision(DEFAULT_HLL_P)
+    }
+
+    /// Creates an `ApproxDistinct` that uses HLL sketches with `2^p` registers.
+    ///
+    /// This only has effect for types that use the HLL accumulator path. Small
+    /// integer and boolean types use exact bitmap counting regardless of this
+    /// value. Valid range: `HLL_P_MIN..=HLL_P_MAX` (4..=18).
+    pub fn with_hll_precision(p: usize) -> Self {
+        assert!(
+            (HLL_P_MIN..=HLL_P_MAX).contains(&p),
+            "HLL precision must be in {HLL_P_MIN}..={HLL_P_MAX}, got {p}",
+        );
         Self {
             signature: Signature::any(1, Volatility::Immutable),
+            hll_precision: p,
         }
     }
 }
@@ -753,6 +817,7 @@ impl AggregateUDFImpl for ApproxDistinct {
 
     fn accumulator(&self, acc_args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
         let data_type = acc_args.expr_fields[0].data_type();
+        let p = self.hll_precision;
 
         // For primitive types, use specialized accumulators for better performance.
         let accumulator: Box<dyn Accumulator> = match data_type {
@@ -763,68 +828,68 @@ impl AggregateUDFImpl for ApproxDistinct {
             | DataType::Int16 => {
                 return get_fixed_domain_approx_accumulator(data_type);
             }
-            DataType::UInt32 => Box::new(NumericHLLAccumulator::<UInt32Type>::new()),
-            DataType::UInt64 => Box::new(NumericHLLAccumulator::<UInt64Type>::new()),
-            DataType::Int32 => Box::new(NumericHLLAccumulator::<Int32Type>::new()),
-            DataType::Int64 => Box::new(NumericHLLAccumulator::<Int64Type>::new()),
-            DataType::Date32 => Box::new(NumericHLLAccumulator::<Date32Type>::new()),
-            DataType::Date64 => Box::new(NumericHLLAccumulator::<Date64Type>::new()),
+            DataType::UInt32 => Box::new(NumericHLLAccumulator::<UInt32Type>::with_precision(p)),
+            DataType::UInt64 => Box::new(NumericHLLAccumulator::<UInt64Type>::with_precision(p)),
+            DataType::Int32 => Box::new(NumericHLLAccumulator::<Int32Type>::with_precision(p)),
+            DataType::Int64 => Box::new(NumericHLLAccumulator::<Int64Type>::with_precision(p)),
+            DataType::Date32 => Box::new(NumericHLLAccumulator::<Date32Type>::with_precision(p)),
+            DataType::Date64 => Box::new(NumericHLLAccumulator::<Date64Type>::with_precision(p)),
             DataType::Time32(TimeUnit::Second) => {
-                Box::new(NumericHLLAccumulator::<Time32SecondType>::new())
+                Box::new(NumericHLLAccumulator::<Time32SecondType>::with_precision(p))
             }
             DataType::Time32(TimeUnit::Millisecond) => {
-                Box::new(NumericHLLAccumulator::<Time32MillisecondType>::new())
+                Box::new(NumericHLLAccumulator::<Time32MillisecondType>::with_precision(p))
             }
             DataType::Time64(TimeUnit::Microsecond) => {
-                Box::new(NumericHLLAccumulator::<Time64MicrosecondType>::new())
+                Box::new(NumericHLLAccumulator::<Time64MicrosecondType>::with_precision(p))
             }
             DataType::Time64(TimeUnit::Nanosecond) => {
-                Box::new(NumericHLLAccumulator::<Time64NanosecondType>::new())
+                Box::new(NumericHLLAccumulator::<Time64NanosecondType>::with_precision(p))
             }
             DataType::Timestamp(TimeUnit::Second, _) => {
-                Box::new(NumericHLLAccumulator::<TimestampSecondType>::new())
+                Box::new(NumericHLLAccumulator::<TimestampSecondType>::with_precision(p))
             }
             DataType::Timestamp(TimeUnit::Millisecond, _) => {
-                Box::new(NumericHLLAccumulator::<TimestampMillisecondType>::new())
+                Box::new(NumericHLLAccumulator::<TimestampMillisecondType>::with_precision(p))
             }
             DataType::Timestamp(TimeUnit::Microsecond, _) => {
-                Box::new(NumericHLLAccumulator::<TimestampMicrosecondType>::new())
+                Box::new(NumericHLLAccumulator::<TimestampMicrosecondType>::with_precision(p))
             }
             DataType::Timestamp(TimeUnit::Nanosecond, _) => {
-                Box::new(NumericHLLAccumulator::<TimestampNanosecondType>::new())
+                Box::new(NumericHLLAccumulator::<TimestampNanosecondType>::with_precision(p))
             }
             DataType::Interval(IntervalUnit::YearMonth) => {
-                Box::new(NumericHLLAccumulator::<IntervalYearMonthType>::new())
+                Box::new(NumericHLLAccumulator::<IntervalYearMonthType>::with_precision(p))
             }
             DataType::Interval(IntervalUnit::DayTime) => {
-                Box::new(NumericHLLAccumulator::<IntervalDayTimeType>::new())
+                Box::new(NumericHLLAccumulator::<IntervalDayTimeType>::with_precision(p))
             }
             DataType::Interval(IntervalUnit::MonthDayNano) => {
-                Box::new(NumericHLLAccumulator::<IntervalMonthDayNanoType>::new())
+                Box::new(NumericHLLAccumulator::<IntervalMonthDayNanoType>::with_precision(p))
             }
             DataType::Decimal32(_, _) => {
-                Box::new(NumericHLLAccumulator::<Decimal32Type>::new())
+                Box::new(NumericHLLAccumulator::<Decimal32Type>::with_precision(p))
             }
             DataType::Decimal64(_, _) => {
-                Box::new(NumericHLLAccumulator::<Decimal64Type>::new())
+                Box::new(NumericHLLAccumulator::<Decimal64Type>::with_precision(p))
             }
             DataType::Decimal128(_, _) => {
-                Box::new(NumericHLLAccumulator::<Decimal128Type>::new())
+                Box::new(NumericHLLAccumulator::<Decimal128Type>::with_precision(p))
             }
             DataType::Decimal256(_, _) => {
-                Box::new(NumericHLLAccumulator::<Decimal256Type>::new())
+                Box::new(NumericHLLAccumulator::<Decimal256Type>::with_precision(p))
             }
             DataType::Duration(TimeUnit::Second) => {
-                Box::new(NumericHLLAccumulator::<DurationSecondType>::new())
+                Box::new(NumericHLLAccumulator::<DurationSecondType>::with_precision(p))
             }
             DataType::Duration(TimeUnit::Millisecond) => {
-                Box::new(NumericHLLAccumulator::<DurationMillisecondType>::new())
+                Box::new(NumericHLLAccumulator::<DurationMillisecondType>::with_precision(p))
             }
             DataType::Duration(TimeUnit::Microsecond) => {
-                Box::new(NumericHLLAccumulator::<DurationMicrosecondType>::new())
+                Box::new(NumericHLLAccumulator::<DurationMicrosecondType>::with_precision(p))
             }
             DataType::Duration(TimeUnit::Nanosecond) => {
-                Box::new(NumericHLLAccumulator::<DurationNanosecondType>::new())
+                Box::new(NumericHLLAccumulator::<DurationNanosecondType>::with_precision(p))
             }
             DataType::Utf8
             | DataType::LargeUtf8
@@ -840,7 +905,7 @@ impl AggregateUDFImpl for ApproxDistinct {
             | DataType::Map(_, _)
             | DataType::Struct(_)
             | DataType::Union(_, _)
-            | DataType::LargeBinary => Box::new(HLLAccumulator::new()),
+            | DataType::LargeBinary => Box::new(HLLAccumulator::with_precision(p)),
             DataType::Null => {
                 Box::new(NoopAccumulator::new(ScalarValue::UInt64(Some(0))))
             }
@@ -863,7 +928,7 @@ impl AggregateUDFImpl for ApproxDistinct {
     ) -> Result<Box<dyn GroupsAccumulator>> {
         let data_type = args.expr_fields[0].data_type();
         if is_hll_groups_type(data_type) {
-            Ok(Box::new(HllGroupsAccumulator::new()))
+            Ok(Box::new(HllGroupsAccumulator::with_precision(self.hll_precision)))
         } else {
             not_impl_err!(
                 "GroupsAccumulator for 'approx_distinct' is not implemented for data type {data_type}"
@@ -925,6 +990,7 @@ fn is_hll_groups_type(data_type: &DataType) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hyperloglog::NUM_REGISTERS;
     use std::hash::BuildHasher;
 
     #[cfg(not(feature = "force_hash_collisions"))]
@@ -958,7 +1024,7 @@ mod tests {
                 array.data_type()
             );
 
-            let mut acc = NumericHLLAccumulator::<T>::new();
+            let mut acc = NumericHLLAccumulator::<T>::default();
             acc.update_batch(&[Arc::clone(&array)]).unwrap();
             let per_group_count = match acc.evaluate().unwrap() {
                 ScalarValue::UInt64(Some(v)) => v,
@@ -966,7 +1032,7 @@ mod tests {
             };
 
             let group_indices = vec![0usize; array.len()];
-            let mut acc = HllGroupsAccumulator::new();
+            let mut acc = HllGroupsAccumulator::default();
             acc.update_batch(std::slice::from_ref(&array), &group_indices, None, 1)
                 .unwrap();
             let groups_count = acc
@@ -1115,7 +1181,7 @@ mod tests {
             let filter =
                 BooleanArray::from(vec![Some(true), None, Some(false), None, Some(true)]);
 
-            let mut acc = HllGroupsAccumulator::new();
+            let mut acc = HllGroupsAccumulator::default();
             // put all rows in group 0
             let group_indices = vec![0usize; 5];
             acc.update_batch(&[values], &group_indices, Some(&filter), 1)
@@ -1147,7 +1213,7 @@ mod tests {
             ]);
             let group_indices = vec![0usize, 1, 0, 1, 0];
 
-            let mut direct = HllGroupsAccumulator::new();
+            let mut direct = HllGroupsAccumulator::default();
             direct
                 .update_batch(
                     std::slice::from_ref(&values),
@@ -1164,12 +1230,12 @@ mod tests {
                 .unwrap()
                 .clone();
 
-            let converter = HllGroupsAccumulator::new();
+            let converter = HllGroupsAccumulator::default();
             let state = converter
                 .convert_to_state(std::slice::from_ref(&values), Some(&filter))
                 .unwrap();
             assert_eq!(state[0].null_count(), 0);
-            let mut merged = HllGroupsAccumulator::new();
+            let mut merged = HllGroupsAccumulator::default();
             merged.merge_batch(&state, &group_indices, 2).unwrap();
             let merged = merged
                 .evaluate(EmitTo::All)
@@ -1184,7 +1250,7 @@ mod tests {
 
         #[test]
         fn groups_convert_to_state_preserves_empty_and_filtered_rows() {
-            let converter = HllGroupsAccumulator::new();
+            let converter = HllGroupsAccumulator::default();
             let empty_values: ArrayRef =
                 Arc::new(Int64Array::from(Vec::<Option<i64>>::new()));
             let state = converter
@@ -1207,7 +1273,7 @@ mod tests {
                 assert_eq!(state.value(row), b"");
             }
 
-            let mut merged = HllGroupsAccumulator::new();
+            let mut merged = HllGroupsAccumulator::default();
             merged
                 .merge_batch(&[Arc::new(state.clone())], &group_indices, 2)
                 .unwrap();
@@ -1236,7 +1302,7 @@ mod tests {
             assert!(!batch2.as_string_view().data_buffers().is_empty());
 
             let group_indices = vec![0usize, 0];
-            let mut acc = HllGroupsAccumulator::new();
+            let mut acc = HllGroupsAccumulator::default();
             acc.update_batch(&[batch1], &group_indices, None, 1)
                 .unwrap();
             acc.update_batch(&[batch2], &group_indices, None, 1)
@@ -1255,7 +1321,7 @@ mod tests {
             // Multiset: {"aaa" x2, "bbb", LONG}, so 3 distinct values.
             let mixed: ArrayRef =
                 Arc::new(StringViewArray::from(vec!["aaa", "bbb", LONG, "aaa"]));
-            let mut acc_single = HLLAccumulator::new();
+            let mut acc_single = HLLAccumulator::default();
             acc_single.update_batch(&[mixed]).unwrap();
 
             // Same multiset, but split so "aaa" lands in both an all-inline batch
@@ -1267,7 +1333,7 @@ mod tests {
             assert!(inline_only.as_string_view().data_buffers().is_empty());
             assert!(!with_buffer.as_string_view().data_buffers().is_empty());
 
-            let mut acc_split = HLLAccumulator::new();
+            let mut acc_split = HLLAccumulator::default();
             acc_split.update_batch(&[inline_only]).unwrap();
             acc_split.update_batch(&[with_buffer]).unwrap();
 
@@ -1293,127 +1359,361 @@ mod tests {
         hll.count() as u64
     }
 
-    fn serialize(g: &mut GroupHll) -> Vec<u8> {
+    fn serialize(g: &mut GroupHll, p: usize) -> Vec<u8> {
         let mut buf = Vec::new();
-        g.serialize(&mut buf);
+        g.serialize(&mut buf, p);
         buf
     }
 
     #[test]
     fn sparse_stays_sparse_for_small_groups() {
-        let mut g = GroupHll::default();
+        let p = DEFAULT_HLL_P;
+        let mut g = GroupHll::new_sparse();
         let hashes: Vec<u64> = (0..50).map(h).collect();
         for &hash in &hashes {
-            g.add_hash(hash);
+            g.add_hash(hash, p);
         }
         // duplicates must not change the estimate or trigger promotion
         for &hash in &hashes {
-            g.add_hash(hash);
+            g.add_hash(hash, p);
         }
         assert!(
             matches!(g, GroupHll::Sparse(_)),
             "small group must be sparse"
         );
-        assert_eq!(g.count(), reference_count(&hashes));
-        // sparse serialized state is far smaller than a dense 16 KiB sketch
+        assert_eq!(g.count(p), reference_count(&hashes));
+        // sparse serialized state is far smaller than a dense sketch
         // and must not exceed the sparse limit contract enforced by merge_serialized
-        let serialized = serialize(&mut g);
+        let serialized = serialize(&mut g, p);
         assert!(serialized.len() < NUM_REGISTERS);
         assert!(serialized.len() <= SPARSE_LIMIT * size_of::<u64>());
     }
 
     #[test]
     fn promotes_to_dense_for_large_groups() {
-        let mut g = GroupHll::default();
+        let p = DEFAULT_HLL_P;
+        let mut g = GroupHll::new_sparse();
         let hashes: Vec<u64> = (0..(SPARSE_LIMIT as u64 * 4)).map(h).collect();
         for &hash in &hashes {
-            g.add_hash(hash);
+            g.add_hash(hash, p);
         }
         assert!(matches!(g, GroupHll::Dense(_)), "large group must be dense");
-        assert_eq!(g.count(), reference_count(&hashes));
+        assert_eq!(g.count(p), reference_count(&hashes));
     }
 
     #[test]
     fn serialize_then_merge_roundtrips() {
+        let p = DEFAULT_HLL_P;
         for n in [0u64, 10, SPARSE_LIMIT as u64 * 4] {
             let hashes: Vec<u64> = (0..n).map(h).collect();
-            let mut src = GroupHll::default();
+            let mut src = GroupHll::new_sparse();
             for &hash in &hashes {
-                src.add_hash(hash);
+                src.add_hash(hash, p);
             }
-            let bytes = serialize(&mut src);
-            let mut dst = GroupHll::default();
-            dst.merge_serialized(&bytes).unwrap();
-            assert_eq!(dst.count(), reference_count(&hashes), "n = {n}");
+            let bytes = serialize(&mut src, p);
+            let mut dst = GroupHll::new_sparse();
+            dst.merge_serialized(&bytes, p).unwrap();
+            assert_eq!(dst.count(p), reference_count(&hashes), "n = {n}");
         }
     }
 
     #[test]
     fn sparse_limit_group_serializes_as_mergeable_sparse_state() {
+        let p = DEFAULT_HLL_P;
         let hashes: Vec<u64> = (0..SPARSE_LIMIT as u64).map(h).collect();
-        let mut src = GroupHll::default();
+        let mut src = GroupHll::new_sparse();
         for &hash in &hashes {
-            src.add_hash(hash);
+            src.add_hash(hash, p);
         }
         assert!(matches!(src, GroupHll::Sparse(_)));
 
-        let bytes = serialize(&mut src);
+        let bytes = serialize(&mut src, p);
         assert_eq!(bytes.len(), SPARSE_LIMIT * size_of::<u64>());
 
-        let mut dst = GroupHll::default();
-        dst.merge_serialized(&bytes).unwrap();
-        assert_eq!(dst.count(), reference_count(&hashes));
+        let mut dst = GroupHll::new_sparse();
+        dst.merge_serialized(&bytes, p).unwrap();
+        assert_eq!(dst.count(p), reference_count(&hashes));
     }
 
     #[test]
     fn medium_sparse_group_serializes_as_mergeable_dense_state() {
+        let p = DEFAULT_HLL_P;
         let n = SPARSE_LIMIT as u64 + 44;
         let hashes: Vec<u64> = (0..n).map(h).collect();
-        let mut src = GroupHll::default();
+        let mut src = GroupHll::new_sparse();
         for &hash in &hashes {
-            src.add_hash(hash);
+            src.add_hash(hash, p);
         }
         assert!(
             matches!(src, GroupHll::Sparse(_)),
             "group should not promote during update before the compaction threshold"
         );
 
-        let bytes = serialize(&mut src);
+        let bytes = serialize(&mut src, p);
         assert_eq!(bytes.len(), NUM_REGISTERS);
 
-        let mut dst = GroupHll::default();
-        dst.merge_serialized(&bytes).unwrap();
-        assert_eq!(dst.count(), reference_count(&hashes));
+        let mut dst = GroupHll::new_sparse();
+        dst.merge_serialized(&bytes, p).unwrap();
+        assert_eq!(dst.count(p), reference_count(&hashes));
     }
 
     #[test]
     fn merge_combines_disjoint_groups() {
+        let p = DEFAULT_HLL_P;
         // sparse + sparse, sparse + dense, dense + dense
         let left: Vec<u64> = (0..100).map(h).collect();
         let right: Vec<u64> = (100..(SPARSE_LIMIT as u64 * 4)).map(h).collect();
         let all: Vec<u64> = left.iter().chain(right.iter()).copied().collect();
 
-        let mut a = GroupHll::default();
+        let mut a = GroupHll::new_sparse();
         for &hash in &left {
-            a.add_hash(hash);
+            a.add_hash(hash, p);
         }
-        let mut b = GroupHll::default();
+        let mut b = GroupHll::new_sparse();
         for &hash in &right {
-            b.add_hash(hash);
+            b.add_hash(hash, p);
         }
-        let b_bytes = serialize(&mut b);
-        a.merge_serialized(&b_bytes).unwrap();
-        assert_eq!(a.count(), reference_count(&all));
+        let b_bytes = serialize(&mut b, p);
+        a.merge_serialized(&b_bytes, p).unwrap();
+        assert_eq!(a.count(p), reference_count(&all));
     }
 
     #[test]
     fn empty_group_counts_zero() {
-        let mut g = GroupHll::default();
-        assert_eq!(g.count(), 0);
-        let bytes = serialize(&mut g);
+        let p = DEFAULT_HLL_P;
+        let mut g = GroupHll::new_sparse();
+        assert_eq!(g.count(p), 0);
+        let bytes = serialize(&mut g, p);
         assert!(bytes.is_empty());
-        let mut dst = GroupHll::default();
-        dst.merge_serialized(&bytes).unwrap();
-        assert_eq!(dst.count(), 0);
+        let mut dst = GroupHll::new_sparse();
+        dst.merge_serialized(&bytes, p).unwrap();
+        assert_eq!(dst.count(p), 0);
+    }
+
+    // --- non-default precision tests ---
+
+    #[test]
+    fn group_hll_at_precision_12_serialize_roundtrip() {
+        let p = 12;
+        let hashes: Vec<u64> = (0..100).map(h).collect();
+        let mut src = GroupHll::new_sparse();
+        for &hash in &hashes {
+            src.add_hash(hash, p);
+        }
+        let src_count = src.count(p);
+        let bytes = serialize(&mut src, p);
+        let mut dst = GroupHll::new_sparse();
+        dst.merge_serialized(&bytes, p).unwrap();
+        // After serialization and merge, count must agree exactly with pre-serialize count.
+        assert_eq!(dst.count(p), src_count);
+    }
+
+    #[test]
+    fn group_hll_dense_at_precision_12_serialize_roundtrip() {
+        let p = 12;
+        let hashes: Vec<u64> = (0..(SPARSE_LIMIT as u64 * 4)).map(h).collect();
+        let mut src = GroupHll::new_sparse();
+        for &hash in &hashes {
+            src.add_hash(hash, p);
+        }
+        assert!(matches!(src, GroupHll::Dense(_)));
+        let bytes = serialize(&mut src, p);
+        assert_eq!(bytes.len(), 1 << p);
+        let mut dst = GroupHll::new_sparse();
+        dst.merge_serialized(&bytes, p).unwrap();
+        assert_eq!(dst.count(p), src.count(p));
+    }
+
+    // --- TryFrom<&[u8]> error path tests ---
+
+    #[test]
+    fn try_from_empty_bytes_is_err() {
+        let result = HyperLogLog::<u8>::try_from(&[][..]);
+        assert!(result.is_err(), "empty slice must be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid HLL state length"), "got: {msg}");
+    }
+
+    #[test]
+    fn try_from_non_power_of_two_is_err() {
+        // 3 bytes is not a power of two
+        let result = HyperLogLog::<u8>::try_from(&[0u8; 3][..]);
+        assert!(result.is_err(), "non-power-of-two slice must be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid HLL state length"), "got: {msg}");
+    }
+
+    #[test]
+    fn try_from_out_of_range_precision_is_err() {
+        // 2 bytes => p = 1, which is below HLL_P_MIN (4)
+        let result = HyperLogLog::<u8>::try_from(&[0u8; 2][..]);
+        assert!(result.is_err(), "precision below min must be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("implies precision"), "got: {msg}");
+    }
+
+    // --- ApproxDistinct with non-default precision ---
+
+    use arrow::datatypes::{Schema, UnionFields, UnionMode};
+    use std::sync::Arc;
+
+    fn make_acc_args<'a>(
+        schema: &'a Schema,
+        return_field: &'a FieldRef,
+        expr_field: &'a FieldRef,
+    ) -> AccumulatorArgs<'a> {
+        AccumulatorArgs {
+            return_field: FieldRef::clone(return_field),
+            schema,
+            ignore_nulls: false,
+            order_bys: &[],
+            is_reversed: false,
+            name: "approx_distinct",
+            is_distinct: false,
+            exprs: &[],
+            expr_fields: std::slice::from_ref(expr_field),
+        }
+    }
+
+    #[cfg(not(feature = "force_hash_collisions"))]
+    #[test]
+    fn approx_distinct_with_hll_precision_12_produces_correct_estimate() {
+        use arrow::array::Int64Array;
+
+        let func = ApproxDistinct::with_hll_precision(12);
+        let values: ArrayRef = Arc::new(Int64Array::from_iter_values(0..1000i64));
+        let expr_field: FieldRef =
+            Arc::new(Field::new("v", DataType::Int64, false));
+        let schema = Schema::new(vec![(*expr_field).clone()]);
+        let return_field: FieldRef =
+            Arc::new(Field::new("r", DataType::UInt64, false));
+        let acc_args = make_acc_args(&schema, &return_field, &expr_field);
+        let mut acc = func.accumulator(acc_args).unwrap();
+        acc.update_batch(&[values]).unwrap();
+        let result = acc.evaluate().unwrap();
+        match result {
+            ScalarValue::UInt64(Some(count)) => {
+                // p=12 → ~1.6% error; allow 10% margin
+                assert!(
+                    count > 900 && count < 1100,
+                    "count {count} out of expected range for p=12"
+                );
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    #[cfg(not(feature = "force_hash_collisions"))]
+    #[test]
+    fn approx_distinct_union_type_uses_hll_accumulator() {
+        let union_type = DataType::Union(
+            UnionFields::try_new(
+                vec![0i8],
+                vec![Field::new("a", DataType::Int32, false)],
+            )
+            .unwrap(),
+            UnionMode::Dense,
+        );
+        let func = ApproxDistinct::new();
+        let expr_field: FieldRef =
+            Arc::new(Field::new("v", union_type.clone(), false));
+        let schema = Schema::new(vec![(*expr_field).clone()]);
+        let return_field: FieldRef =
+            Arc::new(Field::new("r", DataType::UInt64, false));
+        let acc_args = make_acc_args(&schema, &return_field, &expr_field);
+        // Confirm the accumulator can be created and evaluated for Union type.
+        let mut acc = func.accumulator(acc_args).unwrap();
+        let result = acc.evaluate().unwrap();
+        assert_eq!(result, ScalarValue::UInt64(Some(0)));
+    }
+
+    #[test]
+    #[should_panic(expected = "HLL precision must be in")]
+    fn with_hll_precision_out_of_range_panics() {
+        let _ = ApproxDistinct::with_hll_precision(HLL_P_MAX + 1);
+    }
+
+    // merge_dense Sparse arm: a sparse group absorbs an incoming dense state.
+    #[test]
+    fn merge_dense_into_sparse_group_produces_dense() {
+        let p = DEFAULT_HLL_P;
+        // Build a dense sketch with some hashes.
+        let hashes_a: Vec<u64> = (0..100).map(h).collect();
+        let mut dense_src = GroupHll::new_sparse();
+        for &hash in &hashes_a {
+            dense_src.add_hash(hash, p);
+        }
+        // Force promotion to dense.
+        let extra: Vec<u64> = (100..(SPARSE_LIMIT as u64 * 3)).map(h).collect();
+        for &hash in &extra {
+            dense_src.add_hash(hash, p);
+        }
+        assert!(matches!(dense_src, GroupHll::Dense(_)));
+        let dense_bytes = serialize(&mut dense_src, p);
+
+        // Target starts sparse with a few hashes.
+        let hashes_b: Vec<u64> = (1000..1010).map(h).collect();
+        let mut sparse_dst = GroupHll::new_sparse();
+        for &hash in &hashes_b {
+            sparse_dst.add_hash(hash, p);
+        }
+        assert!(matches!(sparse_dst, GroupHll::Sparse(_)));
+
+        // Merging the dense state into the sparse group should promote it.
+        sparse_dst.merge_serialized(&dense_bytes, p).unwrap();
+        assert!(
+            matches!(sparse_dst, GroupHll::Dense(_)),
+            "sparse group must be dense after absorbing a dense state"
+        );
+    }
+
+    // HllGroupsAccumulator at non-default precision: full update → state → merge → evaluate.
+    #[cfg(not(feature = "force_hash_collisions"))]
+    #[test]
+    fn groups_accumulator_with_precision_12_roundtrips() {
+        use arrow::array::Int64Array;
+
+        let p = 12;
+        let values: ArrayRef = Arc::new(Int64Array::from_iter_values(0..200i64));
+        let group_indices = vec![0usize; 200];
+
+        // Partial accumulator at p=12.
+        let mut partial = HllGroupsAccumulator::with_precision(p);
+        partial
+            .update_batch(&[Arc::clone(&values)], &group_indices, None, 1)
+            .unwrap();
+
+        // Emit partial state and merge into a final accumulator at the same precision.
+        let state = partial.state(EmitTo::All).unwrap();
+        let mut final_acc = HllGroupsAccumulator::with_precision(p);
+        final_acc
+            .merge_batch(&state, &group_indices[..1], 1)
+            .unwrap();
+
+        let result = final_acc.evaluate(EmitTo::All).unwrap();
+        let counts = result
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        let count = counts.value(0);
+        // 200 distinct values, p=12 → ~1.6% error; allow 10% margin.
+        assert!(count > 180 && count < 220, "count {count} out of range");
+    }
+
+    // NumericHLLAccumulator::with_precision propagates precision through evaluate.
+    #[cfg(not(feature = "force_hash_collisions"))]
+    #[test]
+    fn numeric_hll_accumulator_with_precision_12() {
+        use arrow::array::Int64Array;
+
+        let values: ArrayRef = Arc::new(Int64Array::from_iter_values(0..500i64));
+        let mut acc = NumericHLLAccumulator::<Int64Type>::with_precision(12);
+        acc.update_batch(&[values]).unwrap();
+        match acc.evaluate().unwrap() {
+            ScalarValue::UInt64(Some(count)) => {
+                assert!(count > 450 && count < 550, "count {count} out of range");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 }

--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -18,7 +18,7 @@
 //! Defines physical expressions that can evaluated at runtime during query execution
 
 use crate::hyperloglog::{
-    DEFAULT_HLL_P, HLL_HASH_STATE, HLL_P_MAX, HLL_P_MIN, HyperLogLog, count_from_hashes,
+    DEFAULT_HLL_P, HLL_HASH_STATE, HLL_P_MIN, HyperLogLog, count_from_hashes,
 };
 use arrow::array::{
     Array, ArrayRef, BinaryArray, BinaryBuilder, BooleanArray, PrimitiveArray,
@@ -84,16 +84,16 @@ impl<T: Hash + ?Sized> TryFrom<&[u8]> for HyperLogLog<T> {
             );
         }
         let p = v.len().ilog2() as usize;
-        if !(HLL_P_MIN..=HLL_P_MAX).contains(&p) {
+        if !(HLL_P_MIN..=DEFAULT_HLL_P).contains(&p) {
             return internal_err!(
                 "approx_distinct: HLL state length {} implies precision {} outside {}..={}",
                 v.len(),
                 p,
                 HLL_P_MIN,
-                HLL_P_MAX
+                DEFAULT_HLL_P
             );
         }
-        Ok(HyperLogLog::<T>::from_registers(v.to_vec()))
+        Ok(HyperLogLog::<T>::from_registers(v))
     }
 }
 
@@ -169,11 +169,7 @@ impl Accumulator for HLLAccumulator {
         create_hashes([array], &HLL_HASH_STATE, &mut self.hashes)?;
 
         match array.logical_nulls() {
-            None => {
-                for &hash in &self.hashes {
-                    self.hll.add_hashed(hash);
-                }
-            }
+            None => self.hll.add_hashed_slice(&self.hashes),
             Some(nulls) => {
                 for row in 0..array.len() {
                     if nulls.is_valid(row) {
@@ -724,11 +720,11 @@ impl ApproxDistinct {
     ///
     /// This only has effect for types that use the HLL accumulator path. Small
     /// integer and boolean types use exact bitmap counting regardless of this
-    /// value. Valid range: `HLL_P_MIN..=HLL_P_MAX` (4..=18).
+    /// value. Valid range: `HLL_P_MIN..=DEFAULT_HLL_P` (4..=14).
     pub fn with_hll_precision(p: usize) -> Result<Self> {
-        if !(HLL_P_MIN..=HLL_P_MAX).contains(&p) {
+        if !(HLL_P_MIN..=DEFAULT_HLL_P).contains(&p) {
             return plan_err!(
-                "HLL precision must be in {HLL_P_MIN}..={HLL_P_MAX}, got {p}"
+                "HLL precision must be in {HLL_P_MIN}..={DEFAULT_HLL_P}, got {p}"
             );
         }
         Ok(Self {
@@ -1691,7 +1687,7 @@ mod tests {
 
     #[test]
     fn with_hll_precision_out_of_range_returns_err() {
-        let result = ApproxDistinct::with_hll_precision(HLL_P_MAX + 1);
+        let result = ApproxDistinct::with_hll_precision(DEFAULT_HLL_P + 1);
         assert!(result.is_err(), "precision above max must be rejected");
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("HLL precision must be in"), "got: {msg}");
@@ -1772,14 +1768,14 @@ mod tests {
     #[test]
     fn hll_accumulator_size_includes_register_buffer() {
         let acc = HLLAccumulator::with_precision(10);
+        // Registers are now inline in the struct — size_of_val captures them.
         assert!(acc.size() >= 1 << 10, "register buffer must be counted");
-        assert!(acc.size() > size_of_val(&acc), "heap must be counted");
     }
 
     #[test]
     fn numeric_hll_accumulator_size_includes_register_buffer() {
         let acc = NumericHLLAccumulator::<Int64Type>::with_precision(10);
+        // Registers are now inline in the struct — size_of_val captures them.
         assert!(acc.size() >= 1 << 10, "register buffer must be counted");
-        assert!(acc.size() > size_of_val(&acc), "heap must be counted");
     }
 }

--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -38,7 +38,7 @@ use datafusion_common::ScalarValue;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::{
     DataFusionError, Result, downcast_value, internal_datafusion_err, internal_err,
-    not_impl_err,
+    not_impl_err, plan_err,
 };
 use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion_expr::utils::format_state_name;
@@ -208,7 +208,9 @@ impl Accumulator for HLLAccumulator {
     }
 
     fn size(&self) -> usize {
-        size_of_val(self) + self.hashes.capacity() * size_of::<u64>()
+        size_of_val(self)
+            + self.hll.register_heap_size()
+            + self.hashes.capacity() * size_of::<u64>()
     }
 }
 
@@ -278,7 +280,7 @@ where
     }
 
     fn size(&self) -> usize {
-        size_of_val(self)
+        size_of_val(self) + self.hll.register_heap_size()
     }
 }
 
@@ -456,7 +458,11 @@ impl GroupHll {
             GroupHll::Sparse(v) => {
                 v.sort_unstable();
                 v.dedup();
-                if v.len() > SPARSE_LIMIT {
+                let num_registers = 1_usize << p;
+                // Promote to dense if sparse byte length would equal the dense register count,
+                // making the two encodings ambiguous in merge_serialized (occurs when
+                // v.len() == 1 << (p-3), i.e. p <= 11).
+                if v.len() > SPARSE_LIMIT || v.len() * size_of::<u64>() == num_registers {
                     scratch.extend_from_slice(fold_sparse_to_hll(v, p).as_ref());
                 } else {
                     for &h in v.iter() {
@@ -474,9 +480,8 @@ impl GroupHll {
 /// This is dramatically faster than the generic `GroupsAccumulatorAdapter`
 /// fallback for high-cardinality `GROUP BY`s: it processes the whole input in a
 /// single vectorized pass (no per-group `take`/slice and no dynamic dispatch),
-/// and the sparse representation avoids allocating a 16 KiB sketch for every
+/// and the sparse representation avoids allocating a full sketch for every
 /// group when most groups only see a few distinct values.
-///
 ///
 /// # Example
 ///
@@ -708,7 +713,10 @@ pub struct ApproxDistinct {
 
 impl ApproxDistinct {
     pub fn new() -> Self {
-        Self::with_hll_precision(DEFAULT_HLL_P)
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+            hll_precision: DEFAULT_HLL_P,
+        }
     }
 
     /// Creates an `ApproxDistinct` that uses HLL sketches with `2^p` registers.
@@ -716,15 +724,16 @@ impl ApproxDistinct {
     /// This only has effect for types that use the HLL accumulator path. Small
     /// integer and boolean types use exact bitmap counting regardless of this
     /// value. Valid range: `HLL_P_MIN..=HLL_P_MAX` (4..=18).
-    pub fn with_hll_precision(p: usize) -> Self {
-        assert!(
-            (HLL_P_MIN..=HLL_P_MAX).contains(&p),
-            "HLL precision must be in {HLL_P_MIN}..={HLL_P_MAX}, got {p}",
-        );
-        Self {
+    pub fn with_hll_precision(p: usize) -> Result<Self> {
+        if !(HLL_P_MIN..=HLL_P_MAX).contains(&p) {
+            return plan_err!(
+                "HLL precision must be in {HLL_P_MIN}..={HLL_P_MAX}, got {p}"
+            );
+        }
+        Ok(Self {
             signature: Signature::any(1, Volatility::Immutable),
             hll_precision: p,
-        }
+        })
     }
 }
 
@@ -1458,6 +1467,40 @@ mod tests {
     }
 
     #[test]
+    fn serialize_avoids_sparse_dense_collision_at_p10() {
+        let p = 10;
+        // 128 == 1 << (p-3): sparse byte length 128*8=1024 == 1<<p, the collision point.
+        let hashes: Vec<u64> = (0..128_u64).map(h).collect();
+        let mut src = GroupHll::new_sparse();
+        for &hash in &hashes {
+            src.add_hash(hash, p);
+        }
+        assert!(matches!(src, GroupHll::Sparse(_)));
+        let bytes = serialize(&mut src, p);
+        assert_eq!(bytes.len(), 1 << p, "must emit dense to avoid collision");
+        let mut dst = GroupHll::new_sparse();
+        dst.merge_serialized(&bytes, p).unwrap();
+        assert_eq!(dst.count(p), src.count(p));
+    }
+
+    #[test]
+    fn serialize_avoids_sparse_dense_collision_at_p4() {
+        let p = 4;
+        // 2 == 1 << (p-3): sparse byte length 2*8=16 == 1<<p, the collision point.
+        let hashes: Vec<u64> = (0..2_u64).map(h).collect();
+        let mut src = GroupHll::new_sparse();
+        for &hash in &hashes {
+            src.add_hash(hash, p);
+        }
+        assert!(matches!(src, GroupHll::Sparse(_)));
+        let bytes = serialize(&mut src, p);
+        assert_eq!(bytes.len(), 1 << p, "must emit dense to avoid collision");
+        let mut dst = GroupHll::new_sparse();
+        dst.merge_serialized(&bytes, p).unwrap();
+        assert_eq!(dst.count(p), src.count(p));
+    }
+
+    #[test]
     fn merge_combines_disjoint_groups() {
         let p = DEFAULT_HLL_P;
         // sparse + sparse, sparse + dense, dense + dense
@@ -1580,7 +1623,7 @@ mod tests {
     fn approx_distinct_with_hll_precision_12_produces_correct_estimate() {
         use arrow::array::Int64Array;
 
-        let func = ApproxDistinct::with_hll_precision(12);
+        let func = ApproxDistinct::with_hll_precision(12).unwrap();
         let values: ArrayRef = Arc::new(Int64Array::from_iter_values(0..1000i64));
         let expr_field: FieldRef =
             Arc::new(Field::new("v", DataType::Int64, false));
@@ -1621,29 +1664,27 @@ mod tests {
         let return_field: FieldRef =
             Arc::new(Field::new("r", DataType::UInt64, false));
         let acc_args = make_acc_args(&schema, &return_field, &expr_field);
-        // Confirm the accumulator can be created and evaluated for Union type.
         let mut acc = func.accumulator(acc_args).unwrap();
         let result = acc.evaluate().unwrap();
         assert_eq!(result, ScalarValue::UInt64(Some(0)));
     }
 
     #[test]
-    #[should_panic(expected = "HLL precision must be in")]
-    fn with_hll_precision_out_of_range_panics() {
-        let _ = ApproxDistinct::with_hll_precision(HLL_P_MAX + 1);
+    fn with_hll_precision_out_of_range_returns_err() {
+        let result = ApproxDistinct::with_hll_precision(HLL_P_MAX + 1);
+        assert!(result.is_err(), "precision above max must be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("HLL precision must be in"), "got: {msg}");
     }
 
-    // merge_dense Sparse arm: a sparse group absorbs an incoming dense state.
     #[test]
     fn merge_dense_into_sparse_group_produces_dense() {
         let p = DEFAULT_HLL_P;
-        // Build a dense sketch with some hashes.
         let hashes_a: Vec<u64> = (0..100).map(h).collect();
         let mut dense_src = GroupHll::new_sparse();
         for &hash in &hashes_a {
             dense_src.add_hash(hash, p);
         }
-        // Force promotion to dense.
         let extra: Vec<u64> = (100..(SPARSE_LIMIT as u64 * 3)).map(h).collect();
         for &hash in &extra {
             dense_src.add_hash(hash, p);
@@ -1651,7 +1692,6 @@ mod tests {
         assert!(matches!(dense_src, GroupHll::Dense(_)));
         let dense_bytes = serialize(&mut dense_src, p);
 
-        // Target starts sparse with a few hashes.
         let hashes_b: Vec<u64> = (1000..1010).map(h).collect();
         let mut sparse_dst = GroupHll::new_sparse();
         for &hash in &hashes_b {
@@ -1659,15 +1699,10 @@ mod tests {
         }
         assert!(matches!(sparse_dst, GroupHll::Sparse(_)));
 
-        // Merging the dense state into the sparse group should promote it.
         sparse_dst.merge_serialized(&dense_bytes, p).unwrap();
-        assert!(
-            matches!(sparse_dst, GroupHll::Dense(_)),
-            "sparse group must be dense after absorbing a dense state"
-        );
+        assert!(matches!(sparse_dst, GroupHll::Dense(_)));
     }
 
-    // HllGroupsAccumulator at non-default precision: full update → state → merge → evaluate.
     #[cfg(not(feature = "force_hash_collisions"))]
     #[test]
     fn groups_accumulator_with_precision_12_roundtrips() {
@@ -1677,13 +1712,11 @@ mod tests {
         let values: ArrayRef = Arc::new(Int64Array::from_iter_values(0..200i64));
         let group_indices = vec![0usize; 200];
 
-        // Partial accumulator at p=12.
         let mut partial = HllGroupsAccumulator::with_precision(p);
         partial
             .update_batch(&[Arc::clone(&values)], &group_indices, None, 1)
             .unwrap();
 
-        // Emit partial state and merge into a final accumulator at the same precision.
         let state = partial.state(EmitTo::All).unwrap();
         let mut final_acc = HllGroupsAccumulator::with_precision(p);
         final_acc
@@ -1691,16 +1724,11 @@ mod tests {
             .unwrap();
 
         let result = final_acc.evaluate(EmitTo::All).unwrap();
-        let counts = result
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .unwrap();
-        let count = counts.value(0);
-        // 200 distinct values, p=12 → ~1.6% error; allow 10% margin.
+        let count = result.as_any().downcast_ref::<UInt64Array>().unwrap().value(0);
+        // p=12 → ~1.6% error; allow 10% margin
         assert!(count > 180 && count < 220, "count {count} out of range");
     }
 
-    // NumericHLLAccumulator::with_precision propagates precision through evaluate.
     #[cfg(not(feature = "force_hash_collisions"))]
     #[test]
     fn numeric_hll_accumulator_with_precision_12() {
@@ -1715,5 +1743,19 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn hll_accumulator_size_includes_register_buffer() {
+        let acc = HLLAccumulator::with_precision(10);
+        assert!(acc.size() >= 1 << 10, "register buffer must be counted");
+        assert!(acc.size() > size_of_val(&acc), "heap must be counted");
+    }
+
+    #[test]
+    fn numeric_hll_accumulator_size_includes_register_buffer() {
+        let acc = NumericHLLAccumulator::<Int64Type>::with_precision(10);
+        assert!(acc.size() >= 1 << 10, "register buffer must be counted");
+        assert!(acc.size() > size_of_val(&acc), "heap must be counted");
     }
 }

--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -309,9 +309,7 @@ enum GroupHll {
 /// the given precision.
 fn fold_sparse_to_hll(hashes: &[u64], p: usize) -> HyperLogLog<u8> {
     let mut hll = HyperLogLog::<u8>::with_precision(p);
-    for &h in hashes {
-        hll.add_hashed(h);
-    }
+    hll.add_hashed_slice(hashes);
     hll
 }
 
@@ -407,9 +405,7 @@ impl GroupHll {
             GroupHll::Sparse(v) => {
                 let cap_before = v.capacity();
                 let mut hll = other.clone();
-                for &h in v.iter() {
-                    hll.add_hashed(h);
-                }
+                hll.add_hashed_slice(v);
                 let num_registers = 1_usize << p;
                 *self = GroupHll::Dense(Box::new(hll));
                 (num_registers as isize) - ((cap_before * size_of::<u64>()) as isize)

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -23,12 +23,12 @@
 //! within datafusion, so that function can
 //! be efficiently implemented.
 //!
-//! Specifically, like Redis's version, this HLL structure uses
+//! Specifically, like Redis's version, the default HLL structure uses
 //! 2**14 = 16384 registers, which means the standard error is
-//! 1.04/(16384**0.5) = 0.8125%. Unlike Redis, the register takes
-//! up full [`u8`] size instead of a raw int* and thus saves some
+//! 1.04/(16384**0.5) = 0.8125%. The precision `p` is now a runtime
+//! parameter; supported range is 4 ≤ p ≤ 18. Unlike Redis, the register
+//! takes up full [`u8`] size instead of a raw int* and thus saves some
 //! tricky bit shifting techniques used in the original version.
-//! This results in a memory usage increase from 12Kib to 16Kib.
 //! Also only the dense version is adopted, so there's no automatic
 //! conversion, largely to simplify the code.
 //!
@@ -38,20 +38,24 @@ use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::marker::PhantomData;
 
-/// The greater is P, the smaller the error.
-const HLL_P: usize = 14_usize;
-/// The number of bits of the hash value used determining the number of leading zeros
-const HLL_Q: usize = 64_usize - HLL_P;
-pub(crate) const NUM_REGISTERS: usize = 1_usize << HLL_P;
-/// Mask to obtain index into the registers
-const HLL_P_MASK: u64 = (NUM_REGISTERS as u64) - 1;
+/// Default precision — matches the historical hardcoded value.
+pub(crate) const DEFAULT_HLL_P: usize = 14_usize;
+/// Number of registers at the default precision.
+pub(crate) const NUM_REGISTERS: usize = 1_usize << DEFAULT_HLL_P;
+
+/// Minimum and maximum supported precision values.
+pub(crate) const HLL_P_MIN: usize = 4;
+pub(crate) const HLL_P_MAX: usize = 18;
 
 #[derive(Clone, Debug)]
 pub(crate) struct HyperLogLog<T>
 where
     T: Hash + ?Sized,
 {
-    registers: [u8; NUM_REGISTERS],
+    registers: Vec<u8>,
+    p: usize,
+    q: usize,     // 64 - p
+    p_mask: u64,  // (1 << p) - 1
     phantom: PhantomData<T>,
 }
 
@@ -70,20 +74,64 @@ impl<T> HyperLogLog<T>
 where
     T: Hash + ?Sized,
 {
-    /// Creates a new, empty HyperLogLog.
+    /// Creates a new, empty HyperLogLog with the default precision (14).
     pub fn new() -> Self {
-        let registers = [0; NUM_REGISTERS];
-        Self::new_with_registers(registers)
+        Self::with_precision(DEFAULT_HLL_P)
     }
 
-    /// Creates a HyperLogLog from already populated registers
-    /// note that this method should not be invoked in untrusted environment
-    /// because the internal structure of registers are not examined.
-    pub(crate) fn new_with_registers(registers: [u8; NUM_REGISTERS]) -> Self {
+    /// Creates a new, empty HyperLogLog with the given precision `p`.
+    ///
+    /// The number of registers is `2^p`. Supported range: `HLL_P_MIN..=HLL_P_MAX`.
+    pub fn with_precision(p: usize) -> Self {
+        assert!(
+            (HLL_P_MIN..=HLL_P_MAX).contains(&p),
+            "HLL precision must be in {HLL_P_MIN}..={HLL_P_MAX}, got {p}",
+        );
+        let num_registers = 1_usize << p;
+        let q = 64 - p;
+        let p_mask = (num_registers as u64) - 1;
         Self {
-            registers,
+            registers: vec![0u8; num_registers],
+            p,
+            q,
+            p_mask,
             phantom: PhantomData,
         }
+    }
+
+    /// Creates a HyperLogLog from already populated registers.
+    ///
+    /// The precision is inferred from the register slice length, which must be
+    /// a power of two in the range `2^HLL_P_MIN..=2^HLL_P_MAX`.
+    ///
+    /// Note that this method should not be invoked in an untrusted environment
+    /// because the internal structure of registers is not examined.
+    pub(crate) fn from_registers(registers: Vec<u8>) -> Self {
+        let len = registers.len();
+        assert!(
+            len.is_power_of_two(),
+            "register slice length must be a power of two, got {len}",
+        );
+        let p = len.ilog2() as usize;
+        assert!(
+            (HLL_P_MIN..=HLL_P_MAX).contains(&p),
+            "inferred precision {p} is outside {HLL_P_MIN}..={HLL_P_MAX}",
+        );
+        let q = 64 - p;
+        let p_mask = (len as u64) - 1;
+        Self {
+            registers,
+            p,
+            q,
+            p_mask,
+            phantom: PhantomData,
+        }
+    }
+
+    /// The precision of this sketch.
+    #[inline]
+    pub(crate) fn precision(&self) -> usize {
+        self.p
     }
 
     /// The HLL hash state is shared through `datafusion_common::hash_utils`
@@ -105,30 +153,26 @@ where
     /// by [`Self::add`].
     #[inline]
     pub(crate) fn add_hashed(&mut self, hash: u64) {
-        let index = (hash & HLL_P_MASK) as usize;
-        let p = ((hash >> HLL_P) | (1_u64 << HLL_Q)).trailing_zeros() + 1;
-        self.registers[index] = self.registers[index].max(p as u8);
+        let index = (hash & self.p_mask) as usize;
+        let rho = ((hash >> self.p) | (1_u64 << self.q)).trailing_zeros() + 1;
+        self.registers[index] = self.registers[index].max(rho as u8);
     }
 
-    /// Get the register histogram (each value in register index into
-    /// the histogram; u32 is enough because we only have 2**14=16384 registers
     #[inline]
-    fn get_histogram(&self) -> [u32; HLL_Q + 2] {
-        let mut histogram = [0; HLL_Q + 2];
-        // hopefully this can be unrolled
-        for r in self.registers {
-            histogram[r as usize] += 1;
+    fn get_histogram(&self) -> [u32; 64 - HLL_P_MIN + 2] {
+        let mut histogram = [0u32; 64 - HLL_P_MIN + 2];
+        for r in &self.registers {
+            histogram[*r as usize] += 1;
         }
         histogram
     }
 
-    /// Merge the other [`HyperLogLog`] into this one
+    /// Merge the other [`HyperLogLog`] into this one.
     pub fn merge(&mut self, other: &HyperLogLog<T>) {
-        assert!(
-            self.registers.len() == other.registers.len(),
-            "unexpected got unequal register size, expect {}, got {}",
-            self.registers.len(),
-            other.registers.len()
+        assert_eq!(
+            self.p, other.p,
+            "cannot merge HLL sketches with different precisions ({} vs {})",
+            self.p, other.p
         );
         for i in 0..self.registers.len() {
             self.registers[i] = self.registers[i].max(other.registers[i]);
@@ -137,40 +181,44 @@ where
 
     /// Guess the number of unique elements seen by the HyperLogLog.
     pub fn count(&self) -> usize {
-        count_from_histogram(&self.get_histogram())
+        count_from_histogram(&self.get_histogram()[..self.q + 2], self.p)
     }
 }
 
-/// Compute `index` and `rho` (register value) for a precomputed hash, exactly as
-/// [`HyperLogLog::add_hashed`] does.
+/// Compute `index` and `rho` (register value) for a precomputed hash at a given
+/// precision, exactly as [`HyperLogLog::add_hashed`] does.
 #[inline]
-pub(crate) fn register_for_hash(hash: u64) -> (usize, u8) {
-    let index = (hash & HLL_P_MASK) as usize;
-    let rho = (((hash >> HLL_P) | (1_u64 << HLL_Q)).trailing_zeros() + 1) as u8;
+pub(crate) fn register_for_hash(hash: u64, p: usize) -> (usize, u8) {
+    let q = 64 - p;
+    let p_mask: u64 = ((1_usize << p) as u64) - 1;
+    let index = (hash & p_mask) as usize;
+    let rho = (((hash >> p) | (1_u64 << q)).trailing_zeros() + 1) as u8;
     (index, rho)
 }
 
 /// Estimate the cardinality of a set of precomputed hashes without
-/// materializing a full [`NUM_REGISTERS`]-byte register array.
+/// materializing a full register array.
 ///
 /// This is equivalent to adding every hash to a fresh [`HyperLogLog`] via
 /// [`HyperLogLog::add_hashed`] and calling [`HyperLogLog::count`], but only does
 /// work proportional to the number of hashes. It is used to cheaply estimate the
 /// many small groups produced by a high-cardinality `GROUP BY`, where allocating
-/// and scanning a 16 KiB sketch per group would dominate the runtime.
+/// and scanning a sketch per group would dominate the runtime.
 ///
 /// `hashes` may contain duplicates (duplicate hashes are idempotent).
-pub(crate) fn count_from_hashes(hashes: &[u64]) -> usize {
+pub(crate) fn count_from_hashes(hashes: &[u64], p: usize) -> usize {
     if hashes.is_empty() {
         return 0;
     }
+    let num_registers = 1_usize << p;
+    let q = 64 - p;
     // For each touched register index keep the maximum rho. Sorting by
     // (index, rho) groups equal indices together with the max rho last.
     let mut idx_rho: Vec<(usize, u8)> =
-        hashes.iter().map(|&hash| register_for_hash(hash)).collect();
+        hashes.iter().map(|&hash| register_for_hash(hash, p)).collect();
     idx_rho.sort_unstable();
 
-    let mut histogram = [0u32; HLL_Q + 2];
+    let mut histogram = [0u32; 64 - HLL_P_MIN + 2];
     let mut touched = 0u32;
     let mut i = 0;
     while i < idx_rho.len() {
@@ -185,16 +233,17 @@ pub(crate) fn count_from_hashes(hashes: &[u64]) -> usize {
         touched += 1;
     }
     // All remaining registers are still zero.
-    histogram[0] = NUM_REGISTERS as u32 - touched;
-    count_from_histogram(&histogram)
+    histogram[0] = num_registers as u32 - touched;
+    count_from_histogram(&histogram[..q + 2], p)
 }
 
 /// Apply the HyperLogLog cardinality estimator to a register histogram.
 #[inline]
-fn count_from_histogram(histogram: &[u32; HLL_Q + 2]) -> usize {
-    let m = NUM_REGISTERS as f64;
-    let mut z = m * hll_tau((m - histogram[HLL_Q + 1] as f64) / m);
-    for i in histogram[1..=HLL_Q].iter().rev() {
+fn count_from_histogram(histogram: &[u32], p: usize) -> usize {
+    let q = 64 - p;
+    let m = (1_usize << p) as f64;
+    let mut z = m * hll_tau((m - histogram[q + 1] as f64) / m);
+    for i in histogram[1..=q].iter().rev() {
         z += *i as f64;
         z *= 0.5;
     }
@@ -283,16 +332,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{HyperLogLog, NUM_REGISTERS};
+    use super::{DEFAULT_HLL_P, HLL_P_MAX, HLL_P_MIN, HyperLogLog, NUM_REGISTERS};
 
-    fn compare_with_delta(got: usize, expected: usize) {
+    fn compare_with_delta(got: usize, expected: usize, p: usize) {
         let expected = expected as f64;
         let diff = (got as f64) - expected;
         let diff = diff.abs() / expected;
         // times 6 because we want the tests to be stable
         // so we allow a rather large margin of error
         // this is adopted from redis's unit test version as well
-        let margin = 1.04 / ((NUM_REGISTERS as f64).sqrt()) * 6.0;
+        let margin = 1.04 / (((1_usize << p) as f64).sqrt()) * 6.0;
         assert!(
             diff <= margin,
             "{} is not near {} percent of {} which is ({}, {})",
@@ -310,7 +359,7 @@ mod tests {
             for i in 0..$SIZE {
                 hll.add(&i);
             }
-            compare_with_delta(hll.count(), $SIZE);
+            compare_with_delta(hll.count(), $SIZE, DEFAULT_HLL_P);
         }};
     }
 
@@ -379,14 +428,14 @@ mod tests {
             let b = s.as_bytes();
             hll.add(b);
         }
-        compare_with_delta(hll.count(), 1000);
+        compare_with_delta(hll.count(), 1000, DEFAULT_HLL_P);
     }
 
     #[test]
     fn test_string() {
         let mut hll = HyperLogLog::<String>::new();
         hll.extend((0..1000).map(|i| i.to_string()));
-        compare_with_delta(hll.count(), 1000);
+        compare_with_delta(hll.count(), 1000, DEFAULT_HLL_P);
     }
 
     #[test]
@@ -405,7 +454,7 @@ mod tests {
         other.extend((0..1000).map(|i| i.to_string()));
 
         hll.merge(&other);
-        compare_with_delta(hll.count(), 1000);
+        compare_with_delta(hll.count(), 1000, DEFAULT_HLL_P);
     }
 
     #[test]
@@ -414,6 +463,102 @@ mod tests {
         for i in 0..1_000_000 {
             hll.add(&(i % 1000));
         }
-        compare_with_delta(hll.count(), 1000);
+        compare_with_delta(hll.count(), 1000, DEFAULT_HLL_P);
+    }
+
+    // --- precision-parameter tests ---
+
+    #[test]
+    fn test_precision_default_matches_new() {
+        assert_eq!(HyperLogLog::<u64>::new().precision(), DEFAULT_HLL_P);
+        assert_eq!(NUM_REGISTERS, 1 << DEFAULT_HLL_P);
+    }
+
+    #[test]
+    fn test_precision_12_accuracy() {
+        let p = 12;
+        let mut hll = HyperLogLog::<u64>::with_precision(p);
+        for i in 0..10_000u64 {
+            hll.add(&i);
+        }
+        compare_with_delta(hll.count(), 10_000, p);
+    }
+
+    #[test]
+    fn test_precision_10_accuracy() {
+        let p = 10;
+        let mut hll = HyperLogLog::<u64>::with_precision(p);
+        for i in 0..10_000u64 {
+            hll.add(&i);
+        }
+        compare_with_delta(hll.count(), 10_000, p);
+    }
+
+    #[test]
+    fn test_from_registers_roundtrip() {
+        for p in [10, 12, 14] {
+            let mut src = HyperLogLog::<u64>::with_precision(p);
+            for i in 0..1000u64 {
+                src.add(&i);
+            }
+            let bytes = src.as_ref().to_vec();
+            assert_eq!(bytes.len(), 1 << p);
+
+            let dst = HyperLogLog::<u64>::from_registers(bytes);
+            assert_eq!(dst.precision(), p);
+            assert_eq!(dst.count(), src.count());
+        }
+    }
+
+    #[test]
+    fn test_merge_same_precision() {
+        for p in [10, 12, 14] {
+            let mut a = HyperLogLog::<u64>::with_precision(p);
+            a.extend(0..500u64);
+            let mut b = HyperLogLog::<u64>::with_precision(p);
+            b.extend(500..1000u64);
+            a.merge(&b);
+            compare_with_delta(a.count(), 1000, p);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot merge HLL sketches with different precisions")]
+    fn test_merge_different_precision_panics() {
+        let mut a = HyperLogLog::<u64>::with_precision(12);
+        let b = HyperLogLog::<u64>::with_precision(14);
+        a.merge(&b);
+    }
+
+    #[test]
+    fn test_precision_range_bounds() {
+        // boundary values must not panic
+        let _ = HyperLogLog::<u64>::with_precision(HLL_P_MIN);
+        let _ = HyperLogLog::<u64>::with_precision(HLL_P_MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "HLL precision must be in")]
+    fn test_precision_below_min_panics() {
+        let _ = HyperLogLog::<u64>::with_precision(HLL_P_MIN - 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "HLL precision must be in")]
+    fn test_precision_above_max_panics() {
+        let _ = HyperLogLog::<u64>::with_precision(HLL_P_MAX + 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "register slice length must be a power of two")]
+    fn test_from_registers_non_power_of_two_panics() {
+        let _ = HyperLogLog::<u64>::from_registers(vec![0u8; 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "inferred precision")]
+    fn test_from_registers_out_of_range_precision_panics() {
+        // 2 bytes => p = 1, below HLL_P_MIN
+        let _ = HyperLogLog::<u64>::from_registers(vec![0u8; 2]);
     }
 }

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -201,9 +201,18 @@ where
     /// Process a slice of pre-computed hashes.
     /// The precision branch is hoisted outside the loop.
     pub(crate) fn add_hashed_slice(&mut self, hashes: &[u64]) {
-        let (p, q, p_mask) = self.hll_params();
-        for &hash in hashes {
-            hll_update_register(&mut self.registers, p, q, p_mask, hash);
+        if self.p == DEFAULT_HLL_P {
+            const P: usize = DEFAULT_HLL_P;
+            const Q: usize = 64 - DEFAULT_HLL_P;
+            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
+            for &hash in hashes {
+                hll_update_register(&mut self.registers, P, Q, MASK, hash);
+            }
+        } else {
+            let (p, q, p_mask) = self.hll_params();
+            for &hash in hashes {
+                hll_update_register(&mut self.registers, p, q, p_mask, hash);
+            }
         }
     }
 
@@ -380,6 +389,21 @@ where
     T: Hash,
 {
     fn extend<S: IntoIterator<Item = T>>(&mut self, iter: S) {
+        if self.p == DEFAULT_HLL_P {
+            const P: usize = DEFAULT_HLL_P;
+            const Q: usize = 64 - DEFAULT_HLL_P;
+            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
+            for elem in iter {
+                hll_update_register(
+                    &mut self.registers,
+                    P,
+                    Q,
+                    MASK,
+                    HLL_HASH_STATE.hash_one(&elem),
+                );
+            }
+            return;
+        }
         let (p, q, p_mask) = self.hll_params();
         for elem in iter {
             hll_update_register(
@@ -398,6 +422,21 @@ where
     T: 'a + Hash + ?Sized,
 {
     fn extend<S: IntoIterator<Item = &'a T>>(&mut self, iter: S) {
+        if self.p == DEFAULT_HLL_P {
+            const P: usize = DEFAULT_HLL_P;
+            const Q: usize = 64 - DEFAULT_HLL_P;
+            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
+            for elem in iter {
+                hll_update_register(
+                    &mut self.registers,
+                    P,
+                    Q,
+                    MASK,
+                    HLL_HASH_STATE.hash_one(elem),
+                );
+            }
+            return;
+        }
         let (p, q, p_mask) = self.hll_params();
         for elem in iter {
             hll_update_register(

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -40,7 +40,8 @@ use std::marker::PhantomData;
 
 /// Default precision — matches the historical hardcoded value.
 pub(crate) const DEFAULT_HLL_P: usize = 14_usize;
-/// Number of registers at the default precision.
+/// Number of registers at the default precision. Only used in tests.
+#[cfg(test)]
 pub(crate) const NUM_REGISTERS: usize = 1_usize << DEFAULT_HLL_P;
 
 /// Minimum and maximum supported precision values.
@@ -54,8 +55,8 @@ where
 {
     registers: Vec<u8>,
     p: usize,
-    q: usize,     // 64 - p
-    p_mask: u64,  // (1 << p) - 1
+    q: usize,    // 64 - p
+    p_mask: u64, // (1 << p) - 1
     phantom: PhantomData<T>,
 }
 
@@ -219,8 +220,10 @@ pub(crate) fn count_from_hashes(hashes: &[u64], p: usize) -> usize {
     let q = 64 - p;
     // For each touched register index keep the maximum rho. Sorting by
     // (index, rho) groups equal indices together with the max rho last.
-    let mut idx_rho: Vec<(usize, u8)> =
-        hashes.iter().map(|&hash| register_for_hash(hash, p)).collect();
+    let mut idx_rho: Vec<(usize, u8)> = hashes
+        .iter()
+        .map(|&hash| register_for_hash(hash, p))
+        .collect();
     idx_rho.sort_unstable();
 
     let mut histogram = [0u32; 64 - HLL_P_MIN + 2];

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -25,10 +25,10 @@
 //!
 //! Specifically, like Redis's version, the default HLL structure uses
 //! 2**14 = 16384 registers, which means the standard error is
-//! 1.04/(16384**0.5) = 0.8125%. The precision `p` is now a runtime
-//! parameter; supported range is 4 ≤ p ≤ 18. Unlike Redis, the register
-//! takes up full [`u8`] size instead of a raw int* and thus saves some
-//! tricky bit shifting techniques used in the original version.
+//! 1.04/(16384**0.5) = 0.8125%. The precision `p` is a runtime parameter;
+//! supported range is `HLL_P_MIN..=DEFAULT_HLL_P` (4..=14). Unlike Redis,
+//! the register takes up full [`u8`] size instead of a raw int* and thus
+//! saves some tricky bit shifting techniques used in the original version.
 //! Also only the dense version is adopted, so there's no automatic
 //! conversion, largely to simplify the code.
 //!
@@ -44,23 +44,43 @@ pub(crate) const DEFAULT_HLL_P: usize = 14_usize;
 #[cfg(test)]
 pub(crate) const NUM_REGISTERS: usize = 1_usize << DEFAULT_HLL_P;
 
-/// Minimum and maximum supported precision values.
+/// Minimum supported precision value.
 pub(crate) const HLL_P_MIN: usize = 4;
-pub(crate) const HLL_P_MAX: usize = 18;
 
 #[derive(Clone, Debug)]
 pub(crate) struct HyperLogLog<T>
 where
     T: Hash + ?Sized,
 {
-    registers: Vec<u8>,
     p: usize,
     q: usize,    // 64 - p
     p_mask: u64, // (1 << p) - 1
     phantom: PhantomData<T>,
+    // Only registers[..1 << p] is meaningful; the rest is zero-padding.
+    registers: [u8; 1 << DEFAULT_HLL_P],
 }
 
 pub(crate) use datafusion_common::hash_utils::HLL_RANDOM_STATE as HLL_HASH_STATE;
+
+/// Update one register given a pre-computed hash.
+/// Used by `add_hashed` for single-element updates.
+/// Loop callers hoist the branch explicitly for better codegen.
+macro_rules! hll_update {
+    ($self:expr, $hash:expr) => {{
+        if $self.p == DEFAULT_HLL_P {
+            const P: usize = DEFAULT_HLL_P;
+            const Q: usize = 64 - DEFAULT_HLL_P;
+            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
+            let index = ($hash & MASK) as usize;
+            let rho = (($hash >> P) | (1_u64 << Q)).trailing_zeros() + 1;
+            $self.registers[index] = $self.registers[index].max(rho as u8);
+        } else {
+            let index = ($hash & $self.p_mask) as usize;
+            let rho = (($hash >> $self.p) | (1_u64 << $self.q)).trailing_zeros() + 1;
+            $self.registers[index] = $self.registers[index].max(rho as u8);
+        }
+    }};
+}
 
 impl<T> Default for HyperLogLog<T>
 where
@@ -82,50 +102,52 @@ where
 
     /// Creates a new, empty HyperLogLog with the given precision `p`.
     ///
-    /// The number of registers is `2^p`. Supported range: `HLL_P_MIN..=HLL_P_MAX`.
+    /// The number of registers is `2^p`. Supported range: `HLL_P_MIN..=DEFAULT_HLL_P`.
+    #[inline(always)]
     pub fn with_precision(p: usize) -> Self {
         assert!(
-            (HLL_P_MIN..=HLL_P_MAX).contains(&p),
-            "HLL precision must be in {HLL_P_MIN}..={HLL_P_MAX}, got {p}",
+            (HLL_P_MIN..=DEFAULT_HLL_P).contains(&p),
+            "HLL precision must be in {HLL_P_MIN}..={DEFAULT_HLL_P}, got {p}",
         );
-        let num_registers = 1_usize << p;
         let q = 64 - p;
-        let p_mask = (num_registers as u64) - 1;
+        let p_mask = ((1_usize << p) as u64) - 1;
         Self {
-            registers: vec![0u8; num_registers],
             p,
             q,
             p_mask,
             phantom: PhantomData,
+            registers: [0u8; 1 << DEFAULT_HLL_P],
         }
     }
 
     /// Creates a HyperLogLog from already populated registers.
     ///
     /// The precision is inferred from the register slice length, which must be
-    /// a power of two in the range `2^HLL_P_MIN..=2^HLL_P_MAX`.
+    /// a power of two in the range `2^HLL_P_MIN..=2^DEFAULT_HLL_P`.
     ///
     /// Note that this method should not be invoked in an untrusted environment
     /// because the internal structure of registers is not examined.
-    pub(crate) fn from_registers(registers: Vec<u8>) -> Self {
-        let len = registers.len();
+    pub(crate) fn from_registers(v: &[u8]) -> Self {
+        let len = v.len();
         assert!(
             len.is_power_of_two(),
             "register slice length must be a power of two, got {len}",
         );
         let p = len.ilog2() as usize;
         assert!(
-            (HLL_P_MIN..=HLL_P_MAX).contains(&p),
-            "inferred precision {p} is outside {HLL_P_MIN}..={HLL_P_MAX}",
+            (HLL_P_MIN..=DEFAULT_HLL_P).contains(&p),
+            "inferred precision {p} is outside {HLL_P_MIN}..={DEFAULT_HLL_P}",
         );
         let q = 64 - p;
         let p_mask = (len as u64) - 1;
+        let mut registers = [0u8; 1 << DEFAULT_HLL_P];
+        registers[..len].copy_from_slice(v);
         Self {
-            registers,
             p,
             q,
             p_mask,
             phantom: PhantomData,
+            registers,
         }
     }
 
@@ -136,20 +158,15 @@ where
     }
 
     /// Heap bytes used by the register buffer (not captured by `size_of_val`).
+    /// Always 0 — registers are stored inline in the struct.
     pub(crate) fn register_heap_size(&self) -> usize {
-        self.registers.len()
-    }
-
-    /// The HLL hash state is shared through `datafusion_common::hash_utils`
-    /// so sketches remain compatible across accumulators.
-    #[inline]
-    fn hash_value(&self, obj: &T) -> u64 {
-        HLL_HASH_STATE.hash_one(obj)
+        0
     }
 
     /// Adds an element to the HyperLogLog.
+    #[cfg(test)]
     pub fn add(&mut self, obj: &T) {
-        let hash = self.hash_value(obj);
+        let hash = HLL_HASH_STATE.hash_one(obj);
         self.add_hashed(hash);
     }
 
@@ -157,17 +174,39 @@ where
     ///
     /// The hash should be computed using [`HLL_HASH_STATE`], the same hasher used
     /// by [`Self::add`].
-    #[inline]
+    #[inline(always)]
     pub(crate) fn add_hashed(&mut self, hash: u64) {
-        let index = (hash & self.p_mask) as usize;
-        let rho = ((hash >> self.p) | (1_u64 << self.q)).trailing_zeros() + 1;
-        self.registers[index] = self.registers[index].max(rho as u8);
+        hll_update!(self, hash);
+    }
+
+    /// Process a slice of pre-computed hashes.
+    /// The precision branch is hoisted outside the loop.
+    pub(crate) fn add_hashed_slice(&mut self, hashes: &[u64]) {
+        if self.p == DEFAULT_HLL_P {
+            const P: usize = DEFAULT_HLL_P;
+            const Q: usize = 64 - DEFAULT_HLL_P;
+            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
+            for &hash in hashes {
+                let index = (hash & MASK) as usize;
+                let rho = ((hash >> P) | (1_u64 << Q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
+            }
+        } else {
+            let p = self.p;
+            let q = self.q;
+            let p_mask = self.p_mask;
+            for &hash in hashes {
+                let index = (hash & p_mask) as usize;
+                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
+            }
+        }
     }
 
     #[inline]
     fn get_histogram(&self) -> [u32; 64 - HLL_P_MIN + 2] {
         let mut histogram = [0u32; 64 - HLL_P_MIN + 2];
-        for r in &self.registers {
+        for r in &self.registers[..1 << self.p] {
             histogram[*r as usize] += 1;
         }
         histogram
@@ -180,7 +219,8 @@ where
             "cannot merge HLL sketches with different precisions ({} vs {})",
             self.p, other.p
         );
-        for i in 0..self.registers.len() {
+        let n = 1 << self.p;
+        for i in 0..n {
             self.registers[i] = self.registers[i].max(other.registers[i]);
         }
     }
@@ -312,7 +352,7 @@ where
     T: Hash + ?Sized,
 {
     fn as_ref(&self) -> &[u8] {
-        &self.registers
+        &self.registers[..1 << self.p]
     }
 }
 
@@ -321,8 +361,26 @@ where
     T: Hash,
 {
     fn extend<S: IntoIterator<Item = T>>(&mut self, iter: S) {
-        for elem in iter {
-            self.add(&elem);
+        if self.p == DEFAULT_HLL_P {
+            const P: usize = DEFAULT_HLL_P;
+            const Q: usize = 64 - DEFAULT_HLL_P;
+            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
+            for elem in iter {
+                let hash = HLL_HASH_STATE.hash_one(&elem);
+                let index = (hash & MASK) as usize;
+                let rho = ((hash >> P) | (1_u64 << Q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
+            }
+        } else {
+            let p = self.p;
+            let q = self.q;
+            let p_mask = self.p_mask;
+            for elem in iter {
+                let hash = HLL_HASH_STATE.hash_one(&elem);
+                let index = (hash & p_mask) as usize;
+                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
+            }
         }
     }
 }
@@ -332,15 +390,33 @@ where
     T: 'a + Hash + ?Sized,
 {
     fn extend<S: IntoIterator<Item = &'a T>>(&mut self, iter: S) {
-        for elem in iter {
-            self.add(elem);
+        if self.p == DEFAULT_HLL_P {
+            const P: usize = DEFAULT_HLL_P;
+            const Q: usize = 64 - DEFAULT_HLL_P;
+            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
+            for elem in iter {
+                let hash = HLL_HASH_STATE.hash_one(elem);
+                let index = (hash & MASK) as usize;
+                let rho = ((hash >> P) | (1_u64 << Q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
+            }
+        } else {
+            let p = self.p;
+            let q = self.q;
+            let p_mask = self.p_mask;
+            for elem in iter {
+                let hash = HLL_HASH_STATE.hash_one(elem);
+                let index = (hash & p_mask) as usize;
+                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
+            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_HLL_P, HLL_P_MAX, HLL_P_MIN, HyperLogLog, NUM_REGISTERS};
+    use super::{DEFAULT_HLL_P, HLL_P_MIN, HyperLogLog, NUM_REGISTERS};
 
     fn compare_with_delta(got: usize, expected: usize, p: usize) {
         let expected = expected as f64;
@@ -512,7 +588,7 @@ mod tests {
             let bytes = src.as_ref().to_vec();
             assert_eq!(bytes.len(), 1 << p);
 
-            let dst = HyperLogLog::<u64>::from_registers(bytes);
+            let dst = HyperLogLog::<u64>::from_registers(&bytes);
             assert_eq!(dst.precision(), p);
             assert_eq!(dst.count(), src.count());
         }
@@ -542,7 +618,7 @@ mod tests {
     fn test_precision_range_bounds() {
         // boundary values must not panic
         let _ = HyperLogLog::<u64>::with_precision(HLL_P_MIN);
-        let _ = HyperLogLog::<u64>::with_precision(HLL_P_MAX);
+        let _ = HyperLogLog::<u64>::with_precision(DEFAULT_HLL_P);
     }
 
     #[test]
@@ -554,19 +630,19 @@ mod tests {
     #[test]
     #[should_panic(expected = "HLL precision must be in")]
     fn test_precision_above_max_panics() {
-        let _ = HyperLogLog::<u64>::with_precision(HLL_P_MAX + 1);
+        let _ = HyperLogLog::<u64>::with_precision(DEFAULT_HLL_P + 1);
     }
 
     #[test]
     #[should_panic(expected = "register slice length must be a power of two")]
     fn test_from_registers_non_power_of_two_panics() {
-        let _ = HyperLogLog::<u64>::from_registers(vec![0u8; 3]);
+        let _ = HyperLogLog::<u64>::from_registers(&vec![0u8; 3]);
     }
 
     #[test]
     #[should_panic(expected = "inferred precision")]
     fn test_from_registers_out_of_range_precision_panics() {
         // 2 bytes => p = 1, below HLL_P_MIN
-        let _ = HyperLogLog::<u64>::from_registers(vec![0u8; 2]);
+        let _ = HyperLogLog::<u64>::from_registers(&vec![0u8; 2]);
     }
 }

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -62,22 +62,41 @@ where
 
 pub(crate) use datafusion_common::hash_utils::HLL_RANDOM_STATE as HLL_HASH_STATE;
 
+/// Write one hash into the register array using pre-hoisted `p`/`q`/`p_mask`.
+///
+/// Taking these as parameters (rather than reading from a struct) lets callers
+/// hoist them outside tight loops, keeping them in CPU registers across all
+/// iterations with zero per-element struct reads.
+#[inline(always)]
+pub(crate) fn hll_update_register(
+    registers: &mut [u8; 1 << DEFAULT_HLL_P],
+    p: usize,
+    q: usize,
+    p_mask: u64,
+    hash: u64,
+) {
+    let index = (hash & p_mask) as usize;
+    let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
+    registers[index] = registers[index].max(rho as u8);
+}
+
 /// Update one register given a pre-computed hash.
-/// Used by `add_hashed` for single-element updates.
-/// Loop callers hoist the branch explicitly for better codegen.
+/// Uses compile-time constants for the default precision path.
 macro_rules! hll_update {
     ($self:expr, $hash:expr) => {{
         if $self.p == DEFAULT_HLL_P {
             const P: usize = DEFAULT_HLL_P;
             const Q: usize = 64 - DEFAULT_HLL_P;
             const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
-            let index = ($hash & MASK) as usize;
-            let rho = (($hash >> P) | (1_u64 << Q)).trailing_zeros() + 1;
-            $self.registers[index] = $self.registers[index].max(rho as u8);
+            hll_update_register(&mut $self.registers, P, Q, MASK, $hash);
         } else {
-            let index = ($hash & $self.p_mask) as usize;
-            let rho = (($hash >> $self.p) | (1_u64 << $self.q)).trailing_zeros() + 1;
-            $self.registers[index] = $self.registers[index].max(rho as u8);
+            hll_update_register(
+                &mut $self.registers,
+                $self.p,
+                $self.q,
+                $self.p_mask,
+                $hash,
+            );
         }
     }};
 }
@@ -182,24 +201,24 @@ where
     /// Process a slice of pre-computed hashes.
     /// The precision branch is hoisted outside the loop.
     pub(crate) fn add_hashed_slice(&mut self, hashes: &[u64]) {
+        let (p, q, p_mask) = self.hll_params();
+        for &hash in hashes {
+            hll_update_register(&mut self.registers, p, q, p_mask, hash);
+        }
+    }
+
+    /// Returns `(p, q, p_mask)` as register-resident locals for hoisting into loops.
+    /// For the default precision returns compile-time constants.
+    #[inline(always)]
+    pub(crate) fn hll_params(&self) -> (usize, usize, u64) {
         if self.p == DEFAULT_HLL_P {
-            const P: usize = DEFAULT_HLL_P;
-            const Q: usize = 64 - DEFAULT_HLL_P;
-            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
-            for &hash in hashes {
-                let index = (hash & MASK) as usize;
-                let rho = ((hash >> P) | (1_u64 << Q)).trailing_zeros() + 1;
-                self.registers[index] = self.registers[index].max(rho as u8);
-            }
+            (
+                DEFAULT_HLL_P,
+                64 - DEFAULT_HLL_P,
+                (1u64 << DEFAULT_HLL_P) - 1,
+            )
         } else {
-            let p = self.p;
-            let q = self.q;
-            let p_mask = self.p_mask;
-            for &hash in hashes {
-                let index = (hash & p_mask) as usize;
-                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
-                self.registers[index] = self.registers[index].max(rho as u8);
-            }
+            (self.p, self.q, self.p_mask)
         }
     }
 
@@ -361,26 +380,15 @@ where
     T: Hash,
 {
     fn extend<S: IntoIterator<Item = T>>(&mut self, iter: S) {
-        if self.p == DEFAULT_HLL_P {
-            const P: usize = DEFAULT_HLL_P;
-            const Q: usize = 64 - DEFAULT_HLL_P;
-            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
-            for elem in iter {
-                let hash = HLL_HASH_STATE.hash_one(&elem);
-                let index = (hash & MASK) as usize;
-                let rho = ((hash >> P) | (1_u64 << Q)).trailing_zeros() + 1;
-                self.registers[index] = self.registers[index].max(rho as u8);
-            }
-        } else {
-            let p = self.p;
-            let q = self.q;
-            let p_mask = self.p_mask;
-            for elem in iter {
-                let hash = HLL_HASH_STATE.hash_one(&elem);
-                let index = (hash & p_mask) as usize;
-                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
-                self.registers[index] = self.registers[index].max(rho as u8);
-            }
+        let (p, q, p_mask) = self.hll_params();
+        for elem in iter {
+            hll_update_register(
+                &mut self.registers,
+                p,
+                q,
+                p_mask,
+                HLL_HASH_STATE.hash_one(&elem),
+            );
         }
     }
 }
@@ -390,26 +398,15 @@ where
     T: 'a + Hash + ?Sized,
 {
     fn extend<S: IntoIterator<Item = &'a T>>(&mut self, iter: S) {
-        if self.p == DEFAULT_HLL_P {
-            const P: usize = DEFAULT_HLL_P;
-            const Q: usize = 64 - DEFAULT_HLL_P;
-            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
-            for elem in iter {
-                let hash = HLL_HASH_STATE.hash_one(elem);
-                let index = (hash & MASK) as usize;
-                let rho = ((hash >> P) | (1_u64 << Q)).trailing_zeros() + 1;
-                self.registers[index] = self.registers[index].max(rho as u8);
-            }
-        } else {
-            let p = self.p;
-            let q = self.q;
-            let p_mask = self.p_mask;
-            for elem in iter {
-                let hash = HLL_HASH_STATE.hash_one(elem);
-                let index = (hash & p_mask) as usize;
-                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
-                self.registers[index] = self.registers[index].max(rho as u8);
-            }
+        let (p, q, p_mask) = self.hll_params();
+        for elem in iter {
+            hll_update_register(
+                &mut self.registers,
+                p,
+                q,
+                p_mask,
+                HLL_HASH_STATE.hash_one(elem),
+            );
         }
     }
 }

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -47,6 +47,8 @@ pub(crate) const NUM_REGISTERS: usize = 1_usize << DEFAULT_HLL_P;
 /// Minimum supported precision value.
 pub(crate) const HLL_P_MIN: usize = 4;
 
+// Derived constants for the default precision — used as instruction immediates
+// in hot loops to avoid loading p/q/p_mask from the struct on every iteration.
 const DEFAULT_Q: usize = 64 - DEFAULT_HLL_P;
 const DEFAULT_MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
 
@@ -153,10 +155,7 @@ where
         self.add_hashed(hash);
     }
 
-    /// Adds a pre-computed hash value directly to the HyperLogLog.
-    ///
-    /// The hash should be computed using [`HLL_HASH_STATE`], the same hasher used
-    /// by [`Self::add`].
+    /// Adds a pre-computed hash. Hash must be produced by [`HLL_HASH_STATE`].
     #[inline(always)]
     pub(crate) fn add_hashed(&mut self, hash: u64) {
         let index = (hash & self.p_mask) as usize;
@@ -164,11 +163,10 @@ where
         self.registers[index] = self.registers[index].max(rho as u8);
     }
 
-    /// Process a slice of pre-computed hashes.
+    /// Adds a slice of pre-computed hashes. Hashes must use [`HLL_HASH_STATE`].
     pub(crate) fn add_hashed_slice(&mut self, hashes: &[u64]) {
-        // For p == DEFAULT_HLL_P, use compile-time constants so LLVM emits
-        // them as instruction immediates (same codegen as pre-refactor).
-        // For other precisions, hoist the struct fields outside the loop.
+        // Default precision: use module-level constants so LLVM emits immediates.
+        // Other precisions: hoist struct fields outside the loop.
         if self.p == DEFAULT_HLL_P {
             for &hash in hashes {
                 let index = (hash & DEFAULT_MASK) as usize;

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -47,6 +47,12 @@ pub(crate) const NUM_REGISTERS: usize = 1_usize << DEFAULT_HLL_P;
 /// Minimum supported precision value.
 pub(crate) const HLL_P_MIN: usize = 4;
 
+// Pre-computed constants for the default precision path.
+// Used in the `if self.p == DEFAULT_HLL_P` fast path throughout all hot loops
+// so LLVM can constant-fold p/q/mask as instruction immediates.
+const DEFAULT_Q: usize = 64 - DEFAULT_HLL_P;
+const DEFAULT_MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
+
 #[derive(Clone, Debug)]
 pub(crate) struct HyperLogLog<T>
 where
@@ -78,27 +84,6 @@ pub(crate) fn hll_update_register(
     let index = (hash & p_mask) as usize;
     let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
     registers[index] = registers[index].max(rho as u8);
-}
-
-/// Update one register given a pre-computed hash.
-/// Uses compile-time constants for the default precision path.
-macro_rules! hll_update {
-    ($self:expr, $hash:expr) => {{
-        if $self.p == DEFAULT_HLL_P {
-            const P: usize = DEFAULT_HLL_P;
-            const Q: usize = 64 - DEFAULT_HLL_P;
-            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
-            hll_update_register(&mut $self.registers, P, Q, MASK, $hash);
-        } else {
-            hll_update_register(
-                &mut $self.registers,
-                $self.p,
-                $self.q,
-                $self.p_mask,
-                $hash,
-            );
-        }
-    }};
 }
 
 impl<T> Default for HyperLogLog<T>
@@ -195,39 +180,34 @@ where
     /// by [`Self::add`].
     #[inline(always)]
     pub(crate) fn add_hashed(&mut self, hash: u64) {
-        hll_update!(self, hash);
+        self.for_each_hash(std::iter::once(hash));
     }
 
     /// Process a slice of pre-computed hashes.
     /// The precision branch is hoisted outside the loop.
     pub(crate) fn add_hashed_slice(&mut self, hashes: &[u64]) {
-        if self.p == DEFAULT_HLL_P {
-            const P: usize = DEFAULT_HLL_P;
-            const Q: usize = 64 - DEFAULT_HLL_P;
-            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
-            for &hash in hashes {
-                hll_update_register(&mut self.registers, P, Q, MASK, hash);
-            }
-        } else {
-            let (p, q, p_mask) = self.hll_params();
-            for &hash in hashes {
-                hll_update_register(&mut self.registers, p, q, p_mask, hash);
-            }
-        }
+        self.for_each_hash(hashes.iter().copied());
     }
 
-    /// Returns `(p, q, p_mask)` as register-resident locals for hoisting into loops.
-    /// For the default precision returns compile-time constants.
+    /// Feed an iterator of hashes into the sketch.
+    /// Resolves the precision branch once, then loops with branch-free inner body.
     #[inline(always)]
-    pub(crate) fn hll_params(&self) -> (usize, usize, u64) {
+    fn for_each_hash(&mut self, hashes: impl Iterator<Item = u64>) {
         if self.p == DEFAULT_HLL_P {
-            (
-                DEFAULT_HLL_P,
-                64 - DEFAULT_HLL_P,
-                (1u64 << DEFAULT_HLL_P) - 1,
-            )
+            for hash in hashes {
+                hll_update_register(
+                    &mut self.registers,
+                    DEFAULT_HLL_P,
+                    DEFAULT_Q,
+                    DEFAULT_MASK,
+                    hash,
+                );
+            }
         } else {
-            (self.p, self.q, self.p_mask)
+            let (p, q, p_mask) = (self.p, self.q, self.p_mask);
+            for hash in hashes {
+                hll_update_register(&mut self.registers, p, q, p_mask, hash);
+            }
         }
     }
 
@@ -390,29 +370,26 @@ where
 {
     fn extend<S: IntoIterator<Item = T>>(&mut self, iter: S) {
         if self.p == DEFAULT_HLL_P {
-            const P: usize = DEFAULT_HLL_P;
-            const Q: usize = 64 - DEFAULT_HLL_P;
-            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
             for elem in iter {
                 hll_update_register(
                     &mut self.registers,
-                    P,
-                    Q,
-                    MASK,
+                    DEFAULT_HLL_P,
+                    DEFAULT_Q,
+                    DEFAULT_MASK,
                     HLL_HASH_STATE.hash_one(&elem),
                 );
             }
-            return;
-        }
-        let (p, q, p_mask) = self.hll_params();
-        for elem in iter {
-            hll_update_register(
-                &mut self.registers,
-                p,
-                q,
-                p_mask,
-                HLL_HASH_STATE.hash_one(&elem),
-            );
+        } else {
+            let (p, q, p_mask) = (self.p, self.q, self.p_mask);
+            for elem in iter {
+                hll_update_register(
+                    &mut self.registers,
+                    p,
+                    q,
+                    p_mask,
+                    HLL_HASH_STATE.hash_one(&elem),
+                );
+            }
         }
     }
 }
@@ -423,29 +400,26 @@ where
 {
     fn extend<S: IntoIterator<Item = &'a T>>(&mut self, iter: S) {
         if self.p == DEFAULT_HLL_P {
-            const P: usize = DEFAULT_HLL_P;
-            const Q: usize = 64 - DEFAULT_HLL_P;
-            const MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
             for elem in iter {
                 hll_update_register(
                     &mut self.registers,
-                    P,
-                    Q,
-                    MASK,
+                    DEFAULT_HLL_P,
+                    DEFAULT_Q,
+                    DEFAULT_MASK,
                     HLL_HASH_STATE.hash_one(elem),
                 );
             }
-            return;
-        }
-        let (p, q, p_mask) = self.hll_params();
-        for elem in iter {
-            hll_update_register(
-                &mut self.registers,
-                p,
-                q,
-                p_mask,
-                HLL_HASH_STATE.hash_one(elem),
-            );
+        } else {
+            let (p, q, p_mask) = (self.p, self.q, self.p_mask);
+            for elem in iter {
+                hll_update_register(
+                    &mut self.registers,
+                    p,
+                    q,
+                    p_mask,
+                    HLL_HASH_STATE.hash_one(elem),
+                );
+            }
         }
     }
 }

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -47,9 +47,6 @@ pub(crate) const NUM_REGISTERS: usize = 1_usize << DEFAULT_HLL_P;
 /// Minimum supported precision value.
 pub(crate) const HLL_P_MIN: usize = 4;
 
-// Pre-computed constants for the default precision path.
-// Used in the `if self.p == DEFAULT_HLL_P` fast path throughout all hot loops
-// so LLVM can constant-fold p/q/mask as instruction immediates.
 const DEFAULT_Q: usize = 64 - DEFAULT_HLL_P;
 const DEFAULT_MASK: u64 = (1u64 << DEFAULT_HLL_P) - 1;
 
@@ -67,24 +64,6 @@ where
 }
 
 pub(crate) use datafusion_common::hash_utils::HLL_RANDOM_STATE as HLL_HASH_STATE;
-
-/// Write one hash into the register array using pre-hoisted `p`/`q`/`p_mask`.
-///
-/// Taking these as parameters (rather than reading from a struct) lets callers
-/// hoist them outside tight loops, keeping them in CPU registers across all
-/// iterations with zero per-element struct reads.
-#[inline(always)]
-pub(crate) fn hll_update_register(
-    registers: &mut [u8; 1 << DEFAULT_HLL_P],
-    p: usize,
-    q: usize,
-    p_mask: u64,
-    hash: u64,
-) {
-    let index = (hash & p_mask) as usize;
-    let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
-    registers[index] = registers[index].max(rho as u8);
-}
 
 impl<T> Default for HyperLogLog<T>
 where
@@ -180,33 +159,29 @@ where
     /// by [`Self::add`].
     #[inline(always)]
     pub(crate) fn add_hashed(&mut self, hash: u64) {
-        self.for_each_hash(std::iter::once(hash));
+        let index = (hash & self.p_mask) as usize;
+        let rho = ((hash >> self.p) | (1_u64 << self.q)).trailing_zeros() + 1;
+        self.registers[index] = self.registers[index].max(rho as u8);
     }
 
     /// Process a slice of pre-computed hashes.
-    /// The precision branch is hoisted outside the loop.
     pub(crate) fn add_hashed_slice(&mut self, hashes: &[u64]) {
-        self.for_each_hash(hashes.iter().copied());
-    }
-
-    /// Feed an iterator of hashes into the sketch.
-    /// Resolves the precision branch once, then loops with branch-free inner body.
-    #[inline(always)]
-    fn for_each_hash(&mut self, hashes: impl Iterator<Item = u64>) {
+        // For p == DEFAULT_HLL_P, use compile-time constants so LLVM emits
+        // them as instruction immediates (same codegen as pre-refactor).
+        // For other precisions, hoist the struct fields outside the loop.
         if self.p == DEFAULT_HLL_P {
-            for hash in hashes {
-                hll_update_register(
-                    &mut self.registers,
-                    DEFAULT_HLL_P,
-                    DEFAULT_Q,
-                    DEFAULT_MASK,
-                    hash,
-                );
+            for &hash in hashes {
+                let index = (hash & DEFAULT_MASK) as usize;
+                let rho =
+                    ((hash >> DEFAULT_HLL_P) | (1_u64 << DEFAULT_Q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
             }
         } else {
             let (p, q, p_mask) = (self.p, self.q, self.p_mask);
-            for hash in hashes {
-                hll_update_register(&mut self.registers, p, q, p_mask, hash);
+            for &hash in hashes {
+                let index = (hash & p_mask) as usize;
+                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
             }
         }
     }
@@ -371,24 +346,19 @@ where
     fn extend<S: IntoIterator<Item = T>>(&mut self, iter: S) {
         if self.p == DEFAULT_HLL_P {
             for elem in iter {
-                hll_update_register(
-                    &mut self.registers,
-                    DEFAULT_HLL_P,
-                    DEFAULT_Q,
-                    DEFAULT_MASK,
-                    HLL_HASH_STATE.hash_one(&elem),
-                );
+                let hash = HLL_HASH_STATE.hash_one(&elem);
+                let index = (hash & DEFAULT_MASK) as usize;
+                let rho =
+                    ((hash >> DEFAULT_HLL_P) | (1_u64 << DEFAULT_Q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
             }
         } else {
             let (p, q, p_mask) = (self.p, self.q, self.p_mask);
             for elem in iter {
-                hll_update_register(
-                    &mut self.registers,
-                    p,
-                    q,
-                    p_mask,
-                    HLL_HASH_STATE.hash_one(&elem),
-                );
+                let hash = HLL_HASH_STATE.hash_one(&elem);
+                let index = (hash & p_mask) as usize;
+                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
             }
         }
     }
@@ -401,24 +371,19 @@ where
     fn extend<S: IntoIterator<Item = &'a T>>(&mut self, iter: S) {
         if self.p == DEFAULT_HLL_P {
             for elem in iter {
-                hll_update_register(
-                    &mut self.registers,
-                    DEFAULT_HLL_P,
-                    DEFAULT_Q,
-                    DEFAULT_MASK,
-                    HLL_HASH_STATE.hash_one(elem),
-                );
+                let hash = HLL_HASH_STATE.hash_one(elem);
+                let index = (hash & DEFAULT_MASK) as usize;
+                let rho =
+                    ((hash >> DEFAULT_HLL_P) | (1_u64 << DEFAULT_Q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
             }
         } else {
             let (p, q, p_mask) = (self.p, self.q, self.p_mask);
             for elem in iter {
-                hll_update_register(
-                    &mut self.registers,
-                    p,
-                    q,
-                    p_mask,
-                    HLL_HASH_STATE.hash_one(elem),
-                );
+                let hash = HLL_HASH_STATE.hash_one(elem);
+                let index = (hash & p_mask) as usize;
+                let rho = ((hash >> p) | (1_u64 << q)).trailing_zeros() + 1;
+                self.registers[index] = self.registers[index].max(rho as u8);
             }
         }
     }

--- a/datafusion/functions-aggregate/src/hyperloglog.rs
+++ b/datafusion/functions-aggregate/src/hyperloglog.rs
@@ -134,6 +134,11 @@ where
         self.p
     }
 
+    /// Heap bytes used by the register buffer (not captured by `size_of_val`).
+    pub(crate) fn register_heap_size(&self) -> usize {
+        self.registers.len()
+    }
+
     /// The HLL hash state is shared through `datafusion_common::hash_utils`
     /// so sketches remain compatible across accumulators.
     #[inline]


### PR DESCRIPTION




## Which issue does this PR close?
 
Resolves https://github.com/apache/datafusion/issues/23815

## Rationale for this change

Adds runtime-configurable HLL precision to approx_distinct. Previously the register count was a compile-time constant (p=14, 16 KiB per sketch); now any precision between 4 to 18 is supported.


## What changes are included in this PR?

 - HyperLogLog::with_precision(p): constructs a sketch at the requested precision; new() still defaults to p=14.
- HyperLogLog::from_registers(vec): replaces new_with_registers([u8; 16384]); infers p from the slice length.
- ApproxDistinct::with_hll_precision(p): forwards p through every HLL accumulator path (HLLAccumulator, NumericHLLAccumulator, HllGroupsAccumulator). Has no effect for types that use exact bitmap counting (Boolean, Int8, UInt8, Int16, UInt16) — those paths are unaffected regardless of the value passed.

## Are these changes tested?

 9 new tests cover: construction at non-default precisions, accuracy within expected error bounds at p=10 and p=12, roundtrip serialization at p=10/12/14, cross-precision merge panic (programming error guard), and boundary validation.

## Are there any user-facing changes?

None for existing callers. Old ApproxDistinct::new() and HyperLogLog::new() continue to use p=14.
