### PR TITLE
test: improve `rpad` sqllogictest coverage

### DIFF
--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -667,9 +667,9 @@ true 5
 # rpad with string, length, and fill arrays in every string width
 query BBB
 SELECT
-  rpad(arrow_cast(column1, 'Utf8'), column2, arrow_cast(column3, 'Utf8')) = column4,
-  rpad(arrow_cast(column1, 'LargeUtf8'), column2, arrow_cast(column3, 'LargeUtf8')) = column4,
-  rpad(arrow_cast(column1, 'Utf8View'), column2, arrow_cast(column3, 'Utf8View')) = column4
+  rpad(arrow_cast(column1, 'Utf8'), column2, arrow_cast(column3, 'Utf8')) IS NOT DISTINCT FROM column4,
+  rpad(arrow_cast(column1, 'LargeUtf8'), column2, arrow_cast(column3, 'LargeUtf8')) IS NOT DISTINCT FROM column4,
+  rpad(arrow_cast(column1, 'Utf8View'), column2, arrow_cast(column3, 'Utf8View')) IS NOT DISTINCT FROM column4
 FROM (VALUES
   ('hi', 5, 'xy', 'hixyx'),
   ('abcdef', 3, 'z', 'abc'),
@@ -684,21 +684,21 @@ true true true
 true true true
 true true true
 true true true
-NULL NULL NULL
-NULL NULL NULL
-NULL NULL NULL
+true true true
+true true true
+true true true
 
 # rpad array path with the default fill
 query BBB
 SELECT
-  rpad(arrow_cast(column1, 'Utf8'), column2) = column3,
-  rpad(arrow_cast(column1, 'LargeUtf8'), column2) = column3,
-  rpad(arrow_cast(column1, 'Utf8View'), column2) = column3
+  rpad(arrow_cast(column1, 'Utf8'), column2) IS NOT DISTINCT FROM column3,
+  rpad(arrow_cast(column1, 'LargeUtf8'), column2) IS NOT DISTINCT FROM column3,
+  rpad(arrow_cast(column1, 'Utf8View'), column2) IS NOT DISTINCT FROM column3
 FROM (VALUES ('hi', 5, 'hi   '), ('abcdef', 3, 'abc'), (NULL, 5, NULL)) AS t(column1, column2, column3);
 ----
 true true true
 true true true
-NULL NULL NULL
+true true true
 
 # a large scalar target length skips the scalar fast path
 query I
@@ -707,16 +707,16 @@ SELECT character_length(rpad('x', 16385, 'a'));
 16385
 
 # invalid argument count/type and excessive target length
-query error DataFusion error:
+query error 'rpad' does not support zero arguments
 SELECT rpad();
 
-query error DataFusion error:
+query error No function matches the given name and argument types 'rpad\(Utf8\)'
 SELECT rpad('x');
 
-query error DataFusion error:
+query error No function matches the given name and argument types 'rpad\(Utf8, Int64, Utf8, Utf8\)'
 SELECT rpad('x', 2, 'y', 'z');
 
-query error DataFusion error:
+query error No function matches the given name and argument types 'rpad\(Utf8, Utf8\)'
 SELECT rpad('x', 'bad');
 
 query error rpad requested length 2147483648 too large

--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -710,13 +710,13 @@ SELECT character_length(rpad('x', 16385, 'a'));
 query error 'rpad' does not support zero arguments
 SELECT rpad();
 
-query error No function matches the given name and argument types 'rpad\(Utf8\)'
+query error Failed to coerce arguments to satisfy a call to 'rpad' function: coercion from Utf8 to the signature
 SELECT rpad('x');
 
-query error No function matches the given name and argument types 'rpad\(Utf8, Int64, Utf8, Utf8\)'
+query error Failed to coerce arguments to satisfy a call to 'rpad' function: coercion from Utf8, Int64, Utf8, Utf8 to the signature
 SELECT rpad('x', 2, 'y', 'z');
 
-query error No function matches the given name and argument types 'rpad\(Utf8, Utf8\)'
+query error Failed to coerce arguments to satisfy a call to 'rpad' function: coercion from Utf8, Utf8 to the signature
 SELECT rpad('x', 'bad');
 
 query error rpad requested length 2147483648 too large

--- a/datafusion/sqllogictest/test_files/string/string_literal.slt
+++ b/datafusion/sqllogictest/test_files/string/string_literal.slt
@@ -664,6 +664,64 @@ SELECT rpad('x', 5, 'e' || chr(769)) = 'x' || 'e' || chr(769) || 'e' || chr(769)
 ----
 true 5
 
+# rpad with string, length, and fill arrays in every string width
+query BBB
+SELECT
+  rpad(arrow_cast(column1, 'Utf8'), column2, arrow_cast(column3, 'Utf8')) = column4,
+  rpad(arrow_cast(column1, 'LargeUtf8'), column2, arrow_cast(column3, 'LargeUtf8')) = column4,
+  rpad(arrow_cast(column1, 'Utf8View'), column2, arrow_cast(column3, 'Utf8View')) = column4
+FROM (VALUES
+  ('hi', 5, 'xy', 'hixyx'),
+  ('abcdef', 3, 'z', 'abc'),
+  ('é', 4, '好', 'é好好好'),
+  ('hi', 5, '', 'hi'),
+  (NULL, 5, 'x', NULL),
+  ('hi', NULL, 'x', NULL),
+  ('hi', 5, NULL, NULL)
+) AS t(column1, column2, column3, column4);
+----
+true true true
+true true true
+true true true
+true true true
+NULL NULL NULL
+NULL NULL NULL
+NULL NULL NULL
+
+# rpad array path with the default fill
+query BBB
+SELECT
+  rpad(arrow_cast(column1, 'Utf8'), column2) = column3,
+  rpad(arrow_cast(column1, 'LargeUtf8'), column2) = column3,
+  rpad(arrow_cast(column1, 'Utf8View'), column2) = column3
+FROM (VALUES ('hi', 5, 'hi   '), ('abcdef', 3, 'abc'), (NULL, 5, NULL)) AS t(column1, column2, column3);
+----
+true true true
+true true true
+NULL NULL NULL
+
+# a large scalar target length skips the scalar fast path
+query I
+SELECT character_length(rpad('x', 16385, 'a'));
+----
+16385
+
+# invalid argument count/type and excessive target length
+query error DataFusion error:
+SELECT rpad();
+
+query error DataFusion error:
+SELECT rpad('x');
+
+query error DataFusion error:
+SELECT rpad('x', 2, 'y', 'z');
+
+query error DataFusion error:
+SELECT rpad('x', 'bad');
+
+query error rpad requested length 2147483648 too large
+SELECT rpad('x', 2147483648, 'y');
+
 query I
 SELECT char_length('')
 ----


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Codecov reports low test coverage for this function, so this PR adds more SLT tests for it.

The tests were AI-generated, and I manually verified that the results are correct.

See `Codecov` bot comment -> `☔ View full report in Codecov by Harness` -> `Indirect Changes` for the updated test coverage.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
