### PR TITLE
IN LIST: index 32- and 64-bit integers by byte

### DIFF
--- a/datafusion/physical-expr/benches/in_list_strategy.rs
+++ b/datafusion/physical-expr/benches/in_list_strategy.rs
@@ -44,14 +44,14 @@
 //! | Utf8View length-12 cases | Utf8View | 12-byte strings | 16, 64 |
 //! | Utf8View long-string cases | Utf8View | 24-byte strings | 4, 16, 64, 256 |
 //! | Shared-prefix string cases | Utf8, Utf8View | same prefix, different suffix | 16, 32, 64 |
-//! | Fixed-size binary cases | FixedSizeBinary(16) | fixed-width binary values | 4, 64, 256, 10000 |
+//! | Fixed-size binary cases | FixedSizeBinary(1), FixedSizeBinary(2), FixedSizeBinary(16) | fixed-width binary values | 16 (1 byte), 64 (2 bytes), 4/64/256/10000 (16 bytes) |
 
 use arrow::array::types::IntervalMonthDayNano;
 use arrow::array::*;
 use arrow::datatypes::{Field, Int32Type, IntervalMonthDayNanoType, Schema};
 use arrow::record_batch::RecordBatch;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use datafusion_common::ScalarValue;
+use datafusion_common::{HashSet, ScalarValue};
 use datafusion_physical_expr::expressions::{col, in_list, lit};
 use half::f16;
 use rand::distr::Alphanumeric;
@@ -996,32 +996,48 @@ fn bench_nulls(c: &mut Criterion) {
 }
 
 // =============================================================================
-// FIXED SIZE BINARY BENCHMARKS (FixedSizeBinary<16>, e.g. UUIDs)
+// FIXED SIZE BINARY BENCHMARKS
 // =============================================================================
 
-/// Generates a random 16-byte value (UUID-sized).
-fn random_fixed_binary_16(rng: &mut StdRng) -> Vec<u8> {
-    let mut buf = vec![0u8; 16];
+fn random_fixed_binary(rng: &mut StdRng, width: i32) -> Vec<u8> {
+    let mut buf = vec![0u8; width as usize];
     rng.fill(&mut buf[..]);
     buf
 }
 
-/// Benchmarks FixedSizeBinary(16) IN list evaluation.
 /// FixedSizeBinary doesn't use the generic numeric helpers since its array
 /// construction differs from primitive types.
 fn bench_fixed_size_binary_inner(
     c: &mut Criterion,
-    name: &str,
+    width: i32,
     list_size: usize,
-    match_rate: f64,
+    match_pct: u32,
 ) {
-    let seed = 0xF1ED_B1A7_u64.wrapping_add(list_size as u64 * 0x6666);
+    assert!(match_pct <= 100);
+    if let Some(domain_size) = match width {
+        1 => Some(1_usize << 8),
+        2 => Some(1_usize << 16),
+        _ => None,
+    } {
+        // The input generator needs at least one value outside the list.
+        assert!(list_size < domain_size);
+    }
+    let match_rate = f64::from(match_pct) / 100.0;
+
+    let seed = 0xF1ED_B1A7_u64
+        .wrapping_add(list_size as u64 * 0x6666)
+        .wrapping_add(width as u64 * 0x7777);
     let mut rng = StdRng::seed_from_u64(seed);
 
-    // Generate IN list values (16-byte each)
-    let haystack: Vec<Vec<u8>> = (0..list_size)
-        .map(|_| random_fixed_binary_16(&mut rng))
-        .collect();
+    // Keep the number of distinct values equal to the configured list size.
+    let mut haystack_set = HashSet::with_capacity(list_size);
+    let mut haystack = Vec::with_capacity(list_size);
+    while haystack.len() < list_size {
+        let value = random_fixed_binary(&mut rng, width);
+        if haystack_set.insert(value.clone()) {
+            haystack.push(value);
+        }
+    }
 
     // Generate array with controlled match rate
     let values: Vec<Vec<u8>> = (0..ARRAY_SIZE)
@@ -1029,7 +1045,12 @@ fn bench_fixed_size_binary_inner(
             if !haystack.is_empty() && rng.random_bool(match_rate) {
                 haystack.choose(&mut rng).unwrap().clone()
             } else {
-                random_fixed_binary_16(&mut rng)
+                loop {
+                    let value = random_fixed_binary(&mut rng, width);
+                    if !haystack_set.contains(&value) {
+                        break value;
+                    }
+                }
             }
         })
         .collect();
@@ -1040,28 +1061,28 @@ fn bench_fixed_size_binary_inner(
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
     let exprs: Vec<_> = haystack
         .iter()
-        .map(|v| lit(ScalarValue::FixedSizeBinary(16, Some(v.clone()))))
+        .map(|v| lit(ScalarValue::FixedSizeBinary(width, Some(v.clone()))))
         .collect();
     let expr = in_list(col("a", &schema).unwrap(), exprs, &false, &schema).unwrap();
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array) as ArrayRef])
         .unwrap();
 
     c.bench_with_input(
-        BenchmarkId::new("fixed_size_binary", name),
+        BenchmarkId::new(
+            "fixed_size_binary",
+            format!("fsb{width}/list={list_size}/match={match_pct}%"),
+        ),
         &batch,
         |b, batch| b.iter(|| expr.evaluate(batch).unwrap()),
     );
 }
 
 fn bench_fixed_size_binary(c: &mut Criterion) {
-    for list_size in [4, 64, 256, 10000] {
+    for (width, list_size) in
+        [(1, 16), (2, 64), (16, 4), (16, 64), (16, 256), (16, 10000)]
+    {
         for match_pct in MATCH_RATES {
-            bench_fixed_size_binary_inner(
-                c,
-                &format!("fsb16/list={list_size}/match={match_pct}%"),
-                list_size,
-                match_pct as f64 / 100.0,
-            );
+            bench_fixed_size_binary_inner(c, width, list_size, match_pct);
         }
     }
 }

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -38,6 +38,7 @@ use datafusion_expr::{ColumnarValue, expr_vec_fmt};
 
 mod array_static_filter;
 mod branchless_filter;
+mod byte_view_filter;
 mod fixed_size_binary_filter;
 mod primitive_filter;
 mod result;
@@ -216,7 +217,7 @@ impl InListExpr {
             expr,
             list,
             negated,
-            Some(instantiate_static_filter(array)?),
+            Some(instantiate_static_filter(array, &expr_data_type)?),
         ))
     }
 
@@ -243,7 +244,7 @@ impl InListExpr {
 
         // Try to create a static filter if all list expressions are constants
         let static_filter = match try_evaluate_constant_list(&list, schema)? {
-            Some(in_array) => Some(instantiate_static_filter(in_array)?),
+            Some(in_array) => Some(instantiate_static_filter(in_array, &expr_data_type)?),
             None => None, // Non-constant expressions, fall back to dynamic evaluation
         };
 
@@ -3608,6 +3609,23 @@ mod tests {
                 wrap_in_dict(Arc::clone(&utf8_needle)),
                 wrap_in_dict(Arc::clone(&utf8_in)),
             )?
+        );
+
+        // Utf8View in_array, Utf8View and Dict(Utf8View) needles
+        let utf8view_in =
+            Arc::new(StringViewArray::from(vec!["a", "b", "c", "d", "e"])) as ArrayRef;
+        let utf8view_needle =
+            Arc::new(StringViewArray::from(vec!["a", "missing", "b"])) as ArrayRef;
+        assert_eq!(
+            expected,
+            eval_in_list_from_array(
+                Arc::clone(&utf8view_needle),
+                Arc::clone(&utf8view_in),
+            )?
+        );
+        assert_eq!(
+            expected,
+            eval_in_list_from_array(wrap_in_dict(utf8view_needle), utf8view_in)?
         );
 
         // Struct in_array, Struct needle: multi-column join

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -38,6 +38,7 @@ use datafusion_expr::{ColumnarValue, expr_vec_fmt};
 
 mod array_static_filter;
 mod branchless_filter;
+mod fixed_size_binary_filter;
 mod primitive_filter;
 mod result;
 mod static_filter;
@@ -3547,6 +3548,39 @@ mod tests {
                 "dict-needle failed for {dt:?}"
             );
         }
