### PR TITLE
feat: add aggregate observability counters to the cache layer

### DIFF
--- a/datafusion/execution/src/cache/cache_manager.rs
+++ b/datafusion/execution/src/cache/cache_manager.rs
@@ -16,7 +16,9 @@
 // under the License.
 
 use crate::cache::default_cache::DefaultCache;
-pub use crate::cache::{Cache, CacheValue, SchemaFingerprint, TableScopedPath};
+pub use crate::cache::{
+    Cache, CacheStatistics, CacheValue, SchemaFingerprint, TableScopedPath,
+};
 use datafusion_common::HashMap;
 use datafusion_common::heap_size::{DFHeapSize, DFHeapSizeCtx};
 use datafusion_common::{Result, Statistics};
@@ -407,6 +409,30 @@ impl CacheManager {
     pub fn get_metadata_cache_limit(&self) -> usize {
         self.file_metadata_cache.cache_limit()
     }
+
+    /// Aggregate counters for the file statistics cache.
+    ///
+    /// Returns `None` if the cache is disabled or if the configured
+    /// implementation does not track statistics. See [`CacheStatistics`].
+    pub fn get_file_statistic_cache_statistics(&self) -> Option<CacheStatistics> {
+        self.file_statistic_cache.as_ref()?.statistics()
+    }
+
+    /// Aggregate counters for the list files cache.
+    ///
+    /// Returns `None` if the cache is disabled or if the configured
+    /// implementation does not track statistics. See [`CacheStatistics`].
+    pub fn get_list_files_cache_statistics(&self) -> Option<CacheStatistics> {
+        self.list_files_cache.as_ref()?.statistics()
+    }
+
+    /// Aggregate counters for the file embedded metadata cache.
+    ///
+    /// Returns `None` if the configured implementation does not track
+    /// statistics. See [`CacheStatistics`].
+    pub fn get_file_metadata_cache_statistics(&self) -> Option<CacheStatistics> {
+        self.file_metadata_cache.statistics()
+    }
 }
 
 #[derive(Clone)]
@@ -575,5 +601,49 @@ mod tests {
             Some(Duration::from_secs(60)),
             "TTL should be overridden to 60 seconds when set in config"
         );
+    }
+
+    /// The counters must be reachable from the `CacheManager` for the caches
+    /// whose byte budgets are the ones users actually hit.
+    #[test]
+    fn test_cache_statistics_reachable_from_cache_manager() {
+        let cache_manager =
+            CacheManager::try_new(&CacheManagerConfig::default()).unwrap();
+
+        // The default caches are all instrumented and start at zero.
+        assert_eq!(
+            cache_manager.get_file_metadata_cache_statistics(),
+            Some(CacheStatistics::default())
+        );
+        assert_eq!(
+            cache_manager.get_file_statistic_cache_statistics(),
+            Some(CacheStatistics::default())
+        );
+        assert_eq!(
+            cache_manager.get_list_files_cache_statistics(),
+            Some(CacheStatistics::default())
+        );
+
+        // A miss on the metadata cache is visible through the manager.
+        assert!(
+            cache_manager
+                .get_file_metadata_cache()
+                .get(&Path::from("missing.parquet"))
+                .is_none()
+        );
+        let stats = cache_manager
+            .get_file_metadata_cache_statistics()
+            .expect("default metadata cache is instrumented");
+        assert_eq!(stats.misses, 1);
+        assert_eq!(stats.hits, 0);
+        assert_eq!(stats.hit_rate(), Some(0.0));
+
+        // A disabled cache has no statistics to report.
+        let config = CacheManagerConfig::default()
+            .with_file_statistics_cache_limit(0)
+            .with_list_files_cache_limit(0);
+        let cache_manager = CacheManager::try_new(&config).unwrap();
+        assert_eq!(cache_manager.get_file_statistic_cache_statistics(), None);
+        assert_eq!(cache_manager.get_list_files_cache_statistics(), None);
     }
 }

