### PR TITLE
perf(aggregate): consecutive-keys (last-group) cache for GROUP BY on clustered data

### DIFF
--- a/datafusion/physical-expr-common/src/binary_map.rs
+++ b/datafusion/physical-expr-common/src/binary_map.rs
@@ -360,6 +360,19 @@ where
         // Ensure lengths are equivalent
         assert_eq!(values.len(), batch_hashes.len());
 
+        // Consecutive-keys fast path: real-world data frequently arrives
+        // with runs of identical values (time-ordered logs, clustered
+        // writes). Remembering the previous non-null row's value and
+        // payload lets a run reuse the payload with one (adjacent,
+        // cache-hot) byte comparison instead of a hash-table probe into
+        // a table that may not be cache-resident. A miss costs a single
+        // well-predicted compare. Same idea as ClickHouse's "consecutive
+        // keys optimization". Intervening nulls don't invalidate the
+        // cached mapping (the payload for a value never changes within
+        // one `insert_if_new` call or across calls).
+        let mut prev_value: Option<&[u8]> = None;
+        let mut prev_payload = V::default();
+
         for (value, &hash) in values.iter().zip(batch_hashes.iter()) {
             // handle null value
             let Some(value) = value else {
@@ -380,6 +393,17 @@ where
 
             // get the value as bytes
             let value: &[u8] = value.as_ref();
+
+            // Consecutive-keys fast path: the comparison reads bytes that
+            // were just scanned (adjacent rows in the same values buffer),
+            // so it is cache-hot; a hit skips the hash-table probe.
+            if let Some(prev) = prev_value
+                && prev == value
+            {
+                observe_payload_fn(prev_payload);
+                continue;
+            }
+
             let value_len = O::usize_as(value.len());
 
             // value is "small"
@@ -464,6 +488,8 @@ where
                     payload
                 }
             };
+            prev_value = Some(value);
+            prev_payload = payload;
             observe_payload_fn(payload);
         }
         // Check for overflow in offsets (if more data was sent than can be represented)
@@ -644,6 +670,41 @@ mod tests {
         assert_eq!(set.len(), 1);
         assert_eq!(set.non_null_len(), 0);
         assert_set(set, &[None]);
+    }
+
+    /// Runs of identical values (with interleaved nulls) must map to the
+    /// same payload as scattered occurrences — exercises the
+    /// consecutive-keys fast path in `insert_if_new_inner`.
+    #[test]
+    fn string_map_consecutive_keys_runs() {
+        let mut map: ArrowBytesMap<i32, i32> = ArrowBytesMap::new(OutputType::Utf8);
+        // runs: aaa aaa | null | aaa bbb bbb | long(>8B) x2 | aaa
+        let values: ArrayRef = Arc::new(StringArray::from(vec![
+            Some("aaa"),
+            Some("aaa"),
+            None,
+            Some("aaa"),
+            Some("bbb"),
+            Some("bbb"),
+            Some("longer_than_short_value_len"),
+            Some("longer_than_short_value_len"),
+            Some("aaa"),
+        ]));
+        let mut next = 0;
+        let mut seen = vec![];
+        map.insert_if_new(
+            &values,
+            |_| {
+                let id = next;
+                next += 1;
+                id
+            },
+            |id| seen.push(id),
+        );
+        // aaa=0, null=1, bbb=2, long=3; run members share ids, the "aaa"
+        // after the null and at the end still resolve to 0.
+        assert_eq!(seen, vec![0, 0, 1, 0, 2, 2, 3, 3, 0]);
+        assert_eq!(next, 4, "make_payload_fn must run once per distinct");
     }
 
     #[test]

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -270,6 +270,20 @@ where
         // Ensure lengths are equivalent
         assert_eq!(values.len(), self.hashes_buffer.len());
 