+
+        // FixedSizeBinary in_array, FixedSizeBinary and Dictionary needles
+        let fsb_in = Arc::new(FixedSizeBinaryArray::try_from_iter(
+            [
+                [1, 2, 3, 4].as_slice(),
+                [5, 6, 7, 8].as_slice(),
+                [9, 10, 11, 12].as_slice(),
+            ]
+            .into_iter(),
+        )?) as ArrayRef;
+        let fsb_needle = Arc::new(FixedSizeBinaryArray::try_from_iter(
+            [
+                [1, 2, 3, 4].as_slice(),
+                [13, 14, 15, 16].as_slice(),
+                [5, 6, 7, 8].as_slice(),
+            ]
+            .into_iter(),
+        )?) as ArrayRef;
+        assert_eq!(
+            expected,
+            eval_in_list_from_array(Arc::clone(&fsb_needle), Arc::clone(&fsb_in))?
+        );
+        assert_eq!(
+            expected,
+            eval_in_list_from_array(
+                wrap_in_dict(Arc::clone(&fsb_needle)),
+                Arc::clone(&fsb_in),
+            )?
+        );
+        assert_eq!(
+            expected,
+            eval_in_list_from_array(wrap_in_dict(fsb_needle), wrap_in_dict(fsb_in))?
+        );
 
         // Utf8 (falls through to ArrayStaticFilter)
         let utf8_in = Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef;

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -40,6 +40,7 @@ mod array_static_filter;
 mod branchless_filter;
 mod byte_view_filter;
 mod fixed_size_binary_filter;
+mod integer_set;
 mod primitive_filter;
 mod result;
 mod static_filter;

--- a/datafusion/physical-expr/src/expressions/in_list/branchless_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/branchless_filter.rs
@@ -71,7 +71,7 @@
 use std::mem::size_of;
 
 use arrow::array::{Array, ArrayRef, AsArray, BooleanArray, PrimitiveArray};
-use arrow::buffer::{BooleanBuffer, ScalarBuffer};
+use arrow::buffer::{BooleanBuffer, NullBuffer, ScalarBuffer};
 use arrow::datatypes::*;
 use arrow::util::bit_iterator::BitIndexIterator;
 use datafusion_common::{Result, exec_datafusion_err, internal_datafusion_err};
@@ -244,6 +244,20 @@ where
             check_values,
         })
     }
+
+    /// Evaluates values that the caller has already checked use `T`'s physical
+    /// representation. `nulls`, when present, must cover the same slice.
+    #[inline]
+    pub(super) fn contains_raw_values(
+        &self,
+        input_values: &[BranchlessNative<T>],
+        nulls: Option<&NullBuffer>,
+        negated: bool,
+    ) -> BooleanArray {
+        debug_assert!(nulls.is_none_or(|nulls| nulls.len() == input_values.len()));
+        let matches = (self.check_values)(self.in_list_values.as_ref(), input_values);
+        build_result_from_contains(nulls, self.null_count > 0, negated, matches)
+    }
 }
 
 impl<T> StaticFilter for BranchlessFilter<T>
@@ -272,14 +286,7 @@ where
             exec_datafusion_err!("BranchlessFilter: expected {} array", T::DATA_TYPE)
         })?;
         let input_values = branchless_values::<T>(v);
