### PR TITLE
fix(proto): preserve empty projection when ser/de MemoryScanExec

### DIFF
--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -1179,15 +1179,11 @@ pub trait PhysicalPlanNodeExt: Sized {
         })?;
         let schema: SchemaRef = SchemaRef::new(proto_schema.try_into()?);
 
-        let projection = if !scan.projection.is_empty() {
-            Some(
-                scan.projection
-                    .iter()
-                    .map(|i| *i as usize)
-                    .collect::<Vec<_>>(),
-            )
-        } else {
-            None
+        // Decode the empty-projection sentinel written by the encoder.
+        let projection = match scan.projection.as_slice() {
+            [] => None,
+            [u32::MAX] => Some(Vec::new()),
+            indices => Some(indices.iter().map(|i| *i as usize).collect::<Vec<_>>()),
         };
 
         let mut sort_information = vec![];
@@ -2364,12 +2360,16 @@ pub trait PhysicalPlanNodeExt: Sized {
             let proto_schema: protobuf::Schema =
                 source_conf.original_schema().as_ref().try_into()?;
 
-            let proto_projection = source_conf
-                .projection()
-                .as_ref()
-                .map_or_else(Vec::new, |v| {
-                    v.iter().map(|x| *x as u32).collect::<Vec<u32>>()
-                });
+            // Proto3 `repeated` cannot distinguish `None` from `Some(vec![])`.
+            // `Some(vec![])` projects away every column and so changes the output
+            // schema; it is encoded with the single-element sentinel `[u32::MAX]`
+            // (never a valid column index). Every other state is sent as-is. See
+            // `try_into_memory_scan_physical_plan` for the matching decoder.
+            let proto_projection = match source_conf.projection().as_ref() {
+                None => Vec::new(),
+                Some(v) if v.is_empty() => vec![u32::MAX],
+                Some(v) => v.iter().map(|x| *x as u32).collect::<Vec<u32>>(),
+            };
 
             let proto_sort_information = source_conf
                 .sort_information()

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -33,6 +33,7 @@ use datafusion::datasource::file_format::parquet::ParquetSink;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl, PartitionedFile,
 };
+use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::datasource::physical_plan::{
     ArrowSource, FileGroup, FileOutputMode, FileScanConfig, FileScanConfigBuilder,
@@ -3214,6 +3215,24 @@ async fn roundtrip_logical_plan_sort_merge_join() -> Result<()> {
     let query = "SELECT t1.* FROM t0 join t1 on t0.a = t1.a";
     let plan = ctx.sql(query).await?.create_physical_plan().await?;
     roundtrip_test(plan)
+}
+
+#[test]
+fn roundtrip_memory_source_projections() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]));
+
+    // `None` (all columns), `Some(vec![])` (no columns) and a partial projection are
+    // three distinct output schemas and must each survive a round-trip.
+    for projection in [None, Some(vec![]), Some(vec![1])] {
+        let source =
+            MemorySourceConfig::try_new(&[vec![]], Arc::clone(&schema), projection)?;
+        roundtrip_test(Arc::new(DataSourceExec::new(Arc::new(source))))?;
+    }
+
+    Ok(())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Which issue does this PR close?

Finishes the work started in #23082 (`HashJoinExec`, `NestedLoopJoinExec`) and #21885 (`FilterExec`) — `MemoryScanExec` was the last physical plan node left with an ambiguous projection.

## Rationale for this change

`MemorySourceConfig`'s projection is `Option<Vec<usize>>` but is encoded as a bare `repeated uint32`:

```rust
// encode
let proto_projection = source_conf.projection().as_ref().map_or_else(Vec::new, |v| ...);
// decode
let projection = if !scan.projection.is_empty() { Some(...) } else { None };
```

So `Some(vec![])` — project away every column — serializes exactly like `None` and always decodes back as `None`, and the decoded scan reports every column again.


## What changes are included in this PR?

Encode an empty projection with the single-element `[u32::MAX]` sentinel — the same convention `HashJoinExec` and `NestedLoopJoinExec` already use — and decode it back to `Some(vec![])`. Every other state is unchanged on the wire, so `None` and non-empty projections round-trip exactly as before.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No API change. The wire format changes only for the previously-unrepresentable `Some(vec![])` case, matching what the joins already do.