### PR TITLE
Docs: Update PR template to ask for user-visible rationale

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
       description: Please describe what you are trying to do.
       placeholder: >
         A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-        (This section helps Arrow developers understand the context and *why* for this feature, in addition to the *what*)
+        (This section helps DataFusion developers understand the context and *why* for this feature, in addition to the *what*)
   - type: textarea
     attributes:
       label: Describe the solution you'd like

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,12 +11,19 @@ We generally require a GitHub issue to be filed for all bug fixes and enhancemen
 <!--
  Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
  Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
+
+Please explain the problem you are trying to solve in terms of the user-visible
+behavior, rather than the implementation.
+
+For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
+implementation. "COUNT(DISTINCT) returns wrong results when the column contains
+nulls" is the user-visible problem.
 -->
 
 ## What changes are included in this PR?
 
 <!--
-There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
+There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
 -->
 
 ## Are these changes tested?
@@ -33,8 +40,6 @@ If tests are not included in your PR, please explain why (for example, are they 
 
 <!--
 If there are user-facing changes then we may require documentation to be updated before approving the PR.
--->
 
-<!--
 If there are any breaking changes to public APIs, please add the `api change` label.
 -->


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #23839.

## Rationale for this change

PR descriptions are most useful when they describe the problem being solved from the user's point of view, rather than describing what is wrong with some part of the code. 


## What changes are included in this PR?

1. Update `.github/pull_request_template.md` to ask authors to explain the   problem in terms of user-visible behavior (with an example), and to add the   `api change` label for breaking public API changes.

## Are these changes tested?

No tests needed: template-only change.

## Are there any user-facing changes?

No changes to the code or documentation; contributors will see the updated
templates when opening PRs and feature requests.