-        let matches =
-            (self.check_values)(self.in_list_values.as_ref(), input_values.as_ref());
-        Ok(build_result_from_contains(
-            v.nulls(),
-            self.null_count > 0,
-            negated,
-            matches,
-        ))
+        Ok(self.contains_raw_values(input_values.as_ref(), v.nulls(), negated))
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/in_list/byte_view_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/byte_view_filter.rs
@@ -1,0 +1,309 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Filters for `Utf8View` and `BinaryView` `IN` lists whose non-null values are
+//! at most 12 bytes.
+//!
+//! Arrow stores such values directly in a `u128` view: the low 32 bits contain
+//! the length and the remaining bits contain zero-padded bytes. Equality of the
+//! views is therefore equality of the values. Long views contain a prefix and
+//! buffer location instead, so a list containing one uses the generic filter.
+//!
+//! Lists with up to four non-null values use the existing 128-bit branchless
+//! filter. Larger lists use a `HashSet<u128>`. `Decimal128Type` only lets the
+//! branchless filter compare the same 128 bits; no decimal operations are used.
+//! A long input value cannot match an inline list value because its length is
+//! part of the view.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, AsArray, BooleanArray, GenericByteViewArray, MAX_INLINE_VIEW_LEN,
+    PrimitiveArray,
+};
+use arrow::buffer::ScalarBuffer;
+use arrow::datatypes::{
+    BinaryViewType, ByteViewType, DataType, Decimal128Type, StringViewType,
+};
+use arrow::util::bit_iterator::BitIndexIterator;
+use datafusion_common::{HashSet, Result, exec_datafusion_err};
+
+use super::branchless_filter::{BranchlessFilter, BranchlessFilterType};
+use super::result::build_in_list_result;
+use super::static_filter::{StaticFilter, handle_dictionary};
+
+#[inline(always)]
+fn view_len(view: u128) -> u32 {
+    view as u32
+}
+
+fn downcast_byte_view<T: ByteViewType>(
+    array: &dyn Array,
+) -> Result<&GenericByteViewArray<T>> {
+    array.as_byte_view_opt::<T>().ok_or_else(|| {
+        exec_datafusion_err!(
+            "Expected concrete {} array, got {}",
+            T::DATA_TYPE,
+            array.data_type()
+        )
+    })
+}
+
+/// A byte-view array whose non-null values all use Arrow's inline layout.
+struct InlineViews<'a, T: ByteViewType> {
+    array: &'a GenericByteViewArray<T>,
+}
+
+impl<'a, T: ByteViewType> InlineViews<'a, T> {
+    fn try_new(array: &'a ArrayRef) -> Result<Option<Self>> {
+        let array = downcast_byte_view::<T>(array.as_ref())?;
+        Ok(all_inline(array).then_some(Self { array }))
+    }
+}
+
+fn all_inline<T: ByteViewType>(array: &GenericByteViewArray<T>) -> bool {
+    let is_inline = |idx: usize| view_len(array.views()[idx]) <= MAX_INLINE_VIEW_LEN;
+    match array.nulls() {
+        Some(nulls) => {
+            BitIndexIterator::new(nulls.validity(), nulls.offset(), nulls.len())
+                .all(is_inline)
+        }
+        None => (0..array.len()).all(is_inline),
+    }
+}
+
+fn as_decimal128<T: ByteViewType>(inline: &InlineViews<'_, T>) -> ArrayRef {
+    let array = inline.array;
+    let views = array.views();
+    // `views.inner()` is already sliced to the array's offset.
+    let values = ScalarBuffer::<i128>::new(views.inner().clone(), 0, views.len());
+    Arc::new(PrimitiveArray::<Decimal128Type>::new(
+        values,
+        array.nulls().cloned(),
+    ))
+}
+
+fn branchless_filter<T: ByteViewType>(
+    inline: &InlineViews<'_, T>,
+) -> Result<Arc<dyn StaticFilter + Send + Sync>> {
+    let values = as_decimal128(inline);
+
+    Ok(Arc::new(ByteViewBranchless::<T> {
+        inner: BranchlessFilter::<Decimal128Type>::try_new(&values)?,
+        _marker: PhantomData,
+    }))
+}
+
+struct ByteViewBranchless<T: ByteViewType> {
+    inner: BranchlessFilter<Decimal128Type>,
+    _marker: PhantomData<T>,
+}
+
+/// Exact set membership for inline views.
+///
+/// Arrow requires unused inline bytes to be zero, so equal values have equal
+/// `u128` views.
+struct ByteViewHashSet<T: ByteViewType> {
+    set: HashSet<u128>,
+    null_count: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T: ByteViewType> ByteViewHashSet<T> {
+    fn new(inline: &InlineViews<'_, T>) -> Self {
+        let array = inline.array;
+        let mut set = HashSet::with_capacity(array.len() - array.null_count());
+        match array.nulls() {
+            Some(nulls) => {
+                BitIndexIterator::new(nulls.validity(), nulls.offset(), nulls.len())
+                    .for_each(|idx| {
+                        set.insert(array.views()[idx]);
+                    });
+            }
+            None => set.extend(array.views().iter().copied()),
+        }
+
+        Self {
+            set,
+            null_count: array.null_count(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: ByteViewType> StaticFilter for ByteViewHashSet<T> {
+    fn null_count(&self) -> usize {
+        self.null_count
+    }
+
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
+        let array = downcast_byte_view::<T>(v)?;
+        let views = array.views();
+        Ok(build_in_list_result(
+            array.len(),
+            array.nulls(),
+            self.null_count > 0,
+            negated,
+            |idx| {
+                // SAFETY: `build_in_list_result` visits indices in `0..array.len()`.
+                self.set.contains(unsafe { views.get_unchecked(idx) })
+            },
+        ))
+    }
+}
+
+impl<T: ByteViewType> StaticFilter for ByteViewBranchless<T> {
+    fn null_count(&self) -> usize {
+        self.inner.null_count()
+    }
+
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
+        let array = downcast_byte_view::<T>(v)?;
+        let values: &[i128] = array.views().inner().typed_data();
+        Ok(self
+            .inner
+            .contains_raw_values(values, array.nulls(), negated))
+    }
+}
+
+fn use_branchless(count: usize) -> bool {
+    count <= <Decimal128Type as BranchlessFilterType>::MAX_LIST_LEN
+}
+
+fn instantiate_typed_filter<T: ByteViewType>(
+    in_array: &ArrayRef,
+) -> Result<Option<Arc<dyn StaticFilter + Send + Sync>>> {
+    let Some(inline) = InlineViews::<T>::try_new(in_array)? else {
+        return Ok(None);
+    };
+
+    let count = inline.array.len() - inline.array.null_count();
+    if use_branchless(count) {
+        branchless_filter(&inline).map(Some)
+    } else {
+        Ok(Some(Arc::new(ByteViewHashSet::new(&inline))))
+    }
+}
+
+/// Returns a filter when every non-null byte view is inline.
+pub(super) fn instantiate_byte_view_filter(
+    in_array: &ArrayRef,
+) -> Result<Option<Arc<dyn StaticFilter + Send + Sync>>> {
+    match in_array.data_type() {
+        DataType::Utf8View => instantiate_typed_filter::<StringViewType>(in_array),
+        DataType::BinaryView => instantiate_typed_filter::<BinaryViewType>(in_array),
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{BinaryViewArray, StringViewArray};
+    use arrow::datatypes::StringViewType;
+
+    fn assert_contains(
+        filter: &dyn StaticFilter,
+        needles: &dyn Array,
+        expected: Vec<Option<bool>>,
+    ) -> Result<()> {
+        assert_eq!(
+            filter.contains(needles, false)?,
+            BooleanArray::from(expected)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn hash_set_nulls_and_slices() -> Result<()> {
+        let haystack: ArrayRef = Arc::new(
+            StringViewArray::from(vec![
+                Some("outside"),
+                Some("a"),
+                Some("b"),
+                None,
+                Some("c"),
+                Some("d"),
+                Some("e"),
+                Some("tail"),
+            ])
+            .slice(1, 6),
+        );
+        let inline = InlineViews::<StringViewType>::try_new(&haystack)?
+            .expect("all non-null values are inline");
+        let filter = ByteViewHashSet::new(&inline);
+        let needles =
+            StringViewArray::from(vec![Some("b"), Some("missing"), None, Some("e")]);
+
+        assert_contains(&filter, &needles, vec![Some(true), None, None, Some(true)])?;
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), None, None, Some(false)])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn routing_and_boundaries() -> Result<()> {
+        assert!(use_branchless(4));
+        assert!(!use_branchless(5));
+
+        let inline = "abcdefghijkl";
+        let long = "abcdefghijklm";
+        let values = StringViewArray::from(vec![
+            "outside", inline, "one", "two", "three", "four", "tail",
+        ]);
+        let needles = StringViewArray::from(vec![inline, long, "missing"]);
+
+        // Covers the branchless/hash-set cutoff and a non-zero view offset.
+        for haystack in [
+            Arc::new(values.slice(1, 4)) as ArrayRef,
+            Arc::new(values.slice(1, 5)) as ArrayRef,
+        ] {
+            let filter = instantiate_byte_view_filter(&haystack)?.unwrap();
+            assert_contains(
+                &*filter,
+                &needles,
+                vec![Some(true), Some(false), Some(false)],
+            )?;
+        }
+
+        let mixed: ArrayRef = Arc::new(StringViewArray::from(vec!["short", long]));
+        assert!(instantiate_byte_view_filter(&mixed)?.is_none());
+
+        let all_null: ArrayRef = Arc::new(StringViewArray::from(vec![None::<&str>]));
+        let filter = instantiate_byte_view_filter(&all_null)?.unwrap();
+        let needle = StringViewArray::from(vec!["missing"]);
+        assert_eq!(filter.contains(&needle, false)?, BooleanArray::new_null(1));
+        assert_eq!(filter.contains(&needle, true)?, BooleanArray::new_null(1));
+
+        let binary: ArrayRef = Arc::new(BinaryViewArray::from(vec![
+            b"a".as_slice(),
+            b"b".as_slice(),
+            b"c".as_slice(),
+            b"d".as_slice(),
+            b"e".as_slice(),
+        ]));
+        let filter = instantiate_byte_view_filter(&binary)?.unwrap();
+        let needles = BinaryViewArray::from(vec![b"a".as_slice(), b"z".as_slice()]);
+        assert_contains(&*filter, &needles, vec![Some(true), Some(false)])?;
+        Ok(())
+    }
+}

--- a/datafusion/physical-expr/src/expressions/in_list/fixed_size_binary_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/fixed_size_binary_filter.rs
@@ -1,0 +1,467 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Optimized filters for fixed-size binary `IN` lists.
+//!
+//! Supported widths use an Arrow primitive type with the same in-memory size:
+//!
+//! | Width | Primitive type | Branchless through | Larger lists |
+//! |------:|----------------|-------------------:|--------------|
+//! | 1     | `UInt8`        | 16 values          | bitmap       |
+//! | 2     | `UInt16`       | 8 values           | bitmap       |
+//! | 4     | `UInt32`       | 32 values          | hash set     |
+//! | 8     | `UInt64`       | 16 values          | hash set     |
+//! | 16    | `Decimal128`   | 4 values           | hash set     |
+//!
+//! The limits count non-null list values.
+//!
+//! The list and input bytes are read the same way, so each primitive value is
+//! an exact key for comparison, bitmap lookup, or hashing. No arithmetic,
+//! ordering, or decimal operations are used.
+//!
+//! Aligned Arrow buffers are reused without copying. Unaligned buffers are
+//! copied into aligned primitive storage.
+
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::mem::{align_of, size_of};
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, AsArray, BooleanArray, FixedSizeBinaryArray, PrimitiveArray,
+};
+use arrow::buffer::{Buffer, ScalarBuffer};
+use arrow::datatypes::{
+    ArrowPrimitiveType, DataType, Decimal128Type, UInt8Type, UInt16Type, UInt32Type,
+    UInt64Type,
+};
+use datafusion_common::{HashSet, Result, exec_datafusion_err, internal_datafusion_err};
+
+use super::branchless_filter::{
+    BranchlessFilter, BranchlessFilterType, BranchlessNative,
+};
+use super::primitive_filter::{BitmapFilter, BitmapFilterType};
+use super::result::build_in_list_result;
+use super::static_filter::{StaticFilter, handle_dictionary};
+
+type StaticFilterRef = Arc<dyn StaticFilter + Send + Sync>;
+
+fn use_branchless<T: BranchlessFilterType>(count: usize) -> bool {
+    count <= T::MAX_LIST_LEN
+}
+
+/// Reinterpret fixed-size binary values as same-width primitive values.
+///
+/// Arrow buffers are normally sufficiently aligned, making this zero-copy. A
+/// valid Arrow array can still be constructed from a sliced, unaligned buffer;
+/// in that case, copy each value into aligned primitive storage.
+fn as_primitive<T>(array: &FixedSizeBinaryArray) -> Result<PrimitiveArray<T>>
+where
+    T: ArrowPrimitiveType,
+{
+    let width = size_of::<T::Native>();
+    if usize::try_from(array.value_length()).ok() != Some(width) {
+        return Err(internal_datafusion_err!(
+            "FixedSizeBinary filter: expected {width}-byte values, got {}",
+            array.value_length()
+        ));
+    }
+
+    let source = array.values();
+    let values = if source.as_ptr().align_offset(align_of::<T::Native>()) == 0 {
+        ScalarBuffer::new(source.clone(), 0, array.len())
+    } else {
+        ScalarBuffer::new(Buffer::from(source.as_slice()), 0, array.len())
+    };
+
+    Ok(PrimitiveArray::<T>::new(values, array.nulls().cloned()))
+}
+
+/// Generic hash-set membership for the 4-, 8-, and 16-byte representations.
+///
+/// The standard primitive filters are concrete per Arrow type. This local
+/// generic form lets the three supported widths share one implementation.
+struct HashSetFilter<T: ArrowPrimitiveType> {
+    null_count: usize,
+    values: HashSet<T::Native>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> HashSetFilter<T>
+where
+    T: ArrowPrimitiveType,
+    T::Native: Copy + Eq + Hash,
+{
+    fn new(in_array: &PrimitiveArray<T>) -> Self {
+        let mut values = HashSet::with_capacity(in_array.len());
+        for value in in_array.iter().flatten() {
+            values.insert(value);
+        }
+
+        Self {
+            null_count: in_array.null_count(),
+            values,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> StaticFilter for HashSetFilter<T>
+where
+    T: ArrowPrimitiveType + Send + Sync + 'static,
+    T::Native: Copy + Eq + Hash + Send + Sync,
+{
+    fn null_count(&self) -> usize {
+        self.null_count
+    }
+
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
+
+        let v = v.as_primitive_opt::<T>().ok_or_else(|| {
+            internal_datafusion_err!("HashSetFilter: expected {} array", T::DATA_TYPE)
+        })?;
+        let input_values = v.values();
+        Ok(build_in_list_result(
+            v.len(),
+            v.nulls(),
+            self.null_count > 0,
+            negated,
+            #[inline(always)]
+            |index| self.values.contains(&input_values[index]),
+        ))
+    }
+}
+
+/// Adapts a primitive filter to concrete, same-width `FixedSizeBinary` arrays.
+struct FixedSizeBinaryFilter<T: ArrowPrimitiveType> {
+    data_type: DataType,
+    inner: StaticFilterRef,
+    _marker: PhantomData<T>,
+}
+
+impl<T: ArrowPrimitiveType> FixedSizeBinaryFilter<T> {
+    fn new(data_type: DataType, inner: StaticFilterRef) -> Self {
+        Self {
+            data_type,
+            inner,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> StaticFilter for FixedSizeBinaryFilter<T>
+where
+    T: ArrowPrimitiveType + Send + Sync + 'static,
+{
+    fn null_count(&self) -> usize {
+        self.inner.null_count()
+    }
+
+    fn contains(&self, v: &dyn Array, negated: bool) -> Result<BooleanArray> {
+        handle_dictionary!(self, v, negated);
+
+        if v.data_type() != &self.data_type {
+            return Err(exec_datafusion_err!(
+                "FixedSizeBinary filter: expected {} array, got {}",
+                self.data_type,
+                v.data_type()
+            ));
+        }
+        let array = v.as_fixed_size_binary_opt().ok_or_else(|| {
+            exec_datafusion_err!(
+                "FixedSizeBinary filter: expected concrete {} array",
+                self.data_type
+            )
+        })?;
+        let primitive = as_primitive::<T>(array)?;
+        self.inner.contains(&primitive, negated)
+    }
+}
+
+fn branchless_or_bitmap<T>(
+    array: &FixedSizeBinaryArray,
+    count: usize,
+) -> Result<StaticFilterRef>
+where
+    T: BranchlessFilterType + BitmapFilterType,
+    BranchlessNative<T>: Copy + Eq + Send + Sync,
+{
+    let primitive: ArrayRef = Arc::new(as_primitive::<T>(array)?);
+    let inner: StaticFilterRef = if use_branchless::<T>(count) {
+        Arc::new(BranchlessFilter::<T>::try_new(&primitive)?)
+    } else {
+        Arc::new(BitmapFilter::<T>::try_new(&primitive)?)
+    };
+    Ok(Arc::new(FixedSizeBinaryFilter::<T>::new(
+        array.data_type().clone(),
+        inner,
+    )))
+}
+
+fn branchless_or_hash_set<T>(
+    array: &FixedSizeBinaryArray,
+    count: usize,
+) -> Result<StaticFilterRef>
+where
+    T: BranchlessFilterType,
+    T::Native: Copy + Eq + Hash + Send + Sync,
+    BranchlessNative<T>: Copy + Eq + Send + Sync,
+{
+    let primitive = as_primitive::<T>(array)?;
+    let inner: StaticFilterRef = if use_branchless::<T>(count) {
+        let primitive: ArrayRef = Arc::new(primitive);
+        Arc::new(BranchlessFilter::<T>::try_new(&primitive)?)
+    } else {
+        Arc::new(HashSetFilter::<T>::new(&primitive))
+    };
+    Ok(Arc::new(FixedSizeBinaryFilter::<T>::new(
+        array.data_type().clone(),
+        inner,
+    )))
+}
+
+/// Creates an optimized filter for supported concrete `FixedSizeBinary` arrays.
+pub(super) fn instantiate_fixed_size_binary_filter(
+    in_array: &ArrayRef,
+) -> Result<Option<StaticFilterRef>> {
+    let DataType::FixedSizeBinary(width) = in_array.data_type() else {
+        return Ok(None);
+    };
+    let Some(array) = in_array.as_fixed_size_binary_opt() else {
+        return Ok(None);
+    };
+
+    let count = array.len() - array.null_count();
+
+    let filter = match width {
+        1 => branchless_or_bitmap::<UInt8Type>(array, count)?,
+        2 => branchless_or_bitmap::<UInt16Type>(array, count)?,
+        4 => branchless_or_hash_set::<UInt32Type>(array, count)?,
+        8 => branchless_or_hash_set::<UInt64Type>(array, count)?,
+        16 => branchless_or_hash_set::<Decimal128Type>(array, count)?,
+        _ => return Ok(None),
+    };
+    Ok(Some(filter))
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::{DictionaryArray, Int8Array, StringArray};
+    use arrow::buffer::{Buffer, NullBuffer};
+    use arrow::datatypes::Int8Type;
+
+    use super::*;
+
+    fn value(width: i32, index: usize, miss: bool) -> Vec<u8> {
+        let mut value = (index as u128).to_le_bytes()[..width as usize].to_vec();
+        let last = value.last_mut().unwrap();
+        if miss {
+            *last |= 0x80;
+        } else {
+            *last &= 0x7f;
+        }
+        value
+    }
+
+    fn array(width: i32, values: &[Option<Vec<u8>>]) -> FixedSizeBinaryArray {
+        FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            values.iter().map(|value| value.as_deref()),
+            width,
+        )
+        .unwrap()
+    }
+
+    fn make_filter(width: i32, values: &[Option<Vec<u8>>]) -> Result<StaticFilterRef> {
+        let in_array: ArrayRef = Arc::new(array(width, values));
+        Ok(instantiate_fixed_size_binary_filter(&in_array)?.unwrap())
+    }
+
+    #[test]
+    fn filters_supported_widths_across_strategy_thresholds() -> Result<()> {
+        for (width, list_len) in [
+            (1, 16),
+            (1, 17),
+            (2, 8),
+            (2, 9),
+            (4, 32),
+            (4, 33),
+            (8, 16),
+            (8, 17),
+            (16, 4),
+            (16, 5),
+        ] {
+            let mut hit = vec![0x80; width as usize];
+            hit[width as usize - 1] = 0xff;
+            let mut miss = hit.clone();
+            miss[width as usize - 1] ^= 1;
+
+            let mut haystack = (0..list_len - 1)
+                .map(|index| Some(value(width, index, false)))
+                .collect::<Vec<_>>();
+            haystack.push(Some(hit.clone()));
+            let filter = make_filter(width, &haystack)?;
+            let needles = array(width, &[Some(hit), Some(miss), None]);
+            assert_eq!(
+                filter.contains(&needles, false)?,
+                BooleanArray::from(vec![Some(true), Some(false), None]),
+                "width={width}, list_len={list_len}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn handles_slices_nulls_and_not_in() -> Result<()> {
+        let width = 16;
+        let parent = array(
+            width,
+            &[
+                Some(value(width, 0, false)),
+                Some(value(width, 1, false)),
+                None,
+                Some(value(width, 2, false)),
+                Some(value(width, 3, false)),
+                Some(value(width, 4, false)),
+                Some(value(width, 5, false)),
+                Some(value(width, 6, false)),
+            ],
+        );
+        // Five non-null values select the hash-set path.
+        let in_array: ArrayRef = Arc::new(parent.slice(1, 6));
+        let filter = instantiate_fixed_size_binary_filter(&in_array)?.unwrap();
+        let needles = array(
+            width,
+            &[
+                Some(value(width, 2, false)),
+                Some(value(width, 7, false)),
+                None,
+            ],
+        );
+
+        assert_eq!(
+            filter.contains(&needles, false)?,
+            BooleanArray::from(vec![Some(true), None, None])
+        );
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), None, None])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn handles_dictionary_needles() -> Result<()> {
+        let filter = make_filter(4, &[Some(value(4, 7, false))])?;
+        let dictionary_values: ArrayRef = Arc::new(array(
+            4,
+            &[Some(value(4, 7, false)), Some(value(4, 8, false))],
+        ));
+        let keys = Int8Array::from(vec![Some(0), Some(1), None]);
+        let needles =
+            DictionaryArray::<Int8Type>::try_new(keys, dictionary_values).unwrap();
+
+        assert_eq!(
+            filter.contains(&needles, false)?,
+            BooleanArray::from(vec![Some(true), Some(false), None])
+        );
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), Some(true), None])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_unsupported_arrays() -> Result<()> {
+        let filter = make_filter(4, &[Some(value(4, 1, false))])?;
+        let wrong_width = array(8, &[Some(value(8, 1, false))]);
+        let error = filter
+            .contains(&wrong_width, false)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("expected FixedSizeBinary(4) array, got FixedSizeBinary(8)"),
+            "{error}"
+        );
+
+        let wrong_type = StringArray::from(vec!["one"]);
+        let error = filter.contains(&wrong_type, false).unwrap_err().to_string();
+        assert!(
+            error.contains("expected FixedSizeBinary(4) array, got Utf8"),
+            "{error}"
+        );
+
+        for width in [0, 3, 5, 15, 17] {
+            let unsupported: ArrayRef =
+                Arc::new(FixedSizeBinaryArray::new_null(width, 1));
+            assert!(
+                instantiate_fixed_size_binary_filter(&unsupported)?.is_none(),
+                "width={width}"
+            );
+        }
+
+        Ok(())
+    }
+
+    fn unaligned_array(
+        width: i32,
+        values: &[Vec<u8>],
+        nulls: Option<NullBuffer>,
+    ) -> FixedSizeBinaryArray {
+        let mut bytes = vec![0];
+        bytes.extend(values.iter().flatten());
+        let buffer = Buffer::from(bytes).slice(1);
+        assert_ne!(
+            buffer.as_ptr().align_offset(width as usize),
+            0,
+            "test buffer must be unaligned"
+        );
+        FixedSizeBinaryArray::new(width, buffer, nulls)
+    }
+
+    #[test]
+    fn handles_aligned_and_unaligned_buffers() -> Result<()> {
+        let buffer = Buffer::from_vec(vec![1_u64, 2, 3]);
+        let source_ptr = buffer.as_ptr();
+        let array = FixedSizeBinaryArray::new(8, buffer, None);
+        let primitive = as_primitive::<UInt64Type>(&array)?;
+        assert_eq!(primitive.values().inner().as_ptr(), source_ptr);
+
+        let width = 16;
+        let haystack_values = (0..5)
+            .map(|index| value(width, index, false))
+            .collect::<Vec<_>>();
+        let haystack: ArrayRef = Arc::new(unaligned_array(width, &haystack_values, None));
+        let needles = unaligned_array(
+            width,
+            &[
+                value(width, 3, false),
+                value(width, 8, true),
+                value(width, 9, true),
+            ],
+            Some(NullBuffer::from(vec![true, false, true])),
+        );
+        let filter = instantiate_fixed_size_binary_filter(&haystack)?.unwrap();
+
+        assert_eq!(
+            filter.contains(&needles, false)?,
+            BooleanArray::from(vec![Some(true), None, Some(false)])
+        );
+        Ok(())
+    }
+}

--- a/datafusion/physical-expr/src/expressions/in_list/integer_set.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/integer_set.rs
@@ -1,0 +1,165 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Integer membership with a byte index and hash fallback.
+
+use std::{hash::Hash, mem::size_of};
+
+use arrow::buffer::BooleanBuffer;
+use datafusion_common::HashSet;
+
+const BUCKETS: usize = 256;
+const SLOTS: usize = 4;
+
+pub(super) trait IntegerKey: Copy + Eq + Hash {
+    fn byte(self, index: usize) -> usize;
+}
+
+macro_rules! integer_key {
+    ($($t:ty),+ $(,)?) => {
+        $(
+            impl IntegerKey for $t {
+                #[inline(always)]
+                fn byte(self, index: usize) -> usize {
+                    ((self as u64 >> (index * 8)) & 0xff) as usize
+                }
+            }
+        )+
+    };
+}
+
+integer_key!(i32, u32, i64, u64);
+
+pub(super) enum IntegerSet<V> {
+    Indexed {
+        byte: usize,
+        buckets: Box<[[V; SLOTS]; BUCKETS]>,
+    },
+    Hash(HashSet<V>),
+}
+
+impl<V: IntegerKey> IntegerSet<V> {
+    pub(super) fn new(input: impl IntoIterator<Item = V>) -> Self {
+        let input = input.into_iter();
+        let mut set = HashSet::with_capacity(input.size_hint().1.unwrap_or(0));
+        set.extend(input);
+        if !set.is_empty() && set.len() <= BUCKETS * SLOTS {
+            for byte in 0..size_of::<V>() {
+                let mut counts = [0_u16; BUCKETS];
+                for &value in &set {
+                    counts[value.byte(byte)] += 1;
+                }
+                if counts.iter().all(|&count| count <= SLOTS as u16) {
+                    let sentinel = *set.iter().next().expect("set is not empty");
+                    // Padding cannot match a value from another bucket.
+                    let mut buckets = Box::new([[sentinel; SLOTS]; BUCKETS]);
+                    let mut next = [0_u8; BUCKETS];
+                    for &value in &set {
+                        let bucket = value.byte(byte);
+                        buckets[bucket][next[bucket] as usize] = value;
+                        next[bucket] += 1;
+                    }
+                    return Self::Indexed { byte, buckets };
+                }
+            }
+        }
+        Self::Hash(set)
+    }
+
+    pub(super) fn contains_values(&self, values: &[V]) -> BooleanBuffer {
+        match self {
+            Self::Indexed { byte, buckets } => {
+                BooleanBuffer::collect_bool(values.len(), |i| {
+                    let value = values[i];
+                    let [a, b, c, d] = buckets[value.byte(*byte)];
+                    // Compare all four values so the compiler can use SIMD.
+                    (value == a) | (value == b) | (value == c) | (value == d)
+                })
+            }
+            Self::Hash(set) => {
+                BooleanBuffer::collect_bool(values.len(), |i| set.contains(&values[i]))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_matches<V: IntegerKey + std::fmt::Debug>(values: &[V], needles: &[V]) {
+        let expected = values
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>();
+        let actual = IntegerSet::new(values.to_vec()).contains_values(needles);
+        for (i, value) in needles.iter().enumerate() {
+            assert_eq!(actual.value(i), expected.contains(value), "value {value:?}");
+        }
+    }
+
+    #[test]
+    fn matches_standard_set() {
+        let mut state = 1_u64;
+        for len in [0, 1, 7, 32, 129, 256, 257, 1025] {
+            let values = (0..len)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1);
+                    state % 2049
+                })
+                .collect::<Vec<_>>();
+            let needles = (0..2200).collect::<Vec<_>>();
+            assert_matches(&values, &needles);
+        }
+    }
+
+    #[test]
+    fn handles_bounds_and_duplicates() {
+        assert_matches(
+            &[i32::MIN, -1, 0, 1, i32::MAX, 0],
+            &[i32::MIN, i32::MIN + 1, -1, 0, 1, i32::MAX],
+        );
+        assert_matches(
+            &[i64::MIN, -1, 0, 1, i64::MAX, 0],
+            &[i64::MIN, i64::MIN + 1, -1, 0, 1, i64::MAX],
+        );
+        assert_matches(&[u32::MIN, 1, u32::MAX, 1], &[u32::MIN, 1, 2, u32::MAX]);
+        assert_matches(&[u64::MIN, 1, u64::MAX, 1], &[u64::MIN, 1, 2, u64::MAX]);
+    }
+
+    #[test]
+    fn selects_index_or_hash() {
+        assert!(matches!(
+            IntegerSet::new(vec![0_u32, 256, 512, 768, 1024]),
+            IntegerSet::Indexed { byte: 1, .. }
+        ));
+
+        let mut values = Vec::with_capacity(625);
+        for a in 0..5 {
+            for b in 0..5 {
+                for c in 0..5 {
+                    for d in 0..5 {
+                        values.push(a | b << 8 | c << 16 | d << 24);
+                    }
+                }
+            }
+        }
+        assert!(matches!(IntegerSet::new(values), IntegerSet::Hash(_)));
+    }
+}

--- a/datafusion/physical-expr/src/expressions/in_list/primitive_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/primitive_filter.rs
@@ -20,13 +20,14 @@
 //! This module provides membership tests for Arrow primitive types.
 
 use arrow::array::{Array, ArrayRef, AsArray, BooleanArray};
-use arrow::buffer::{BooleanBuffer, NullBuffer};
+use arrow::buffer::BooleanBuffer;
 use arrow::datatypes::*;
 use arrow::util::bit_iterator::BitIndexIterator;
 use datafusion_common::{HashSet, Result, exec_datafusion_err};
-use std::hash::{Hash, Hasher};
+use std::iter::FromIterator;
 
-use super::result::build_in_list_result;
+use super::integer_set::IntegerSet;
+use super::result::{build_in_list_result, build_result_from_contains};
 use super::static_filter::{StaticFilter, handle_dictionary};
 
 /// Storage for the bits used by [`BitmapFilter`].
@@ -222,70 +223,29 @@ where
     }
 }
 
-/// Wrapper for f32 that implements Hash and Eq using bit comparison.
-/// This treats NaN values as equal to each other when they have the same bit pattern.
-#[derive(Clone, Copy)]
-struct OrderedFloat32(f32);
-
-impl Hash for OrderedFloat32 {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_ne_bytes().hash(state);
-    }
-}
-
-impl PartialEq for OrderedFloat32 {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.to_bits() == other.0.to_bits()
-    }
-}
-
-impl Eq for OrderedFloat32 {}
-
-impl From<f32> for OrderedFloat32 {
-    fn from(v: f32) -> Self {
-        Self(v)
-    }
-}
-
-/// Wrapper for f64 that implements Hash and Eq using bit comparison.
-/// This treats NaN values as equal to each other when they have the same bit pattern.
-#[derive(Clone, Copy)]
-struct OrderedFloat64(f64);
-
-impl Hash for OrderedFloat64 {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_ne_bytes().hash(state);
-    }
-}
-
-impl PartialEq for OrderedFloat64 {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.to_bits() == other.0.to_bits()
-    }
-}
-
-impl Eq for OrderedFloat64 {}
-
-impl From<f64> for OrderedFloat64 {
-    fn from(v: f64) -> Self {
-        Self(v)
-    }
-}
-
 // Macro to generate specialized StaticFilter implementations for primitive types
 macro_rules! primitive_static_filter {
     ($Name:ident, $ArrowType:ty) => {
         primitive_static_filter!(
             $Name,
             $ArrowType,
-            <$ArrowType as ArrowPrimitiveType>::Native,
-            |v| v
+            |v| v,
+            IntegerSet<<$ArrowType as ArrowPrimitiveType>::Native>,
+            IntegerSet::new,
+            IntegerSet::contains_values
         );
     };
-    ($Name:ident, $ArrowType:ty, $SetValueType:ty, $to_set_value:expr) => {
+    (
+        $Name:ident,
+        $ArrowType:ty,
+        $to_set_value:expr,
+        $SetType:ty,
+        $new_set:expr,
+        $contains_values:expr
+    ) => {
         pub(super) struct $Name {
             null_count: usize,
-            values: HashSet<$SetValueType>,
+            values: $SetType,
         }
 
         impl $Name {
@@ -298,12 +258,8 @@ macro_rules! primitive_static_filter {
                         )
                     })?;
 
-                let mut values = HashSet::with_capacity(in_array.len());
                 let null_count = in_array.null_count();
-
-                for v in in_array.iter().flatten() {
-                    values.insert(($to_set_value)(v));
-                }
+                let values = ($new_set)(in_array.iter().flatten().map($to_set_value));
 
                 Ok(Self { null_count, values })
             }
@@ -324,84 +280,14 @@ macro_rules! primitive_static_filter {
                     )
                 })?;
 