+        // Consecutive-keys fast path state: real-world data frequently
+        // arrives with runs of identical values (time-ordered logs,
+        // clustered writes), so remembering the previous non-null row's
+        // view and payload lets a run reuse the payload without probing
+        // the hash table. For inline views (len <= 12) the u128 view
+        // comparison is a complete equality check; for longer values the
+        // view still provides the length + 4-byte-prefix guards before a
+        // byte comparison of two adjacent (cache-hot) rows. A miss costs
+        // a couple of well-predicted compares. Same idea as ClickHouse's
+        // "consecutive keys optimization". Intervening nulls don't
+        // invalidate the cached mapping.
+        let mut prev: Option<(u128, usize)> = None;
+        let mut prev_payload = V::default();
+
         for i in 0..values.len() {
             let view_u128 = input_views[i];
             let hash = self.hashes_buffer[i];
@@ -292,6 +306,29 @@ where
 
             // Extract length from the view (first 4 bytes of u128 in little-endian)
             let len = view_u128 as u32;
+
+            // Consecutive-keys fast path (see comment above the loop).
+            if let Some((prev_view, prev_i)) = prev {
+                let equal = if len <= 12 {
+                    // Inline views embed the full value: u128 equality is
+                    // a complete equality check.
+                    view_u128 == prev_view
+                } else if prev_view as u32 == len
+                    && (prev_view >> 32) as u32 == (view_u128 >> 32) as u32
+                {
+                    // Length and 4-byte prefix (read from the views) matched;
+                    // compare the actual bytes of two adjacent, cache-hot rows.
+                    let cur: &[u8] = values.value(i).as_ref();
+                    let prv: &[u8] = values.value(prev_i).as_ref();
+                    cur == prv
+                } else {
+                    false
+                };
+                if equal {
+                    observe_payload_fn(prev_payload);
+                    continue;
+                }
+            }
 
             // Check if value already exists
             let maybe_payload = {
@@ -371,6 +408,8 @@ where
                     .insert_accounted(new_header, |h| h.hash, &mut self.map_size);
                 payload
             };
+            prev = Some((view_u128, i));
+            prev_payload = payload;
             observe_payload_fn(payload);
         }
     }
@@ -527,6 +566,38 @@ where
 mod tests {
     use arrow::array::{GenericByteViewArray, StringViewArray};
     use datafusion_common::HashMap;
+
+    /// Consecutive-keys fast path: runs of inline (<=12B) and non-inline
+    /// (>12B) values, with interleaved nulls, must produce the same
+    /// payload assignment as scattered occurrences.
+    #[test]
+    fn view_map_consecutive_keys_runs() {
+        let mut map: ArrowBytesViewMap<i32> =
+            ArrowBytesViewMap::new(OutputType::Utf8View);
+        let values: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("inline"),
+            Some("inline"),
+            None,
+            Some("inline"),
+            Some("this value is longer than twelve bytes"),
+            Some("this value is longer than twelve bytes"),
+            Some("this value is also longer, but different"),
+            Some("inline"),
+        ]));
+        let mut next = 0;
+        let mut seen = vec![];
+        map.insert_if_new(
+            &values,
+            |_| {
+                let id = next;
+                next += 1;
+                id
+            },
+            |id| seen.push(id),
+        );
+        assert_eq!(seen, vec![0, 0, 1, 0, 2, 2, 3, 0]);
+        assert_eq!(next, 4, "make_payload_fn must run once per distinct");
+    }
 
     use super::*;
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -32,6 +32,7 @@ use crate::aggregates::group_values::multi_group_by::{
     row_backed::RowsGroupColumn,
 };
 use arrow::array::{Array, ArrayRef, BooleanBufferBuilder};
