### PR TITLE
feat(functions): re-expose string builder API for concat

### DIFF
--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -39,7 +39,7 @@ use datafusion_common::cast::{
 use datafusion_expr_common::columnar_value::ColumnarValue;
 
 /// Trait abstracting concatenating string and binary collections.
-pub(crate) trait ConcatBuilder {
+pub trait ConcatBuilder {
     fn write<const CHECK_VALID: bool>(
         &mut self,
         column: &ColumnarValueRef,
@@ -61,13 +61,13 @@ pub(crate) trait ConcatBuilder {
 ///
 /// For the common "produce one `&str` per row" pattern, prefer
 /// `GenericStringArrayBuilder` instead.
-pub(crate) struct ConcatGenericStringBuilder<O: OffsetSizeTrait + ArrowNativeType> {
+pub struct ConcatGenericStringBuilder<O: OffsetSizeTrait + ArrowNativeType> {
     offsets_buffer: MutableBuffer,
     value_buffer: MutableBuffer,
     _phantom: PhantomData<O>,
 }
-pub(crate) type ConcatStringBuilder = ConcatGenericStringBuilder<i32>;
-pub(crate) type ConcatLargeStringBuilder = ConcatGenericStringBuilder<i64>;
+pub type ConcatStringBuilder = ConcatGenericStringBuilder<i32>;
+pub type ConcatLargeStringBuilder = ConcatGenericStringBuilder<i64>;
 
 impl<O: OffsetSizeTrait + ArrowNativeType> ConcatGenericStringBuilder<O> {
     pub fn with_capacity(item_capacity: usize, data_capacity: usize) -> Self {
@@ -187,7 +187,7 @@ impl<O: OffsetSizeTrait + ArrowNativeType> ConcatBuilder
 ///
 /// For the common "produce one `&str` per row" pattern, prefer
 /// [`StringViewArrayBuilder`] instead.
-pub(crate) struct ConcatStringViewBuilder {
+pub struct ConcatStringViewBuilder {
     views: Vec<u128>,
     data: Vec<u8>,
     block: Vec<u8>,
@@ -1217,7 +1217,7 @@ pub(crate) fn append_view(
 }
 
 #[derive(Debug)]
-pub(crate) enum ColumnarValueRef<'a> {
+pub enum ColumnarValueRef<'a> {
     Scalar(&'a [u8]),
     NullableArray(&'a StringArray),
     NonNullableArray(&'a StringArray),

--- a/datafusion/functions/src/strings.rs
+++ b/datafusion/functions/src/strings.rs
@@ -184,9 +184,11 @@ impl<O: OffsetSizeTrait + ArrowNativeType> ConcatBuilder
 /// fragment) followed by a single `append_offset` to commit the row
 /// as a single string view. The output null buffer is supplied by the caller
 /// at `finish` time, avoiding per-row NULL handling work.
-///
-/// For the common "produce one `&str` per row" pattern, prefer
-/// [`StringViewArrayBuilder`] instead.
+//
+// Add below to the doc comment if StringViewArrayBuilder is made public:
+//
+// For the common "produce one `&str` per row" pattern, prefer
+// [`StringViewArrayBuilder`] instead.
 pub struct ConcatStringViewBuilder {
     views: Vec<u128>,
     data: Vec<u8>,


### PR DESCRIPTION
## Rationale for this change

The builders hidden by https://github.com/apache/datafusion/pull/21695 are useful for third party UDFs that want to implement their own concat functions, e.g. one that faithfully replicates the behavior of Spark's concat.

## What changes are included in this PR?

Make these definitions in datafusion-funcions' `strings` module public:

* `ConcatBuilder` (trait)
* `ConcatGenericStringBuilder` (struct)
* `ConcatStringBuilder`, `ConcatLargeStringBuilder` (typedefs)
* `ConcatStringViewBuilder` (struct)
* `ColumnarValueRef` (enum)

## Are these changes tested?

No functionality has been changed.
Integration tests, doctests, or an example for the newly public APIs can be added on request.

## Are there any user-facing changes?

The APIs listed above are made public, with existing comments. 