### PR TITLE
fix(sql): preserve source qualifiers in CTAS with explicit schema

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -53,7 +53,7 @@ use datafusion_expr::{
     LogicalPlan, LogicalPlanBuilder, OperateFunctionArg, PlanType, Prepare,
     ResetVariable, SetVariable, SortExpr, Statement as PlanStatement, ToStringifiedPlan,
     TransactionAccessMode, TransactionConclusion, TransactionEnd,
-    TransactionIsolationLevel, TransactionStart, Volatility, WriteOp, cast, col,
+    TransactionIsolationLevel, TransactionStart, Volatility, WriteOp, cast,
 };
 use sqlparser::ast::{
     self, BeginTransactionKind, CheckConstraint, ForeignKeyConstraint, IndexColumn,
@@ -555,14 +555,14 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                     input_schema.fields().len()
                                 );
                             }
-                            let input_fields = input_schema.fields();
+                            let input_columns = input_schema.columns();
                             let project_exprs = schema
                                 .fields()
                                 .iter()
-                                .zip(input_fields)
-                                .map(|(field, input_field)| {
+                                .zip(input_columns)
+                                .map(|(field, input_column)| {
                                     cast(
-                                        col(input_field.name()),
+                                        Expr::Column(input_column),
                                         field.data_type().clone(),
                                     )
                                     .alias(field.name())

--- a/datafusion/sqllogictest/test_files/ddl.slt
+++ b/datafusion/sqllogictest/test_files/ddl.slt
@@ -979,6 +979,14 @@ CREATE TABLE dup_src AS VALUES(1, 2);
 statement error DataFusion error: Schema error: Schema contains duplicate unqualified field name column1
 CREATE TABLE dup_ctas AS SELECT * FROM dup_src LEFT JOIN dup_src y ON dup_src.column1 = y.column2;
 
+statement ok
+CREATE TABLE dup_ctas_with_schema(left_c1 bigint, right_c1 bigint) AS
+SELECT dup_src.column1, y.column1
+FROM dup_src CROSS JOIN dup_src y;
+
+statement ok
+DROP TABLE IF EXISTS dup_ctas_with_schema;
+
 statement error DataFusion error: Schema error: Schema contains duplicate unqualified field name column1
 CREATE VIEW dup_view AS SELECT * FROM dup_src LEFT JOIN dup_src y ON dup_src.column1 = y.column2;
 

--- a/datafusion/sqllogictest/test_files/ddl.slt
+++ b/datafusion/sqllogictest/test_files/ddl.slt
@@ -981,11 +981,17 @@ CREATE TABLE dup_ctas AS SELECT * FROM dup_src LEFT JOIN dup_src y ON dup_src.co
 
 statement ok
 CREATE TABLE dup_ctas_with_schema(left_c1 bigint, right_c1 bigint) AS
-SELECT dup_src.column1, y.column1
-FROM dup_src CROSS JOIN dup_src y;
+SELECT dup_src.column1, right_src.column1
+FROM dup_src
+CROSS JOIN (SELECT column2 AS column1 FROM dup_src) right_src;
+
+query II
+SELECT left_c1, right_c1 FROM dup_ctas_with_schema;
+----
+1 2
 
 statement ok
-DROP TABLE IF EXISTS dup_ctas_with_schema;
+DROP TABLE dup_ctas_with_schema;
 
 statement error DataFusion error: Schema error: Schema contains duplicate unqualified field name column1
 CREATE VIEW dup_view AS SELECT * FROM dup_src LEFT JOIN dup_src y ON dup_src.column1 = y.column2;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #23878.

## Rationale for this change

CTAS with an explicit schema fails when qualified source columns have the same name because their qualifiers are not preserved.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Preserve source column qualifiers in the CTAS cast projection.
- Add a SQL logic test for this case.

## Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

This is a bug fix with no public API changes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
