### PR TITLE
refactor(proto): destructure plan and proto structs in aggregate and window serde hooks

### DIFF
--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -2139,8 +2139,32 @@ impl ExecutionPlan for AggregateExec {
     ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalPlanNode>> {
         use datafusion_proto_models::protobuf;
 
-        let input = ctx.encode_child(self.input())?;
-        let group_by = self.group_expr();
+        // Exhaustive destructure: adding a field to `AggregateExec` without
+        // deciding how it is serialized is a compile error, not a silent
+        // round-trip gap.
+        let Self {
+            mode,
+            group_by,
+            aggr_expr,
+            filter_expr,
+            limit_options,
+            input,
+            // Derived at construction by `create_schema` from `input_schema`,
+            // `group_by`, `aggr_expr` and `mode`.
+            schema: _,
+            input_schema,
+            // Runtime execution state, rebuilt empty on decode.
+            metrics: _,
+            // Derived at construction from the input ordering and `group_by`.
+            required_input_ordering: _,
+            // Derived at construction from the input ordering and `group_by`.
+            input_order_mode: _,
+            // Derived at construction by `Self::compute_properties`.
+            cache: _,
+            dynamic_filter,
+        } = self;
+
+        let input = ctx.encode_child(input)?;
         let group_expr =
             ctx.encode_expressions(group_by.expr().iter().map(|(expr, _)| expr))?;
         let group_expr_name = group_by
@@ -2151,18 +2175,15 @@ impl ExecutionPlan for AggregateExec {
         let null_expr =
             ctx.encode_expressions(group_by.null_expr().iter().map(|(expr, _)| expr))?;
         let groups = group_by.groups().iter().flatten().copied().collect();
-        let aggr_expr = self
-            .aggr_expr()
-            .iter()
-            .map(|expr| encode_aggregate_expr(expr, ctx))
-            .collect::<Result<Vec<_>>>()?;
-        let aggr_expr_name = self
-            .aggr_expr()
+        let aggr_expr_name = aggr_expr
             .iter()
             .map(|expr| expr.name().to_string())
             .collect();
-        let filter_expr = self
-            .filter_expr()
+        let aggr_expr = aggr_expr
+            .iter()
+            .map(|expr| encode_aggregate_expr(expr, ctx))
+            .collect::<Result<Vec<_>>>()?;
+        let filter_expr = filter_expr
             .iter()
             .map(|filter| {
                 Ok(protobuf::MaybeFilter {
@@ -2175,7 +2196,7 @@ impl ExecutionPlan for AggregateExec {
             .collect::<Result<Vec<_>>>()?;
         // Match by name because the protobuf and execution enums use different
         // discriminants, so a numeric cast would corrupt the wire format.
-        let mode = match self.mode() {
+        let mode = match mode {
             AggregateMode::Partial => protobuf::AggregateMode::Partial,
             AggregateMode::Final => protobuf::AggregateMode::Final,
             AggregateMode::FinalPartitioned => protobuf::AggregateMode::FinalPartitioned,
@@ -2185,16 +2206,20 @@ impl ExecutionPlan for AggregateExec {
             }
             AggregateMode::PartialReduce => protobuf::AggregateMode::PartialReduce,
         };
-        let limit = self.limit_options().map(|options| protobuf::AggLimit {
+        let limit = limit_options.map(|options| protobuf::AggLimit {
             limit: options.limit() as u64,
             descending: options.descending(),
         });
-        let dynamic_filter = self
-            .dynamic_expressions_produced()
-            .into_iter()
-            .next()
-            .map(|expr| ctx.encode_expr(&expr))
-            .transpose()?;
+        // Only the shared `filter` expr is on the wire; the accumulator bounds
+        // in `AggrDynFilter` are runtime state repopulated during execution.
+        let dynamic_filter = match dynamic_filter {
+            Some(dynamic_filter) => {
+                let expr: Arc<dyn PhysicalExpr> =
+                    Arc::clone(&dynamic_filter.filter) as Arc<dyn PhysicalExpr>;
+                Some(ctx.encode_expr(&expr)?)
+            }
+            None => None,
+        };
 
         Ok(Some(protobuf::PhysicalPlanNode {
             physical_plan_type: Some(
@@ -2207,7 +2232,7 @@ impl ExecutionPlan for AggregateExec {
                         aggr_expr_name,
                         mode: mode as i32,
                         input: Some(Box::new(input)),
-                        input_schema: Some(self.input_schema().as_ref().try_into()?),
+                        input_schema: Some(input_schema.as_ref().try_into()?),
                         null_expr,
                         groups,
                         limit,
@@ -2315,17 +2340,31 @@ impl AggregateExec {
             protobuf::physical_plan_node::PhysicalPlanType::Aggregate,
             "AggregateExec",
         );
-        let input = ctx.decode_required_child(
-            hash_agg.input.as_deref(),
-            "AggregateExec",
-            "input",
-        )?;
+        // Exhaustive destructure: a new field on `AggregateExecNode` is a
+        // compile error here rather than a silently ignored wire field.
+        let protobuf::AggregateExecNode {
+            group_expr,
+            aggr_expr,
+            mode,
+            input,
+            group_expr_name,
+            aggr_expr_name,
+            input_schema,
+            null_expr,
+            groups,
+            filter_expr,
+            limit,
+            has_grouping_set,
+            dynamic_filter,
+        } = hash_agg.as_ref();
+
+        let input =
+            ctx.decode_required_child(input.as_deref(), "AggregateExec", "input")?;
         // Match by name because the protobuf and execution enums use different
         // discriminants, so a numeric cast would corrupt the wire format.
-        let mode = protobuf::AggregateMode::try_from(hash_agg.mode).map_err(|_| {
+        let mode = protobuf::AggregateMode::try_from(*mode).map_err(|_| {
             datafusion_common::internal_datafusion_err!(
-                "Received an AggregateNode message with unknown AggregateMode {}",
-                hash_agg.mode
+                "Received an AggregateNode message with unknown AggregateMode {mode}"
             )
         })?;
         let mode = match mode {
@@ -2338,13 +2377,12 @@ impl AggregateExec {
             }
             protobuf::AggregateMode::PartialReduce => AggregateMode::PartialReduce,
         };
-        let num_expr = hash_agg.group_expr.len();
+        let num_expr = group_expr.len();
         // Grouping expressions refer to the child plan's output schema.
         let child_schema = input.schema();
-        let group_expr = hash_agg
-            .group_expr
+        let group_expr = group_expr
             .iter()
-            .zip(hash_agg.group_expr_name.iter())
+            .zip(group_expr_name.iter())
             .map(|(expr, name)| {
                 Ok((
                     ctx.decode_expr(expr, child_schema.as_ref())?,
@@ -2352,10 +2390,9 @@ impl AggregateExec {
                 ))
             })
             .collect::<Result<Vec<_>>>()?;
-        let null_expr = hash_agg
-            .null_expr
+        let null_expr = null_expr
             .iter()
-            .zip(hash_agg.group_expr_name.iter())
+            .zip(group_expr_name.iter())
             .map(|(expr, name)| {
                 Ok((
                     ctx.decode_expr(expr, child_schema.as_ref())?,
@@ -2363,25 +2400,23 @@ impl AggregateExec {
                 ))
             })
             .collect::<Result<Vec<_>>>()?;
-        let groups = if hash_agg.groups.is_empty() {
+        let groups = if groups.is_empty() {
             vec![]
         } else {
-            hash_agg
-                .groups
+            groups
                 .chunks(num_expr)
                 .map(|group| group.to_vec())
                 .collect()
         };
         // Aggregate arguments, ordering, filters, and dynamic filters refer to
         // the aggregate input schema carried in the protobuf node.
-        let input_schema = hash_agg.input_schema.as_ref().ok_or_else(|| {
+        let input_schema = input_schema.as_ref().ok_or_else(|| {
             datafusion_common::internal_datafusion_err!(
                 "input_schema in AggregateNode is missing."
             )
         })?;
         let input_schema: SchemaRef = SchemaRef::new(input_schema.try_into()?);
-        let filter_expr = hash_agg
-            .filter_expr
+        let filter_expr = filter_expr
             .iter()
             .map(|filter| {
                 filter
@@ -2391,10 +2426,9 @@ impl AggregateExec {
                     .transpose()
             })
             .collect::<Result<Vec<_>>>()?;
-        let aggr_expr = hash_agg
-            .aggr_expr
+        let aggr_expr = aggr_expr
             .iter()
-            .zip(hash_agg.aggr_expr_name.iter())
+            .zip(aggr_expr_name.iter())
             .map(|(expr, name)| {
                 let expr_type = expr.expr_type.as_ref().ok_or_else(|| {
                     datafusion_common::internal_datafusion_err!(
@@ -2446,18 +2480,13 @@ impl AggregateExec {
             .collect::<Result<Vec<_>>>()?;
         let aggregate = AggregateExec::try_new(
             mode,
-            PhysicalGroupBy::new(
-                group_expr,
-                null_expr,
-                groups,
-                hash_agg.has_grouping_set,
-            ),
+            PhysicalGroupBy::new(group_expr, null_expr, groups, *has_grouping_set),
             aggr_expr,
             filter_expr,
             input,
             Arc::clone(&input_schema),
         )?;
-        let aggregate = if let Some(limit) = &hash_agg.limit {
+        let aggregate = if let Some(limit) = limit {
             let options = match limit.descending {
                 Some(descending) => {
                     LimitOptions::new_with_order(limit.limit as usize, descending)
@@ -2468,7 +2497,7 @@ impl AggregateExec {
         } else {
             aggregate
         };
-        let aggregate = if let Some(dynamic_filter) = &hash_agg.dynamic_filter {
+        let aggregate = if let Some(dynamic_filter) = dynamic_filter {
             let dynamic_filter =
                 ctx.decode_expr(dynamic_filter, input_schema.as_ref())?;
             let dynamic_filter = (dynamic_filter

--- a/datafusion/physical-plan/src/analyze.rs
+++ b/datafusion/physical-plan/src/analyze.rs
@@ -311,14 +311,32 @@ impl ExecutionPlan for AnalyzeExec {
     ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalPlanNode>> {
         use datafusion_proto_models::protobuf;
 
-        let input = ctx.encode_child(self.input())?;
-        let (has_metric_categories, metric_categories) = match self.metric_categories() {
+        // Exhaustive destructure: adding a field to `AnalyzeExec` without
+        // deciding how it is serialized is a compile error, not a silent
+        // round-trip gap.
+        let Self {
+            verbose,
+            show_statistics,
+            // TODO: not on the wire. `AnalyzeExecBuilder` always resets this to
+            // `[Summary, Dev]`, so a non-default selection is lost on
+            // round-trip. Fixing it needs a new proto field.
+            metric_types: _,
+            metric_categories,
+            format,
+            input,
+            schema,
+            // Derived at construction from `input` and `schema`.
+            cache: _,
+        } = self;
+
+        let input = ctx.encode_child(input)?;
+        let (has_metric_categories, metric_categories) = match metric_categories {
             Some(categories) => {
                 (true, categories.iter().map(ToString::to_string).collect())
             }
             None => (false, vec![]),
         };
-        let format = match self.format() {
+        let format = match format {
             ExplainFormat::Indent => protobuf::ExplainFormat::Indent,
             ExplainFormat::Tree => protobuf::ExplainFormat::Tree,
             ExplainFormat::PostgresJSON => protobuf::ExplainFormat::Pgjson,
@@ -328,10 +346,10 @@ impl ExecutionPlan for AnalyzeExec {
             physical_plan_type: Some(
                 protobuf::physical_plan_node::PhysicalPlanType::Analyze(Box::new(
                     protobuf::AnalyzeExecNode {
-                        verbose: self.verbose(),
-                        show_statistics: self.show_statistics(),
+                        verbose: *verbose,
+                        show_statistics: *show_statistics,
                         input: Some(Box::new(input)),
-                        schema: Some(self.schema().as_ref().try_into()?),
+                        schema: Some(schema.as_ref().try_into()?),
                         has_metric_categories,
                         metric_categories,
                         format,
@@ -356,12 +374,23 @@ impl AnalyzeExec {
             protobuf::physical_plan_node::PhysicalPlanType::Analyze,
             "AnalyzeExec",
         );
+        // Exhaustive destructure: a new field on `AnalyzeExecNode` is a compile
+        // error here rather than a silently ignored wire field.
+        let protobuf::AnalyzeExecNode {
+            verbose,
+            show_statistics,
+            input,
+            schema,
+            has_metric_categories,
+            metric_categories,
+            format,
+        } = analyze.as_ref();
+
         let input =
-            ctx.decode_required_child(analyze.input.as_deref(), "AnalyzeExec", "input")?;
-        let metric_categories = if analyze.has_metric_categories {
+            ctx.decode_required_child(input.as_deref(), "AnalyzeExec", "input")?;
+        let metric_categories = if *has_metric_categories {
             Some(
-                analyze
-                    .metric_categories
+                metric_categories
                     .iter()
                     .map(|category| category.parse::<MetricCategory>())
                     .collect::<Result<Vec<_>>>()?,
@@ -369,28 +398,26 @@ impl AnalyzeExec {
         } else {
             None
         };
-        let proto_format =
-            protobuf::ExplainFormat::try_from(analyze.format).map_err(|_| {
-                DataFusionError::Internal(format!(
-                    "Received an AnalyzeExecNode message with unknown ExplainFormat {}",
-                    analyze.format
-                ))
-            })?;
+        let proto_format = protobuf::ExplainFormat::try_from(*format).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "Received an AnalyzeExecNode message with unknown ExplainFormat {format}"
+            ))
+        })?;
         let format = match proto_format {
             protobuf::ExplainFormat::Indent => ExplainFormat::Indent,
             protobuf::ExplainFormat::Tree => ExplainFormat::Tree,
             protobuf::ExplainFormat::Pgjson => ExplainFormat::PostgresJSON,
             protobuf::ExplainFormat::Graphviz => ExplainFormat::Graphviz,
         };
-        let schema = analyze.schema.as_ref().ok_or_else(|| {
+        let schema = schema.as_ref().ok_or_else(|| {
             datafusion_common::internal_datafusion_err!(
                 "AnalyzeExec is missing required field 'schema'"
             )
         })?;
         Ok(Arc::new(
             AnalyzeExec::builder(
-                analyze.verbose,
-                analyze.show_statistics,
+                *verbose,
+                *show_statistics,
                 input,
                 Arc::new(arrow::datatypes::Schema::try_from(schema)?),
             )

--- a/datafusion/physical-plan/src/async_func.rs
+++ b/datafusion/physical-plan/src/async_func.rs
@@ -253,14 +253,22 @@ impl ExecutionPlan for AsyncFuncExec {
         ctx: &crate::proto::ExecutionPlanEncodeCtx<'_>,
     ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalPlanNode>> {
         use datafusion_proto_models::protobuf;
-        let input = ctx.encode_child(self.input())?;
-        let async_exprs =
-            ctx.encode_expressions(self.async_exprs.iter().map(|e| &e.func))?;
-        let async_expr_names = self
-            .async_exprs
-            .iter()
-            .map(|e| e.name().to_string())
-            .collect();
+
+        // Exhaustive destructure: adding a field to `AsyncFuncExec` without
+        // deciding how it is serialized is a compile error, not a silent
+        // round-trip gap.
+        let Self {
+            async_exprs,
+            input,
+            // Derived at construction by `AsyncFuncExec::compute_properties`.
+            cache: _,
+            // Runtime execution state, rebuilt empty on decode.
+            metrics: _,
+        } = self;
+
+        let input = ctx.encode_child(input)?;
+        let async_expr_names = async_exprs.iter().map(|e| e.name().to_string()).collect();
+        let async_exprs = ctx.encode_expressions(async_exprs.iter().map(|e| &e.func))?;
         Ok(Some(protobuf::PhysicalPlanNode {
             physical_plan_type: Some(
                 protobuf::physical_plan_node::PhysicalPlanType::AsyncFunc(Box::new(
@@ -297,21 +305,25 @@ impl AsyncFuncExec {
             protobuf::physical_plan_node::PhysicalPlanType::AsyncFunc,
             "AsyncFuncExec",
         );
-        let input = ctx.decode_required_child(
-            async_func.input.as_deref(),
-            "AsyncFuncExec",
-            "input",
-        )?;
+        // Exhaustive destructure: a new field on `AsyncFuncExecNode` is a
+        // compile error here rather than a silently ignored wire field.
+        let protobuf::AsyncFuncExecNode {
+            input,
+            async_exprs,
+            async_expr_names,
+        } = async_func.as_ref();
+
+        let input =
+            ctx.decode_required_child(input.as_deref(), "AsyncFuncExec", "input")?;
         let input_schema = input.schema();
         assert_eq_or_internal_err!(
-            async_func.async_exprs.len(),
-            async_func.async_expr_names.len(),
+            async_exprs.len(),
+            async_expr_names.len(),
             "AsyncFuncExecNode async_exprs length does not match async_expr_names"
         );
-        let async_exprs = async_func
-            .async_exprs
+        let async_exprs = async_exprs
             .iter()
-            .zip(async_func.async_expr_names.iter())
+            .zip(async_expr_names.iter())
             .map(|(expr, name)| {
                 let physical_expr = ctx.decode_expr(expr, input_schema.as_ref())?;
                 Ok(Arc::new(AsyncFuncExpr::try_new(

--- a/datafusion/physical-plan/src/unnest.rs
+++ b/datafusion/physical-plan/src/unnest.rs
@@ -291,25 +291,38 @@ impl ExecutionPlan for UnnestExec {
     ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalPlanNode>> {
         use datafusion_proto_models::protobuf;
 
-        let input = ctx.encode_child(self.input())?;
-        let schema = self.schema().as_ref().try_into()?;
-        let list_type_columns = self
-            .list_column_indices()
+        // Exhaustive destructure: adding a field to `UnnestExec` without
+        // deciding how it is serialized is a compile error, not a silent
+        // round-trip gap.
+        let Self {
+            input,
+            schema,
+            list_column_indices,
+            struct_column_indices,
+            options,
+            // Runtime execution state, rebuilt empty on decode.
+            metrics: _,
+            // Derived at construction by `UnnestExec::compute_properties`.
+            cache: _,
+        } = self;
+
+        let input = ctx.encode_child(input)?;
+        let schema = schema.as_ref().try_into()?;
+        let list_type_columns = list_column_indices
             .iter()
             .map(|column| protobuf::ListUnnest {
                 index_in_input_schema: column.index_in_input_schema as _,
                 depth: column.depth as _,
             })
             .collect();
-        let struct_type_columns = self
-            .struct_column_indices()
+        let struct_type_columns = struct_column_indices
             .iter()
             .map(|index| *index as _)
             .collect();
         let null_handling = {
             use datafusion_common::NullHandling;
             use protobuf::unnest_options::NullHandling as ProtoNullHandling;
-            match self.options().null_handling {
+            match options.null_handling {
                 NullHandling::Preserve => ProtoNullHandling::Preserve,
                 NullHandling::Drop => ProtoNullHandling::Drop,
                 NullHandling::PreserveAndExpandEmpty => {
@@ -319,8 +332,7 @@ impl ExecutionPlan for UnnestExec {
         } as i32;
         let options = protobuf::UnnestOptions {
             null_handling,
-            recursions: self
-                .options()
+            recursions: options
                 .recursions
                 .iter()
                 .map(|recursion| protobuf::RecursionUnnestOption {
@@ -365,10 +377,18 @@ impl UnnestExec {
             protobuf::physical_plan_node::PhysicalPlanType::Unnest,
             "UnnestExec",
         );
-        let input =
-            ctx.decode_required_child(unnest.input.as_deref(), "UnnestExec", "input")?;
-        let schema: Schema = unnest
-            .schema
+        // Exhaustive destructure: a new field on `UnnestExecNode` is a compile
+        // error here rather than a silently ignored wire field.
+        let protobuf::UnnestExecNode {
+            input,
+            schema,
+            list_type_columns,
+            struct_type_columns,
+            options,
+        } = unnest.as_ref();
+
+        let input = ctx.decode_required_child(input.as_deref(), "UnnestExec", "input")?;
+        let schema: Schema = schema
             .as_ref()
             .ok_or_else(|| {
                 datafusion_common::internal_datafusion_err!(
@@ -376,20 +396,18 @@ impl UnnestExec {
                 )
             })?
             .try_into()?;
-        let list_column_indices = unnest
-            .list_type_columns
+        let list_column_indices = list_type_columns
             .iter()
             .map(|column| ListUnnest {
                 index_in_input_schema: column.index_in_input_schema as _,
                 depth: column.depth as _,
             })
             .collect();
-        let struct_column_indices = unnest
-            .struct_type_columns
+        let struct_column_indices = struct_type_columns
             .iter()
             .map(|index| *index as _)
             .collect();
-        let options = unnest.options.as_ref().ok_or_else(|| {
+        let options = options.as_ref().ok_or_else(|| {
             datafusion_common::internal_datafusion_err!(
                 "UnnestExec is missing required field 'options'"
             )

--- a/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
+++ b/datafusion/physical-plan/src/windows/bounded_window_agg_exec.rs
@@ -413,9 +413,31 @@ impl ExecutionPlan for BoundedWindowAggExec {
         use datafusion_proto_models::protobuf;
         use protobuf::window_agg_exec_node::InputOrderMode as ProtoInputOrderMode;
 
-        let input = ctx.encode_child(self.input())?;
-        let window_expr = self
-            .window_expr()
+        // Exhaustive destructure: adding a field to `BoundedWindowAggExec`
+        // without deciding how it is serialized is a compile error, not a
+        // silent round-trip gap.
+        let Self {
+            input,
+            window_expr,
+            // Derived at construction by `create_schema` from the input schema
+            // and the window expressions.
+            schema: _,
+            // Runtime execution state, rebuilt empty on decode.
+            metrics: _,
+            input_order_mode,
+            // Derived at construction from `input_order_mode` and the window
+            // expressions' PARTITION BY.
+            ordered_partition_by_indices: _,
+            // Derived at construction by `Self::compute_properties`.
+            cache: _,
+            // No wire field of its own; it is folded into `partition_keys`
+            // below, since `partition_keys()` returns an empty vec when this is
+            // false and the decoder recovers it as `!partition_keys.is_empty()`.
+            can_repartition: _,
+        } = self;
+
+        let input = ctx.encode_child(input)?;
+        let window_expr = window_expr
             .iter()
             .map(|expr| encode_physical_window_expr(expr, ctx))
             .collect::<Result<Vec<_>>>()?;
@@ -426,7 +448,7 @@ impl ExecutionPlan for BoundedWindowAggExec {
             .collect::<Result<Vec<_>>>()?;
         // A `Some(input_order_mode)` is what tells the shared `Window` decode
         // arm to rebuild a `BoundedWindowAggExec` rather than a `WindowAggExec`.
-        let input_order_mode = match &self.input_order_mode {
+        let input_order_mode = match input_order_mode {
             InputOrderMode::Linear => ProtoInputOrderMode::Linear(EmptyMessage {}),
             InputOrderMode::PartiallySorted(columns) => {
                 ProtoInputOrderMode::PartiallySorted(

--- a/datafusion/physical-plan/src/windows/window_agg_exec.rs
+++ b/datafusion/physical-plan/src/windows/window_agg_exec.rs
@@ -327,9 +327,29 @@ impl ExecutionPlan for WindowAggExec {
     ) -> Result<Option<datafusion_proto_models::protobuf::PhysicalPlanNode>> {
         use datafusion_proto_models::protobuf;
 
-        let input = ctx.encode_child(self.input())?;
-        let window_expr = self
-            .window_expr()
+        // Exhaustive destructure: adding a field to `WindowAggExec` without
+        // deciding how it is serialized is a compile error, not a silent
+        // round-trip gap.
+        let Self {
+            input,
+            window_expr,
+            // Derived at construction by `create_schema` from the input schema
+            // and the window expressions.
+            schema: _,
+            // Runtime execution state, rebuilt empty on decode.
+            metrics: _,
+            // Derived at construction by `get_ordered_partition_by_indices`.
+            ordered_partition_by_indices: _,
+            // Derived at construction by `Self::compute_properties`.
+            cache: _,
+            // No wire field of its own; it is folded into `partition_keys`
+            // below, since `partition_keys()` returns an empty vec when this is
+            // false and the decoder recovers it as `!partition_keys.is_empty()`.
+            can_repartition: _,
+        } = self;
+
+        let input = ctx.encode_child(input)?;
+        let window_expr = window_expr
             .iter()
             .map(|expr| encode_physical_window_expr(expr, ctx))
             .collect::<Result<Vec<_>>>()?;
@@ -378,24 +398,28 @@ impl WindowAggExec {
             protobuf::physical_plan_node::PhysicalPlanType::Window,
             "WindowAggExec",
         );
-        let input = ctx.decode_required_child(
-            window_agg.input.as_deref(),
-            "WindowAggExec",
-            "input",
-        )?;
+        // Exhaustive destructure: a new field on `WindowAggExecNode` is a
+        // compile error here rather than a silently ignored wire field.
+        let protobuf::WindowAggExecNode {
+            input,
+            window_expr,
+            partition_keys,
+            input_order_mode,
+        } = window_agg.as_ref();
+
+        let input =
+            ctx.decode_required_child(input.as_deref(), "WindowAggExec", "input")?;
         let input_schema = input.schema();
-        let window_expr = window_agg
-            .window_expr
+        let window_expr = window_expr
             .iter()
             .map(|expr| decode_physical_window_expr(expr, ctx, input_schema.as_ref()))
             .collect::<Result<Vec<_>>>()?;
-        let partition_keys = window_agg
-            .partition_keys
+        let partition_keys = partition_keys
             .iter()
             .map(|expr| ctx.decode_expr(expr, input_schema.as_ref()))
             .collect::<Result<Vec<_>>>()?;
 
-        if let Some(input_order_mode) = window_agg.input_order_mode.as_ref() {
+        if let Some(input_order_mode) = input_order_mode.as_ref() {
             let input_order_mode = match input_order_mode {
                 ProtoInputOrderMode::Linear(_) => InputOrderMode::Linear,
                 ProtoInputOrderMode::PartiallySorted(
@@ -409,12 +433,15 @@ impl WindowAggExec {
                 window_expr,
                 input,
                 input_order_mode,
+                // `can_repartition` has no wire field: the encoder writes an
+                // empty `partition_keys` when it is false.
                 !partition_keys.is_empty(),
             )?))
         } else {
             Ok(Arc::new(WindowAggExec::try_new(
                 window_expr,
                 input,
+                // See above: `can_repartition` is recovered from `partition_keys`.
                 !partition_keys.is_empty(),
             )?))
         }


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No dedicated issue; this is follow-up cleanup for the proto hook migration EPIC. -->

- Part of #23494.

## Rationale for this change

EPIC #23494 moved every built-in `ExecutionPlan` off the central `downcast_ref` chain in `datafusion-proto` and onto per-plan hooks (`ExecutionPlan::try_to_proto` + an inherent `FooExec::try_from_proto`) that live in the plan's own module.

Those hooks currently read plan state through **getters**. That means adding a field to a plan struct is invisible to serialization: nothing breaks, the field is just silently not serialized, and the omission only shows up later as a plan that quietly changes shape after a round-trip.

This is not hypothetical. `HashJoinExec.fetch` is dropped on round-trip today for exactly this reason (being fixed separately). The same class of bug is one commit away in every other plan.

This PR removes the failure mode for the aggregate, window, and remaining misc plans by making both directions exhaustive:

- **Encode side**: each `try_to_proto` begins with an exhaustive destructure of `self`. Every field is named — no `..`. Adding a field to the plan struct is now a compile error until the author decides what happens to it.
- **Decode side**: each `try_from_proto` destructures the prost-generated node struct exhaustively. Those structs are plain, all-`pub` and not `#[non_exhaustive]`, so this compiles — and a newly added proto field becomes a compile error in every decoder rather than a silently ignored wire field.

Fields that genuinely are not serialized bind to `_` with a short comment saying why: derived at construction, runtime state, or recomputed on decode.

## What changes are included in this PR?

Three commits, one per plan group, each green on its own:

1. `AggregateExec` / `protobuf::AggregateExecNode`
2. `WindowAggExec` and `BoundedWindowAggExec` / `protobuf::WindowAggExecNode` (they share one decoder)
3. `UnnestExec`, `AsyncFuncExec`, `AnalyzeExec` and their nodes

All changes are confined to `datafusion/physical-plan/src/`.

**The wire format is unchanged — byte for byte.** No behavior changes. This is a pure refactor; the encoders build the same proto messages from the same values, just reached through destructured bindings instead of accessors.

### Implicit coupling now documented

`WindowAggExec::can_repartition` / `BoundedWindowAggExec::can_repartition` have no wire field of their own. `partition_keys()` returns an empty vec when `can_repartition` is false, and the decoder recovers the flag as `!partition_keys.is_empty()`. That round trip was previously something you had to already know; it is now an explicit comment on both the encode and the decode side.

### Unserialized fields the refactor documented

Fields bound to `_` because they are legitimately reconstructed rather than transmitted:

| Plan | Field(s) | Why |
| --- | --- | --- |
| `AggregateExec` | `schema`, `required_input_ordering`, `input_order_mode`, `cache` | derived at construction |
| `AggregateExec` | `metrics` | runtime state |
| `WindowAggExec` | `schema`, `ordered_partition_by_indices`, `cache` | derived at construction |
| `BoundedWindowAggExec` | `schema`, `ordered_partition_by_indices`, `cache` | derived at construction |
| `WindowAggExec` / `BoundedWindowAggExec` | `can_repartition` | no wire field; folded into `partition_keys` (see above) |
| `UnnestExec` | `cache` (derived), `metrics` (runtime) | |
| `AsyncFuncExec` | `cache` (derived), `metrics` (runtime) | |
| `AnalyzeExec` | `cache` | derived at construction |

The `AggrDynFilter` case is also now commented: only the shared `filter` expr goes on the wire; the per-accumulator bounds are runtime state repopulated during execution.

### One real gap found, deliberately left alone

**`AnalyzeExec::metric_types` is not serialized.** There is no field for it on `AnalyzeExecNode`, and `AnalyzeExecBuilder` unconditionally resets it to `[MetricType::Summary, MetricType::Dev]`, so a non-default metric type selection does not survive a round trip.

Fixing this requires a new proto field, which is a wire-format change and therefore out of scope for a cleanup PR — a refactor that silently alters the wire format would be worse than the gap it fixes. The field is left bound to `_` with a `TODO` describing the current state, so it can be filed and fixed separately.

## Are these changes tested?

Covered by the existing round-trip test suite, which is the actual proof that the wire format did not move:

- `cargo test -p datafusion-proto --test proto_integration` — 214 passed, 0 failed
- `cargo test -p datafusion-physical-plan --all-features` — 1648 + 9 passed, 0 failed
- `cargo clippy -p datafusion-physical-plan --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all`

No new tests are added: the refactor introduces no new behavior to test, and its safety property (a forgotten field becomes a compile error) is enforced by the compiler rather than by a test.

## Are there any user-facing changes?

No. No public API changes, no wire-format changes, no behavior changes.
