### PR TITLE
Preserve grouping ID during aggregate CSE

### DIFF
--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -826,6 +826,9 @@ fn extract_expressions(expr: &Expr, result: &mut Vec<Expr>) {
             let col = Column::new(qualifier, field_name);
             result.push(Expr::Column(col))
         }
+        result.push(Expr::Column(Column::from_name(
+            Aggregate::INTERNAL_GROUPING_ID,
+        )));
     } else {
         let (qualifier, field_name) = expr.qualified_name();
         let col = Column::new(qualifier, field_name);
@@ -1107,6 +1110,27 @@ mod test {
     }
 
     #[test]
+    fn common_aggregate_grouping_set_preserves_internal_id() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(test_table_scan()?)
+            .aggregate(
+                vec![grouping_set(vec![vec![col("a")]])],
+                vec![avg(col("b")).alias("first"), avg(col("b")).alias("second")],
+            )?
+            .filter(col(Aggregate::INTERNAL_GROUPING_ID).eq(lit(0_u8)))?
+            .build()?;
+
+        assert_optimized_plan_equal!(
+            plan,
+            @ r"
+        Filter: __grouping_id = UInt8(0)
+          Projection: test.a, __grouping_id, __common_expr_1 AS first, __common_expr_1 AS second
+            Aggregate: groupBy=[[GROUPING SETS ((test.a))]], aggr=[[avg(test.b) AS __common_expr_1]]
+              TableScan: test
+        "
+        )
+    }
+
+    #[test]
     fn subexpr_in_same_order() -> Result<()> {
         let table_scan = test_table_scan()?;
 
@@ -1288,20 +1312,31 @@ mod test {
 
     #[test]
     fn test_extract_expressions_from_grouping_set() -> Result<()> {
-        let mut result = Vec::with_capacity(3);
+        let mut result = Vec::with_capacity(4);
         let grouping = grouping_set(vec![vec![col("a"), col("b")], vec![col("c")]]);
         extract_expressions(&grouping, &mut result);
 
-        assert!(result.len() == 3);
+        assert_eq!(
+            result,
+            vec![
+                col("a"),
+                col("b"),
+                col("c"),
+                col(Aggregate::INTERNAL_GROUPING_ID),
+            ]
+        );
         Ok(())
     }
 
     #[test]
     fn test_extract_expressions_from_grouping_set_with_identical_expr() -> Result<()> {
-        let mut result = Vec::with_capacity(2);
+        let mut result = Vec::with_capacity(3);
         let grouping = grouping_set(vec![vec![col("a"), col("b")], vec![col("a")]]);
         extract_expressions(&grouping, &mut result);
-        assert!(result.len() == 2);
+        assert_eq!(
+            result,
+            vec![col("a"), col("b"), col(Aggregate::INTERNAL_GROUPING_ID),]
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #24143.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

See #24143.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Preserve `__grouping_id` in CSE recovery projections for grouping-set aggregates.
- Add regression coverage.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

No.