--- a/datafusion/execution/src/cache/default_cache.rs
+++ b/datafusion/execution/src/cache/default_cache.rs
@@ -23,7 +23,7 @@ use datafusion_common::instant::Instant;
 use datafusion_common::{HashMap, Result};
 
 use crate::cache::lru_queue::LruQueue;
-use crate::cache::{Cache, CacheEntryInfo, CacheKey, CacheValue};
+use crate::cache::{Cache, CacheEntryInfo, CacheKey, CacheStatistics, CacheValue};
 
 /// Source of the current time used by a [`DefaultCache`] when applying TTLs.
 pub trait TimeProvider: Send + Sync {
@@ -55,6 +55,10 @@ struct DefaultCacheState<K: CacheKey, V: CacheValue> {
     memory_limit: usize,
     memory_used: usize,
     ttl: Option<Duration>,
+    /// Aggregate, lifetime counters. Kept inside the state so that they are
+    /// updated under the mutex already held by every `get`/`put`, rather than
+    /// adding a second point of synchronization on the hot path.
+    statistics: CacheStatistics,
 }
 
 impl<K: CacheKey, V: CacheValue> DefaultCacheState<K, V> {
@@ -65,19 +69,25 @@ impl<K: CacheKey, V: CacheValue> DefaultCacheState<K, V> {
             memory_limit,
             memory_used: 0,
             ttl,
+            statistics: CacheStatistics::default(),
         }
     }
 
     fn get(&mut self, key: &K, now: Instant) -> Option<V> {
-        let entry = self.lru_queue.get(key)?;
+        let Some(entry) = self.lru_queue.get(key) else {
+            self.statistics.misses += 1;
+            return None;
+        };
         if let Some(exp) = entry.expires
             && now > exp
         {
             self.remove(key);
+            self.statistics.misses += 1;
             return None;
         }
         let value = entry.value.clone();
         *self.hits.entry(key.clone()).or_insert(0) += 1;
+        self.statistics.hits += 1;
         Some(value)
     }
 
@@ -105,6 +115,8 @@ impl<K: CacheKey, V: CacheValue> DefaultCacheState<K, V> {
         let total_size = key_size + value_size;
 
         if total_size > self.memory_limit {
+            // The entry can never fit, no matter how much of the cache is free.
+            self.statistics.inserts_rejected_too_large += 1;
             // Remove potential stale entry
             return self.remove(key);
         }
@@ -145,9 +157,11 @@ impl<K: CacheKey, V: CacheValue> DefaultCacheState<K, V> {
                 self.memory_used = 0;
                 return;
             };
-            self.memory_used -= evicted_key.size();
-            self.memory_used -= evicted.value.size();
+            let evicted_size = evicted_key.size() + evicted.value.size();
+            self.memory_used -= evicted_size;
             self.hits.remove(&evicted_key);
+            self.statistics.evictions += 1;
+            self.statistics.bytes_evicted += evicted_size as u64;
         }
     }
 
@@ -203,6 +217,14 @@ impl<K: CacheKey, V: CacheValue> DefaultCache<K, V> {
     /// Number of bytes currently accounted for by live entries.
     pub fn memory_used(&self) -> usize {
         self.state.lock().unwrap().memory_used
+    }
+
+    /// Aggregate, lifetime counters for this cache.
+    ///
+    /// See [`Cache::statistics`] and [`CacheStatistics`] for the exact meaning
+    /// of each counter.
+    pub fn cache_statistics(&self) -> CacheStatistics {
+        self.state.lock().unwrap().statistics
     }
 }
 
@@ -293,6 +315,10 @@ impl<K: CacheKey, V: CacheValue> Cache<K, V> for DefaultCache<K, V> {
             })
             .collect()
     }
+
+    fn statistics(&self) -> Option<CacheStatistics> {
+        Some(self.cache_statistics())
+    }
 }
 
 #[cfg(test)]