+use arrow::buffer::BooleanBuffer;
 use arrow::compute::cast;
 use arrow::datatypes::{
     BinaryViewType, DataType, Date32Type, Date64Type, Decimal128Type, Field, Float32Type,
@@ -41,6 +42,7 @@ use arrow::datatypes::{
     TimestampNanosecondType, TimestampSecondType, UInt8Type, UInt16Type, UInt32Type,
     UInt64Type,
 };
+use arrow_ord::cmp::not_distinct;
 use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::{Result, internal_datafusion_err, not_impl_err};
@@ -52,6 +54,66 @@ use hashbrown::hash_table::HashTable;
 
 const NON_INLINED_FLAG: u64 = 0x8000000000000000;
 const VALUE_MASK: u64 = 0x7FFFFFFFFFFFFFFF;
+
+/// Minimum fraction of adjacent-hash-equal row pairs (1/16 ≈ 6%) for the
+/// consecutive-keys run mask to be worth computing. Below it, the mask's
+/// per-column comparison passes cost more than the probes they could skip.
+const RUN_MASK_MIN_HINT_DENOMINATOR: usize = 16;
+
+/// Returns a null-safe "row equals the previous row on every group column"
+/// mask when the batch looks run-heavy, `None` otherwise.
+///
+/// `mask[i] == true` means row `i + 1` equals row `i` on all columns, with
+/// `null == null` counting as equal (matching GROUP BY semantics, via
+/// [`not_distinct`]). Rows covered by the mask can reuse the previous row's
+/// group index and skip both the hash-table probe and (for high-cardinality
+/// keys) its likely cache miss — the same "consecutive keys optimization"
+/// ClickHouse ships, and the multi-column analogue of the single-column
+/// caches in `GroupValuesPrimitive` / `ArrowBytesMap`.
+///
+/// Cost control is a two-tier gate:
+/// - A single sequential scan counts adjacent *hash* matches (hash equality
+///   is a necessary condition for row equality). Shuffled inputs — e.g. the
+///   Final aggregation phase after hash repartitioning, where runs cannot
+///   survive — fail this gate and pay nothing beyond the scan itself.
+///   Correctness never rests on the hashes: they only decide whether the
+///   precise mask below is worth building.
+/// - Only run-heavy batches pay for the per-column vectorized
+///   [`not_distinct`] passes that build the precise mask.
+///
+/// Returns `None` (falling back to the normal per-row path) when the batch
+/// is too small, fails the gate, or a column type is not supported by
+/// [`not_distinct`] (e.g. nested types handled by `RowsGroupColumn`).
+fn adjacent_equal_run_mask(cols: &[ArrayRef], hashes: &[u64]) -> Option<BooleanBuffer> {
+    let n = hashes.len();
+    if n < 2 {
+        return None;
+    }
+
+    let run_hint = hashes.windows(2).filter(|w| w[0] == w[1]).count();
+    if run_hint * RUN_MASK_MIN_HINT_DENOMINATOR < n {
+        return None;
+    }
+
+    let mut mask: Option<BooleanBuffer> = None;
+    for col in cols {
+        let head = col.slice(0, n - 1);
+        let tail = col.slice(1, n - 1);
+        let eq = match not_distinct(&head, &tail) {
+            Ok(eq) => eq,
+            // e.g. nested types: fall back to the normal path
+            Err(_) => return None,
+        };
+        // `not_distinct` never returns nulls, so the values buffer is the
+        // complete answer.
+        let (buf, _nulls) = eq.into_parts();
+        mask = Some(match mask {
+            None => buf,
+            Some(acc) => &acc & &buf,
+        });
+    }
+    mask
+}
 
 /// Trait for storing a single column of group values in [`GroupValuesColumn`]
 ///
@@ -362,7 +424,25 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         batch_hashes.resize(n_rows, 0);
         create_hashes(cols, &self.random_state, batch_hashes)?;
 
+        // Consecutive-keys fast path (see `adjacent_equal_run_mask`). The
+        // streaming path benefits the most: sorted-on-group-keys input has
+        // perfect runs, so all but the first row of every group skip the
+        // probe below.
+        let run_mask = adjacent_equal_run_mask(cols, batch_hashes);
+
         for (row, &target_hash) in batch_hashes.iter().enumerate() {
+            if let Some(mask) = &run_mask
+                && row > 0
+                && mask.value(row - 1)
+            {
+                // Same key as the previous row: reuse its group index.
+                let prev_group = *groups
+                    .last()
+                    .expect("row > 0 implies a previous group index");
+                groups.push(prev_group);
+                continue;
+            }
+
             let entry = self
                 .map
                 .find_mut(target_hash, |(exist_hash, group_idx_view)| {
@@ -463,6 +543,11 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         batch_hashes.resize(n_rows, 0);
         create_hashes(cols, &self.random_state, &mut batch_hashes)?;
 
+        // Consecutive-keys fast path: rows equal to their predecessor reuse
+        // its group index (filled in a final pass below) and skip the map
+        // probe entirely. See `adjacent_equal_run_mask` for the gating.
+        let run_mask = adjacent_equal_run_mask(cols, &batch_hashes);
+
         // General steps for one round `vectorized equal_to & append`:
         //   1. Collect vectorized context by checking hash values of `cols` in `map`,
         //      mainly fill `vectorized_append_row_indices`, `vectorized_equal_to_row_indices`
@@ -484,7 +569,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         //
 
         // 1. Collect vectorized context by checking hash values of `cols` in `map`
-        self.collect_vectorized_process_context(&batch_hashes, groups);
+        self.collect_vectorized_process_context(&batch_hashes, groups, run_mask.as_ref());
 
         // 2. Perform `vectorized_append`
         self.vectorized_append(cols)?;
@@ -495,6 +580,20 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         // 4. Perform scalarized inter for remaining rows
         // (about remaining rows, can see comments for `remaining_row_indices`)
         self.scalarized_intern_remaining(cols, &batch_hashes, groups)?;
+
+        // 5. Fill the rows skipped by the consecutive-keys fast path with
+        // their predecessor's group index. Ascending order makes multi-row
+        // runs propagate forward from the run head, which was resolved by
+        // the normal path above.
+        if let Some(mask) = run_mask {
+            for row in 1..n_rows {
+                if mask.value(row - 1) {
+                    debug_assert_eq!(groups[row], usize::MAX);
+                    debug_assert_ne!(groups[row - 1], usize::MAX);
+                    groups[row] = groups[row - 1];
+                }
+            }
+        }
 
         self.hashes_buffer = batch_hashes;
 
@@ -518,6 +617,7 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
         &mut self,
         batch_hashes: &[u64],
         groups: &mut [usize],
+        run_mask: Option<&BooleanBuffer>,
     ) {
         self.vectorized_operation_buffers.append_row_indices.clear();
         self.vectorized_operation_buffers
@@ -528,6 +628,15 @@ impl<const STREAMING: bool> GroupValuesColumn<STREAMING> {
             .clear();
 
         for (row, &target_hash) in batch_hashes.iter().enumerate() {
+            // Consecutive-keys fast path: this row equals its predecessor on
+            // every group column; it reuses the predecessor's group index in
+            // the final fill pass of `vectorized_intern` and needs no probe.
+            if let Some(mask) = run_mask
+                && row > 0
+                && mask.value(row - 1)
+            {
+                continue;
+            }
             let entry = self
                 .map
                 .find(target_hash, |(exist_hash, _)| target_hash == *exist_hash);
@@ -1658,6 +1767,92 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Consecutive-keys fast path on the multi-column paths: a run only
+    /// counts when EVERY column matches its predecessor (with null == null
+    /// being equal, per GROUP BY semantics). Covers both the vectorized
+    /// (`STREAMING = false`) and scalarized (`STREAMING = true`) interns —
+    /// both must produce identical group assignments to a run-free shuffle
+    /// of the same values.
+    #[test]
+    fn test_intern_consecutive_keys_multi_column() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8View, true),
+        ]));
+
+        // Runs designed to hit every interesting case:
+        //   rows 0-1: identical on both cols (run)
+        //   row 2:    `a` continues the run but `b` changes → NOT a run
+        //   row 3:    identical to row 2 (run)
+        //   row 4:    null in both cols
+        //   row 5:    null in both cols again → null == null run
+        //   row 6:    same `a` as 5 is null vs 1 → not a run
+        let col_a: ArrayRef = Arc::new(Int64Array::from(vec![
+            Some(1),
+            Some(1),
+            Some(1),
+            Some(1),
+            None,
+            None,
+            Some(1),
+        ]));
+        let col_b: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("x"),
+            Some("x"),
+            Some("y"),
+            Some("y"),
+            None,
+            None,
+            Some("x"),
+        ]));
+        let cols = vec![col_a, col_b];
+
+        // Expected groups: (1,x)=0, (1,y)=1, (null,null)=2, (1,x)=0 again
+        let expected = vec![0, 0, 1, 1, 2, 2, 0];
+
+        // Vectorized path
+        let mut vectorized =
+            GroupValuesColumn::<false>::try_new(Arc::clone(&schema)).unwrap();
+        let mut groups = vec![];
+        // Repeat the batch: the second pass exercises "run head found in
+        // existing map" (equal_to path) rather than append.
+        for _ in 0..2 {
+            vectorized.intern(&cols, &mut groups).unwrap();
+            assert_eq!(groups, expected, "vectorized path");
+        }
+        assert_eq!(vectorized.len(), 3);
+
+        // Scalarized (streaming) path
+        let mut scalarized =
+            GroupValuesColumn::<true>::try_new(Arc::clone(&schema)).unwrap();
+        for _ in 0..2 {
+            scalarized.intern(&cols, &mut groups).unwrap();
+            assert_eq!(groups, expected, "scalarized path");
+        }
+        assert_eq!(scalarized.len(), 3);
+    }
+
+    /// The run mask is gated on an adjacent-hash heuristic; a batch with no
+    /// runs at all must take the normal path and still be correct.
+    #[test]
+    fn test_intern_consecutive_keys_no_runs() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8View, true),
+        ]));
+        let col_a: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3, 4, 1, 2, 3, 4]));
+        let col_b: ArrayRef = Arc::new(StringViewArray::from(vec![
+            "p", "q", "r", "s", "p", "q", "r", "s",
+        ]));
+        let cols = vec![col_a, col_b];
+
+        let mut gv = GroupValuesColumn::<false>::try_new(schema).unwrap();
+        let mut groups = vec![];
+        gv.intern(&cols, &mut groups).unwrap();
+        assert_eq!(groups, vec![0, 1, 2, 3, 0, 1, 2, 3]);
+        assert_eq!(gv.len(), 4);
     }
 
     #[test]

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -116,6 +116,23 @@ pub struct GroupValuesPrimitive<T: ArrowPrimitiveType> {
     values: Vec<T::Native>,
     /// The random state used to generate hashes
     random_state: RandomState,
+    /// The key interned by the previous non-null row (canonicalized).
+    /// Valid only when `last_group != usize::MAX`.
+    ///
+    /// Real-world data frequently arrives with runs of identical keys
+    /// (time-ordered logs, clustered writes), so remembering the previous
+    /// row's `(key, group)` lets `intern` skip both the hash computation
+    /// and the hash-table probe for every row of a run after the first —
+    /// one register compare against state that stays in L1 instead of a
+    /// random access into a table that does not. Same idea as
+    /// ClickHouse's "consecutive keys optimization". A miss costs a
+    /// single well-predicted compare, so the break-even hit rate is
+    /// far below 1%.
+    last_key: T::Native,
+    /// Group index of `last_key`; `usize::MAX` means "no cached key".
+    /// Invalidated on `emit` / `clear_shrink` because both reassign
+    /// group indices.
+    last_group: usize,
 }
 
 impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T> {
@@ -127,6 +144,8 @@ impl<T: ArrowPrimitiveType> GroupValuesPrimitive<T> {
             values: Vec::with_capacity(128),
             null_group: None,
             random_state: crate::aggregates::AGGREGATION_HASH_SEED,
+            last_key: Default::default(),
+            last_group: usize::MAX,
         }
     }
 }
