### PR TITLE
Add benchmarks for hashjoin candidate equality filtering

### DIFF
--- a/benchmarks/sql_benchmarks/hj/benchmarks/q24.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q24.benchmark
@@ -1,0 +1,31 @@
+name Q24
+group hj
+
+init sql_benchmarks/hj/init/set_config_no_stats.sql
+
+load sql_benchmarks/hj/init/load.sql
+
+assert I
+SELECT count(*) > 0 FROM lineitem
+----
+true
+
+expect_plan HashJoinExec
+
+run
+-- Q24: single-hot-bucket long string-key inner join.
+-- Build rows all share one long string key, so each matching probe row fans
+-- out to the whole build side. count(*) focuses the benchmark on hash match
+-- and equality filtering without buffering joined rows.
+-- Thresholds zeroed to force Partitioned mode (simulates absent row-count stats).
+SELECT count(*)
+FROM (
+  SELECT 'single_hot_bucket_string_join_key' as k
+  FROM supplier
+  WHERE s_suppkey <= 3000
+) s
+JOIN (
+  SELECT 'single_hot_bucket_string_join_key' as k
+  FROM lineitem
+  WHERE l_orderkey % 3000 = 0
+) l ON s.k = l.k;

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q25.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q25.benchmark
@@ -1,0 +1,33 @@
+name Q25
+group hj
+
+init sql_benchmarks/hj/init/set_config_no_stats.sql
+
+load sql_benchmarks/hj/init/load.sql
+
+assert I
+SELECT count(*) > 0 FROM lineitem
+----
+true
+
+expect_plan HashJoinExec
+
+run
+-- Q25: skewed high-fanout multi-column string-key inner join.
+-- This tracks candidate-pair filtering for composite keys: the first key is
+-- skewed and the second long string key must also be checked before emitting
+-- each match. count(*) isolates the match path.
+-- Thresholds zeroed to force Partitioned mode (simulates absent row-count stats).
+SELECT count(*)
+FROM (
+  SELECT CAST((s_suppkey % 256) + 1 AS INT) as k1,
+         'multi_column_high_fanout_key' as k2
+  FROM supplier
+  WHERE s_suppkey <= 20000
+) s
+JOIN (
+  SELECT CAST(1 AS INT) as k1,
+         'multi_column_high_fanout_key' as k2
+  FROM lineitem
+  WHERE l_orderkey % 250 = 0
+) l ON s.k1 = l.k1 AND s.k2 = l.k2;

--- a/benchmarks/src/hj.rs
+++ b/benchmarks/src/hj.rs
@@ -472,6 +472,52 @@ const HASH_QUERIES: &[HashJoinQuery] = &[
         probe_size: "2.3M_long_keys_count",
         isolate_partitioned_join: true,
     },
+    // Q24: single-hot-bucket long string-key inner join.
+    // Build rows all share one long string key, so each matching probe row fans
+    // out to the whole build side. The output is counted to focus on the hash
+    // match/equality path without buffering the joined rows.
+    HashJoinQuery {
+        sql: r###"SELECT count(*)
+        FROM (
+          SELECT 'single_hot_bucket_string_join_key' as k
+          FROM supplier
+          WHERE s_suppkey <= 3000
+        ) s
+        JOIN (
+          SELECT 'single_hot_bucket_string_join_key' as k
+          FROM lineitem
+          WHERE l_orderkey % 3000 = 0
+        ) l ON s.k = l.k"###,
+        density: 1.0,
+        prob_hit: 1.0,
+        build_size: "3K_(single_hot_bucket)",
+        probe_size: "20K_long_keys_count",
+        isolate_partitioned_join: true,
+    },
+    // Q25: skewed high-fanout multi-column string-key inner join.
+    // This tracks the same candidate-pair filtering path for composite join
+    // keys, where the first key is skewed and the second long string key must
+    // also be checked before emitting each match.
+    HashJoinQuery {
+        sql: r###"SELECT count(*)
+        FROM (
+          SELECT CAST((s_suppkey % 256) + 1 AS INT) as k1,
+                 'multi_column_high_fanout_key' as k2
+          FROM supplier
+          WHERE s_suppkey <= 20000
+        ) s
+        JOIN (
+          SELECT CAST(1 AS INT) as k1,
+                 'multi_column_high_fanout_key' as k2
+          FROM lineitem
+          WHERE l_orderkey % 250 = 0
+        ) l ON s.k1 = l.k1 AND s.k2 = l.k2"###,
+        density: 1.0,
+        prob_hit: 1.0,
+        build_size: "20K_(fanout~78_multi_key)",
+        probe_size: "240K_multi_key_count",
+        isolate_partitioned_join: true,
+    },
 ];
 
 impl RunOpt {


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #23237.

## Rationale for this change

Issue #23237 identifies hash join candidate equality filtering as a potential
performance bottleneck. Before changing that implementation, we need stable
benchmarks that reproduce the relevant workloads and let us measure the effect
of a proposed optimization independently.

The existing hash join benchmark suite covers high-fanout joins, but it does
not isolate these two cases:

1. A single hot hash bucket in which all build-side rows use the same long
   string key.
2. A skewed composite-key join in which candidate pairs must be checked across
   multiple key columns.

This PR intentionally adds only the benchmarks. The implementation change for
`equal_rows_arr` will be submitted separately so that the benchmark workloads
can be reviewed and established independently of the optimization.

## What changes are included in this PR?

This PR adds two hash join benchmarks:

- **Q24: single-hot-bucket long string-key join**
  - Creates 3,000 build-side rows with the same long string key.
  - Selects matching probe-side rows that use that same key.
  - Causes every selected probe row to fan out across the entire build-side
    bucket.
  - Uses `count(*)` so the benchmark emphasizes hash match and candidate
    equality processing without materializing and retaining the full joined
    output.

- **Q25: skewed composite-key join**
  - Uses an integer key and a long string key.
  - Distributes the build-side integer key over 256 values while all selected
    probe rows use one value.
  - Produces a high-fanout set of candidate matches for one integer-key value.
  - Requires the second string-key column to be checked as part of composite
    join-key equality.
  - Uses `count(*)` to focus the measurement on the join match path.

Both benchmarks:

- Assert that the input data is available.
- Assert that the physical plan contains `HashJoinExec`.
- Use the no-statistics configuration and force Partitioned hash join mode.
- Are registered in the `hj` benchmark runner with descriptive build/probe
  metadata.
- Can be used to compare the existing implementation against the follow-up
  optimization for #23237.

## Are these changes tested?

No hash join implementation is changed by this PR.


## Are there any user-facing changes?

No.