### PR TITLE
fix: return error instead of panic when decoding ParquetScan/AvroScan without features

### DIFF
--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -1086,8 +1086,8 @@ pub trait PhysicalPlanNodeExt: Sized {
                     ParquetSource::try_from_proto(self.node(), &decode_ctx)
                 }
                 #[cfg(not(feature = "parquet"))]
-                panic!(
-                    "Unable to process a Parquet PhysicalPlan when `parquet` feature is not enabled"
+                not_impl_err!(
+                    "Unable to process a Parquet PhysicalPlan when the `parquet` feature is not enabled"
                 )
             }
             PhysicalPlanType::AvroScan(scan) => {
@@ -1423,8 +1423,8 @@ pub trait PhysicalPlanNodeExt: Sized {
         }
 
         #[cfg(not(feature = "parquet"))]
-        panic!(
-            "Unable to process a Parquet PhysicalPlan when `parquet` feature is not enabled"
+        not_impl_err!(
+            "Unable to process a Parquet PhysicalPlan when the `parquet` feature is not enabled"
         )
     }
 
@@ -1449,7 +1449,9 @@ pub trait PhysicalPlanNodeExt: Sized {
         }
 
         #[cfg(not(feature = "avro"))]
-        panic!("Unable to process a Avro PhysicalPlan when `avro` feature is not enabled")
+        not_impl_err!(
+            "Unable to process an Avro PhysicalPlan when the `avro` feature is not enabled"
+        )
     }
 
     #[deprecated(


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24197.

## Rationale for this change

Explained in #24197.

## What changes are included in this PR?

I just replaced the three feature-gate `panic!`s in `datafusion/proto/src/physical_plan/mod.rs` with `not_impl_err!`, following the existing `ParquetSink` convention in the same file. Also fixes "a Avro" to "an Avro" in the message.

## Are these changes tested?

Checked the same feature combinations as the `datafusion-proto features` CI job and ran `cargo test -p datafusion-proto`. Manually verified with a no-default-features build that decoding panicked before and returns `NotImplemented` after. No regression test added because the error path only exists in feature-disabled builds, which CI only runs `cargo check` on.

## Are there any user-facing changes?

No API changes.
