### PR TITLE
Fix duplicated words in documentation

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -953,7 +953,7 @@ Several queries are included to test hash joins under various workloads.
 
 ## Sort Merge Join
 
-This benchmark focuses on the performance of queries with sort merge joins joins, minimizing other overheads such as scanning data sources or evaluating predicates.
+This benchmark focuses on the performance of queries with sort merge joins, minimizing other overheads such as scanning data sources or evaluating predicates.
 
 Several queries are included to test sort merge joins under various workloads.
 

--- a/docs/source/library-user-guide/building-logical-plans.md
+++ b/docs/source/library-user-guide/building-logical-plans.md
@@ -86,7 +86,7 @@ Filter: person.id > Int32(500) [id:Int32;N, name:Utf8;N]
 DataFusion logical plans can be created using the [LogicalPlanBuilder] struct. There is also a [DataFrame] API which is
 a higher-level API that delegates to [LogicalPlanBuilder].
 
-There are several functions that can can be used to create a new builder, such as
+There are several functions that can be used to create a new builder, such as
 
 - `empty` - create an empty plan with no fields
 - `values` - create a plan from a set of literal values

--- a/docs/source/user-guide/explain-usage.md
+++ b/docs/source/user-guide/explain-usage.md
@@ -169,7 +169,7 @@ debugging to see why and when DataFusion added and removed operators from a plan
 
 During execution, DataFusion operators collect detailed metrics. You can access
 them programmatically via [`ExecutionPlan::metrics`] as well as with the
-`EXPLAIN ANALYZE` command. For example here is the same query query as
+`EXPLAIN ANALYZE` command. For example here is the same query as
 above but with `EXPLAIN ANALYZE` (note the output is edited for clarity)
 
 [`executionplan::metrics`]: https://docs.rs/datafusion/latest/datafusion/physical_plan/trait.ExecutionPlan.html#method.metrics
@@ -365,7 +365,7 @@ For this query, let's again read the plan from the bottom to the top:
   - `gby=[UserID@0 as UserID]`: Represents `GROUP BY` in the [physical plan] and groups together the same values of `UserID`.
   - `aggr=[count(*)]`: Applies the `COUNT` aggregate on all rows for each group.
 - `RepartitionExec`
-  - `partitioning=Hash([UserID@0], 10)`: Divides the input into into 10 (new) output partitions based on the value of `hash(UserID)`. You can read more about this in the [partitioning] documentation.
+  - `partitioning=Hash([UserID@0], 10)`: Divides the input into 10 (new) output partitions based on the value of `hash(UserID)`. You can read more about this in the [partitioning] documentation.
   - `input_partitions=10`: Number of input partitions.
 - `CoalesceBatchesExec`
   - `target_batch_size=8192`: Combines smaller batches in to larger batches. In this case approximately 8192 rows in each batch.


### PR DESCRIPTION
A few duplicated words in the docs:

- `docs/source/library-user-guide/building-logical-plans.md`: "functions that can can be used" -> "that can be used".
- `docs/source/user-guide/explain-usage.md`: "the same query query as" -> "the same query as"; "Divides the input into into 10" -> "into 10".
- `benchmarks/README.md`: "sort merge joins joins" -> "sort merge joins".

Documentation only.
