### PR TITLE
perf: precompile formats in to_time

### DIFF
--- a/datafusion/functions/src/datetime/to_time.rs
+++ b/datafusion/functions/src/datetime/to_time.rs
@@ -22,7 +22,7 @@ use arrow::array::types::Time64NanosecondType;
 use arrow::array::{Array, PrimitiveArray, StringArrayType};
 use arrow::datatypes::DataType;
 use arrow::datatypes::DataType::*;
-use chrono::NaiveTime;
+use chrono::format::{Item, Parsed, StrftimeItems, parse};
 use datafusion_common::{Result, ScalarValue, exec_err};
 use datafusion_expr::{
     ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
@@ -141,6 +141,7 @@ impl ScalarUDFImpl for ToTimeFunc {
 /// Convert string arguments to time (standalone function, not a method on ToTimeFunc)
 fn string_to_time(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     let formats = collect_formats(args)?;
+    let formats = compile_formats(&formats);
 
     match &args[0] {
         ColumnarValue::Scalar(ScalarValue::Utf8(s))
@@ -207,10 +208,25 @@ fn timestamp_to_time(arg: &ColumnarValue) -> Result<ColumnarValue> {
     arg.cast_to(&Time64(arrow::datatypes::TimeUnit::Nanosecond), None)
 }
 
+struct CompiledTimeFormat<'a> {
+    source: &'a str,
+    items: Vec<Item<'a>>,
+}
+
+fn compile_formats<'a>(formats: &[&'a str]) -> Vec<CompiledTimeFormat<'a>> {
+    formats
+        .iter()
+        .map(|source| CompiledTimeFormat {
+            source,
+            items: StrftimeItems::new(source).collect(),
+        })
+        .collect()
+}
+
 /// Parse time array using the provided formats
 fn parse_time_array<'a, A: StringArrayType<'a>>(
     array: &A,
-    formats: &[&str],
+    formats: &[CompiledTimeFormat<'_>],
 ) -> Result<PrimitiveArray<Time64NanosecondType>> {
     let mut values = Vec::with_capacity(array.len());
     for i in 0..array.len() {
@@ -224,10 +240,12 @@ fn parse_time_array<'a, A: StringArrayType<'a>>(
 }
 
 /// Parse time string using provided formats
-fn parse_time_with_formats(s: &str, formats: &[&str]) -> Result<i64> {
+fn parse_time_with_formats(s: &str, formats: &[CompiledTimeFormat<'_>]) -> Result<i64> {
     for format in formats {
-        if let Ok(time) = NaiveTime::parse_from_str(s, format) {
-            // Use Arrow's time_to_time64ns function instead of custom implementation
+        let mut parsed = Parsed::new();
+        if parse(&mut parsed, s, format.items.iter()).is_ok()
+            && let Ok(time) = parsed.to_naive_time()
+        {
             return Ok(time_to_time64ns(time));
         }
     }
@@ -235,5 +253,8 @@ fn parse_time_with_formats(s: &str, formats: &[&str]) -> Result<i64> {
         "Error parsing '{}' as time. Tried formats: {:?}",
         s,
         formats
+            .iter()
+            .map(|format| format.source)
+            .collect::<Vec<_>>()
     )
 }

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -3524,6 +3524,7 @@ statement ok
 drop table time_strings;
 
 # Table input with multiple formats
+# `%Q` is intentionally invalid; subsequent formats should still be tried.
 query D rowsort
 select to_time(
     time_str,

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -3523,6 +3523,27 @@ select to_time(time_str) from time_strings;
 statement ok
 drop table time_strings;
 
+# Table input with multiple formats
+query D rowsort
+select to_time(
+    time_str,
+    '%Q',
+    '%H:%M:%S',
+    '%H-%M-%S',
+    '%H/%M/%S'
+) from (
+    values
+        ('12:30:45'),
+        ('14-25-30'),
+        ('09/05/01'),
+        (NULL)
+) as formatted_time_strings(time_str);
+----
+09:05:01
+12:30:45
+14:25:30
+NULL
+
 # Error cases
 
 query error Error parsing 'not_a_time' as time


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`to_time` previously parsed the Chrono format strings for every non-null input value. For array inputs, this repeated the same format parsing for each row in a batch.

This PR precompiles the format strings once per udf invocation and reuses the compiled format items while parsing each value.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Precompile and reuse the to_time format strings.
- Add tests for multiple formats and NULL values.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. Existing tests pass, and new slt coverage was added for multiple formats and NULL values.

## Are there any user-facing changes?

No. This is an internal performance optimization.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

## Benchmarks
```
group                      main                            optimize-to-time
-----                       ----------                             ----------------
to_time_10pct_nulls_100k    1.83      7.3±0.34ms        ? ?/sec    1.00      4.0±0.47ms        ? ?/sec
to_time_no_nulls_100k       1.82      7.9±0.33ms        ? ?/sec    1.00      4.4±0.42ms        ? ?/sec
```