@@ -308,7 +334,7 @@ mod tests {
     use crate::cache::cache_manager::{CachedFileMetadataEntry, FileMetadata};
     use crate::cache::default_cache::DefaultCache;
     use crate::cache::default_cache::TimeProvider;
-    use crate::cache::{Cache, CacheEntryInfo};
+    use crate::cache::{Cache, CacheEntryInfo, CacheStatistics};
     use crate::cache::{CacheKey, CacheValue};
     use crate::cache::{SchemaFingerprint, TableScopedPath};
     use arrow::array::{Int32Array, ListArray, RecordBatch};
@@ -2011,5 +2037,171 @@ mod tests {
         assert!(!cache.contains_key(&key1));
         assert!(!cache.contains_key(&key2));
         assert!(cache.contains_key(&key3));
+    }
+
+    #[test]
+    fn test_statistics_hits_and_misses() {
+        let cache = DefaultCache::new(DEFAULT_LIST_FILES_CACHE_MEMORY_LIMIT);
+        let table_ref = Some(TableReference::from("table"));
+        let (key1, value1) =
+            create_test_list_files_entry("path1", 1, 100, table_ref.clone());
+        let (key2, _value2) = create_test_list_files_entry("path2", 1, 100, table_ref);
+
+        assert_eq!(cache.cache_statistics(), CacheStatistics::default());
+        assert_eq!(cache.cache_statistics().hit_rate(), None);
+
+        // Lookup on an empty cache is a miss
+        assert!(cache.get(&key1).is_none());
+        assert_eq!(cache.cache_statistics().misses, 1);
+        assert_eq!(cache.cache_statistics().hits, 0);
+
+        cache.put(&key1, value1);
+
+        // Two hits on the entry we just inserted
+        assert!(cache.get(&key1).is_some());
+        assert!(cache.get(&key1).is_some());
+        assert_eq!(cache.cache_statistics().hits, 2);
+        assert_eq!(cache.cache_statistics().misses, 1);
+
+        // A lookup of an absent key is a miss
+        assert!(cache.get(&key2).is_none());
+        assert_eq!(cache.cache_statistics().misses, 2);
+
+        // `contains_key` is a probe, not a lookup, and is not counted
+        assert!(cache.contains_key(&key1));
+        assert!(!cache.contains_key(&key2));
+        assert_eq!(cache.cache_statistics().hits, 2);
+        assert_eq!(cache.cache_statistics().misses, 2);
+
+        assert_eq!(cache.cache_statistics().lookups(), 4);
+        assert_eq!(cache.cache_statistics().hit_rate(), Some(0.5));
+
+        // Statistics are exposed through the `Cache` trait too
+        assert_eq!(cache.statistics(), Some(cache.cache_statistics()));
+
+        // `clear` neither resets the counters nor counts as an eviction
+        cache.clear();
+        let stats = cache.cache_statistics();
+        assert_eq!(stats.hits, 2);
+        assert_eq!(stats.misses, 2);
+        assert_eq!(stats.evictions, 0);
+        assert_eq!(stats.bytes_evicted, 0);
+
+        // ... and a lookup after the clear is a miss
+        assert!(cache.get(&key1).is_none());
+        assert_eq!(cache.cache_statistics().misses, 3);
+    }
+
+    #[test]
+    fn test_statistics_expired_entry_counts_as_miss() {
+        let ttl = Duration::from_millis(100);
+        let mock_time = Arc::new(MockTimeProvider::new());
+        let cache = DefaultCache::new_with_ttl(10000, Some(ttl))
+            .with_time_provider(Arc::clone(&mock_time) as Arc<dyn TimeProvider>);
+
+        let table_ref = Some(TableReference::from("table"));
+        let (key, value) = create_test_list_files_entry("path1", 1, 50, table_ref);
+        cache.put(&key, value);
+
+        assert!(cache.get(&key).is_some());
+        assert_eq!(cache.cache_statistics().hits, 1);
+
+        mock_time.inc(Duration::from_millis(150));
+
+        // Expiration is not eviction: the entry is dropped lazily on access and
+        // the access itself is a miss.
+        assert!(cache.get(&key).is_none());
+        let stats = cache.cache_statistics();
+        assert_eq!(stats.hits, 1);
+        assert_eq!(stats.misses, 1);
+        assert_eq!(stats.evictions, 0);
+    }
+
+    #[test]
+    fn test_statistics_evictions() {
+        let table_ref = Some(TableReference::from("table"));
+        let (key1, value1) =
+            create_test_list_files_entry("path1", 1, 100, table_ref.clone());
+        let (key2, value2) =
+            create_test_list_files_entry("path2", 1, 100, table_ref.clone());
+        let (key3, value3) =
+            create_test_list_files_entry("path3", 1, 100, table_ref.clone());
+        let (key4, value4) =
+            create_test_list_files_entry("path4", 1, 100, table_ref.clone());
+
+        let entry_size = key1.size() + value1.size();
+
+        // A cache that fits exactly two entries
+        let cache = DefaultCache::new(entry_size * 2);
+        cache.put(&key1, value1);
+        cache.put(&key2, value2);
+        assert_eq!(cache.cache_statistics().evictions, 0);
+
+        // The third insert evicts the LRU entry
+        cache.put(&key3, value3);
+        let stats = cache.cache_statistics();
+        assert_eq!(stats.evictions, 1);
+        assert_eq!(stats.bytes_evicted, entry_size as u64);
+
+        // Replacing an existing entry with an equally sized one is not an eviction
+        let (_, value3_again) =
+            create_test_list_files_entry("path3", 1, 100, table_ref.clone());
+        cache.put(&key3, value3_again);
+        assert_eq!(cache.cache_statistics().evictions, 1);
+
+        // Explicitly removing an entry is not an eviction either
+        cache.remove(&key2);
+        assert_eq!(cache.cache_statistics().evictions, 1);
+
+        // Neither is dropping a whole table's entries
+        cache.put(&key4, value4);
+        cache
+            .drop_table_entries(&TableReference::from("table"))
+            .unwrap();
+        assert_eq!(cache.cache_statistics().evictions, 1);
+        assert_eq!(cache.len(), 0);
+
+        // Shrinking the limit evicts, and that is counted
+        let (key5, value5) = create_test_list_files_entry("path5", 1, 100, table_ref);
+        cache.put(&key5, value5);
+        cache.update_cache_limit(1);
+        let stats = cache.cache_statistics();
+        assert_eq!(stats.evictions, 2);
+        assert_eq!(stats.bytes_evicted, (entry_size * 2) as u64);
+    }
+
+    #[test]
+    fn test_statistics_inserts_rejected_too_large() {
+        let table_ref = Some(TableReference::from("table"));
+        let (key1, value1) =
+            create_test_list_files_entry("path1", 1, 100, table_ref.clone());
+        let entry_size = key1.size() + value1.size();
+
+        let cache = DefaultCache::new(entry_size);
+        cache.put(&key1, value1);
+        assert_eq!(cache.cache_statistics().inserts_rejected_too_large, 0);
+
+        // An entry larger than the whole cache can never fit and is rejected
+        // rather than evicting its way to space that will never be enough.
+        let (key_large, value_large) =
+            create_test_list_files_entry("large", 1, 1000, table_ref.clone());
+        cache.put(&key_large, value_large);
+        let stats = cache.cache_statistics();
+        assert_eq!(stats.inserts_rejected_too_large, 1);
+        assert_eq!(stats.evictions, 0);
+        assert!(!cache.contains_key(&key_large));
+
+        // A rejected insert also drops any stale entry stored under the same
+        // key. That removal is still a rejection, not an eviction.
+        assert!(cache.contains_key(&key1));
+        let (_, value1_too_large) =
+            create_test_list_files_entry("path1", 1, 1000, table_ref);
+        cache.put(&key1, value1_too_large);
+        let stats = cache.cache_statistics();
+        assert_eq!(stats.inserts_rejected_too_large, 2);
+        assert_eq!(stats.evictions, 0);
+        assert!(!cache.contains_key(&key1));
+        assert_eq!(cache.len(), 0);
+        assert_eq!(cache.memory_used(), 0);
     }
 }

