### PR TITLE
fix: box aws-config loading future avoid clippy warning

### DIFF
--- a/datafusion-cli/src/object_storage.rs
+++ b/datafusion-cli/src/object_storage.rs
@@ -180,7 +180,10 @@ struct CredentialsFromConfig {
 impl CredentialsFromConfig {
     /// Attempt find AWS S3 credentials via the AWS SDK
     pub async fn try_new() -> Result<Self> {
-        let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+        // Loading the SDK config produces a large future, so box it to avoid
+        // potentially triggering the `large_futures` clippy lint.
+        let config =
+            Box::pin(aws_config::defaults(BehaviorVersion::latest()).load()).await;
         let region = config.region().map(|r| r.to_string());
 
         let credentials = config


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## Rationale for this change

In aws-config >= 1.10, the future returned by `ConfigLoader::load()` is large enough that it triggers the clippy `large_futures` error (as seen in the CI failures for #24163). Fix this by using `Box::pin`.

## What changes are included in this PR?

See above.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.
