### PR TITLE
chore: add runendencoded & listview types to dfschema equality methods

### DIFF
--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -671,6 +671,8 @@ impl DFSchema {
     /// logically equivalent. For example:
     /// - a Dictionary<K,V> type is logically equal to a plain V type
     /// - a Dictionary<K1, V1> is also logically equal to Dictionary<K2, V1>
+    /// - a RunEndEncoded<K,V> type is logically equal to a plain V type
+    /// - a RunEndEncoded<K1, V1> is also logically equal to RunEndEncoded<K2, V1>
     /// - Utf8 and Utf8View are logically equal
     pub fn datatype_is_logically_equal(dt1: &DataType, dt2: &DataType) -> bool {
         // check nested fields
@@ -682,8 +684,17 @@ impl DFSchema {
             | (othertype, DataType::Dictionary(_, v1)) => {
                 Self::datatype_is_logically_equal(v1.as_ref(), othertype)
             }
+            (DataType::RunEndEncoded(_, v1), DataType::RunEndEncoded(_, v2)) => {
+                Self::datatype_is_logically_equal(v1.data_type(), v2.data_type())
+            }
+            (DataType::RunEndEncoded(_, v1), othertype)
+            | (othertype, DataType::RunEndEncoded(_, v1)) => {
+                Self::datatype_is_logically_equal(v1.data_type(), othertype)
+            }
             (DataType::List(f1), DataType::List(f2))
             | (DataType::LargeList(f1), DataType::LargeList(f2))
+            | (DataType::ListView(f1), DataType::ListView(f2))
+            | (DataType::LargeListView(f1), DataType::LargeListView(f2))
             | (DataType::FixedSizeList(f1, _), DataType::FixedSizeList(f2, _)) => {
                 // Don't compare the names of the technical inner field
                 // Usually "item" but that's not mandated
@@ -742,8 +753,17 @@ impl DFSchema {
                 Self::datatype_is_semantically_equal(k1.as_ref(), k2.as_ref())
                     && Self::datatype_is_semantically_equal(v1.as_ref(), v2.as_ref())
             }
+            (DataType::RunEndEncoded(k1, v1), DataType::RunEndEncoded(k2, v2)) => {
+                Self::datatype_is_semantically_equal(k1.data_type(), k2.data_type())
+                    && Self::datatype_is_semantically_equal(
+                        v1.data_type(),
+                        v2.data_type(),
+                    )
+            }
             (DataType::List(f1), DataType::List(f2))
             | (DataType::LargeList(f1), DataType::LargeList(f2))
+            | (DataType::ListView(f1), DataType::ListView(f2))
+            | (DataType::LargeListView(f1), DataType::LargeListView(f2))
             | (DataType::FixedSizeList(f1, _), DataType::FixedSizeList(f2, _)) => {
                 // Don't compare the names of the technical inner field
                 // Usually "item" but that's not mandated
@@ -1754,11 +1774,19 @@ mod tests {
             &DataType::List(Field::new_list_field(DataType::Int8, true).into()),
             &DataType::List(Field::new("element", DataType::Int8, false).into())
         ));
+        assert!(DFSchema::datatype_is_logically_equal(
+            &DataType::ListView(Field::new_list_field(DataType::Int8, true).into()),
+            &DataType::ListView(Field::new("element", DataType::Int8, false).into())
+        ));
 
         // Fails if element type is different
         assert!(!DFSchema::datatype_is_logically_equal(
             &DataType::List(Field::new_list_field(DataType::Int8, true).into()),
             &DataType::List(Field::new_list_field(DataType::Int16, true).into())
+        ));
+        assert!(!DFSchema::datatype_is_logically_equal(
+            &DataType::ListView(Field::new_list_field(DataType::Int8, true).into()),
+            &DataType::ListView(Field::new_list_field(DataType::Int16, true).into())
         ));
 
         // Test maps
@@ -1897,6 +1925,50 @@ mod tests {
     }
 
     #[test]
+    fn test_datatype_is_logically_equivalent_to_ree() {
+        // RunEndEncoded is logically equal to its value type
+        assert!(DFSchema::datatype_is_logically_equal(
+            &DataType::Utf8,
+            &DataType::RunEndEncoded(
+                Field::new("run", DataType::Int32, false).into(),
+                Field::new("val", DataType::Utf8, true).into(),
+            )
+        ));
+
+        // Dictionary is logically equal to the logically equivalent value type
+        assert!(DFSchema::datatype_is_logically_equal(
+            &DataType::Utf8View,
+            &DataType::RunEndEncoded(
+                Field::new("run", DataType::Int32, false).into(),
+                Field::new("val", DataType::Utf8, true).into(),
+            )
+        ));
+
+        assert!(DFSchema::datatype_is_logically_equal(
+            &DataType::RunEndEncoded(
+                Field::new("run", DataType::Int32, false).into(),
+                Field::new(
+                    "val",
+                    DataType::List(Field::new("element", DataType::Utf8, false).into()),
+                    true
+                )
+                .into(),
+            ),
+            &DataType::RunEndEncoded(
+                Field::new("run", DataType::Int64, false).into(),
+                Field::new(
+                    "val",
+                    DataType::List(
+                        Field::new("element", DataType::Utf8View, false).into()
+                    ),
+                    true
+                )
+                .into(),
+            ),
+        ));
+    }
+
+    #[test]
     fn test_datatype_is_semantically_equal() {
         assert!(DFSchema::datatype_is_semantically_equal(
             &DataType::Int8,
@@ -1945,11 +2017,19 @@ mod tests {
             &DataType::List(Field::new_list_field(DataType::Int8, true).into()),
             &DataType::List(Field::new("element", DataType::Int8, false).into())
         ));
+        assert!(DFSchema::datatype_is_semantically_equal(
+            &DataType::ListView(Field::new_list_field(DataType::Int8, true).into()),
+            &DataType::ListView(Field::new("element", DataType::Int8, false).into())
+        ));
 
         // Fails if element type is different
         assert!(!DFSchema::datatype_is_semantically_equal(
             &DataType::List(Field::new_list_field(DataType::Int8, true).into()),
             &DataType::List(Field::new_list_field(DataType::Int16, true).into())
+        ));
+        assert!(!DFSchema::datatype_is_semantically_equal(
+            &DataType::ListView(Field::new_list_field(DataType::Int8, true).into()),
+            &DataType::ListView(Field::new_list_field(DataType::Int16, true).into())
         ));
 
         // Test maps
@@ -2063,6 +2143,18 @@ mod tests {
         assert!(!DFSchema::datatype_is_semantically_equal(
             &DataType::Utf8,
             &DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8))
+        ));
+    }
+
+    #[test]
+    fn test_datatype_is_not_semantically_equivalent_to_ree() {
+        // RunEndEncoded is not semantically equal to its value type
+        assert!(!DFSchema::datatype_is_semantically_equal(
+            &DataType::Utf8,
+            &DataType::RunEndEncoded(
+                Field::new("run", DataType::Int32, false).into(),
+                Field::new("val", DataType::Utf8, true).into(),
+            )
         ));
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

Some of these methods omit support for these newer types, so plugging some holes where possible, to work towards ensuring these types have proper support in DataFusion.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Added match arms for runendencoded & [large]listview types to dfschema methods `datatype_is_logically_equal` and `datatype_is_semantically_equal`

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

No