-                let haystack_has_nulls = self.null_count > 0;
                 let needle_values = v.values();
-                let needle_nulls = v.nulls();
-                let needle_has_nulls = v.null_count() > 0;
-
-                // Truth table for `value [NOT] IN (set)` with SQL three-valued logic:
-                // ("-" means the value doesn't affect the result)
-                //
-                // | needle_null | haystack_null | negated | in set? | result |
-                // |-------------|---------------|---------|---------|--------|
-                // | true        | -             | false   | -       | null   |
-                // | true        | -             | true    | -       | null   |
-                // | false       | true          | false   | yes     | true   |
-                // | false       | true          | false   | no      | null   |
-                // | false       | true          | true    | yes     | false  |
-                // | false       | true          | true    | no      | null   |
-                // | false       | false         | false   | yes     | true   |
-                // | false       | false         | false   | no      | false  |
-                // | false       | false         | true    | yes     | false  |
-                // | false       | false         | true    | no      | true   |
-
-                // Compute the "contains" result using collect_bool (fast batched approach)
-                // This ignores nulls - we handle them separately
-                let contains_buffer = if negated {
-                    BooleanBuffer::collect_bool(needle_values.len(), |i| {
-                        !self.values.contains(&($to_set_value)(needle_values[i]))
-                    })
-                } else {
-                    BooleanBuffer::collect_bool(needle_values.len(), |i| {
-                        self.values.contains(&($to_set_value)(needle_values[i]))
-                    })
-                };
-
-                // Compute the null mask
-                // Output is null when:
-                // 1. needle value is null, OR
-                // 2. needle value is not in set AND haystack has nulls
-                let result_nulls = match (needle_has_nulls, haystack_has_nulls) {
-                    (false, false) => {
-                        // No nulls anywhere
-                        None
-                    }
-                    (true, false) => {
-                        // Only needle has nulls - just use needle's null mask
-                        needle_nulls.cloned()
-                    }
-                    (false, true) => {
-                        // Only haystack has nulls - result is null when value not in set
-                        // Valid (not null) when original "in set" is true
-                        // For NOT IN: contains_buffer = !original, so validity = !contains_buffer
-                        let validity = if negated {
-                            !&contains_buffer
-                        } else {
-                            contains_buffer.clone()
-                        };
-                        Some(NullBuffer::new(validity))
-                    }
-                    (true, true) => {
-                        // Both have nulls - combine needle nulls with haystack-induced nulls
-                        let needle_validity =
-                            needle_nulls.map(|n| n.inner().clone()).unwrap_or_else(
-                                || BooleanBuffer::new_set(needle_values.len()),
-                            );
-
-                        // Valid when original "in set" is true (see above)
-                        let haystack_validity = if negated {
-                            !&contains_buffer
-                        } else {
-                            contains_buffer.clone()
-                        };
-
-                        // Combined validity: valid only where both are valid
-                        let combined_validity = &needle_validity & &haystack_validity;
-                        Some(NullBuffer::new(combined_validity))
-                    }
-                };
-
-                Ok(BooleanArray::new(contains_buffer, result_nulls))
+                let contains = ($contains_values)(&self.values, needle_values);
+                Ok(build_result_from_contains(
+                    v.nulls(),
+                    self.null_count > 0,
+                    negated,
+                    contains,
+                ))
             }
         }
     };
