### PR TITLE
 refactor: move arrow integer hex dispatch to datafusion-common

### DIFF
--- a/datafusion/common/src/utils/hex.rs
+++ b/datafusion/common/src/utils/hex.rs
@@ -23,6 +23,8 @@
 //! integer, trimming leading zeros. All four take a [`HexCase`] to choose
 //! between lowercase and uppercase digits.
 
+use arrow::datatypes::ArrowNativeType;
+
 use crate::Result;
 use crate::error::_internal_err;
 
@@ -71,6 +73,44 @@ impl HexCase {
         }
     }
 }
+
+/// Trait for converting integer types to hexadecimal in a buffer
+pub trait ToHex: ArrowNativeType {
+    /// Writes the hex representation into `buf` and returns the written
+    /// subslice. Digits are right-aligned with leading zeros trimmed.
+    fn write_hex(self, case: HexCase, buf: &mut [u8; 16]) -> &[u8];
+}
+
+macro_rules! impl_to_hex_signed {
+    ($ty:ty) => {
+        impl ToHex for $ty {
+            #[inline(always)]
+            fn write_hex(self, case: HexCase, buf: &mut [u8; 16]) -> &[u8] {
+                encode_u64(self as i64 as u64, case, buf)
+            }
+        }
+    };
+}
+
+macro_rules! impl_to_hex_unsigned {
+    ($ty:ty) => {
+        impl ToHex for $ty {
+            #[inline(always)]
+            fn write_hex(self, case: HexCase, buf: &mut [u8; 16]) -> &[u8] {
+                encode_u64(self as u64, case, buf)
+            }
+        }
+    };
+}
+
+impl_to_hex_signed!(i8);
+impl_to_hex_signed!(i16);
+impl_to_hex_signed!(i32);
+impl_to_hex_signed!(i64);
+impl_to_hex_unsigned!(u8);
+impl_to_hex_unsigned!(u16);
+impl_to_hex_unsigned!(u32);
+impl_to_hex_unsigned!(u64);
 
 /// Appends the hex encoding of `bytes` to `out`.
 ///

--- a/datafusion/functions/src/string/to_hex.rs
+++ b/datafusion/functions/src/string/to_hex.rs
@@ -24,7 +24,7 @@ use arrow::datatypes::{
     Int64Type, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
 };
 use datafusion_common::cast::as_primitive_array;
-use datafusion_common::utils::hex::{HexCase, encode_u64};
+use datafusion_common::utils::hex::{HexCase, ToHex};
 use datafusion_common::{Result, ScalarValue, exec_err, internal_err};
 use datafusion_expr::{
     Coercion, ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
@@ -57,7 +57,7 @@ where
     // Process all values directly (including null slots - we write empty strings for nulls)
     // The null bitmap will mark which entries are actually null
     for value in integer_array.values() {
-        values.extend_from_slice(value.write_hex(&mut hex_buffer));
+        values.extend_from_slice(value.write_hex(HexCase::Lower, &mut hex_buffer));
         offsets.push(values.len() as i32);
     }
 
@@ -76,50 +76,10 @@ where
 #[inline]
 fn to_hex_scalar<T: ToHex>(value: T) -> String {
     let mut hex_buffer = [0u8; 16];
-    let hex = value.write_hex(&mut hex_buffer);
+    let hex = value.write_hex(HexCase::Lower, &mut hex_buffer);
     // SAFETY: hex holds only ASCII hex digits.
     unsafe { std::str::from_utf8_unchecked(hex).to_string() }
 }
-
-/// Trait for converting integer types to hexadecimal in a buffer
-trait ToHex: ArrowNativeType {
-    /// Writes the hex representation into `buf` and returns the written
-    /// subslice. Digits are right-aligned in `buf` with leading zeros trimmed.
-    fn write_hex(self, buf: &mut [u8; 16]) -> &[u8];
-}
-
-/// Signed values use their two's complement representation, matching a cast to
-/// the corresponding unsigned type.
-macro_rules! impl_to_hex_signed {
-    ($ty:ty) => {
-        impl ToHex for $ty {
-            #[inline]
-            fn write_hex(self, buf: &mut [u8; 16]) -> &[u8] {
-                encode_u64(self as i64 as u64, HexCase::Lower, buf)
-            }
-        }
-    };
-}
-
-macro_rules! impl_to_hex_unsigned {
-    ($ty:ty) => {
-        impl ToHex for $ty {
-            #[inline]
-            fn write_hex(self, buf: &mut [u8; 16]) -> &[u8] {
-                encode_u64(self as u64, HexCase::Lower, buf)
-            }
-        }
-    };
-}
-
-impl_to_hex_signed!(i8);
-impl_to_hex_signed!(i16);
-impl_to_hex_signed!(i32);
-impl_to_hex_signed!(i64);
-impl_to_hex_unsigned!(u8);
-impl_to_hex_unsigned!(u16);
-impl_to_hex_unsigned!(u32);
-impl_to_hex_unsigned!(u64);
 
 #[user_doc(
     doc_section(label = "String Functions"),

--- a/datafusion/spark/src/function/math/hex.rs
+++ b/datafusion/spark/src/function/math/hex.rs
@@ -28,7 +28,7 @@ use arrow::{
 use datafusion_common::cast::as_large_binary_array;
 use datafusion_common::cast::as_string_view_array;
 use datafusion_common::types::{NativeType, logical_int64, logical_string};
-use datafusion_common::utils::hex::{HexCase, encode_bytes_into, encode_u64};
+use datafusion_common::utils::hex::{HexCase, ToHex, encode_bytes_into};
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{
     DataFusionError,
@@ -184,7 +184,7 @@ fn hex_encode_int64(
     for v in iter {
         if let Some(num) = v {
             let mut temp = [0u8; 16];
-            let slice = encode_u64(num as u64, HexCase::Upper, &mut temp);
+            let slice = num.write_hex(HexCase::Upper, &mut temp);
             // SAFETY: slice contains only ASCII hex digests, which are valid UTF-8
             unsafe {
                 builder.append_value(from_utf8_unchecked(slice));


### PR DESCRIPTION
## Which issue does this PR close?

 - Closes #23811.

 ## Rationale for this change

 Share Arrow integer-to-hex dispatch between `to_hex` and Spark `hex`.

 ## What changes are included in this PR?
move tohex and integer implementations to common

 ## Are these changes tested?
Existing `to_hex` and spark `hex` tests cover both 

 ## Are there any user-facing changes?
No behavior change but ToHex is public now