### PR TITLE
perf: parse next_day's day-of-week without allocating, and once per batch

### DIFF
--- a/datafusion/spark/src/function/datetime/next_day.rs
+++ b/datafusion/spark/src/function/datetime/next_day.rs
@@ -89,7 +89,8 @@ impl ScalarUDFImpl for SparkNextDay {
                         if let Some(days) = days {
                             if let Some(day_of_week) = day_of_week {
                                 Ok(ColumnarValue::Scalar(ScalarValue::Date32(
-                                    spark_next_day(*days, day_of_week.as_str()),
+                                    parse_day_of_week(day_of_week)
+                                        .and_then(|dow| spark_next_day(*days, dow)),
                                 )))
                             } else {
                                 // TODO: if spark.sql.ansi.enabled is false,
@@ -114,11 +115,16 @@ impl ScalarUDFImpl for SparkNextDay {
                         | ScalarValue::Utf8View(day_of_week),
                     ) => {
                         if let Some(day_of_week) = day_of_week {
+                            // The day name is the same for every row, so parse it
+                            // once here rather than on each call below.
+                            let Some(day_of_week) = parse_day_of_week(day_of_week) else {
+                                return Ok(ColumnarValue::Scalar(ScalarValue::Date32(
+                                    None,
+                                )));
+                            };
                             let result: Date32Array = date_array
                                 .as_primitive::<Date32Type>()
-                                .unary_opt(|days| {
-                                    spark_next_day(days, day_of_week.as_str())
-                                })
+                                .unary_opt(|days| spark_next_day(days, day_of_week))
                                 .with_data_type(DataType::Date32);
                             Ok(ColumnarValue::Array(Arc::new(result) as ArrayRef))
                         } else {
@@ -193,7 +199,8 @@ where
         .map(|(days, day_of_week)| {
             if let Some(days) = days {
                 if let Some(day_of_week) = day_of_week {
-                    spark_next_day(days, day_of_week)
+                    parse_day_of_week(day_of_week)
+                        .and_then(|dow| spark_next_day(days, dow))
                 } else {
                     // TODO: if spark.sql.ansi.enabled is false,
                     //  returns NULL instead of an error for a malformed dayOfWeek.
@@ -207,42 +214,53 @@ where
     Ok(Arc::new(result) as ArrayRef)
 }
 
-fn spark_next_day(days: i32, day_of_week: &str) -> Option<i32> {
+/// Longest day name accepted by Spark, `"WEDNESDAY"`.
+const MAX_DAY_NAME_LEN: usize = 9;
+
+/// Maps an already-upper-cased day name to its [`Weekday`].
+fn weekday_from_upper(name: &[u8]) -> Option<Weekday> {
+    match name {
+        b"MO" | b"MON" | b"MONDAY" => Some(Weekday::Mon),
+        b"TU" | b"TUE" | b"TUESDAY" => Some(Weekday::Tue),
+        b"WE" | b"WED" | b"WEDNESDAY" => Some(Weekday::Wed),
+        b"TH" | b"THU" | b"THURSDAY" => Some(Weekday::Thu),
+        b"FR" | b"FRI" | b"FRIDAY" => Some(Weekday::Fri),
+        b"SA" | b"SAT" | b"SATURDAY" => Some(Weekday::Sat),
+        b"SU" | b"SUN" | b"SUNDAY" => Some(Weekday::Sun),
+        // TODO: if spark.sql.ansi.enabled is false,
+        //  returns NULL instead of an error for a malformed dayOfWeek.
+        _ => None,
+    }
+}
+
+/// Parses a Spark day-of-week name, without allocating for ASCII input.
+fn parse_day_of_week(day_of_week: &str) -> Option<Weekday> {
+    let bytes = day_of_week.as_bytes();
+    if day_of_week.is_ascii() {
+        // No accepted name is longer than `MAX_DAY_NAME_LEN`, so anything longer
+        // cannot match and the upper-casing fits in a stack buffer.
+        if bytes.len() > MAX_DAY_NAME_LEN {
+            return None;
+        }
+        let mut buf = [0u8; MAX_DAY_NAME_LEN];
+        let buf = &mut buf[..bytes.len()];
+        buf.copy_from_slice(bytes);
+        buf.make_ascii_uppercase();
+        weekday_from_upper(buf)
+    } else {
+        // `str::to_uppercase` is Unicode-aware, matching Spark's
+        // `toUpperCase(Locale.ROOT)`. Handling non-ASCII input on the branch
+        // above would change which strings match, so it keeps the allocation.
+        weekday_from_upper(day_of_week.to_uppercase().as_bytes())
+    }
+}
+
+fn spark_next_day(days: i32, day_of_week: Weekday) -> Option<i32> {
     let date = Date32Type::to_naive_date_opt(days)?;
 
-    let day_of_week = day_of_week.to_uppercase();
-    let day_of_week = match day_of_week.as_str() {
-        "MO" | "MON" | "MONDAY" => Some("MONDAY"),
-        "TU" | "TUE" | "TUESDAY" => Some("TUESDAY"),
-        "WE" | "WED" | "WEDNESDAY" => Some("WEDNESDAY"),
-        "TH" | "THU" | "THURSDAY" => Some("THURSDAY"),
-        "FR" | "FRI" | "FRIDAY" => Some("FRIDAY"),
-        "SA" | "SAT" | "SATURDAY" => Some("SATURDAY"),
-        "SU" | "SUN" | "SUNDAY" => Some("SUNDAY"),
-        _ => {
-            // TODO: if spark.sql.ansi.enabled is false,
-            //  returns NULL instead of an error for a malformed dayOfWeek.
-            None
-        }
-    };
-
-    if let Some(day_of_week) = day_of_week {
-        let day_of_week = day_of_week.parse::<Weekday>();
-        match day_of_week {
-            Ok(day_of_week) => Some(Date32Type::from_naive_date(
-                date + Duration::days(
-                    (7 - date.weekday().days_since(day_of_week)) as i64,
-                ),
-            )),
-            Err(_) => {
-                // TODO: if spark.sql.ansi.enabled is false,
-                //  returns NULL instead of an error for a malformed dayOfWeek.
-                None
-            }
-        }
-    } else {
-        None
-    }
+    Some(Date32Type::from_naive_date(
+        date + Duration::days((7 - date.weekday().days_since(day_of_week)) as i64),
+    ))
 }
 
 #[cfg(test)]
@@ -282,7 +300,38 @@ mod tests {
 
     #[test]
     fn next_day_rejects_whitespace_padded_day_names() {
-        let monday = 19723; // 2024-01-01
-        assert_eq!(spark_next_day(monday, " MO "), None);
+        assert_eq!(parse_day_of_week(" MO "), None);
+    }
+
+    #[test]
+    fn parse_day_of_week_is_case_insensitive() {
+        for (input, expected) in [
+            ("mon", Weekday::Mon),
+            ("MONDAY", Weekday::Mon),
+            ("Tu", Weekday::Tue),
+            ("wEdNeSdAy", Weekday::Wed),
+            ("THU", Weekday::Thu),
+            ("fri", Weekday::Fri),
+            ("Sat", Weekday::Sat),
+            ("su", Weekday::Sun),
+        ] {
+            assert_eq!(parse_day_of_week(input), Some(expected), "input: {input}");
+        }
+    }
+
+    #[test]
+    fn parse_day_of_week_rejects_unknown_names() {
+        for input in ["", "M", "MOND", "WEDNESDAYS", "funday", "🙂"] {
+            assert_eq!(parse_day_of_week(input), None, "input: {input}");
+        }
+    }
+
+    /// The ASCII fast path must accept exactly what the Unicode-aware
+    /// `to_uppercase` accepts, since Spark upper-cases with `Locale.ROOT`.
+    #[test]
+    fn parse_day_of_week_matches_unicode_uppercasing() {
+        // U+017F LATIN SMALL LETTER LONG S upper-cases to 'S'.
+        assert_eq!(parse_day_of_week("\u{17f}un"), Some(Weekday::Sun));
+        assert_eq!(parse_day_of_week("\u{17f}unday"), Some(Weekday::Sun));
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

`spark_next_day` did a surprising amount of work per row to turn a day name into
a `Weekday`:

```rust
let day_of_week = day_of_week.to_uppercase();          // heap allocation + Unicode casing
let day_of_week = match day_of_week.as_str() {
    "MO" | "MON" | "MONDAY" => Some("MONDAY"),          // 21 literals
    ...
};
let day_of_week = day_of_week.parse::<Weekday>();       // second case-insensitive match
```

So every row allocated a `String`, matched it against 21 literals to produce
*another* string literal, and then re-parsed that literal back into the enum the
match had already identified.

On top of that, `next_day(col, 'MONDAY')` — the common form, where the day name
is a constant — ran all of the above once per row even though the answer is the
same for the whole batch.

## What changes are included in this PR?

- The literal match now yields a `Weekday` directly, so the round-trip through
  `"MONDAY"` and `parse::<Weekday>()` is gone.
- `parse_day_of_week` upper-cases ASCII input in a `[u8; 9]` stack buffer
  (`"WEDNESDAY"` is the longest accepted name, so anything longer cannot match
  and returns early). No allocation on this path.
- Non-ASCII input still goes through `str::to_uppercase`. That is deliberate:
  `to_uppercase` is Unicode-aware, matching Spark's `toUpperCase(Locale.ROOT)`,
  and handling it with ASCII casing would change which strings match. For
  example U+017F (`ſ`, long s) upper-cases to `S`, so `"ſun"` is accepted by
  Spark and by this function, on both the old and new code.
- `spark_next_day` now takes a `Weekday` rather than a `&str`, which lets the
  array-plus-scalar branch parse the name once before the loop instead of inside
  `unary_opt`.

No change to which inputs are accepted or what they return.

## Are these changes tested?

`spark/datetime/next_day.slt` asserts concrete dates across abbreviations, full
names, mixed case, invalid names, and NULL inputs; all 53 `spark/datetime`
sqllogictest files pass, along with the 261 `datafusion-spark` unit tests.

The existing `next_day_rejects_whitespace_padded_day_names` test now targets
`parse_day_of_week` directly, since that is where the rejection lives. Three
tests were added:

- `parse_day_of_week_is_case_insensitive` — abbreviations and full names in
  lower, upper, and mixed case.
- `parse_day_of_week_rejects_unknown_names` — empty, too short, too long
  (past the stack-buffer bound), non-day words, and non-ASCII.
- `parse_day_of_week_matches_unicode_uppercasing` — pins that the ASCII fast
  path and the Unicode fallback accept the same set, using the `ſ` → `S` case
  above. This is the test that would catch the fast path silently narrowing
  what `next_day` accepts.

The benchmark used below is added separately in #23882, so the baseline can be
measured on `main` before this change lands.

### Benchmarks

Criterion, `apache/main` @ `f1ab86dad` as baseline. Median of the reported
change interval.

| Benchmark | 1024 | 8192 |
| --- | --- | --- |
| `next_day/scalar_day` | −47.2% | −46.0% |
| `next_day/array_day` | −37.6% | −33.7% |

`scalar_day` is `next_day(col, 'MONDAY')`; `array_day` passes the day name as a
column, so it still parses per row and gains only from the allocation removal.

## Are there any user-facing changes?

No. `next_day` accepts the same inputs and returns the same results.
