### PR TITLE
minor(fix): correct to_date results for formatted pre-epoch datetimes

### DIFF
--- a/datafusion/functions/src/datetime/to_date.rs
+++ b/datafusion/functions/src/datetime/to_date.rs
@@ -100,7 +100,7 @@ impl ToDateFunc {
                 args,
                 |s, format| {
                     string_to_timestamp_millis_formatted(s, format)
-                        .map(|n| n / (24 * 60 * 60 * 1_000))
+                        .map(|n| n.div_euclid(24 * 60 * 60 * 1_000))
                         .and_then(|v| {
                             v.try_into().map_err(|_| {
                                 internal_datafusion_err!("Unable to cast to Date32 for converting from i64 to i32 failed")

--- a/datafusion/sqllogictest/test_files/datetime/dates.slt
+++ b/datafusion/sqllogictest/test_files/datetime/dates.slt
@@ -139,6 +139,12 @@ SELECT to_date('01-14-2023 01:01:30+05:30', '%q', '%d-%m-%Y %H/%M/%S', '%+', '%m
 ----
 2023-01-13
 
+# Formatted pre-epoch datetimes retain their calendar date
+query D
+SELECT to_date('1969-12-31 12:00:00', '%Y-%m-%d %H:%M:%S');
+----
+1969-12-31
+
 statement error DataFusion error: Execution error: to_date function unsupported data type at index 1: List
 SELECT to_date('2022-08-03T14:38:50+05:30', make_array('%s', '%q', '%d-%m-%Y %H:%M:%S%#z', '%+'));
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes N\A but I can open an issue

 ## Rationale for this change

 Formatted `to_date` inputs are parsed as milliseconds since the Unix epoch and then converted to `Date32` days. Integer division truncates toward zero, so negative sub-day timestamps are incorrectly mapped to day `0` instead of day `-1`.

 ```sql
 -- DataFusion before this change
 SELECT to_date('1969-12-31 12:00:00', '%Y-%m-%d %H:%M:%S');
 -- 1970-01-01

 -- PostgreSQL
 SELECT to_date('1969-12-31 12:00:00', 'YYYY-MM-DD HH24:MI:SS');
 -- 1969-12-31

 -- DuckDB
 SELECT CAST(strptime('1969-12-31 12:00:00', '%Y-%m-%d %H:%M:%S') AS DATE);
 -- 1969-12-31
```

## What changes are included in this PR?

Use Euclidean division when converting formatted timestamp milliseconds to days, preserving the correct date for timestamps before the Unix epoch.

## Are these changes tested?
Yes new slt test for this case.

## Are there any user-facing changes?

No API changes. Formatted pre-epoch datetimes now return the correct date.