### PR TITLE
fix(ffi): preserve aggregate null-handling support

### DIFF
--- a/datafusion/ffi/src/tests/mod.rs
+++ b/datafusion/ffi/src/tests/mod.rs
@@ -31,8 +31,9 @@ use datafusion_expr::{Expr, TableType};
 use datafusion_physical_plan::ExecutionPlan;
 use sync_provider::create_sync_table_provider;
 use udf_udaf_udwf::{
-    create_ffi_abs_func, create_ffi_random_func, create_ffi_rank_func,
-    create_ffi_stddev_func, create_ffi_sum_func, create_ffi_table_func,
+    create_ffi_abs_func, create_ffi_first_value_func, create_ffi_random_func,
+    create_ffi_rank_func, create_ffi_stddev_func, create_ffi_sum_func,
+    create_ffi_table_func,
 };
 
 use crate::catalog_provider::FFI_CatalogProvider;
@@ -117,6 +118,9 @@ pub struct ForeignLibraryModule {
     pub create_context_aware_optimizer_rule: extern "C" fn() -> FFI_PhysicalOptimizerRule,
 
     pub version: extern "C" fn() -> u64,
+
+    /// Create an aggregate UDAF using first_value
+    pub create_first_value_udaf: extern "C" fn() -> FFI_AggregateUDF,
 }
 
 pub fn create_test_schema() -> Arc<Schema> {
@@ -266,5 +270,6 @@ pub extern "C" fn datafusion_ffi_get_module() -> ForeignLibraryModule {
         create_context_aware_optimizer_rule:
             physical_optimizer::create_context_aware_optimizer_rule,
         version: super::version,
+        create_first_value_udaf: create_ffi_first_value_func,
     }
 }

--- a/datafusion/ffi/src/tests/udf_udaf_udwf.rs
+++ b/datafusion/ffi/src/tests/udf_udaf_udwf.rs
@@ -17,17 +17,21 @@
 
 use std::sync::Arc;
 
-use arrow_schema::DataType;
+use arrow_schema::{DataType, FieldRef};
 use datafusion_catalog::TableFunctionImpl;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{
-    AggregateUDF, ColumnarValue, ExpressionPlacement, ScalarFunctionArgs, ScalarUDF,
-    ScalarUDFImpl, Signature, Volatility, WindowUDF,
+    Accumulator, AggregateUDF, AggregateUDFImpl, ColumnarValue, ExpressionPlacement,
+    GroupsAccumulator, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+    Volatility, WindowUDF,
 };
 use datafusion_functions::math::abs::AbsFunc;
 use datafusion_functions::math::random::RandomFunc;
 use datafusion_functions_aggregate::stddev::Stddev;
 use datafusion_functions_aggregate::sum::Sum;
+use datafusion_functions_aggregate_common::accumulator::{
+    AccumulatorArgs, StateFieldsArgs,
+};
 use datafusion_functions_table::generate_series::RangeFunc;
 use datafusion_functions_window::rank::Rank;
 
@@ -170,8 +174,56 @@ pub(crate) extern "C" fn create_ffi_table_func(
     FFI_TableFunction::new_with_ffi_codec(udtf, None, codec)
 }
 
+#[derive(Debug, Default, Hash, Eq, PartialEq)]
+struct SumWithNullHandling {
+    inner: Sum,
+}
+
+impl AggregateUDFImpl for SumWithNullHandling {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn signature(&self) -> &Signature {
+        self.inner.signature()
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
+        self.inner.return_type(arg_types)
+    }
+
+    fn accumulator(
+        &self,
+        args: AccumulatorArgs,
+    ) -> datafusion_common::Result<Box<dyn Accumulator>> {
+        self.inner.accumulator(args)
+    }
+
+    fn state_fields(
+        &self,
+        args: StateFieldsArgs,
+    ) -> datafusion_common::Result<Vec<FieldRef>> {
+        self.inner.state_fields(args)
+    }
+
+    fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
+        self.inner.groups_accumulator_supported(args)
+    }
+
+    fn create_groups_accumulator(
+        &self,
+        args: AccumulatorArgs,
+    ) -> datafusion_common::Result<Box<dyn GroupsAccumulator>> {
+        self.inner.create_groups_accumulator(args)
+    }
+
+    fn supports_null_handling_clause(&self) -> bool {
+        true
+    }
+}
+
 pub(crate) extern "C" fn create_ffi_sum_func() -> FFI_AggregateUDF {
-    let udaf: Arc<AggregateUDF> = Arc::new(Sum::new().into());
+    let udaf: Arc<AggregateUDF> = Arc::new(SumWithNullHandling::default().into());
 
     udaf.into()
 }

