### PR TITLE
test: add UnionArray hashing SQL coverage.

### DIFF
--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -573,14 +573,17 @@ fn register_union_table(ctx: &SessionContext) {
             ],
         )
         .unwrap(),
-        ScalarBuffer::from(vec![3, 1, 3]),
+        ScalarBuffer::from(vec![3, 1, 3, 3, 1, 3]),
         None,
         vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(Int32Array::from(vec![1, 2, 3, 1, 5, 3])),
             Arc::new(StringArray::from(vec![
                 Some("foo"),
                 Some("bar"),
                 Some("baz"),
+                Some("qux"),
+                Some("bar"),
+                Some("quux"),
             ])),
         ],
     )

--- a/datafusion/sqllogictest/test_files/union_function.slt
+++ b/datafusion/sqllogictest/test_files/union_function.slt
@@ -28,6 +28,9 @@ select union_column, union_extract(union_column, 'int') from union_table;
 {int=1} 1
 {string=bar} NULL
 {int=3} 3
+{int=1} 1
+{string=bar} NULL
+{int=3} 3
 
 query error DataFusion error: Execution error: field bool not found on union
 select union_extract(union_column, 'bool') from union_table;
@@ -56,6 +59,9 @@ select union_column, union_tag(union_column) from union_table;
 {int=1} int
 {string=bar} string
 {int=3} int
+{int=1} int
+{string=bar} string
+{int=3} int
 
 query error DataFusion error: Error during planning: 'union_tag' does not support zero arguments
 select union_tag() from union_table;
@@ -65,3 +71,44 @@ select union_tag(union_column, 'int') from union_table;
 
 query error DataFusion error: Execution error: union_tag only support unions, got Utf8
 select union_tag('int') from union_table;
+
+##########
+## UNION Hashing Tests
+##########
+
+query ?I
+select union_column, count(*)
+from union_table
+group by union_column
+order by union_column;
+----
+{string=bar} 2
+{int=1} 2
+{int=3} 2
+
+query ?
+select distinct union_column
+from union_table
+order by union_column;
+----
+{string=bar}
+{int=1}
+{int=3}
+
+query I
+select count(distinct union_column) from union_table;
+----
+3
+
+query ?II
+select
+	union_column,
+	count(*),
+	sum(union_extract(union_column, 'int'))
+from union_table
+group by union_column
+order by union_column;
+----
+{string=bar} 2 NULL
+{int=1} 2 2
+{int=3} 2 6


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18791.

## Rationale for this change

Add regression coverage for SQL operations on UnionArray columns.

## What changes are included in this PR?

Adds SQL logic tests for grouping, distinct, and aggregation on UnionArray columns.

## Are these changes tested?

Yes. The focused SQL logic test passes:

`cargo test --profile=ci --test sqllogictests -- union_function.slt`

## Are there any user-facing changes?

No.