@@ -412,17 +298,36 @@ primitive_static_filter!(Int64StaticFilter, Int64Type);
 primitive_static_filter!(UInt32StaticFilter, UInt32Type);
 primitive_static_filter!(UInt64StaticFilter, UInt64Type);
 
-// Macro to generate specialized StaticFilter implementations for float types
-// Floats require a wrapper type (OrderedFloat*) to implement Hash/Eq due to NaN semantics
-macro_rules! float_static_filter {
-    ($Name:ident, $ArrowType:ty, $OrderedType:ty) => {
-        primitive_static_filter!($Name, $ArrowType, $OrderedType, <$OrderedType>::from);
-    };
+#[inline]
+fn float32_contains(values: &HashSet<[u8; 4]>, needles: &[f32]) -> BooleanBuffer {
+    BooleanBuffer::collect_bool(needles.len(), |i| {
+        values.contains(&needles[i].to_ne_bytes())
+    })
 }
 
-// Generate specialized filters for float types using ordered wrappers
-float_static_filter!(Float32StaticFilter, Float32Type, OrderedFloat32);
-float_static_filter!(Float64StaticFilter, Float64Type, OrderedFloat64);
+#[inline]
+fn float64_contains(values: &HashSet<[u8; 8]>, needles: &[f64]) -> BooleanBuffer {
+    BooleanBuffer::collect_bool(needles.len(), |i| {
+        values.contains(&needles[i].to_ne_bytes())
+    })
+}
+
+primitive_static_filter!(
+    Float32StaticFilter,
+    Float32Type,
+    f32::to_ne_bytes,
+    HashSet<[u8; 4]>,
+    HashSet::from_iter,
+    float32_contains
+);
+primitive_static_filter!(
+    Float64StaticFilter,
+    Float64Type,
+    f64::to_ne_bytes,
+    HashSet<[u8; 8]>,
+    HashSet::from_iter,
+    float64_contains
+);
 
 #[cfg(test)]
 mod tests {
@@ -430,7 +335,8 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::{
-        DictionaryArray, Float16Array, Int8Array, Int16Array, UInt8Array, UInt16Array,
+        DictionaryArray, Float16Array, Float32Array, Int8Array, Int16Array, UInt8Array,
+        UInt16Array, UInt32Array,
     };
     use half::f16;
 
@@ -583,5 +489,40 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn static_filter_handles_slices_nulls_and_dictionaries() -> Result<()> {
+        let mut values = (0..36).map(Some).collect::<Vec<_>>();
+        values[2] = None;
+        let haystack: ArrayRef = Arc::new(UInt32Array::from(values).slice(1, 34));
+        let filter = UInt32StaticFilter::try_new(&haystack)?;
+
+        let keys = Int8Array::from(vec![Some(0), Some(1), None, Some(2)]);
+        let values = Arc::new(UInt32Array::from(vec![1, 35, 34]));
+        let needles = DictionaryArray::try_new(keys, values)?;
+        assert_contains(&filter, &needles, vec![Some(true), None, None, Some(true)])?;
+        assert_eq!(
+            filter.contains(&needles, true)?,
+            BooleanArray::from(vec![Some(false), None, None, Some(false)])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn static_filter_floats_use_bit_equality() -> Result<()> {
+        let nan_a = f32::from_bits(0x7fc0_0001);
+        let nan_b = f32::from_bits(0x7fc0_0002);
+        let haystack: ArrayRef =
+            Arc::new(Float32Array::from(vec![Some(-0.0), Some(nan_a)]));
+        let filter = Float32StaticFilter::try_new(&haystack)?;
+        let needles =
+            Float32Array::from(vec![Some(0.0), Some(-0.0), Some(nan_a), Some(nan_b)]);
+
+        assert_contains(
+            &filter,
+            &needles,
+            vec![Some(false), Some(true), Some(true), Some(false)],
+        )
     }
 }

--- a/datafusion/physical-expr/src/expressions/in_list/strategy.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/strategy.rs
@@ -34,14 +34,24 @@ use super::array_static_filter::ArrayStaticFilter;
 use super::branchless_filter::{
     BranchlessFilter, BranchlessFilterType, BranchlessNative,
 };
+use super::byte_view_filter::instantiate_byte_view_filter;
 use super::fixed_size_binary_filter::instantiate_fixed_size_binary_filter;
 use super::primitive_filter::*;
 use super::static_filter::StaticFilter;
 
 type StaticFilterRef = Arc<dyn StaticFilter + Send + Sync>;
 
-pub(super) fn instantiate_static_filter(in_array: ArrayRef) -> Result<StaticFilterRef> {
+pub(super) fn instantiate_static_filter(
+    in_array: ArrayRef,
+    expr_data_type: &DataType,
+) -> Result<StaticFilterRef> {
     let in_array = flatten_dictionary_haystack(in_array)?;
+
+    if view_types_match(expr_data_type, in_array.data_type())
+        && let Some(filter) = instantiate_byte_view_filter(&in_array)?
+    {
+        return Ok(filter);
+    }
 
     if let Some(filter) = instantiate_fixed_size_binary_filter(&in_array)? {
         return Ok(filter);
@@ -52,6 +62,20 @@ pub(super) fn instantiate_static_filter(in_array: ArrayRef) -> Result<StaticFilt
     }
 
     instantiate_standard_filter(in_array)
+}
+
+/// Raw view access requires the expression and list to use the same view type.
+/// Dictionary wrappers do not change the expression's value type.
+fn view_types_match(expr_type: &DataType, list_type: &DataType) -> bool {
+    matches!(list_type, DataType::Utf8View | DataType::BinaryView)
+        && dictionary_value_type(expr_type) == list_type
+}
+
+fn dictionary_value_type(mut data_type: &DataType) -> &DataType {
+    while let DataType::Dictionary(_, value_type) = data_type {
+        data_type = value_type;
+    }
+    data_type
 }
 
 fn flatten_dictionary_haystack(in_array: ArrayRef) -> Result<ArrayRef> {
@@ -172,6 +196,16 @@ mod tests {
 
     fn uint32_array(values: Vec<Option<u32>>) -> ArrayRef {
         Arc::new(UInt32Array::from(values))
+    }
+
+    #[test]
+    fn byte_view_routing_requires_same_physical_type() {
+        let dict_view =
+            DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8View));
+
+        assert!(view_types_match(&DataType::Utf8View, &DataType::Utf8View));
+        assert!(view_types_match(&dict_view, &DataType::Utf8View));
+        assert!(!view_types_match(&DataType::Utf8, &DataType::Utf8View));
     }
 
     #[test]

--- a/datafusion/physical-expr/src/expressions/in_list/strategy.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/strategy.rs
@@ -34,6 +34,7 @@ use super::array_static_filter::ArrayStaticFilter;
 use super::branchless_filter::{
     BranchlessFilter, BranchlessFilterType, BranchlessNative,
 };
+use super::fixed_size_binary_filter::instantiate_fixed_size_binary_filter;
 use super::primitive_filter::*;
 use super::static_filter::StaticFilter;
 
@@ -41,6 +42,10 @@ type StaticFilterRef = Arc<dyn StaticFilter + Send + Sync>;
 
 pub(super) fn instantiate_static_filter(in_array: ArrayRef) -> Result<StaticFilterRef> {
     let in_array = flatten_dictionary_haystack(in_array)?;
+
+    if let Some(filter) = instantiate_fixed_size_binary_filter(&in_array)? {
+        return Ok(filter);
+    }
 
     if let Some(filter) = instantiate_branchless_filter(&in_array)? {
         return Ok(filter);

--- a/datafusion/physical-expr/src/expressions/in_list/strategy.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/strategy.rs
@@ -152,7 +152,6 @@ fn instantiate_standard_filter(in_array: ArrayRef) -> Result<StaticFilterRef> {
         DataType::Int64 => Ok(Arc::new(Int64StaticFilter::try_new(&in_array)?)),
         DataType::UInt32 => Ok(Arc::new(UInt32StaticFilter::try_new(&in_array)?)),
         DataType::UInt64 => Ok(Arc::new(UInt64StaticFilter::try_new(&in_array)?)),
-        // Float primitive types (use ordered wrappers for Hash/Eq)
         DataType::Float32 => Ok(Arc::new(Float32StaticFilter::try_new(&in_array)?)),
         DataType::Float64 => Ok(Arc::new(Float64StaticFilter::try_new(&in_array)?)),
         _ => {


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #19241.
- Stacked on [#24088](https://github.com/apache/datafusion/pull/24088) and [#24102](https://github.com/apache/datafusion/pull/24102), which follow [#23014](https://github.com/apache/datafusion/pull/23014).

> [!NOTE]
> This description covers only the final commit, [`689cae2a42`](https://github.com/apache/datafusion/commit/689cae2a4239b2a96795a0cfec5679bdb97228cf), relative to the combined lower-stack head [`b0443b6bb0`](https://github.com/apache/datafusion/commit/b0443b6bb0411d05d8ab5eae0926599ee502a37d). The earlier commits visible in this stacked PR belong to the PRs above.

## Rationale for this change

DataFusion builds a reusable static filter when every expression in an `IN` list is constant. The lower PRs in this stack already use a branchless comparison chain for short primitive lists. Once that existing path's limit is exceeded—32 non-null list entries for `Int32`/`UInt32`, or 16 for `Int64`/`UInt64`—the integer filters previously used a general-purpose hash-table lookup for each ordinary primitive-array input value.

A hash table works for every value distribution, but an integer constant set often contains a cheaper index: one of the integer's bytes may divide the set into very small groups. If every possible value of that byte identifies at most four list members, membership can be evaluated as:

```text
input integer
    -> extract one selected byte
    -> directly select 1 of 256 buckets
    -> compare with the bucket's 4 full-width integers
```

This replaces hashing and hash-table probing with one table lookup and a fixed amount of comparison work. The index is constructed once with the static filter and reused across input batches.

## What changes are included in this PR?

### Where this fits in strategy selection

This commit does not change the existing small-list thresholds. For constant `IN` lists, normal routing remains:

| Type | Existing short-list strategy | Larger-list strategy after this commit |
|---|---|---|
| `Int32`, `UInt32` | Branchless comparisons for up to 32 non-null entries | New `IntegerSet` |
| `Int64`, `UInt64` | Branchless comparisons for up to 16 non-null entries | New `IntegerSet` |

The branchless cutoff counts non-null list entries before deduplication. `IntegerSet` then deduplicates those entries, so its admission rules below use the number of **distinct non-null values**.

### Building the byte index

`IntegerSet` builds the indexed representation as follows:

1. Insert all non-null `IN`-list values into DataFusion's existing `HashSet`. This removes duplicates without changing membership semantics and also prepares the fallback representation.
2. Consider indexing only when there are 1–1,024 distinct values. The upper bound follows directly from 256 byte values × 4 slots per bucket.
3. Starting at the least-significant byte, examine all four byte positions of a 32-bit value or all eight positions of a 64-bit value.
4. For each position, count how many distinct values have each of its 256 possible byte values.
5. Select the first position for which every bucket contains at most four values.
6. Allocate 256 buckets of four full-width integers and place every set member in the bucket selected by that byte.

For example, `0`, `256`, `512`, `768`, and `1024` all have the same lowest byte, so the lowest-byte bucket would need five slots and cannot be used. Their next byte differs, so that byte provides a valid index.

The byte is extracted numerically with shifts and a mask rather than read from memory, so selection is independent of machine endianness. Signed values are partitioned by their bit representation, but the final membership checks still compare the original full-width signed or unsigned values.

### Padding buckets safely

Lookup always compares four candidates, even when a bucket contains fewer than four real members. To avoid storing a length for every bucket or branching on it, construction initializes every slot with an arbitrary real member of the set, then overwrites the populated slots.

This padding cannot create a false match:

- A query equal to the padding value necessarily has the same selected byte, so it routes to that value's real bucket, where the value genuinely is a member.
- A query routed to any other bucket differs from the padding value in the selected byte and therefore cannot equal it.

The selected byte only narrows the candidates. All four final checks use complete 32- or 64-bit equality, so sharing a bucket is not itself a match.

### Probing the index

For each input value, the indexed path:

1. extracts the selected byte;
2. directly loads that byte's four-entry bucket;
3. compares the input with all four full-width candidates; and
4. combines the comparisons with bitwise `|`.

In simplified form:

```text
[a, b, c, d] = buckets[selected_byte(input)]
found = (input == a) | (input == b) | (input == c) | (input == d)
```

Using `|` rather than short-circuiting `||` makes the work independent of which slot matches and exposes a regular, branch-free four-comparison expression that is amenable to compiler auto-vectorization. The implementation requires no target-specific SIMD intrinsics; whether the compiler emits SIMD remains target- and compiler-dependent. Even without vectorization, the probe is bounded to one direct lookup and four comparisons.

### Hash fallback

`IntegerSet` retains the already-built `HashSet` when:

- the distinct set is empty;
- it contains more than 1,024 values; or
- every byte position has at least one bucket containing more than four values.

The last case matters for correlated or adversarial distributions: having at most 1,024 values is necessary for the fixed table to hold the set, but it is not sufficient for any single byte to partition it well. Because construction creates the `HashSet` first, fallback reuses it rather than rebuilding the set.

### Construction and memory cost

The indexed representation contains exactly 1,024 full-width slots: a 4 KiB bucket payload for `Int32`/`UInt32`, or 8 KiB for `Int64`/`UInt64`, plus small enum and allocation metadata. This is a fixed cost even when many slots are padding.

Construction still pays the previous one-time hash/deduplication cost, then scans the distinct values for at most four or eight candidate byte positions. While constructing an accepted index, peak memory briefly includes both the hash set and the fixed table; the hash set is dropped when the indexed representation is returned. The tradeoff is therefore a small amount of one-time work and bounded memory for cheaper repeated probes.

### Preserving `IN` / `NOT IN` semantics

The index changes only how raw membership is computed. Its membership bitmap is passed to the shared `build_result_from_contains` helper, which applies SQL three-valued logic:

- a null input value produces `NULL`;
- a matching non-null value produces `TRUE` for `IN` and `FALSE` for `NOT IN`, even when the list also contains `NULL`;
- a non-matching value produces `NULL` when the list contains `NULL`; and
- otherwise, a non-match produces `FALSE` for `IN` and `TRUE` for `NOT IN`.

Duplicate non-null values are removed before indexing, while list nulls are tracked separately, so neither changes the result. Existing handling for sliced arrays and dictionary-encoded inputs is retained; dictionary values are evaluated and then remapped through their keys.

### Related primitive-filter cleanup

To plug `IntegerSet` into the existing primitive filters without duplicating result logic, this commit also:

- generalizes the primitive-filter macro so each type can provide its set representation, constructor, and batched membership function;
- routes precomputed membership bitmaps through the common result builder; and
- replaces the custom `Float32`/`Float64` hash-key wrappers with `[u8; 4]` and `[u8; 8]` keys.

Floats remain hash-backed; they do **not** use the integer byte index. Their fixed byte-array keys preserve the previous exact bit-pattern equality, including the distinction between `0.0` and `-0.0` and between different NaN payloads.

### Scope

- The new byte index applies only to constant/static filters for `Int32`, `UInt32`, `Int64`, and `UInt64`.
- The existing branchless strategy continues to handle their short lists.
- Narrow integers keep their existing bitmap strategies.
- Floats and temporal types with 32- or 64-bit physical representations are not routed through `IntegerSet` by this change.
- Dynamic, non-constant `IN` lists and all other data types keep their existing strategies.
- No public API or SQL-visible behavior changes.

## Are these changes tested?

Yes. The tests added by the final commit:

- compare `IntegerSet` membership with `std::collections::HashSet` over empty, small, and larger generated inputs;
- cover minimum and maximum values, negative values, misses adjacent to bounds, and duplicates for all four supported integer types;
- verify that an index can select a higher byte when the lowest byte is overfull;
- force a distribution-based hash fallback with 625 distinct values for which every byte position has an overfull bucket;
- exercise a sliced, nullable `UInt32` list with dictionary-encoded needles for both `IN` and `NOT IN`; and
- verify that the refactored `Float32` keys preserve exact bit equality for `0.0`/`-0.0` and distinct NaN payloads.

## Are there any user-facing changes?

No. This is an internal representation and evaluation optimization for constant integer `IN` lists. Query results and public APIs are unchanged.

## Local benchmark snapshot

This final commit does not modify the benchmark source. Both revisions use the same existing `datafusion/physical-expr/benches/in_list_strategy.rs` inherited from the lower stack, so the comparison isolates the integer-filter implementation. The benchmark was built and run in separate target directories after compilation completed:

```bash
cargo bench --target-dir <target-dir> \
  -p datafusion-physical-expr \
  --bench in_list_strategy -- '<filter>' --noplot
```

Criterion defaults and central point estimates were used. Filter construction is outside the timed loop, so these measurements cover repeated evaluation rather than index-construction cost. Each timed iteration evaluates 8,192 input rows. Lower is better.

`Before` is the exact combined head of [#24088](https://github.com/apache/datafusion/pull/24088) and [#24102](https://github.com/apache/datafusion/pull/24102) ([`b0443b6bb0`](https://github.com/apache/datafusion/commit/b0443b6bb0411d05d8ab5eae0926599ee502a37d)); `After` is this PR ([`689cae2a42`](https://github.com/apache/datafusion/commit/689cae2a4239b2a96795a0cfec5679bdb97228cf)).

The nine reported cases improve 1.85x–5.31x, with a 3.32x geometric mean speedup (69.9% less time).

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `i32 / 64 / miss` | 17.13 us | 6.53 us | -61.9% (2.62x) |
| `i32 / 64 / 50% hit` | 34.77 us | 6.55 us | -81.2% (5.31x) |
| `i32 / 256 / miss` | 15.28 us | 6.56 us | -57.1% (2.33x) |
| `i32 / 256 / 50% hit` | 32.20 us | 6.54 us | -79.7% (4.92x) |
| `i64 / 32 / miss` | 13.92 us | 7.53 us | -45.9% (1.85x) |
| `i64 / 32 / 50% hit` | 30.59 us | 7.53 us | -75.4% (4.06x) |
| `i64 / 128 / miss` | 16.23 us | 7.76 us | -52.2% (2.09x) |
| `i64 / 128 / 50% hit` | 31.91 us | 7.66 us | -76.0% (4.16x) |
| `nullable i32 / 64 / 50% hit / 20% null` | 32.01 us | 6.79 us | -78.8% (4.72x) |

The baseline and this PR were measured without competing Cargo or rustc processes.

These cases cover random full-width signed-integer distributions. The reported set does not measure filter construction, deliberately forced hash fallback, unsigned integers, or a `NULL` inside the `IN` list; the nullable row has nulls in the input array.