--- a/datafusion/ffi/src/tests/udf_udaf_udwf.rs
+++ b/datafusion/ffi/src/tests/udf_udaf_udwf.rs
@@ -17,21 +17,18 @@
 
 use std::sync::Arc;
 
-use arrow_schema::{DataType, FieldRef};
+use arrow_schema::DataType;
 use datafusion_catalog::TableFunctionImpl;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{
-    Accumulator, AggregateUDF, AggregateUDFImpl, ColumnarValue, ExpressionPlacement,
-    GroupsAccumulator, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
-    Volatility, WindowUDF,
+    AggregateUDF, ColumnarValue, ExpressionPlacement, ScalarFunctionArgs, ScalarUDF,
+    ScalarUDFImpl, Signature, Volatility, WindowUDF,
 };
 use datafusion_functions::math::abs::AbsFunc;
 use datafusion_functions::math::random::RandomFunc;
+use datafusion_functions_aggregate::first_last::FirstValue;
 use datafusion_functions_aggregate::stddev::Stddev;
 use datafusion_functions_aggregate::sum::Sum;
-use datafusion_functions_aggregate_common::accumulator::{
-    AccumulatorArgs, StateFieldsArgs,
-};
 use datafusion_functions_table::generate_series::RangeFunc;
 use datafusion_functions_window::rank::Rank;
 
@@ -174,56 +171,14 @@ pub(crate) extern "C" fn create_ffi_table_func(
     FFI_TableFunction::new_with_ffi_codec(udtf, None, codec)
 }
 
-#[derive(Debug, Default, Hash, Eq, PartialEq)]
-struct SumWithNullHandling {
-    inner: Sum,
-}
-
-impl AggregateUDFImpl for SumWithNullHandling {
-    fn name(&self) -> &str {
-        self.inner.name()
-    }
-
-    fn signature(&self) -> &Signature {
-        self.inner.signature()
-    }
-
-    fn return_type(&self, arg_types: &[DataType]) -> datafusion_common::Result<DataType> {
-        self.inner.return_type(arg_types)
-    }
-
-    fn accumulator(
-        &self,
-        args: AccumulatorArgs,
-    ) -> datafusion_common::Result<Box<dyn Accumulator>> {
-        self.inner.accumulator(args)
-    }
-
-    fn state_fields(
-        &self,
-        args: StateFieldsArgs,
-    ) -> datafusion_common::Result<Vec<FieldRef>> {
-        self.inner.state_fields(args)
-    }
-
-    fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
-        self.inner.groups_accumulator_supported(args)
-    }
-
-    fn create_groups_accumulator(
-        &self,
-        args: AccumulatorArgs,
-    ) -> datafusion_common::Result<Box<dyn GroupsAccumulator>> {
-        self.inner.create_groups_accumulator(args)
-    }
-
-    fn supports_null_handling_clause(&self) -> bool {
-        true
-    }
-}
-
 pub(crate) extern "C" fn create_ffi_sum_func() -> FFI_AggregateUDF {
-    let udaf: Arc<AggregateUDF> = Arc::new(SumWithNullHandling::default().into());
+    let udaf: Arc<AggregateUDF> = Arc::new(Sum::new().into());
+
+    udaf.into()
+}
+
+pub(crate) extern "C" fn create_ffi_first_value_func() -> FFI_AggregateUDF {
+    let udaf: Arc<AggregateUDF> = Arc::new(FirstValue::new().into());
 
     udaf.into()
 }

--- a/datafusion/ffi/src/udaf/mod.rs
+++ b/datafusion/ffi/src/udaf/mod.rs
@@ -145,6 +145,10 @@ pub struct FFI_AggregateUDF {
     /// the foreign interface. See [`crate::get_library_marker_id`] and
     /// the crate's `README.md` for more information.
     pub library_marker_id: extern "C" fn() -> usize,
+
+    /// FFI equivalent to [`AggregateUDF::supports_null_handling_clause`]
+    pub supports_null_handling_clause:
+        unsafe extern "C" fn(udaf: &FFI_AggregateUDF) -> bool,
 }
 
 unsafe impl Send for FFI_AggregateUDF {}
@@ -327,6 +331,12 @@ unsafe extern "C" fn order_sensitivity_fn_wrapper(
     unsafe { udaf.inner().order_sensitivity().into() }
 }
 
