### PR TITLE
fix: reject nested arrays in array_distance

### DIFF
--- a/datafusion/functions-nested/src/distance.rs
+++ b/datafusion/functions-nested/src/distance.rs
@@ -18,9 +18,7 @@
 //! [ScalarUDFImpl] definitions for array_distance function.
 
 use crate::utils::make_scalar_function;
-use arrow::array::{
-    Array, ArrayRef, Float64Array, LargeListArray, ListArray, OffsetSizeTrait,
-};
+use arrow::array::{Array, ArrayRef, Float64Array, OffsetSizeTrait};
 use arrow::datatypes::{
     DataType,
     DataType::{FixedSizeList, LargeList, List, Null},
@@ -35,7 +33,6 @@ use datafusion_expr::{
     ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     Volatility,
 };
-use datafusion_functions::downcast_arg;
 use datafusion_macros::user_doc;
 use itertools::Itertools;
 use std::sync::Arc;
@@ -44,13 +41,13 @@ make_udf_expr_and_func!(
     ArrayDistance,
     array_distance,
     array,
-    "returns the Euclidean distance between two numeric arrays.",
+    "returns the Euclidean distance between two one-dimensional numeric arrays.",
     array_distance_udf
 );
 
 #[user_doc(
     doc_section(label = "Array Functions"),
-    description = "Returns the Euclidean distance between two input arrays of equal length.",
+    description = "Returns the Euclidean distance between two one-dimensional input arrays of equal length.",
     syntax_example = "array_distance(array1, array2)",
     sql_example = r#"```sql
 > select array_distance([1, 2], [1, 4]);
@@ -106,16 +103,30 @@ impl ScalarUDFImpl for ArrayDistance {
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         let [_, _] = take_function_args(self.name(), arg_types)?;
         let coercion = Some(&ListCoercion::FixedSizedListToList);
-        let arg_types = arg_types.iter().map(|arg_type| {
-            if matches!(arg_type, Null | List(_) | LargeList(_) | FixedSizeList(..)) {
+        let arg_types = arg_types.iter().map(|arg_type| match arg_type {
+            Null => Ok(coerced_type_with_base_type_only(
+                arg_type,
+                &DataType::Float64,
+                coercion,
+            )),
+            List(field) | LargeList(field) | FixedSizeList(field, _) => {
+                // Distance between nested lists is not supported
+                if matches!(
+                    field.data_type(),
+                    List(_) | LargeList(_) | FixedSizeList(..)
+                ) {
+                    return plan_err!(
+                        "{} only supports one-dimensional arrays, got {arg_type}",
+                        self.name()
+                    );
+                }
                 Ok(coerced_type_with_base_type_only(
                     arg_type,
                     &DataType::Float64,
                     coercion,
                 ))
-            } else {
-                plan_err!("{} does not support type {arg_type}", self.name())
             }
+            _ => plan_err!("{} does not support type {arg_type}", self.name()),
         });
 
         arg_types.try_collect()
@@ -171,43 +182,6 @@ fn compute_array_distance(
         Some(arr) => arr,
         None => return Ok(None),
     };
-
-    let mut value1 = value1;
-    let mut value2 = value2;
-
-    loop {
-        match value1.data_type() {
-            List(_) => {
-                if downcast_arg!(value1, ListArray).null_count() > 0 {
-                    return Ok(None);
-                }
-                value1 = downcast_arg!(value1, ListArray).value(0);
-            }
-            LargeList(_) => {
-                if downcast_arg!(value1, LargeListArray).null_count() > 0 {
-                    return Ok(None);
-                }
-                value1 = downcast_arg!(value1, LargeListArray).value(0);
-            }
-            _ => break,
-        }
-
-        match value2.data_type() {
-            List(_) => {
-                if downcast_arg!(value2, ListArray).null_count() > 0 {
-                    return Ok(None);
-                }
-                value2 = downcast_arg!(value2, ListArray).value(0);
-            }
-            LargeList(_) => {
-                if downcast_arg!(value2, LargeListArray).null_count() > 0 {
-                    return Ok(None);
-                }
-                value2 = downcast_arg!(value2, LargeListArray).value(0);
-            }
-            _ => break,
-        }
-    }
 
     // Check for NULL values inside the arrays
     if value1.null_count() != 0 || value2.null_count() != 0 {

--- a/datafusion/sqllogictest/test_files/array/array_length.slt
+++ b/datafusion/sqllogictest/test_files/array/array_length.slt
@@ -159,21 +159,6 @@ select array_distance([2], [3]), list_distance([1], [2]), list_distance([1], [-2
 query error
 select list_distance([1], [1, 2]);
 
-query R
-select array_distance([[1, 1]], [1, 2]);
-----
-1
-
-query R
-select array_distance([[1, 1]], [[1, 2]]);
-----
-1
-
-query R
-select array_distance([[1, 1]], [[1, 2]]);
-----
-1
-
 query RR
 select array_distance([1, 1, 0, 0], [2, 2, 1, 1]), list_distance([1, 2, 3], [1, 2, 3]);
 ----
@@ -203,6 +188,40 @@ query R
 select list_distance([1, 2, 3], [1, 2, 3]) AS distance;
 ----
 0
+
+# array_distance with null outer arrays
+query RR
+select
+  array_distance(arrow_cast(NULL, 'List(Float64)'), [1, 2]),
+  array_distance([1, 2], arrow_cast(NULL, 'List(Float64)'));
+----
+NULL NULL
+
+# invalid argument count and types
+query error DataFusion error: Error during planning: Execution error: Function 'array_distance' user-defined coercion failed with: Execution error: array_distance function requires 2 arguments
+select array_distance();
+
+query error DataFusion error: Error during planning: Execution error: Function 'array_distance' user-defined coercion failed with: Execution error: array_distance function requires 2 arguments
+select array_distance([1]);
+
+query error DataFusion error: Error during planning: Execution error: Function 'array_distance' user-defined coercion failed with: Execution error: array_distance function requires 2 arguments
+select array_distance([1], [2], [3]);
+
+query error array_distance does not support type Int64
+select array_distance(1, [1]);
+
+query error array_distance does not support types
+select array_distance([1], arrow_cast([1], 'LargeList(Float64)'));
+
+query error array_distance only supports one-dimensional arrays
+select array_distance([[1, 1]], [1, 2]);
+
+query error array_distance only supports one-dimensional arrays
+select array_distance([[1, 1]], [[1, 2]]);
+
+query error array_distance only supports one-dimensional arrays
+select array_distance([[1, 2], [100, 100]], [[1, 4], [0, 0]]);
+
 
 # array_distance with columns
 query RRR

--- a/docs/source/library-user-guide/upgrading/55.0.0.md
+++ b/docs/source/library-user-guide/upgrading/55.0.0.md
@@ -899,3 +899,20 @@ See [PR #23827](https://github.com/apache/datafusion/pull/23827) for details.
 The Minimum Supported Rust Version (MSRV) has been updated to [`1.94.0`].
 
 [`1.94.0`]: https://releases.rs/docs/1.94.0/
+
+### `array_distance` scalar function now rejects multidimensional arrays
+
+`array_distance` only supports one-dimensional arrays. Previously, when given
+multidimensional arrays, it computed the distance using only the first
+subarray and ignored the remaining subarrays. For example:
+
+```sql
+SELECT array_distance(
+    [[1, 2], [100, 100]],
+    [[1, 4], [0, 0]]
+);
+```
+
+Previously, this query returned `2.0`, the distance between `[1, 2]` and
+`[1, 4]`. It now returns a planning error stating that `array_distance` only
+supports one-dimensional arrays.

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -3606,7 +3606,7 @@ array_dims(array)
 
 ### `array_distance`
 
-Returns the Euclidean distance between two input arrays of equal length.
+Returns the Euclidean distance between two one-dimensional input arrays of equal length.
 
 ```sql
 array_distance(array1, array2)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
See reproducer in `datafusion-cli`, now `array_distance()` allows nested list as input, and it will use the 1st inner array to compute the distance.
```
> select array_distance([[1, 2], [100, 100]], [[1, 4], [0, 0]]);
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| array_distance(make_array(make_array(Int64(1),Int64(2)),make_array(Int64(100),Int64(100))),make_array(make_array(Int64(1),Int64(4)),make_array(Int64(0),Int64(0)))) |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 2.0                                                                                                                                                                 |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row(s) fetched.
Elapsed 0.000 seconds.
```

This look like an invalid input, this PR reject nested array in this function

## What changes are included in this PR?

At function planning, reject `array_distance` with nested array input args

## Are these changes tested?

Yes, slt (plus some extra tests that I found that has not been covered in `codecov`)
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