@@ -151,6 +170,15 @@ where
                     // so the bit-equal `is_eq` matches and the stored value is
                     // the canonical representative.
                     let key = key.canonicalize();
+
+                    // Consecutive-keys fast path: if this row's key equals
+                    // the previous row's, reuse its group index and skip
+                    // both the hash and the table probe entirely.
+                    if self.last_group != usize::MAX && key.is_eq(self.last_key) {
+                        groups.push(self.last_group);
+                        continue;
+                    }
+
                     let state = &self.random_state;
                     let hash = key.hash(state);
                     let insert = self.map.entry(
@@ -161,7 +189,7 @@ where
                         |&(_, h)| h,
                     );
 
-                    match insert {
+                    let g = match insert {
                         hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
                         hashbrown::hash_table::Entry::Vacant(v) => {
                             let g = self.values.len();
@@ -169,7 +197,10 @@ where
                             self.values.push(key);
                             g
                         }
-                    }
+                    };
+                    self.last_key = key;
+                    self.last_group = g;
+                    g
                 }
             };
             groups.push(group_id)
@@ -190,6 +221,11 @@ where
     }
 
     fn emit(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
+        // Both emit modes reassign group indices (All clears them,
+        // First(n) shifts them down by n), so the consecutive-keys cache
+        // must be invalidated.
+        self.last_group = usize::MAX;
+
         fn build_primitive<T: ArrowPrimitiveType>(
             values: Vec<T::Native>,
             null_idx: Option<usize>,
@@ -244,6 +280,7 @@ where
         self.values.shrink_to(num_rows);
         self.map.clear();
         self.map.shrink_to(num_rows, |_| 0); // hasher does not matter since the map is cleared
+        self.last_group = usize::MAX;
     }
 }
 
