### PR TITLE
Add setter for `TaskContext::task_id`

### DIFF
--- a/datafusion/execution/src/task.rs
+++ b/datafusion/execution/src/task.rs
@@ -52,7 +52,7 @@ use std::{collections::HashMap, sync::Arc};
 pub struct TaskContext {
     /// Session Id
     session_id: String,
-    /// Optional Task Identify
+    /// Optional task identity
     task_id: Option<String>,
     /// Session configuration
     session_config: SessionConfig,
@@ -165,6 +165,12 @@ impl TaskContext {
     /// Update the [`RuntimeEnv`]
     pub fn with_runtime(mut self, runtime: Arc<RuntimeEnv>) -> Self {
         self.runtime = runtime;
+        self
+    }
+
+    /// Update the `task_id`
+    pub fn with_task_id(mut self, task_id: String) -> Self {
+        self.task_id = Some(task_id);
         self
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #22072

## Rationale for this change

Without a way to set `TaskContext::task_id` the field is a bit pointless. This MR adds a way to set the field.
This does not automatically make the field useful for correlation purposes (as hinted at by the linked issue) since it's not filled in anywhere yet, but at least the capability is already there.

## Are these changes tested?

Not sure how to meaningfully test this

## Are there any user-facing changes?

No