+unsafe extern "C" fn supports_null_handling_clause_fn_wrapper(
+    udaf: &FFI_AggregateUDF,
+) -> bool {
+    unsafe { udaf.inner().supports_null_handling_clause() }
+}
+
 unsafe extern "C" fn coerce_types_fn_wrapper(
     udaf: &FFI_AggregateUDF,
     arg_types: SVec<WrappedSchema>,
@@ -401,6 +411,7 @@ impl From<Arc<AggregateUDF>> for FFI_AggregateUDF {
             release: release_fn_wrapper,
             private_data: Box::into_raw(private_data) as *mut c_void,
             library_marker_id: crate::get_library_marker_id,
+            supports_null_handling_clause: supports_null_handling_clause_fn_wrapper,
         }
     }
 }
@@ -595,6 +606,10 @@ impl AggregateUDFImpl for ForeignAggregateUDF {
         unsafe { (self.udaf.order_sensitivity)(&self.udaf).into() }
     }
 
+    fn supports_null_handling_clause(&self) -> bool {
+        unsafe { (self.udaf.supports_null_handling_clause)(&self.udaf) }
+    }
+
     fn simplify(&self) -> Option<AggregateFunctionSimplification> {
         None
     }
@@ -771,6 +786,19 @@ mod tests {
         let return_field = foreign_udaf.return_field(&[input_field])?;
 
         assert_eq!(&metadata, return_field.metadata());
+        Ok(())
+    }
+
+    #[test]
+    fn test_supports_null_handling_clause() -> Result<()> {
+        let first_value = create_test_foreign_udaf(
+            datafusion::functions_aggregate::first_last::FirstValue::new(),
+        )?;
+        assert!(first_value.supports_null_handling_clause());
+
+        let sum = create_test_foreign_udaf(Sum::new())?;
+        assert!(!sum.supports_null_handling_clause());
+
         Ok(())
     }
 

--- a/datafusion/ffi/tests/ffi_udaf.rs
+++ b/datafusion/ffi/tests/ffi_udaf.rs
@@ -66,6 +66,21 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_supports_null_handling_clause() -> Result<()> {
+        let module = get_module()?;
+
+        let ffi_sum_func = (module.create_sum_udaf)();
+        let foreign_sum_func: Arc<dyn AggregateUDFImpl> = (&ffi_sum_func).into();
+        assert!(foreign_sum_func.supports_null_handling_clause());
+
+        let ffi_stddev_func = (module.create_stddev_udaf)();
+        let foreign_stddev_func: Arc<dyn AggregateUDFImpl> = (&ffi_stddev_func).into();
+        assert!(!foreign_stddev_func.supports_null_handling_clause());
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_ffi_grouping_udaf() -> Result<()> {
         let module = get_module()?;

--- a/datafusion/ffi/tests/ffi_udaf.rs
+++ b/datafusion/ffi/tests/ffi_udaf.rs
@@ -70,13 +70,14 @@ mod tests {
     fn test_supports_null_handling_clause() -> Result<()> {
         let module = get_module()?;
 
+        let ffi_first_value_func = (module.create_first_value_udaf)();
+        let foreign_first_value_func: Arc<dyn AggregateUDFImpl> =
+            (&ffi_first_value_func).into();
+        assert!(foreign_first_value_func.supports_null_handling_clause());
+
         let ffi_sum_func = (module.create_sum_udaf)();
         let foreign_sum_func: Arc<dyn AggregateUDFImpl> = (&ffi_sum_func).into();
-        assert!(foreign_sum_func.supports_null_handling_clause());
-
-        let ffi_stddev_func = (module.create_stddev_udaf)();
-        let foreign_stddev_func: Arc<dyn AggregateUDFImpl> = (&ffi_stddev_func).into();
-        assert!(!foreign_stddev_func.supports_null_handling_clause());
+        assert!(!foreign_sum_func.supports_null_handling_clause());
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

Part of #22331.

## Rationale for this change

`ForeignAggregateUDF` inherits the default `supports_null_handling_clause`, so producer overrides are lost across the FFI boundary.

## What changes are included in this PR?

- Forward `supports_null_handling_clause` through `FFI_AggregateUDF`.
- Use `first_value` as the positive case and `sum` as the negative case in forced-foreign and dynamic-library tests.

## Are these changes tested?

- `cargo test -p datafusion-ffi --features integration-tests`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

The FFI ABI changes. Foreign libraries must rebuild against the new DataFusion version.