### PR TITLE
docs: Fixes incorrect type name in `UserDefinedLogicalNode` comment

### DIFF
--- a/datafusion/expr/src/logical_plan/extension.rs
+++ b/datafusion/expr/src/logical_plan/extension.rs
@@ -314,7 +314,7 @@ pub trait UserDefinedLogicalNodeCore:
     }
 }
 
-/// Automatically derive UserDefinedLogicalNode to `UserDefinedLogicalNode`
+/// Automatically derive `UserDefinedLogicalNode` from `UserDefinedLogicalNodeCore`
 /// to avoid boiler plate for implementing `as_any`, `Hash`, `PartialEq` and `PartialOrd`.
 impl<T: UserDefinedLogicalNodeCore> UserDefinedLogicalNode for T {
     fn as_any(&self) -> &dyn Any {


### PR DESCRIPTION
## Which issue does this PR close?

- N/A. This fixes a trivial doc comment. No issue filed.

## Rationale for this change

The doc comment in `datafusion/expr/src/logical_plan/extension.rs` incorrectly said it "derives UserDefinedLogicalNode to `UserDefinedLogicalNode`" ( It named the same type twice ). This PR fixes this trivial documentation. 

## What changes are included in this PR?

A single line containing the documentation fix, which corrects the source trait name from `UserDefinedLogicalNode` to `UserDefinedLogicalNodeCore`.

## Are these changes tested?

No tests needed as this is a comment-only change.

## Are there any user-facing changes?

No.
