### PR TITLE
perf: optimize char -> byte offset mapping in `regexp_count`

### DIFF
--- a/datafusion/functions/src/regex/mod.rs
+++ b/datafusion/functions/src/regex/mod.rs
@@ -146,6 +146,22 @@ where
     Ok(result)
 }
 
+/// Maps `start`, a 1-based character position, to a byte offset in `value`.
+/// Positions `1..=n` (for an `n`-character string) map to the corresponding
+/// character's first byte; position `n + 1`, the end of the string, maps to
+/// `value.len()`. Returns `None` for larger positions. Callers must validate
+/// `start >= 1`.
+pub(crate) fn start_to_byte_offset(value: &str, start: i64) -> Option<usize> {
+    // If `start - 1` does not fit in `usize`, it is necessarily past the end
+    // of the string.
+    let start_index = usize::try_from(start - 1).ok()?;
+    value
+        .char_indices()
+        .map(|(offset, _)| offset)
+        .chain(std::iter::once(value.len()))
+        .nth(start_index)
+}
+
 pub fn compile_regex(regex: &str, flags: Option<&str>) -> Result<Regex, ArrowError> {
     let pattern = match flags {
         None | Some("") => regex.to_string(),
@@ -163,4 +179,33 @@ pub fn compile_regex(regex: &str, flags: Option<&str>) -> Result<Regex, ArrowErr
     Regex::new(&pattern).map_err(|_| {
         ArrowError::ComputeError(format!("Regular expression did not compile: {pattern}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::start_to_byte_offset;
+
+    #[test]
+    fn start_to_byte_offset_ascii() {
+        assert_eq!(start_to_byte_offset("abc", 1), Some(0));
+        assert_eq!(start_to_byte_offset("abc", 3), Some(2));
+        // The end of the string is a valid position.
+        assert_eq!(start_to_byte_offset("abc", 4), Some(3));
+        assert_eq!(start_to_byte_offset("abc", 5), None);
+        assert_eq!(start_to_byte_offset("abc", i64::MAX), None);
+    }
+
+    #[test]
+    fn start_to_byte_offset_empty_string() {
+        assert_eq!(start_to_byte_offset("", 1), Some(0));
+        assert_eq!(start_to_byte_offset("", 2), None);
+    }
+
+    #[test]
+    fn start_to_byte_offset_multibyte() {
+        assert_eq!(start_to_byte_offset("😀a", 1), Some(0));
+        assert_eq!(start_to_byte_offset("😀a", 2), Some(4));
+        assert_eq!(start_to_byte_offset("😀a", 3), Some(5));
+        assert_eq!(start_to_byte_offset("😀a", 4), None);
+    }
 }

--- a/datafusion/functions/src/regex/regexpcount.rs
+++ b/datafusion/functions/src/regex/regexpcount.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::regex::{compile_and_cache_regex, compile_regex};
+use crate::regex::{compile_and_cache_regex, compile_regex, start_to_byte_offset};
 use arrow::array::{Array, ArrayRef, AsArray, Datum, Int64Array, StringArrayType};
 use arrow::datatypes::{DataType, Int64Type};
 use arrow::datatypes::{
@@ -565,27 +565,10 @@ fn count_matches(
             ));
         }
 
-        let char_len = value.chars().count();
-        let start_index = (start as usize).saturating_sub(1);
-
-        if start_index > char_len {
+        let Some(byte_offset) = start_to_byte_offset(value, start) else {
             return Ok(0);
-        }
-
-        // Find the byte offset for the start position (1-based character index)
-        let byte_offset = if start_index == char_len {
-            value.len()
-        } else {
-            value
-                .char_indices()
-                .nth(start_index)
-                .map(|(idx, _)| idx)
-                .unwrap_or(value.len())
         };
-
-        // Use string slicing instead of collecting chars into a new String
-        let find_slice = &value[byte_offset..];
-        let count = pattern.find_iter(find_slice).count();
+        let count = pattern.find_iter(&value[byte_offset..]).count();
         Ok(count as i64)
     } else {
         let count = pattern.find_iter(value).count();

--- a/datafusion/functions/src/regex/regexpinstr.rs
+++ b/datafusion/functions/src/regex/regexpinstr.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
-use crate::regex::compile_regex;
+use crate::regex::{compile_regex, start_to_byte_offset};
 
 #[user_doc(
     doc_section(label = "Regular Expression Functions"),
@@ -388,17 +388,7 @@ fn get_index(
         ));
     }
 
-    let Ok(start_index) = usize::try_from(start - 1) else {
-        return Ok(0);
-    };
-    // Include the terminal byte boundary so an empty pattern can match after
-    // the last character, including in an empty string.
-    let Some(byte_start_offset) = value
-        .char_indices()
-        .map(|(offset, _)| offset)
-        .chain(std::iter::once(value.len()))
-        .nth(start_index)
-    else {
+    let Some(byte_start_offset) = start_to_byte_offset(value, start) else {
         return Ok(0);
     };
     let search_slice = &value[byte_start_offset..];

--- a/datafusion/sqllogictest/test_files/regexp/regexp_count.slt
+++ b/datafusion/sqllogictest/test_files/regexp/regexp_count.slt
@@ -76,6 +76,21 @@ SELECT regexp_count('abc', '', 5);
 ----
 0
 
+query I
+SELECT regexp_count('', '');
+----
+1
+
+query I
+SELECT regexp_count('😀', '', 2);
+----
+1
+
+query I
+SELECT regexp_count('abc', 'x*', 4);
+----
+1
+
 statement error
 External error: query failed: DataFusion error: Arrow error: Compute error: regexp_count() requires start to be 1 based
 SELECT regexp_count('123123123123', '123', 0);


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## Rationale for this change

`regexp_count` takes an optional argument, `start`, that specifies a character-based position. The current implementation involves calling `start.chars().count` for every input row, which scans the entire string. This is unnecessarily expensive for the common case that `start` identifies a character position near the start of the string: once we've converted `start` into a byte offset, we can stop scanning the rest of the string.

Fix this by doing a lazy walk of the string and stopping early. This was first done for `regexp_instr` in #24054; this PR refactors that code into a shared helper. In passing, this also fixes a 32-bit portability bug with the previous code in `regexp_count` as well.

regexp_count benchmark, with_start cases:

- `size=1024 str_len=32`:  -5.7%
- `size=1024 str_len=128`: -11.5%
- `size=4096 str_len=32`:  -4.1%
- `size=4096 str_len=128`: -6.6%

## What changes are included in this PR?

* Refactor char position -> byte offset mapping from `regexp_instr` into a new helper, `start_to_byte_offset`
* Use `start_to_byte_offset` in both `regexp_instr` (no functional change) and `regexp_count`
* Add SLT cases verifying that `regexp_count` handles zero-width patterns the same way that PostgreSQL does (this was the primary motivation for #24054)

## Are these changes tested?

Yes — new unit tests for the shared helper; new SLT cases pin the existing zero-width-pattern behavior of the refactored path (verified against PostgreSQL 18.4); existing `regexp_instr`/`regexp_count` tests cover the rest.

## Are there any user-facing changes?

No.
