### PR TITLE
fix: clear stale sliding aggregate state for empty RANGE frames

### DIFF
--- a/datafusion/physical-expr/src/window/sliding_aggregate.rs
+++ b/datafusion/physical-expr/src/window/sliding_aggregate.rs
@@ -210,6 +210,23 @@ impl AggregateWindowExpr for SlidingAggregateWindowExpr {
         filter_mask: Option<&BooleanArray>,
     ) -> Result<ScalarValue> {
         if cur_range.start == cur_range.end {
+            // Keep the accumulator synchronized with `last_range`. RANGE frames
+            // can become empty between two non-empty frames when the ORDER BY
+            // values contain gaps.
+            let retract_bound = last_range.end - last_range.start;
+            if retract_bound > 0 {
+                let slice_mask =
+                    filter_mask.map(|m| m.slice(last_range.start, retract_bound));
+                let retract: Vec<ArrayRef> = value_slice
+                    .iter()
+                    .map(|v| v.slice(last_range.start, retract_bound))
+                    .map(|arr| match &slice_mask {
+                        Some(m) => filter_array(&arr, m),
+                        None => Ok(arr),
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                accumulator.retract_batch(&retract)?
+            }
             self.aggregate
                 .default_value(self.aggregate.field().data_type())
         } else {

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -6629,6 +6629,23 @@ FROM (
 2 1
 3 1
 
+# A RANGE frame can transition from non-empty to empty and back to non-empty
+# when the ORDER BY values contain gaps. The sliding accumulator must discard
+# the state from the previous non-empty frame.
+query IIIII
+SELECT k,
+       SUM(v) OVER w,
+       COUNT(v) OVER w,
+       MIN(v) OVER w,
+       MAX(v) OVER w
+FROM (VALUES (0, 100), (10, 90), (30, 10), (40, 20)) AS t(k, v)
+WINDOW w AS (ORDER BY k RANGE BETWEEN 10 PRECEDING AND 5 PRECEDING);
+----
+0 NULL 0 NULL NULL
+10 100 1 100 100
+30 NULL 0 NULL NULL
+40 10 1 10 10
+
 # AVG over a sliding window must yield NULL when the frame has no non-NULL
 # values — including frames that became empty via `retract_batch`. Covers
 # Float64, Decimal, and the narrow-frame retract-to-empty case.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #24184.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

Sliding aggregate window functions can return incorrect results when a bounded `RANGE` frame transitions from non-empty to empty and then back to non-empty.

The empty frame does not clear the previous accumulator state, so stale values are included in subsequent results.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Retract the previous frame from the accumulator when the current frame is empty.
- Add a slt covering

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

Bug fix only.