@@ -255,6 +292,43 @@ mod tests {
     use arrow::datatypes::DataType;
     use datafusion_expr::EmitTo;
     use std::sync::Arc;
+
+    /// Consecutive-keys fast path: runs (with interleaved nulls) map to the
+    /// same group ids as scattered occurrences, and `emit(First(n))` must
+    /// invalidate the cache (group indices shift down by `n`, so a stale
+    /// `last_group` would assign wrong ids).
+    #[test]
+    fn consecutive_keys_runs_and_emit_invalidation() -> Result<()> {
+        let mut gv = GroupValuesPrimitive::<Int32Type>::new(DataType::Int32);
+
+        let arr: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(7),
+            Some(7),
+            None,
+            Some(7),
+            Some(9),
+            Some(9),
+        ]));
+        let mut groups = vec![];
+        gv.intern(&[arr], &mut groups)?;
+        // 7=0, null=1, 9=2; run members and the post-null 7 share ids
+        assert_eq!(groups, vec![0, 0, 1, 0, 2, 2]);
+
+        // Emit the first 2 groups: "7"->gone, "null"->gone, "9" shifts 2->0.
+        gv.emit(EmitTo::First(2))?;
+
+        // Re-intern a run of 9s followed by 7s. A stale cache would claim
+        // "7 is still group 0" — but group 0 is now "9".
+        let arr2: ArrayRef = Arc::new(Int32Array::from(vec![9, 9, 7, 7]));
+        gv.intern(&[arr2], &mut groups)?;
+        assert_eq!(
+            groups,
+            vec![0, 0, 1, 1],
+            "9 is group 0 after shift; 7 is new group 1"
+        );
+
+        Ok(())
+    }
 
     /// Mirror of the `EmitTo::take_needed` regression test, applied to the
     /// concrete `GroupValuesPrimitive` accumulator.


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #23937 (the adaptive-disable follow-up listed there is superseded by the per-batch hash gate for the multi-column path; a persistent-state variant for the single-column paths can be a follow-up if benchmarks warrant it).