--- a/datafusion/execution/src/cache/mod.rs
+++ b/datafusion/execution/src/cache/mod.rs
@@ -91,6 +91,66 @@ pub trait Cache<K: CacheKey, V: CacheValue>: Send + Sync {
     /// Snapshot of all current entries with per-entry metadata (size, hits,
     /// expiration) for diagnostics and observability.
     fn list_entries(&self) -> HashMap<K, CacheEntryInfo<V>>;
+
+    /// Aggregate counters describing how this cache has behaved so far, or
+    /// `None` if the implementation does not track them.
+    ///
+    /// Unlike [`Cache::list_entries`], which only describes entries that are
+    /// currently resident, these counters cover the whole lifetime of the cache
+    /// and therefore survive eviction. They are what makes a thrashing cache
+    /// (0% hit rate because the working set does not fit the byte budget)
+    /// diagnosable.
+    ///
+    /// The default implementation returns `None` so that existing external
+    /// implementations of this trait keep compiling; `None` means
+    /// "not instrumented", which a reporting tool can distinguish from an
+    /// instrumented cache that is genuinely all zeros.
+    fn statistics(&self) -> Option<CacheStatistics> {
+        None
+    }
+}
+
+/// Aggregate, lifetime counters for a [`Cache`].
+///
+/// Obtained via [`Cache::statistics`]. All counters are monotonic for the
+/// lifetime of the cache: they are not reset by [`Cache::clear`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CacheStatistics {
+    /// Lookups ([`Cache::get`]) that returned a value.
+    pub hits: u64,
+    /// Lookups ([`Cache::get`]) that did not return a value, either because the
+    /// key was absent or because the entry had expired.
+    pub misses: u64,
+    /// Entries dropped to stay within the memory budget.
+    ///
+    /// This counts only capacity-driven eviction (including eviction triggered
+    /// by lowering the limit via [`Cache::update_cache_limit`]). Explicit
+    /// invalidation through [`Cache::remove`], [`Cache::clear`] or
+    /// [`Cache::drop_table_entries`], and replacing an entry with a new value
+    /// for the same key, are not evictions.
+    pub evictions: u64,
+    /// Total size, in bytes, of the entries counted by `evictions`.
+    pub bytes_evicted: u64,
+    /// Inserts rejected because the entry on its own was larger than the whole
+    /// cache limit.
+    ///
+    /// A non-zero value means the cache can never hold that entry, no matter
+    /// how much of it is free — a distinct failure mode from ordinary eviction
+    /// pressure, and one that is worth surfacing on its own.
+    pub inserts_rejected_too_large: u64,
+}
+
+impl CacheStatistics {
+    /// Total number of lookups, i.e. `hits + misses`.
+    pub fn lookups(&self) -> u64 {
+        self.hits.saturating_add(self.misses)
+    }
+
+    /// Fraction of lookups that were hits, or `None` if there were no lookups.
+    pub fn hit_rate(&self) -> Option<f64> {
+        let lookups = self.lookups();
+        (lookups > 0).then(|| self.hits as f64 / lookups as f64)
+    }
 }
 
 /// Key type for entries stored in a [`Cache`].
