### PR TITLE
docs: add HashJoinExec metrics to user guide

### DIFF
--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1768,15 +1768,17 @@ pub(crate) struct BuildProbeJoinMetrics {
     pub(crate) build_input_rows: metrics::Count,
     /// Memory used by build-side in bytes
     pub(crate) build_mem_used: metrics::Gauge,
-    /// Total time for joining probe-side batches to the build-side batches
+    /// Total time for join processing after build-side collection
     pub(crate) join_time: metrics::Time,
     /// Number of batches consumed by probe-side of this operator
     pub(crate) input_batches: metrics::Count,
     /// Number of rows consumed by probe-side this operator
     pub(crate) input_rows: metrics::Count,
-    /// Fraction of probe rows that found at least one match
+    /// Fraction of probe rows with at least one build-side join-key match before
+    /// applying any join filter
     pub(crate) probe_hit_rate: metrics::RatioMetrics,
-    /// Average number of build matches per matched probe row
+    /// Average number of build-side join-key matches per matched probe row before
+    /// applying any join filter
     pub(crate) avg_fanout: metrics::RatioMetrics,
 }
 

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1758,6 +1758,7 @@ fn append_probe_indices_in_order(
 /// Metrics for build & probe joins
 #[derive(Clone, Debug)]
 pub(crate) struct BuildProbeJoinMetrics {
+    // Keep these metric descriptions in sync with docs/source/user-guide/metrics.md.
     pub(crate) baseline: BaselineMetrics,
     /// Total time for collecting build-side of join
     pub(crate) build_time: metrics::Time,
@@ -1773,7 +1774,7 @@ pub(crate) struct BuildProbeJoinMetrics {
     pub(crate) input_batches: metrics::Count,
     /// Number of rows consumed by probe-side this operator
     pub(crate) input_rows: metrics::Count,
-    /// Fraction of probe rows that found more than one match
+    /// Fraction of probe rows that found at least one match
     pub(crate) probe_hit_rate: metrics::RatioMetrics,
     /// Average number of build matches per matched probe row
     pub(crate) avg_fanout: metrics::RatioMetrics,

--- a/docs/source/user-guide/metrics.md
+++ b/docs/source/user-guide/metrics.md
@@ -42,6 +42,25 @@ DataFusion operators expose runtime metrics so you can understand where time is 
 | ----------- | ----------------------------------------------------------------- |
 | selectivity | Selectivity of the filter, calculated as output_rows / input_rows |
 
+### HashJoinExec
+
+`HashJoinExec` also exposes the common `BaselineMetrics`. Its
+`elapsed_compute` metric is the sum of the build-side collection time and the
+probe-side join time.
+
+| Metric                  | Description                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------------- |
+| build_time              | Total time spent collecting and building the build side of the join.                         |
+| build_input_batches     | Number of input batches consumed from the build side.                                        |
+| build_input_rows        | Number of input rows consumed from the build side.                                           |
+| build_mem_used          | Peak memory used by the build side, in bytes.                                                |
+| join_time               | Total time spent joining probe-side batches against the build side.                          |
+| input_batches           | Number of input batches consumed from the probe side.                                        |
+| input_rows              | Number of input rows consumed from the probe side.                                           |
+| probe_hit_rate          | Fraction of probe-side rows that matched at least one build-side row.                        |
+| avg_fanout              | Average number of build-side matches per matched probe-side row.                             |
+| array_map_created_count | Number of times `HashJoinExec` created an `ArrayMap` for perfect hash join lookup execution. |
+
 ## TODO
 
 Add metrics for the remaining operators

--- a/docs/source/user-guide/metrics.md
+++ b/docs/source/user-guide/metrics.md
@@ -46,20 +46,20 @@ DataFusion operators expose runtime metrics so you can understand where time is 
 
 `HashJoinExec` also exposes the common `BaselineMetrics`. Its
 `elapsed_compute` metric is the sum of the build-side collection time and the
-probe-side join time.
+subsequent join processing time.
 
-| Metric                  | Description                                                                                  |
-| ----------------------- | -------------------------------------------------------------------------------------------- |
-| build_time              | Total time spent collecting and building the build side of the join.                         |
-| build_input_batches     | Number of input batches consumed from the build side.                                        |
-| build_input_rows        | Number of input rows consumed from the build side.                                           |
-| build_mem_used          | Peak memory used by the build side, in bytes.                                                |
-| join_time               | Total time spent joining probe-side batches against the build side.                          |
-| input_batches           | Number of input batches consumed from the probe side.                                        |
-| input_rows              | Number of input rows consumed from the probe side.                                           |
-| probe_hit_rate          | Fraction of probe-side rows that matched at least one build-side row.                        |
-| avg_fanout              | Average number of build-side matches per matched probe-side row.                             |
-| array_map_created_count | Number of times `HashJoinExec` created an `ArrayMap` for perfect hash join lookup execution. |
+| Metric                  | Description                                                                                               |
+| ----------------------- | --------------------------------------------------------------------------------------------------------- |
+| build_time              | Total time spent collecting and building the build side of the join.                                      |
+| build_input_batches     | Number of input batches consumed from the build side.                                                     |
+| build_input_rows        | Number of input rows consumed from the build side.                                                        |
+| build_mem_used          | Peak memory used by the build side, in bytes.                                                             |
+| join_time               | Total time spent processing the join after build-side collection.                                         |
+| input_batches           | Number of input batches consumed from the probe side.                                                     |
+| input_rows              | Number of input rows consumed from the probe side.                                                        |
+| probe_hit_rate          | Fraction of probe-side rows with a build-side join-key match before applying any join filter.             |
+| avg_fanout              | Average number of build-side join-key matches per matched probe-side row before applying any join filter. |
+| array_map_created_count | Number of times `HashJoinExec` created an `ArrayMap` for perfect hash join lookup execution.              |
 
 ## TODO
 

--- a/docs/source/user-guide/metrics.md
+++ b/docs/source/user-guide/metrics.md
@@ -53,7 +53,7 @@ subsequent join processing time.
 | build_time              | Total time spent collecting and building the build side of the join.                                      |
 | build_input_batches     | Number of input batches consumed from the build side.                                                     |
 | build_input_rows        | Number of input rows consumed from the build side.                                                        |
-| build_mem_used          | Peak memory used by the build side, in bytes.                                                             |
+| build_mem_used          | Peak tracked memory used by the build side, in bytes.                                                     |
 | join_time               | Total time spent processing the join after build-side collection.                                         |
 | input_batches           | Number of input batches consumed from the probe side.                                                     |
 | input_rows              | Number of input rows consumed from the probe side.                                                        |


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #19044.

## Rationale for this change

`HashJoinExec` exposes several operator-specific metrics, but the metrics user guide did not document them yet. This PR follows the metrics documentation tracking issue by adding the `HashJoinExec` section.

## What changes are included in this PR?

- Adds `HashJoinExec` operator-specific metrics to `docs/source/user-guide/metrics.md`.
- Adds a note near `BuildProbeJoinMetrics` to keep metric descriptions in sync with the user guide.
- Clarifies that `join_time` covers join processing after build-side collection.
- Clarifies that `probe_hit_rate` and `avg_fanout` measure join-key matches before applying any join filter.

## Are these changes tested?

This is a documentation/comment-only change with no runtime behavior change.

Checked locally:

- `git diff --check`
- `cargo fmt --check`
- `npx prettier@2.7.1 --check docs/source/user-guide/metrics.md`
- `./dev/rust_lint.sh`
- `cd docs && uv run --package datafusion-docs ./build.sh`
- DataFusion CLI `EXPLAIN ANALYZE` queries with and without a join filter

## Are there any user-facing changes?

Yes. The metrics user guide now documents the existing `HashJoinExec` metrics. There are no runtime behavior or public API changes.

## AI-assisted contribution note

This change is limited to documentation and comments. I verified the metric names and semantics against `BuildProbeJoinMetrics`, the `HashJoinExec` execution path, and local `EXPLAIN ANALYZE` output. I do not have unknowns or assumptions to call out.