## Rationale for this change

`GroupValues::intern` pays the full hash + hash-table-probe cost for every input row, even when a row's group key equals the previous row's. For high-cardinality keys the table is far too large to stay cache-resident, so each probe is typically an L3/DRAM round trip.

Real-world data very often arrives with **runs of identical keys** (time-ordered logs, clustered writes). Measured on ClickBench `hits.parquet` in file order — which is what the Partial aggregation phase sees, since it runs before repartitioning:

| column | avg run length | consecutive-keys hit rate |
|---|---:|---:|
| CounterID | 58,693 | ~100% |
| OS | 15.6 | 93.6% |
| SearchPhrase | 11.7 | 91.5% |
| RegionID | 11.0 | 90.9% |
| UserID | 10.1 | 90.1% |
| URL | 1.4 | 30.2% |

Remembering the previous row's key and group index lets a run reuse the answer: a hit replaces a random memory access with one or two well-predicted compares against L1-resident state; a miss costs a single compare. Break-even hit rate is under 1%. This is the same optimization ClickHouse ships as its *consecutive keys optimization* (`LastElementCache` in `ColumnsHashing`, refined in [ClickHouse#57872](https://github.com/ClickHouse/ClickHouse/pull/57872)).

The win scales with `hit rate × probe cost`: Q33's URL table is the largest string hash table, so even a 30% hit rate pays the most per skipped probe, while Q27's ~6K-entry CounterID table is L1/L2-resident and gains little at ~100% hit rate.