@@ -222,6 +282,83 @@ impl Hash for SchemaFingerprint {
 impl DFHeapSize for SchemaFingerprint {
     fn heap_size(&self, ctx: &mut DFHeapSizeCtx) -> usize {
         self.columns.heap_size(ctx)
+    }
+}
+
+#[cfg(test)]
+mod cache_statistics_tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct Unit;
+
+    impl CacheValue for Unit {
+        fn size(&self) -> usize {
+            0
+        }
+    }
+
+    /// A [`Cache`] implementation that does not override [`Cache::statistics`],
+    /// standing in for an external implementation written before the counters
+    /// existed. It must keep compiling, and report that it is uninstrumented.
+    struct UninstrumentedCache;
+
+    impl Cache<Path, Unit> for UninstrumentedCache {
+        fn get(&self, _key: &Path) -> Option<Unit> {
+            None
+        }
+        fn put(&self, _key: &Path, _value: Unit) -> Option<Unit> {
+            None
+        }
+        fn remove(&self, _k: &Path) -> Option<Unit> {
+            None
+        }
+        fn contains_key(&self, _k: &Path) -> bool {
+            false
+        }
+        fn len(&self) -> usize {
+            0
+        }
+        fn clear(&self) {}
+        fn name(&self) -> String {
+            "UninstrumentedCache".to_string()
+        }
+        fn cache_limit(&self) -> usize {
+            0
+        }
+        fn update_cache_limit(&self, _limit: usize) {}
+        fn cache_ttl(&self) -> Option<Duration> {
+            None
+        }
+        fn update_cache_ttl(&self, _ttl: Option<Duration>) {}
+        fn drop_table_entries(
+            &self,
+            _table_ref: &TableReference,
+        ) -> datafusion_common::Result<()> {
+            Ok(())
+        }
+        fn list_entries(&self) -> HashMap<Path, CacheEntryInfo<Unit>> {
+            HashMap::new()
+        }
+    }
+
+    #[test]
+    fn uninstrumented_cache_reports_no_statistics() {
+        assert_eq!(UninstrumentedCache.statistics(), None);
+    }
+
+    #[test]
+    fn hit_rate_and_lookups() {
+        assert_eq!(CacheStatistics::default().hit_rate(), None);
+        assert_eq!(CacheStatistics::default().lookups(), 0);
+
+        let stats = CacheStatistics {
+            hits: 1,
+            misses: 3,
+            ..Default::default()
+        };
+        assert_eq!(stats.lookups(), 4);
+        assert_eq!(stats.hit_rate(), Some(0.25));
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

- N/A — no existing issue; the motivation is written up below. Happy to file one
  if a maintainer prefers to track it separately.

## Rationale for this change

DataFusion has two parquet caches whose working sets scale linearly with schema
width, but whose limits are fixed byte budgets: `file_statistics_cache`
(default 20 MiB) and `file_metadata_cache` (default 50 MiB). On a
1024-column × 256-file parquet table, measured locally:

- in-memory footer + page-index metadata is ~1.2 MiB/file → a **307 MiB**
  working set against the 50 MiB default
- per-file statistics are ~208 KiB/file → **~52 MiB** against the 20 MiB default
- so both caches sit at a **~0% hit rate**. Worse, the access pattern (a full
  sweep over every file, once per query) is LRU's pathological case, so the
  degradation is a cliff and not a gradient: raising the metadata limit to
  200 MiB against a 307 MiB working set still delivers **0%** of the benefit.
- with both caches at their defaults a representative query took **507 ms**;
  with both caches *disabled*, **483 ms**; with both fully resident, **8.8 ms**.

The point of this PR is the last bullet: at the defaults the caches were pure
overhead, and **a user in that regime today has no way to discover it.**
`DefaultCacheState` keeps a per-entry `hits: HashMap<K, usize>`, but there are
no aggregate counters anywhere, and the only cache introspection in the project
is datafusion-cli's `metadata_cache()` table function — which lists the entries
that are currently resident, and therefore says nothing at all about the ones
that were evicted a microsecond after being inserted. Cache thrashing is
currently invisible and undiagnosable.

This PR adds the counters. It does not change any caching behaviour.

## What changes are included in this PR?

Three small commits:

1. **`CacheStatistics` + `Cache::statistics()`** (`cache/mod.rs`). A plain
   struct of aggregate, lifetime counters:

   | field | meaning |
   | --- | --- |
   | `hits` | `get` calls that returned a value |
   | `misses` | `get` calls that did not — key absent *or* entry expired |
   | `evictions` | entries dropped to stay within the byte budget |
   | `bytes_evicted` | total size of those entries |
   | `inserts_rejected_too_large` | inserts where the entry alone exceeded the whole limit |

   plus `lookups()` and `hit_rate()` helpers.

   `inserts_rejected_too_large` is called out separately on purpose: that path
   already exists in `DefaultCacheState::put`, and a non-zero value means the
   cache can *never* hold that entry no matter how much of it is free. That is a
   different problem from ordinary eviction pressure and wants a different fix
   (raise the limit vs. shrink the working set), so folding it into `evictions`
   would lose the most diagnostic signal in the set. It is exactly what happens
   when one wide-schema file's metadata exceeds the entire cache budget.

2. **`DefaultCache` tracks them** (`cache/default_cache.rs`).

3. **`CacheManager` exposes them** (`cache/cache_manager.rs`):
   `get_file_metadata_cache_statistics()`,
   `get_file_statistic_cache_statistics()` and
   `get_list_files_cache_statistics()`, alongside the existing `*_limit`
   accessors. Each returns `None` when the cache is disabled or when the
   configured implementation is not instrumented.

### On not breaking the `Cache` trait

`Cache` is public API with potential external implementors, so
`statistics()` is **a new trait method with a default implementation** rather
than a required one — existing implementations keep compiling untouched. It
returns `Option<CacheStatistics>` (default `None`) rather than
`CacheStatistics::default()` so that "this implementation is not instrumented"
stays distinguishable from "this instrumented cache has genuinely done nothing
yet"; reporting all-zero counters for a cache that never counted anything would
be actively misleading. A test in `cache/mod.rs` implements `Cache` without
overriding `statistics()`, both to pin the non-breaking guarantee and to assert
the `None`.

### On the hot path

The counters are fields of `DefaultCacheState`, i.e. they live behind the
`Mutex` that every `get`/`put` already takes, and are incremented inside that
existing critical section. No new synchronisation, no atomics, no second lock.

## Are these changes tested?

Yes — new unit tests in `cache/default_cache.rs`, one per counter:

- `test_statistics_hits_and_misses` — hits, misses on absent keys, `clear()`
  neither resetting the counters nor counting as eviction, and that
  `contains_key` is a probe that is deliberately *not* counted
- `test_statistics_expired_entry_counts_as_miss` — a TTL-expired entry is a
  miss, not an eviction
- `test_statistics_evictions` — `evictions`/`bytes_evicted` for LRU eviction and
  for eviction caused by lowering the limit, and that `remove`,
  `drop_table_entries` and same-key replacement are *not* evictions
- `test_statistics_inserts_rejected_too_large` — the rejection path, including
  the case where the rejected insert also drops a stale entry under that key

plus `test_cache_statistics_reachable_from_cache_manager` in
`cache/cache_manager.rs` and the trait-default tests in `cache/mod.rs`.

`cargo test -p datafusion-execution`, `cargo fmt --all` and
`./ci/scripts/rust_clippy.sh` all pass.

## Are there any user-facing changes?

Additive only, no behaviour change:

- new public `CacheStatistics` struct
- new `Cache::statistics()` **with a default implementation**, so this is not a
  breaking change for external implementors
- three new `CacheManager` accessors

Deliberately left out, to keep this reviewable:

- **`EXPLAIN ANALYZE`.** Surfacing cache hit rate per query is the natural
  follow-up and the thing that would actually put this in front of users, but it
  needs a decision about per-query vs. process-lifetime accounting (these
  counters are process-lifetime and monotonic) and touches the metrics plumbing.
  Separate PR.
- **datafusion-cli's `metadata_cache()`.** That table function emits one row per
  resident entry; aggregate counters do not fit that shape without either
  repeating them on every row or adding a second table function. Both grow the
  diff more than they are worth here.
- **A counter reset.** Would be useful for per-query measurement, but only once
  there is a consumer for it — see the `EXPLAIN ANALYZE` item.
- **A counter for zero-size inserts.** `DefaultCache::put` silently drops any
  value whose `size()` is 0 and reports no previous value, which for
  `CachedFileList` means an empty directory listing is never cached — so an
  empty prefix is re-listed on every query, invisibly. That is pre-existing
  behaviour rather than something these counters change, and whether the fix is
  a sixth counter or making zero-size entries cacheable is a separate
  discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


