### PR TITLE
perf: optimize `array_empty` udf

### DIFF
--- a/datafusion/functions-nested/src/empty.rs
+++ b/datafusion/functions-nested/src/empty.rs
@@ -131,7 +131,10 @@ fn general_array_empty<O: OffsetSizeTrait>(array: &ArrayRef) -> Result<ArrayRef>
     let (values, _) = output_buffer.into_parts();
 
     // Add the nulls
-    let result = BooleanArray::new(values, result.nulls().filter(|n| n.null_count() > 0).cloned());
+    let result = BooleanArray::new(
+        values,
+        result.nulls().filter(|n| n.null_count() > 0).cloned(),
+    );
 
     Ok(Arc::new(result))
 }

--- a/datafusion/functions-nested/src/empty.rs
+++ b/datafusion/functions-nested/src/empty.rs
@@ -122,9 +122,17 @@ fn array_empty_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 }
 
 fn general_array_empty<O: OffsetSizeTrait>(array: &ArrayRef) -> Result<ArrayRef> {
-    let result = as_generic_list_array::<O>(array)?
-        .iter()
-        .map(|arr| arr.map(|arr| arr.is_empty()))
-        .collect::<BooleanArray>();
+    let result = as_generic_list_array::<O>(array)?;
+    // No nulls, just look at the offsets
+    let is_empty_iter = result.offsets().lengths().map(|n| n == 0);
+    // SAFETY: this is safe since the iterator lengths is exact size and
+    // trusted - it maps over fixed known number of elements
+    let output_buffer = unsafe { BooleanArray::from_trusted_len_iter(is_empty_iter) };
+
+    let (values, _) = output_buffer.into_parts();
+
+    // Add the nulls
+    let result = BooleanArray::new(values, result.nulls().filter(|n| n.null_count() > 0).cloned());
+
     Ok(Arc::new(result))
 }

--- a/datafusion/functions-nested/src/empty.rs
+++ b/datafusion/functions-nested/src/empty.rs
@@ -123,7 +123,6 @@ fn array_empty_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 
 fn general_array_empty<O: OffsetSizeTrait>(array: &ArrayRef) -> Result<ArrayRef> {
     let result = as_generic_list_array::<O>(array)?;
-    // No nulls, just look at the offsets
     let is_empty_iter = result.offsets().lengths().map(|n| n == 0);
     // SAFETY: this is safe since the iterator lengths is exact size and
     // trusted - it maps over fixed known number of elements


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

I saw that `empty` implementation is inefficient.
I wrote review comments for more why inefficient.

there are some optimizations that do not require benchmark since they are obvious once you understand, this is one of them 

## What changes are included in this PR?
rewrote the function to be fast

## Are these changes tested?
existing tests

## Are there any user-facing changes?
no