## What changes are included in this PR?

Four implementations, one per intern path:

- **`GroupValuesPrimitive`** (single primitive key): cache `(last_key, last_group)` fields; the guard compares the canonicalized value itself, so a hit skips the hash as well as the probe. Invalidated in `emit` / `clear_shrink` since both reassign group indices.
- **`ArrowBytesMap::insert_if_new_inner`** (single `Utf8` / `LargeUtf8` / `Binary` key via `GroupValuesBytes`; also used by distinct-aggregate accumulators, which benefit for free): compare the current row's bytes against the previous input row's — adjacent rows in the same values buffer, so the comparison is cache-hot. Per-call state, no invalidation concerns.
- **`ArrowBytesViewMap::insert_if_new_inner`** (single `Utf8View` / `BinaryView` key via `GroupValuesBytesView`): for inline views (len ≤ 12) the u128 view comparison is a complete equality check; longer values get length + 4-byte-prefix guards from the views before touching bytes.
- **`GroupValuesColumn`** (multi-column keys, both the vectorized and streaming interns): a batch-level adjacent-equality mask (`not_distinct` per column, AND-ed — `null == null` counts as equal, matching GROUP BY semantics), guarded by a two-tier gate: a sequential scan over the already-computed hashes counts adjacent hash matches, and only run-heavy batches (≥ ~6%) build the precise mask. Shuffled inputs — e.g. the Final phase after hash repartitioning — fail the gate and pay nothing beyond that one scan. Correctness never rests on the hashes; they only decide whether the mask is worth building. Nested-type columns (handled by `RowsGroupColumn`) make the helper return `None` and fall back to the normal path.

  Integration is deliberately non-invasive to the vectorized machinery: masked rows are skipped in `collect_vectorized_process_context` (they enter none of the append / equal-to / remaining lists), and a final ascending fill pass assigns each one its predecessor's group index.

Intervening nulls do not invalidate any of the caches (a value's group never changes within an accumulation), and the make-payload-once / observe-per-row-in-order contract of the byte maps is preserved.

## Are these changes tested?

- `consecutive_keys_runs_and_emit_invalidation` (primitive): runs with interleaved nulls, plus the `emit(First(n))` index-shift trap — a stale cache would assign shifted group ids.
- `string_map_consecutive_keys_runs` / `view_map_consecutive_keys_runs`: payload-assignment equality between run and scattered occurrences, interleaved nulls, inline and non-inline string lengths, `make_payload_fn` called exactly once per distinct.
- `test_intern_consecutive_keys_multi_column`: identical group assignments on both intern paths, including the "one column runs while the other breaks the run" case and `null == null` runs; `test_intern_consecutive_keys_no_runs` exercises the gate fallback.
- Probe-verified (temporary `eprintln`) that the fast path fires for exactly the designed rows on both multi-column paths and that the gate rejects the no-runs batch.
- Full `aggregates::` suite (158), `datafusion-physical-expr-common` suite (77), and workspace clippy with `-D warnings` all pass.

## Are there any user-facing changes?

No API changes. Local ClickBench numbers (hits.parquet, 5–8 iterations, `release-nonlto`, macOS ARM, both binaries built from this branch's base commit) — CI benchmarks to confirm:

| query | GROUP BY | delta |
|---|---|---|
| Q33 | URL | **−18.0%** |
| Q18 | UserID, m, SearchPhrase | **−10.8%** |
| Q15 | UserID | **−10.7%** |
| Q32 | WatchID, ClientIP | −10.2% |
| Q12 | SearchPhrase | −8.2% |
| Q7 | AdvEngineID | −6.2% |
| Q17 | UserID, SearchPhrase | −5.4% |
| Q27 | CounterID | −4.8% |
| Q16 | UserID, SearchPhrase | −3.0% |
| Q13 | (COUNT DISTINCT rewrite, untouched path) | noise ±3% |

No regressions observed; queries whose plans don't touch these paths are unchanged.
