### PR TITLE
chore: rows_to_array cleanup for expecting single field

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/row_backed.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/row_backed.rs
@@ -213,8 +213,13 @@ impl RowsGroupColumn {
             .row_converter
             .convert_rows(rows)
             .expect("row conversion during emit");
-        debug_assert_eq!(arrays.len(), 1, "single-field row converter");
-        let array = arrays.swap_remove(0);
+        assert_eq!(
+            arrays.len(),
+            1,
+            "Single field row converter must produce exactly one array, actual length is {}",
+            arrays.len()
+        );
+        let array = arrays.pop().unwrap();
         encode_array_if_necessary(&array, &self.output_type)
             .expect("dictionary re-encode during emit")
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23996

## Rationale for this change

Making the `rows_to_array` method in`RowsGroupColumn` behavior of expecting a singular field explicit, as before it used a generic vector operation of `swap_remove(0)` and a `debug_assert_eq!` for ensuring that there was only a single field extracted

## What changes are included in this PR?

Changed the `debug_assert_eq!` to the non-debug macro with a clear error message & changing the `swap_remove(0)` to a `pop` with `unwrap` now that we are guaranteeing the invariant

## Are these changes tested?

Yes

## Are there any user-facing changes?

No