### PR TITLE
chore: apply workspace lints to all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,20 +209,21 @@ url = "2.5.7"
 uuid = "1.23"
 zstd = { version = "0.13", default-features = false }
 
+# Keep this list sorted alphabetically.
 [workspace.lints.clippy]
-# Detects large stack-allocated futures that may cause stack overflow crashes (see threshold in clippy.toml)
-large_futures = "warn"
-used_underscore_binding = "warn"
-or_fun_call = "warn"
-unnecessary_lazy_evaluations = "warn"
-uninlined_format_args = "warn"
-inefficient_to_string = "warn"
-# https://github.com/apache/datafusion/issues/18503
-needless_pass_by_value = "warn"
 # https://github.com/apache/datafusion/issues/18881
 allow_attributes = "warn"
 assigning_clones = "warn"
+inefficient_to_string = "warn"
+# Detects large stack-allocated futures that may cause stack overflow crashes (see threshold in clippy.toml)
+large_futures = "warn"
+# https://github.com/apache/datafusion/issues/18503
+needless_pass_by_value = "warn"
+or_fun_call = "warn"
+uninlined_format_args = "warn"
+unnecessary_lazy_evaluations = "warn"
 unused_async = "warn"
+used_underscore_binding = "warn"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/datafusion/proto-common/Cargo.toml
+++ b/datafusion/proto-common/Cargo.toml
@@ -31,6 +31,12 @@ rust-version = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+# Note: add additional linter rules in lib.rs.
+# Rust does not support workspace + new linter rules in subcrates yet
+# https://github.com/rust-lang/cargo/issues/13157
+[lints]
+workspace = true
+
 [lib]
 name = "datafusion_proto_common"
 

--- a/datafusion/proto-common/src/from_proto/mod.rs
+++ b/datafusion/proto-common/src/from_proto/mod.rs
@@ -1259,9 +1259,7 @@ fn vec_to_array<T, const N: usize>(v: Vec<T>) -> [T; N] {
 }
 
 /// Converts a vector of `protobuf::Field`s to `Arc<arrow::Field>`s.
-pub fn parse_proto_fields_to_fields<'a, I>(
-    fields: I,
-) -> std::result::Result<Vec<Field>, Error>
+pub fn parse_proto_fields_to_fields<'a, I>(fields: I) -> Result<Vec<Field>, Error>
 where
     I: IntoIterator<Item = &'a protobuf::Field>,
 {

--- a/datafusion/proto-common/src/generated/mod.rs
+++ b/datafusion/proto-common/src/generated/mod.rs
@@ -18,6 +18,7 @@
 // This code is generated so we don't want to fix any lint violations manually
 #[allow(clippy::allow_attributes)]
 #[allow(clippy::all)]
+#[allow(unused_qualifications)]
 #[rustfmt::skip]
 pub mod datafusion_proto_common {
     include!("prost.rs");

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -115,7 +115,7 @@ impl TryFrom<&DataType> for protobuf::ArrowType {
     }
 }
 
-impl TryFrom<&DataType> for protobuf::arrow_type::ArrowTypeEnum {
+impl TryFrom<&DataType> for ArrowTypeEnum {
     type Error = Error;
 
     fn try_from(val: &DataType) -> Result<Self, Self::Error> {
@@ -439,9 +439,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     })
                 }
                 None => Ok(protobuf::ScalarValue {
-                    value: Some(protobuf::scalar_value::Value::NullValue(
-                        (&data_type).try_into()?,
-                    )),
+                    value: Some(Value::NullValue((&data_type).try_into()?)),
                 }),
             },
             ScalarValue::Decimal64(val, p, s) => match *val {
@@ -457,9 +455,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     })
                 }
                 None => Ok(protobuf::ScalarValue {
-                    value: Some(protobuf::scalar_value::Value::NullValue(
-                        (&data_type).try_into()?,
-                    )),
+                    value: Some(Value::NullValue((&data_type).try_into()?)),
                 }),
             },
             ScalarValue::Decimal128(val, p, s) => match *val {
@@ -475,9 +471,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     })
                 }
                 None => Ok(protobuf::ScalarValue {
-                    value: Some(protobuf::scalar_value::Value::NullValue(
-                        (&data_type).try_into()?,
-                    )),
+                    value: Some(Value::NullValue((&data_type).try_into()?)),
                 }),
             },
             ScalarValue::Decimal256(val, p, s) => match *val {
@@ -493,9 +487,7 @@ impl TryFrom<&ScalarValue> for protobuf::ScalarValue {
                     })
                 }
                 None => Ok(protobuf::ScalarValue {
-                    value: Some(protobuf::scalar_value::Value::NullValue(
-                        (&data_type).try_into()?,
-                    )),
+                    value: Some(Value::NullValue((&data_type).try_into()?)),
                 }),
             },
             ScalarValue::Date64(val) => {
@@ -788,8 +780,8 @@ impl From<&Precision<usize>> for protobuf::Precision {
     }
 }
 
