### PR TITLE
fix(common): preserve an exact zero through filter selectivity estimation

### DIFF
--- a/datafusion/common/src/stats.rs
+++ b/datafusion/common/src/stats.rs
@@ -195,8 +195,12 @@ impl Precision<usize> {
     /// Return the estimate of applying a filter with estimated selectivity
     /// `selectivity` to this Precision. A selectivity of `1.0` means that all
     /// rows are selected. A selectivity of `0.5` means half the rows are
-    /// selected. Will always return inexact statistics.
+    /// selected. An exact zero is preserved, since filtering an empty input
+    /// cannot produce rows; any other known value is demoted to inexact.
     pub fn with_estimated_selectivity(self, selectivity: f64) -> Self {
+        if self == Precision::Exact(0) {
+            return self;
+        }
         self.map(|v| ((v as f64 * selectivity).ceil()) as usize)
             .to_inexact()
     }
@@ -1200,6 +1204,44 @@ mod tests {
         assert_eq!(*exact_precision.get_value().unwrap(), 42);
         assert_eq!(*inexact_precision.get_value().unwrap(), 23);
         assert_eq!(absent_precision.get_value(), None);
+    }
+
+    #[test]
+    fn test_with_estimated_selectivity() {
+        // Filtering an empty input cannot produce rows, so the zero stays exact.
+        assert_eq!(
+            Precision::Exact(0).with_estimated_selectivity(0.5),
+            Precision::Exact(0)
+        );
+        assert_eq!(
+            Precision::Exact(0).with_estimated_selectivity(1.0),
+            Precision::Exact(0)
+        );
+
+        // Any other known value is scaled and demoted, since the selectivity is
+        // itself an estimate.
+        assert_eq!(
+            Precision::Exact(100).with_estimated_selectivity(0.5),
+            Precision::Inexact(50)
+        );
+        assert_eq!(
+            Precision::Exact(100).with_estimated_selectivity(1.0),
+            Precision::Inexact(100)
+        );
+        assert_eq!(
+            Precision::Exact(3).with_estimated_selectivity(0.5),
+            Precision::Inexact(2)
+        );
+
+        // An inexact zero is an estimate, not a proof, and stays inexact.
+        assert_eq!(
+            Precision::Inexact(0).with_estimated_selectivity(0.5),
+            Precision::Inexact(0)
+        );
+        assert_eq!(
+            Precision::<usize>::Absent.with_estimated_selectivity(0.5),
+            Precision::Absent
+        );
     }
 
     #[test]

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -384,7 +384,8 @@ impl FilterExec {
                     input_num_rows.with_estimated_selectivity(selectivity);
                 let mut cs = input_stats.to_inexact().column_statistics;
                 for (idx, col_stat) in cs.iter_mut().enumerate() {
-                    col_stat.byte_size = scale_byte_size(col_stat.byte_size, selectivity);
+                    col_stat.byte_size =
+                        col_stat.byte_size.with_estimated_selectivity(selectivity);
                     col_stat.null_count = if null_rejecting_columns.contains(&idx) {
                         Precision::Exact(0)
                     } else {
@@ -1030,16 +1031,6 @@ fn interval_bound_to_precision(
     }
 }
 
-/// Scales a column's `byte_size` by the estimated filter `selectivity`. An
-/// exact zero is preserved: an empty column stays exactly empty after
-/// filtering.
-fn scale_byte_size(byte_size: Precision<usize>, selectivity: f64) -> Precision<usize> {
-    match byte_size {
-        Precision::Exact(0) => Precision::Exact(0),
-        byte_size => byte_size.with_estimated_selectivity(selectivity),
-    }
-}
-
 /// Caps a row-bounded column statistic (a null count or distinct count) at the
 /// filtered row estimate, since a column cannot have more nulls or distinct
 /// values than it has rows. Known counts are demoted to inexact because the
@@ -1133,8 +1124,9 @@ fn collect_new_statistics(
                 } else {
                     cap_at_rows(input_column_stats[idx].null_count, filtered_num_rows)
                 };
-                let byte_size =
-                    scale_byte_size(input_column_stats[idx].byte_size, selectivity);
+                let byte_size = input_column_stats[idx]
+                    .byte_size
+                    .with_estimated_selectivity(selectivity);
                 ColumnStatistics {
                     null_count: capped_null_count,
                     max_value,
@@ -2910,6 +2902,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_filter_statistics_preserves_exactly_empty_input() -> Result<()> {
+        // A satisfiable predicate over an exactly empty input: the filter cannot
+        // produce rows, so the whole estimate stays exact.
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, true)]);
+        let input_stats = Statistics {
+            num_rows: Precision::Exact(0),
+            total_byte_size: Precision::Exact(0),
+            column_statistics: vec![ColumnStatistics {
+                null_count: Precision::Exact(0),
+                byte_size: Precision::Exact(0),
+                ..Default::default()
+            }],
+        };
+        let predicate = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("a", 0)),
+            Operator::Gt,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(5)))),
+        ));
+
+        let input = Arc::new(StatisticsExec::new(input_stats, schema));
+        let filter: Arc<dyn ExecutionPlan> =
+            Arc::new(FilterExec::try_new(predicate, input)?);
+        let statistics =
+            StatisticsContext::new().compute(filter.as_ref(), &StatisticsArgs::new())?;
+
+        assert_eq!(statistics.num_rows, Precision::Exact(0));
+        assert_eq!(statistics.total_byte_size, Precision::Exact(0));
+        assert_eq!(
+            statistics.column_statistics[0].byte_size,
+            Precision::Exact(0)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_filter_statistics_empty_input_equality_ndv_zero() -> Result<()> {
         let cases: Vec<(&str, Schema, Statistics, Arc<dyn PhysicalExpr>)> = vec![
             (
@@ -2963,12 +2991,12 @@ mod tests {
 
             assert_eq!(
                 statistics.num_rows,
-                Precision::Inexact(0),
+                Precision::Exact(0),
                 "case '{desc}': row count mismatch"
             );
             assert_eq!(
                 statistics.column_statistics[0].distinct_count,
-                Precision::Inexact(0),
+                Precision::Exact(0),
                 "case '{desc}': NDV should be capped at zero rows"
             );
         }


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #8227.

## Rationale for this change

`Precision::with_estimated_selectivity` always demoted to inexact, so `Exact(0)` became `Inexact(0)`. Scaling zero by any selectivity is still exactly zero: filtering a provably empty input cannot produce rows.

Because operators widen exact to inexact, emptiness could not propagate up a plan through statistics at all, it was lost at the first `FilterExec`. That operator already preserved the exact zero for a contradictory predicate and for column byte sizes, so the same fact came out exact or inexact depending on the path taken.

This is the same reasoning as #23670, which stops `FileScanConfig::statistics()` demoting an exact zero when a filter is present, applied one level up. The two are independent, but together they let a proof of emptiness survive from the scan through the filter.

## What changes are included in this PR?

- `with_estimated_selectivity` returns an exact zero unchanged. `Inexact(0)` is untouched: an estimate of zero is not a proof of zero.
- `scale_byte_size` in `filter.rs` is removed, subsumed by the above.

## Are these changes tested?

Yes. A unit test for the method, and a `FilterExec` test that a satisfiable predicate over an exactly empty input keeps `num_rows`, `total_byte_size` (proving that `scale_byte_size` can be safely removed) and column `byte_size` exact.

`test_filter_statistics_empty_input_equality_ndv_zero` asserted `Inexact(0)` and now asserts `Exact(0)`, which is expected.

## Are there any user-facing changes?

No breaking changes. `Precision::with_estimated_selectivity` is public and keeps its signature, but its documented contract changes: it previously stated it would always return inexact statistics, and it now preserves an exact zero. Callers relying on the old wording will see `Exact(0)` where they saw `Inexact(0)`. This is an improvement and could be arguably considered a bug-fix, so I consider this contract change justified.

`FilterExec` over a provably empty input therefore reports exact statistics, visible in `EXPLAIN` output that shows statistics.

----

Disclaimer: I used AI to assist in the code generation, I have manually reviewed the output and it matches my intention and understanding.