-impl From<&Precision<datafusion_common::ScalarValue>> for protobuf::Precision {
-    fn from(s: &Precision<datafusion_common::ScalarValue>) -> protobuf::Precision {
+impl From<&Precision<ScalarValue>> for protobuf::Precision {
+    fn from(s: &Precision<ScalarValue>) -> protobuf::Precision {
         match s {
             Precision::Exact(val) => protobuf::Precision {
                 precision_info: protobuf::PrecisionInfo::Exact.into(),
@@ -1076,16 +1068,14 @@ impl TryFrom<&JsonOptions> for protobuf::JsonOptions {
 
 /// Creates a scalar protobuf value from an optional value (T), and
 /// encoding None as the appropriate datatype
-fn create_proto_scalar<I, T: FnOnce(&I) -> protobuf::scalar_value::Value>(
+fn create_proto_scalar<I, T: FnOnce(&I) -> Value>(
     v: Option<&I>,
     null_arrow_type: &DataType,
     constructor: T,
 ) -> Result<protobuf::ScalarValue, Error> {
     let value = v
         .map(constructor)
-        .unwrap_or(protobuf::scalar_value::Value::NullValue(
-            null_arrow_type.try_into()?,
-        ));
+        .unwrap_or(Value::NullValue(null_arrow_type.try_into()?));
 
     Ok(protobuf::ScalarValue { value: Some(value) })
 }
@@ -1141,35 +1131,25 @@ fn encode_scalar_nested_value(
 
     match val {
         ScalarValue::List(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::ListValue(scalar_list_value)),
+            value: Some(Value::ListValue(scalar_list_value)),
         }),
         ScalarValue::LargeList(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::LargeListValue(
-                scalar_list_value,
-            )),
+            value: Some(Value::LargeListValue(scalar_list_value)),
         }),
         ScalarValue::FixedSizeList(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::FixedSizeListValue(
-                scalar_list_value,
-            )),
+            value: Some(Value::FixedSizeListValue(scalar_list_value)),
         }),
         ScalarValue::ListView(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::ListViewValue(
-                scalar_list_value,
-            )),
+            value: Some(Value::ListViewValue(scalar_list_value)),
         }),
         ScalarValue::LargeListView(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::LargeListViewValue(
-                scalar_list_value,
-            )),
+            value: Some(Value::LargeListViewValue(scalar_list_value)),
         }),
         ScalarValue::Struct(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::StructValue(
-                scalar_list_value,
-            )),
+            value: Some(Value::StructValue(scalar_list_value)),
         }),
         ScalarValue::Map(_) => Ok(protobuf::ScalarValue {
-            value: Some(protobuf::scalar_value::Value::MapValue(scalar_list_value)),
+            value: Some(Value::MapValue(scalar_list_value)),
         }),
         _ => unreachable!(),
     }

--- a/datafusion/proto-models/Cargo.toml
+++ b/datafusion/proto-models/Cargo.toml
@@ -31,6 +31,12 @@ rust-version = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+# Note: add additional linter rules in lib.rs.
+# Rust does not support workspace + new linter rules in subcrates yet
+# https://github.com/rust-lang/cargo/issues/13157
+[lints]
+workspace = true
+
 [lib]
 name = "datafusion_proto_models"
 

--- a/datafusion/proto-models/src/generated/mod.rs
+++ b/datafusion/proto-models/src/generated/mod.rs
@@ -18,6 +18,7 @@
 // This code is generated so we don't want to fix any lint violations manually
 #[allow(clippy::allow_attributes)]
 #[allow(clippy::all)]
+#[allow(unused_qualifications)]
 #[rustfmt::skip]
 pub mod datafusion {
     include!("prost.rs");

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -31,6 +31,12 @@ rust-version = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+# Note: add additional linter rules in lib.rs.
+# Rust does not support workspace + new linter rules in subcrates yet
+# https://github.com/rust-lang/cargo/issues/13157
+[lints]
+workspace = true
+
 [lib]
 name = "datafusion_proto"
 

--- a/datafusion/proto/src/bytes/mod.rs
+++ b/datafusion/proto/src/bytes/mod.rs
@@ -213,6 +213,7 @@ pub fn physical_plan_to_bytes_with_extension_codec(
 
 /// Serialize a PhysicalPlan as bytes, using the provided extension codec
 /// and protobuf converter.
+#[expect(clippy::needless_pass_by_value)] // Taking the plan by value is part of the public API
 pub fn physical_plan_to_bytes_with_proto_converter(
     plan: Arc<dyn ExecutionPlan>,
     extension_codec: &dyn PhysicalExtensionCodec,

--- a/datafusion/proto/src/convert.rs
+++ b/datafusion/proto/src/convert.rs
@@ -40,5 +40,5 @@ pub trait FromProto<T>: Sized {
 /// versa). Mirrors [`TryFrom`].
 pub trait TryFromProto<T>: Sized {
     type Error;
-    fn try_from_proto(value: T) -> std::result::Result<Self, Self::Error>;
+    fn try_from_proto(value: T) -> Result<Self, Self::Error>;
 }

--- a/datafusion/proto/src/logical_plan/file_formats.rs
+++ b/datafusion/proto/src/logical_plan/file_formats.rs
@@ -767,11 +767,9 @@ mod parquet {
                 exec_datafusion_err!("Failed to decode TableParquetOptionsProto: {e:?}")
             })?;
             let options = TableParquetOptions::try_from_proto(&proto)?;
-            Ok(Arc::new(
-                datafusion_datasource_parquet::file_format::ParquetFormatFactory {
-                    options: Some(options),
-                },
-            ))
+            Ok(Arc::new(ParquetFormatFactory {
+                options: Some(options),
+            }))
         }
 
         fn try_encode_file_format(

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -680,7 +680,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                 )?
                 .build()
             }
-            LogicalPlanType::CustomScan(scan) => {
+            CustomScan(scan) => {
                 let schema: Schema = convert_required!(scan.schema)?;
                 let schema = Arc::new(schema);
                 let mut projection = None;
@@ -1272,7 +1272,7 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlanType::Dml(dml_node) => {
                 let write_op =
                     from_proto::parse_write_op(dml_node, ctx, extension_codec)?;
-                Ok(LogicalPlan::Dml(datafusion_expr::DmlStatement::new(
+                Ok(LogicalPlan::Dml(DmlStatement::new(
                     from_table_reference(dml_node.table_name.as_ref(), "DML ")?,
                     to_table_source(&dml_node.target, ctx, extension_codec)?,
                     write_op,
@@ -1479,7 +1479,7 @@ impl AsLogicalPlan for LogicalPlanNode {
 
                     Ok(LogicalPlanNode {
                         logical_plan_type: Some(LogicalPlanType::CteWorkTableScan(
-                            protobuf::CteWorkTableScanNode {
+                            CteWorkTableScanNode {
                                 name,
                                 schema: Some(schema),
                             },

--- a/datafusion/proto/src/logical_plan/to_proto.rs
+++ b/datafusion/proto/src/logical_plan/to_proto.rs
@@ -19,8 +19,6 @@
 //! DataFusion logical plans to be serialized and transmitted between
 //! processes.
 
-use std::collections::HashMap;
-
 use datafusion_common::{NullEquality, SplitPoint, TableReference, UnnestOptions};
 use datafusion_expr::dml::{
     MergeIntoAction, MergeIntoClause, MergeIntoClauseKind, MergeIntoOp,
@@ -230,7 +228,7 @@ pub fn serialize_expr(
                 metadata: metadata
                     .as_ref()
                     .map(|m| m.to_hashmap())
-                    .unwrap_or(HashMap::new()),
+                    .unwrap_or_default(),
             });
             protobuf::LogicalExprNode {
                 expr_type: Some(ExprType::Alias(alias)),
@@ -661,7 +659,7 @@ pub fn serialize_expr(
                 metadata: field
                     .as_ref()
                     .map(|f| f.metadata().clone())
-                    .unwrap_or(HashMap::new()),
+                    .unwrap_or_default(),
             })),
         },
         Expr::Lambda(Lambda { params, body }) => protobuf::LogicalExprNode {

--- a/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_logical_plan.rs
@@ -150,7 +150,7 @@ fn roundtrip_expr_test_with_codec(
     let round_trip: Expr =
         from_proto::parse_expr(&proto, ctx.task_ctx().as_ref(), codec).unwrap();
 
-    assert_eq!(format!("{:?}", initial_struct), format!("{round_trip:?}"));
+    assert_eq!(format!("{initial_struct:?}"), format!("{round_trip:?}"));
 
     roundtrip_json_test(&proto);
 }
@@ -1704,7 +1704,7 @@ pub mod proto {
         pub expr: Option<datafusion_proto::protobuf::LogicalExprNode>,
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[derive(Clone, PartialEq, Eq, ::prost::Message)]
     pub struct TopKExecProto {
         #[prost(uint64, tag = "1")]
@@ -2517,7 +2517,7 @@ fn roundtrip_null_scalar_values() {
     for test_case in test_types.into_iter() {
         let proto_scalar: protobuf::ScalarValue = (&test_case).try_into().unwrap();
         let returned_scalar: ScalarValue = (&proto_scalar).try_into().unwrap();
-        assert_eq!(format!("{:?}", test_case), format!("{returned_scalar:?}"));
+        assert_eq!(format!("{test_case:?}"), format!("{returned_scalar:?}"));
     }
 }
 
@@ -3024,7 +3024,7 @@ fn roundtrip_scalar_udf_extension_codec() {
         from_proto::parse_expr(&proto, ctx.task_ctx().as_ref(), &UDFExtensionCodec)
             .expect("parse expr");
 
-    assert_eq!(format!("{:?}", test_expr), format!("{round_trip:?}"));
+    assert_eq!(format!("{test_expr:?}"), format!("{round_trip:?}"));
     roundtrip_json_test(&proto);
 }
 
@@ -3038,7 +3038,7 @@ fn roundtrip_aggregate_udf_extension_codec() {
         from_proto::parse_expr(&proto, ctx.task_ctx().as_ref(), &UDFExtensionCodec)
             .expect("parse expr");
 
-    assert_eq!(format!("{:?}", test_expr), format!("{round_trip:?}"));
+    assert_eq!(format!("{test_expr:?}"), format!("{round_trip:?}"));
     roundtrip_json_test(&proto);
 }
 
@@ -3147,7 +3147,7 @@ fn roundtrip_higher_order_udf_extension_codec() {
         from_proto::parse_expr(&proto, ctx.task_ctx().as_ref(), &UDFExtensionCodec)
             .expect("parse expr");
 
-    assert_eq!(format!("{:?}", test_expr), format!("{round_trip:?}"));
+    assert_eq!(format!("{test_expr:?}"), format!("{round_trip:?}"));
     roundtrip_json_test(&proto);
 }
 

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -282,7 +282,7 @@ fn decode_empty_and_placeholder_row_without_partitions() -> Result<()> {
             },
         ),
     ] {
-        let node = protobuf::PhysicalPlanNode {
+        let node = PhysicalPlanNode {
             physical_plan_type: Some(physical_plan_type),
         };
         let plan = node.try_into_physical_plan(ctx.task_ctx().as_ref(), &codec)?;
@@ -1401,7 +1401,7 @@ fn roundtrip_parquet_exec_with_custom_predicate_expr() -> Result<()> {
         }
 
         fn fmt_sql(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            std::fmt::Display::fmt(self, f)
+            Display::fmt(self, f)
         }
     }
 
@@ -2761,7 +2761,7 @@ fn deprecated_projection_shim_decodes_argument_not_self() -> Result<()> {
     let session_ctx = SessionContext::new();
     let task_ctx = session_ctx.task_ctx();
     let decode_ctx = PhysicalPlanDecodeContext::new(task_ctx.as_ref(), &codec);
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let decoded = unrelated_node.try_into_projection_physical_plan(
         projection_exec_node,
         &decode_ctx,
@@ -3120,20 +3120,20 @@ fn roundtrip_sort_merge_join() -> Result<()> {
         Arc::new(Column::new("col_b", schema_right.index_of("col_b")?)) as _,
     )];
 
-    let filter = datafusion::physical_plan::joins::utils::JoinFilter::new(
+    let filter = JoinFilter::new(
         Arc::new(BinaryExpr::new(
             Arc::new(Column::new("col_a", 1)),
             Operator::Gt,
             Arc::new(Column::new("col_b", 0)),
         )),
         vec![
-            datafusion::physical_plan::joins::utils::ColumnIndex {
+            ColumnIndex {
                 index: 0,
-                side: datafusion_common::JoinSide::Left,
+                side: JoinSide::Left,
             },
-            datafusion::physical_plan::joins::utils::ColumnIndex {
+            ColumnIndex {
                 index: 0,
-                side: datafusion_common::JoinSide::Right,
+                side: JoinSide::Right,
             },
         ],
         Arc::new(Schema::new(vec![field_a, field_b])),
@@ -3339,7 +3339,7 @@ fn roundtrip_hash_table_lookup_expr_to_lit() -> Result<()> {
 
     // Create a HashTableLookupExpr - it will be replaced with lit(true) during serialization
     let hash_map = Arc::new(Map::HashMap(Box::new(JoinHashMapU32::with_capacity(0))));
-    let on_columns = vec![datafusion::physical_plan::expressions::col("col", &schema)?];
+    let on_columns = vec![col("col", &schema)?];
     let lookup_expr: Arc<dyn PhysicalExpr> = Arc::new(HashTableLookupExpr::new(
         on_columns,
         datafusion::physical_plan::joins::SeededRandomState::with_seed(0),
@@ -3419,7 +3419,7 @@ fn custom_proto_converter_intercepts() -> Result<()> {
     impl PhysicalProtoConverterExtension for CustomConverterInterceptor {
         fn proto_to_execution_plan(
             &self,
-            proto: &protobuf::PhysicalPlanNode,
+            proto: &PhysicalPlanNode,
             ctx: &PhysicalPlanDecodeContext<'_>,
         ) -> Result<Arc<dyn ExecutionPlan>> {
             {
@@ -3436,7 +3436,7 @@ fn custom_proto_converter_intercepts() -> Result<()> {
             &self,
             plan: &Arc<dyn ExecutionPlan>,
             codec: &dyn PhysicalExtensionCodec,
-        ) -> Result<protobuf::PhysicalPlanNode>
+        ) -> Result<PhysicalPlanNode>
         where
             Self: Sized,
         {
@@ -3624,7 +3624,7 @@ fn roundtrip_dynamic_filter_expr_pair(
 /// - `dynamic_filter_2` before serialization
 /// - `dynamic_filter_1` after serialization
 /// - `dynamic_filter_2` after serialization
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 fn roundtrip_dynamic_filter_plan_pair() -> Result<(
     Arc<dyn PhysicalExpr>,
     Arc<dyn PhysicalExpr>,
@@ -4670,7 +4670,7 @@ impl ExecutionPlan for CustomExecWithExprs {
         self.child.schema()
     }
 
-    fn properties(&self) -> &Arc<datafusion::physical_plan::PlanProperties> {
+    fn properties(&self) -> &Arc<PlanProperties> {
         self.child.properties()
     }
 
@@ -4948,7 +4948,7 @@ impl PhysicalExpr for WrapperExpr {
         }))
     }
     fn fmt_sql(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self, f)
+        Display::fmt(self, f)
     }
 }
 
@@ -4956,7 +4956,7 @@ impl PhysicalExpr for WrapperExpr {
 #[derive(Clone, PartialEq, prost::Message)]
 struct WrapperExprProto {
     #[prost(message, optional, boxed, tag = "1")]
-    inner: Option<Box<datafusion_proto::protobuf::PhysicalExprNode>>,
+    inner: Option<Box<PhysicalExprNode>>,
 }
 
 #[derive(Debug)]
@@ -5054,8 +5054,7 @@ fn extension_codec_expr_participates_in_deduplication() -> Result<()> {
     // Encode, then round-trip through prost bytes to mimic the wire.
     let proto = converter.physical_expr_to_proto(&composite, &codec)?;
     let bytes = proto.encode_to_vec();
-    let decoded_proto =
-        datafusion_proto::protobuf::PhysicalExprNode::decode(bytes.as_slice()).unwrap();
+    let decoded_proto = PhysicalExprNode::decode(bytes.as_slice()).unwrap();
 
     let ctx = SessionContext::new();
     let task_ctx = ctx.task_ctx();

--- a/datafusion/proto/tests/proto_integration.rs
+++ b/datafusion/proto/tests/proto_integration.rs
@@ -15,5 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Test helpers take owned values for convenience, matching the `#![cfg_attr(test, ...)]`
+// exemption the DataFusion crates apply to their own unit tests.
+#![cfg_attr(test, allow(clippy::needless_pass_by_value))]
+
 /// Run all tests that are found in the `cases` directory
 mod cases;


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #18467
- Broken out of https://github.com/apache/datafusion/pull/24066
- Sibling PR: https://github.com/apache/arrow-rs/pull/10533

## Rationale for this change
The workspace already has a `[workspace.lints]` table, but it was missing from three crates

## What changes are included in this PR?
Inheriting the workspace lints in all crates, and fixing the resulting violations

## Are these changes tested?
Yes, by existing tests and CI

## Are there any user-facing changes?
No