### PR TITLE
feat: add literal constraints to type signatures

### DIFF
--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -96,6 +96,18 @@ pub enum Arity {
     Variable,
 }
 
+/// A value constraint on a function argument.
+///
+/// Unlike type coercion, argument constraints describe the expression passed
+/// to a function rather than its [`DataType`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ArgumentConstraint {
+    /// The argument can be any expression.
+    Any,
+    /// The argument must be a literal value.
+    Literal,
+}
+
 /// The types of arguments for which a function has implementations.
 ///
 /// [`TypeSignature`] **DOES NOT** define the types that a user query could call the
@@ -155,6 +167,12 @@ pub enum Arity {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub enum TypeSignature {
+    /// A type signature with a constraint for each argument.
+    ///
+    /// This variant can be nested inside [`TypeSignature::OneOf`] when
+    /// different alternatives require different argument constraints.
+    /// The number of constraints must match the arity of `signature`.
+    Constrained(Box<TypeSignature>, Vec<ArgumentConstraint>),
     /// One or more arguments of a common type out of a list of valid types.
     ///
     /// For functions that take no arguments (e.g. `random()`), see [`TypeSignature::Nullary`].
@@ -278,6 +296,7 @@ impl TypeSignature {
     /// ```
     pub fn arity(&self) -> Arity {
         match self {
+            TypeSignature::Constrained(signature, _) => signature.arity(),
             TypeSignature::Exact(types) => Arity::Fixed(types.len()),
             TypeSignature::Uniform(count, _) => Arity::Fixed(*count),
             TypeSignature::Numeric(count) => Arity::Fixed(*count),
@@ -325,6 +344,16 @@ impl TypeSignature {
 impl Display for TypeSignature {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            TypeSignature::Constrained(signature, constraints) => {
+                write!(f, "Constrained({signature}; ")?;
+                for (i, constraint) in constraints.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{constraint:?}")?;
+                }
+                write!(f, ")")
+            }
             TypeSignature::Variadic(types) => {
                 write!(f, "Variadic({})", types.iter().join(", "))
             }
@@ -610,8 +639,14 @@ static NUMERICS: &[DataType] = &[
 ];
 
 impl TypeSignature {
+    /// Adds positional argument constraints to this type signature.
+    pub fn with_constraints(self, constraints: Vec<ArgumentConstraint>) -> Self {
+        Self::Constrained(Box::new(self), constraints)
+    }
+
     pub fn to_string_repr(&self) -> Vec<String> {
         match self {
+            TypeSignature::Constrained(signature, _) => signature.to_string_repr(),
             TypeSignature::Nullary => {
                 vec!["NullAry()".to_string()]
             }
@@ -690,6 +725,9 @@ impl TypeSignature {
         parameter_names: Option<&[String]>,
     ) -> Vec<String> {
         match self {
+            TypeSignature::Constrained(signature, _) => {
+                signature.to_string_repr_with_names(parameter_names)
+            }
             TypeSignature::Exact(types) => {
                 if let Some(names) = parameter_names {
                     vec![
@@ -862,6 +900,9 @@ impl TypeSignature {
     /// Check whether 0 input argument is valid for given `TypeSignature`
     pub fn supports_zero_argument(&self) -> bool {
         match &self {
+            TypeSignature::Constrained(signature, _) => {
+                signature.supports_zero_argument()
+            }
             TypeSignature::Exact(vec) => vec.is_empty(),
             TypeSignature::Nullary => true,
             TypeSignature::OneOf(types) => types
@@ -888,6 +929,7 @@ impl TypeSignature {
     /// documentation or error messages.
     pub fn get_example_types(&self) -> Vec<Vec<DataType>> {
         match self {
+            TypeSignature::Constrained(signature, _) => signature.get_example_types(),
             TypeSignature::Exact(types) => vec![types.clone()],
             TypeSignature::OneOf(types) => types
                 .iter()
@@ -1293,6 +1335,15 @@ impl Signature {
             volatility,
             parameter_names: None,
         }
+    }
+
+    /// Adds positional argument constraints to this signature's type signature.
+    pub fn with_type_signature_constraints(
+        mut self,
+        constraints: Vec<ArgumentConstraint>,
+    ) -> Self {
+        self.type_signature = self.type_signature.with_constraints(constraints);
+        self
     }
     /// An arbitrary number of arguments with the same type, from those listed in `common_types`.
     pub fn variadic(common_types: Vec<DataType>, volatility: Volatility) -> Self {

--- a/datafusion/expr-common/src/signature.rs
+++ b/datafusion/expr-common/src/signature.rs
@@ -108,6 +108,12 @@ pub enum ArgumentConstraint {
     Literal,
 }
 
+impl Default for ArgumentConstraint {
+    fn default() -> Self {
+        Self::Any
+    }
+}
+
 /// The types of arguments for which a function has implementations.
 ///
 /// [`TypeSignature`] **DOES NOT** define the types that a user query could call the
@@ -167,12 +173,6 @@ pub enum ArgumentConstraint {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub enum TypeSignature {
-    /// A type signature with a constraint for each argument.
-    ///
-    /// This variant can be nested inside [`TypeSignature::OneOf`] when
-    /// different alternatives require different argument constraints.
-    /// The number of constraints must match the arity of `signature`.
-    Constrained(Box<TypeSignature>, Vec<ArgumentConstraint>),
     /// One or more arguments of a common type out of a list of valid types.
     ///
     /// For functions that take no arguments (e.g. `random()`), see [`TypeSignature::Nullary`].
@@ -296,7 +296,6 @@ impl TypeSignature {
     /// ```
     pub fn arity(&self) -> Arity {
         match self {
-            TypeSignature::Constrained(signature, _) => signature.arity(),
             TypeSignature::Exact(types) => Arity::Fixed(types.len()),
             TypeSignature::Uniform(count, _) => Arity::Fixed(*count),
             TypeSignature::Numeric(count) => Arity::Fixed(*count),
@@ -344,16 +343,6 @@ impl TypeSignature {
 impl Display for TypeSignature {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TypeSignature::Constrained(signature, constraints) => {
-                write!(f, "Constrained({signature}; ")?;
-                for (i, constraint) in constraints.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{constraint:?}")?;
-                }
-                write!(f, ")")
-            }
             TypeSignature::Variadic(types) => {
                 write!(f, "Variadic({})", types.iter().join(", "))
             }
@@ -639,14 +628,8 @@ static NUMERICS: &[DataType] = &[
 ];
 
 impl TypeSignature {
-    /// Adds positional argument constraints to this type signature.
-    pub fn with_constraints(self, constraints: Vec<ArgumentConstraint>) -> Self {
-        Self::Constrained(Box::new(self), constraints)
-    }
-
     pub fn to_string_repr(&self) -> Vec<String> {
         match self {
-            TypeSignature::Constrained(signature, _) => signature.to_string_repr(),
             TypeSignature::Nullary => {
                 vec!["NullAry()".to_string()]
             }
@@ -725,9 +708,6 @@ impl TypeSignature {
         parameter_names: Option<&[String]>,
     ) -> Vec<String> {
         match self {
-            TypeSignature::Constrained(signature, _) => {
-                signature.to_string_repr_with_names(parameter_names)
-            }
             TypeSignature::Exact(types) => {
                 if let Some(names) = parameter_names {
                     vec![
@@ -900,9 +880,6 @@ impl TypeSignature {
     /// Check whether 0 input argument is valid for given `TypeSignature`
     pub fn supports_zero_argument(&self) -> bool {
         match &self {
-            TypeSignature::Constrained(signature, _) => {
-                signature.supports_zero_argument()
-            }
             TypeSignature::Exact(vec) => vec.is_empty(),
             TypeSignature::Nullary => true,
             TypeSignature::OneOf(types) => types
@@ -929,7 +906,6 @@ impl TypeSignature {
     /// documentation or error messages.
     pub fn get_example_types(&self) -> Vec<Vec<DataType>> {
         match self {
-            TypeSignature::Constrained(signature, _) => signature.get_example_types(),
             TypeSignature::Exact(types) => vec![types.clone()],
             TypeSignature::OneOf(types) => types
                 .iter()
@@ -1111,6 +1087,7 @@ pub enum Coercion {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Hash)]
 pub struct EncodingPreservation {
     preserve_dictionary: bool,
+    argument_constraint: ArgumentConstraint,
 }
 
 impl EncodingPreservation {
@@ -1118,6 +1095,7 @@ impl EncodingPreservation {
     pub const fn dictionary() -> Self {
         Self {
             preserve_dictionary: true,
+            argument_constraint: ArgumentConstraint::Any,
         }
     }
 
@@ -1131,9 +1109,38 @@ impl EncodingPreservation {
     pub const fn preserve_dictionary(self) -> bool {
         self.preserve_dictionary
     }
+
+    pub const fn argument_constraint(self) -> ArgumentConstraint {
+        self.argument_constraint
+    }
+
+    pub const fn with_argument_constraint(
+        mut self,
+        constraint: ArgumentConstraint,
+    ) -> Self {
+        self.argument_constraint = constraint;
+        self
+    }
 }
 
 impl Coercion {
+    pub fn with_argument_constraint(mut self, constraint: ArgumentConstraint) -> Self {
+        match &mut self {
+            Self::Exact {
+                encoding_preservation,
+                ..
+            }
+            | Self::Implicit {
+                encoding_preservation,
+                ..
+            } => {
+                *encoding_preservation =
+                    encoding_preservation.with_argument_constraint(constraint);
+            }
+        }
+        self
+    }
+
     pub fn new_exact(desired_type: TypeSignatureClass) -> Self {
         Self::Exact {
             desired_type,
@@ -1337,14 +1344,6 @@ impl Signature {
         }
     }
 
-    /// Adds positional argument constraints to this signature's type signature.
-    pub fn with_type_signature_constraints(
-        mut self,
-        constraints: Vec<ArgumentConstraint>,
-    ) -> Self {
-        self.type_signature = self.type_signature.with_constraints(constraints);
-        self
-    }
     /// An arbitrary number of arguments with the same type, from those listed in `common_types`.
     pub fn variadic(common_types: Vec<DataType>, volatility: Volatility) -> Self {
         Self {

--- a/datafusion/expr/src/expr_schema.rs
+++ b/datafusion/expr/src/expr_schema.rs
@@ -25,7 +25,9 @@ use crate::expr::{
 use crate::expr::{FieldMetadata, LambdaVariable};
 use crate::higher_order_function::HigherOrderReturnFieldArgs;
 use crate::type_coercion::functions::value_fields_with_higher_order_udf_and_lambdas;
-use crate::type_coercion::functions::{UDFCoercionExt, fields_with_udf};
+use crate::type_coercion::functions::{
+    UDFCoercionExt, fields_with_udf, validate_argument_constraints,
+};
 use crate::udf::ReturnFieldArgs;
 use crate::{LogicalPlan, Projection, Subquery, WindowFunctionDefinition, utils};
 use arrow::compute::can_cast_types;
@@ -581,6 +583,11 @@ impl ExprSchemable for Expr {
                 func.return_field(&new_fields)
             }
             Expr::ScalarFunction(ScalarFunction { func, args }) => {
+                validate_argument_constraints(
+                    func.name(),
+                    args,
+                    &func.signature().type_signature,
+                )?;
                 let fields = args
                     .iter()
                     .map(|e| e.to_field(schema).map(|(_, f)| f))

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -102,8 +102,9 @@ pub use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
 pub use datafusion_expr_common::operator::Operator;
 pub use datafusion_expr_common::placement::ExpressionPlacement;
 pub use datafusion_expr_common::signature::{
-    ArrayFunctionArgument, ArrayFunctionSignature, Coercion, EncodingPreservation,
-    Signature, TIMEZONE_WILDCARD, TypeSignature, TypeSignatureClass, Volatility,
+    ArgumentConstraint, ArrayFunctionArgument, ArrayFunctionSignature, Coercion,
+    EncodingPreservation, Signature, TIMEZONE_WILDCARD, TypeSignature,
+    TypeSignatureClass, Volatility,
 };
 pub use datafusion_expr_common::type_coercion::binary;
 pub use expr::{

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -17,7 +17,7 @@
 
 use super::binary::binary_numeric_coercion;
 use crate::{
-    AggregateUDF, HigherOrderTypeSignature, HigherOrderUDF, ScalarUDF, Signature,
+    AggregateUDF, Expr, HigherOrderTypeSignature, HigherOrderUDF, ScalarUDF, Signature,
     TypeSignature, ValueOrLambda, WindowUDF,
 };
 use arrow::datatypes::{Field, FieldRef};
@@ -34,7 +34,7 @@ use datafusion_common::{
     Result, exec_err, internal_err, plan_err, types::NativeType, utils::list_ndims,
 };
 use datafusion_expr_common::signature::{
-    ArrayFunctionArgument, EncodingPreservation, TypeSignatureClass,
+    ArgumentConstraint, ArrayFunctionArgument, EncodingPreservation, TypeSignatureClass,
 };
 use datafusion_expr_common::type_coercion::binary::type_union_resolution;
 use datafusion_expr_common::{
@@ -44,6 +44,55 @@ use datafusion_expr_common::{
 };
 use itertools::Itertools as _;
 use std::sync::Arc;
+
+/// Validates expression constraints declared by a [`TypeSignature`].
+pub fn validate_argument_constraints(
+    function_name: &str,
+    expressions: &[Expr],
+    signature: &TypeSignature,
+) -> Result<()> {
+    match signature {
+        TypeSignature::Constrained(signature, constraints) => {
+            if constraints.len() != expressions.len() {
+                return internal_err!(
+                    "Function '{function_name}' declares {} argument constraints for {} arguments",
+                    constraints.len(),
+                    expressions.len()
+                );
+            }
+            for (index, (expression, constraint)) in
+                expressions.iter().zip(constraints).enumerate()
+            {
+                if *constraint == ArgumentConstraint::Literal
+                    && !matches!(expression, Expr::Literal(..))
+                {
+                    return plan_err!(
+                        "Function '{function_name}' expects argument {} to be a literal",
+                        index + 1
+                    );
+                }
+            }
+            validate_argument_constraints(function_name, expressions, signature)
+        }
+        TypeSignature::OneOf(signatures) => {
+            let constrained = signatures
+                .iter()
+                .filter(|signature| matches!(signature, TypeSignature::Constrained(..)))
+                .collect::<Vec<_>>();
+            if constrained.is_empty()
+                || constrained.iter().any(|signature| {
+                    validate_argument_constraints(function_name, expressions, signature)
+                        .is_ok()
+                })
+            {
+                Ok(())
+            } else {
+                validate_argument_constraints(function_name, expressions, constrained[0])
+            }
+        }
+        _ => Ok(()),
+    }
+}
 
 /// Extension trait to unify common functionality between [`ScalarUDF`], [`AggregateUDF`]
 /// and [`WindowUDF`] for use by signature coercion functions.
@@ -473,6 +522,9 @@ pub fn data_types(
 
 fn is_well_supported_signature(type_signature: &TypeSignature) -> bool {
     match type_signature {
+        TypeSignature::Constrained(signature, _) => {
+            is_well_supported_signature(signature)
+        }
         TypeSignature::OneOf(type_signatures) => {
             type_signatures.iter().all(is_well_supported_signature)
         }
@@ -749,6 +801,9 @@ fn get_valid_types(
     }
 
     let valid_types = match signature {
+        TypeSignature::Constrained(signature, _) => {
+            get_valid_types(function_name, signature, current_types)?
+        }
         TypeSignature::Variadic(valid_types) => valid_types
             .iter()
             .map(|valid_type| vec![valid_type.clone(); current_types.len()])
@@ -1266,13 +1321,38 @@ mod tests {
     use super::*;
     use arrow::datatypes::IntervalUnit;
     use datafusion_common::{
-        assert_contains,
+        ScalarValue, assert_contains,
         types::{logical_binary, logical_int64, logical_string},
     };
     use datafusion_expr_common::{
         columnar_value::ColumnarValue,
         signature::{Coercion, EncodingPreservation, TypeSignatureClass},
     };
+
+    #[test]
+    fn test_validate_literal_argument_constraint() {
+        let signature = TypeSignature::Any(2)
+            .with_constraints(vec![ArgumentConstraint::Any, ArgumentConstraint::Literal]);
+        let literal = Expr::Literal(ScalarValue::Utf8(Some("Int64".into())), None);
+
+        validate_argument_constraints(
+            "test",
+            &[Expr::Column("value".into()), literal.clone()],
+            &signature,
+        )
+        .unwrap();
+
+        let error = validate_argument_constraints(
+            "test",
+            &[literal, Expr::Column("type_name".into())],
+            &signature,
+        )
+        .unwrap_err();
+        assert_contains!(
+            error.to_string(),
+            "Function 'test' expects argument 2 to be a literal"
+        );
+    }
 
     #[test]
     fn test_string_conversion() {

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -52,18 +52,12 @@ pub fn validate_argument_constraints(
     signature: &TypeSignature,
 ) -> Result<()> {
     match signature {
-        TypeSignature::Constrained(signature, constraints) => {
-            if constraints.len() != expressions.len() {
-                return internal_err!(
-                    "Function '{function_name}' declares {} argument constraints for {} arguments",
-                    constraints.len(),
-                    expressions.len()
-                );
-            }
-            for (index, (expression, constraint)) in
-                expressions.iter().zip(constraints).enumerate()
+        TypeSignature::Coercible(coercions) => {
+            for (index, (expression, coercion)) in
+                expressions.iter().zip(coercions).enumerate()
             {
-                if *constraint == ArgumentConstraint::Literal
+                if coercion.encoding_preservation().argument_constraint()
+                    == ArgumentConstraint::Literal
                     && !matches!(expression, Expr::Literal(..))
                 {
                     return plan_err!(
@@ -72,22 +66,16 @@ pub fn validate_argument_constraints(
                     );
                 }
             }
-            validate_argument_constraints(function_name, expressions, signature)
+            Ok(())
         }
         TypeSignature::OneOf(signatures) => {
-            let constrained = signatures
-                .iter()
-                .filter(|signature| matches!(signature, TypeSignature::Constrained(..)))
-                .collect::<Vec<_>>();
-            if constrained.is_empty()
-                || constrained.iter().any(|signature| {
-                    validate_argument_constraints(function_name, expressions, signature)
-                        .is_ok()
-                })
-            {
+            if signatures.iter().any(|signature| {
+                validate_argument_constraints(function_name, expressions, signature)
+                    .is_ok()
+            }) {
                 Ok(())
             } else {
-                validate_argument_constraints(function_name, expressions, constrained[0])
+                validate_argument_constraints(function_name, expressions, &signatures[0])
             }
         }
         _ => Ok(()),
@@ -522,9 +510,6 @@ pub fn data_types(
 
 fn is_well_supported_signature(type_signature: &TypeSignature) -> bool {
     match type_signature {
-        TypeSignature::Constrained(signature, _) => {
-            is_well_supported_signature(signature)
-        }
         TypeSignature::OneOf(type_signatures) => {
             type_signatures.iter().all(is_well_supported_signature)
         }
@@ -801,9 +786,6 @@ fn get_valid_types(
     }
 
     let valid_types = match signature {
-        TypeSignature::Constrained(signature, _) => {
-            get_valid_types(function_name, signature, current_types)?
-        }
         TypeSignature::Variadic(valid_types) => valid_types
             .iter()
             .map(|valid_type| vec![valid_type.clone(); current_types.len()])
@@ -1331,8 +1313,11 @@ mod tests {
 
     #[test]
     fn test_validate_literal_argument_constraint() {
-        let signature = TypeSignature::Any(2)
-            .with_constraints(vec![ArgumentConstraint::Any, ArgumentConstraint::Literal]);
+        let signature = TypeSignature::Coercible(vec![
+            Coercion::new_exact(TypeSignatureClass::Any),
+            Coercion::new_exact(TypeSignatureClass::Any)
+                .with_argument_constraint(ArgumentConstraint::Literal),
+        ]);
         let literal = Expr::Literal(ScalarValue::Utf8(Some("Int64".into())), None);
 
         validate_argument_constraints(

--- a/datafusion/functions/src/core/arrow_cast.rs
+++ b/datafusion/functions/src/core/arrow_cast.rs
@@ -105,14 +105,11 @@ impl ArrowCastFunc {
             signature: Signature::coercible(
                 vec![
                     Coercion::new_exact(TypeSignatureClass::Any),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                        .with_argument_constraint(ArgumentConstraint::Literal),
                 ],
                 Volatility::Immutable,
-            )
-            .with_type_signature_constraints(vec![
-                ArgumentConstraint::Any,
-                ArgumentConstraint::Literal,
-            ]),
+            ),
         }
     }
 }

--- a/datafusion/functions/src/core/arrow_cast.rs
+++ b/datafusion/functions/src/core/arrow_cast.rs
@@ -27,8 +27,8 @@ use datafusion_common::{
 
 use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyContext};
 use datafusion_expr::{
-    Coercion, ColumnarValue, Documentation, Expr, ReturnFieldArgs, ScalarFunctionArgs,
-    ScalarUDFImpl, Signature, TypeSignatureClass, Volatility,
+    ArgumentConstraint, Coercion, ColumnarValue, Documentation, Expr, ReturnFieldArgs,
+    ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignatureClass, Volatility,
 };
 use datafusion_macros::user_doc;
 
@@ -108,7 +108,11 @@ impl ArrowCastFunc {
                     Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
                 ],
                 Volatility::Immutable,
-            ),
+            )
+            .with_type_signature_constraints(vec![
+                ArgumentConstraint::Any,
+                ArgumentConstraint::Literal,
+            ]),
         }
     }
 }

--- a/datafusion/functions/src/core/arrow_try_cast.rs
+++ b/datafusion/functions/src/core/arrow_try_cast.rs
@@ -77,14 +77,11 @@ impl ArrowTryCastFunc {
             signature: Signature::coercible(
                 vec![
                     Coercion::new_exact(TypeSignatureClass::Any),
-                    Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                        .with_argument_constraint(ArgumentConstraint::Literal),
                 ],
                 Volatility::Immutable,
-            )
-            .with_type_signature_constraints(vec![
-                ArgumentConstraint::Any,
-                ArgumentConstraint::Literal,
-            ]),
+            ),
         }
     }
 }

--- a/datafusion/functions/src/core/arrow_try_cast.rs
+++ b/datafusion/functions/src/core/arrow_try_cast.rs
@@ -26,8 +26,8 @@ use datafusion_common::{
 
 use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyContext};
 use datafusion_expr::{
-    Coercion, ColumnarValue, Documentation, Expr, ReturnFieldArgs, ScalarFunctionArgs,
-    ScalarUDFImpl, Signature, TypeSignatureClass, Volatility,
+    ArgumentConstraint, Coercion, ColumnarValue, Documentation, Expr, ReturnFieldArgs,
+    ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignatureClass, Volatility,
 };
 use datafusion_macros::user_doc;
 
@@ -80,7 +80,11 @@ impl ArrowTryCastFunc {
                     Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
                 ],
                 Volatility::Immutable,
-            ),
+            )
+            .with_type_signature_constraints(vec![
+                ArgumentConstraint::Any,
+                ArgumentConstraint::Literal,
+            ]),
         }
     }
 }

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -51,8 +51,9 @@ use datafusion_common::{
 use datafusion_expr::preimage::PreimageResult;
 use datafusion_expr::simplify::SimplifyContext;
 use datafusion_expr::{
-    ColumnarValue, Documentation, Expr, ReturnFieldArgs, ScalarFunctionArgs,
-    ScalarUDFImpl, Signature, TypeSignature, Volatility, interval_arithmetic,
+    ArgumentConstraint, ColumnarValue, Documentation, Expr, ReturnFieldArgs,
+    ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
+    interval_arithmetic,
 };
 use datafusion_expr_common::signature::{Coercion, TypeSignatureClass};
 use datafusion_macros::user_doc;
@@ -147,7 +148,11 @@ impl DatePartFunc {
                     ]),
                 ],
                 Volatility::Immutable,
-            ),
+            )
+            .with_type_signature_constraints(vec![
+                ArgumentConstraint::Literal,
+                ArgumentConstraint::Any,
+            ]),
             aliases: vec![String::from("datepart")],
         }
     }

--- a/datafusion/functions/src/datetime/date_part.rs
+++ b/datafusion/functions/src/datetime/date_part.rs
@@ -122,7 +122,8 @@ impl DatePartFunc {
             signature: Signature::one_of(
                 vec![
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                            .with_argument_constraint(ArgumentConstraint::Literal),
                         Coercion::new_implicit(
                             TypeSignatureClass::Timestamp,
                             // Not consistent with Postgres and DuckDB but to avoid regression we implicit cast string to timestamp
@@ -131,28 +132,28 @@ impl DatePartFunc {
                         ),
                     ]),
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                            .with_argument_constraint(ArgumentConstraint::Literal),
                         Coercion::new_exact(TypeSignatureClass::Native(logical_date())),
                     ]),
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                            .with_argument_constraint(ArgumentConstraint::Literal),
                         Coercion::new_exact(TypeSignatureClass::Time),
                     ]),
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                            .with_argument_constraint(ArgumentConstraint::Literal),
                         Coercion::new_exact(TypeSignatureClass::Interval),
                     ]),
                     TypeSignature::Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string()))
+                            .with_argument_constraint(ArgumentConstraint::Literal),
                         Coercion::new_exact(TypeSignatureClass::Duration),
                     ]),
                 ],
                 Volatility::Immutable,
-            )
-            .with_type_signature_constraints(vec![
-                ArgumentConstraint::Literal,
-                ArgumentConstraint::Any,
-            ]),
+            ),
             aliases: vec![String::from("datepart")],
         }
     }

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -46,7 +46,8 @@ use datafusion_expr::type_coercion::binary::{
     comparison_coercion, like_coercion, regex_coercion, type_union_coercion,
 };
 use datafusion_expr::type_coercion::functions::{
-    UDFCoercionExt, fields_with_udf, value_fields_with_higher_order_udf_and_lambdas,
+    UDFCoercionExt, fields_with_udf, validate_argument_constraints,
+    value_fields_with_higher_order_udf_and_lambdas,
 };
 use datafusion_expr::type_coercion::other::{
     get_coerce_type_for_case_expression, get_coerce_type_for_case_when,
@@ -1133,6 +1134,11 @@ fn coerce_arguments_for_signature<F: UDFCoercionExt>(
     schema: &DFSchema,
     func: &F,
 ) -> Result<Vec<Expr>> {
+    validate_argument_constraints(
+        func.name(),
+        &expressions,
+        &func.signature().type_signature,
+    )?;
     let current_fields = expressions
         .iter()
         .map(|e| e.to_field(schema).map(|(_, f)| f))

--- a/datafusion/sqllogictest/test_files/arrow_typeof.slt
+++ b/datafusion/sqllogictest/test_files/arrow_typeof.slt
@@ -98,7 +98,7 @@ SELECT arrow_cast('1')
 query error DataFusion error: Error during planning: Function 'arrow_cast' requires String, but received Int64 \(DataType: Int64\)
 SELECT arrow_cast('1', 43)
 
-query error DataFusion error: Execution error: arrow_cast requires its second argument to be a non\-empty constant string
+query error DataFusion error: Error during planning: Function 'arrow_cast' expects argument 2 to be a literal
 SELECT arrow_cast('1', arrow_cast('Utf8', 'Utf8'))
 
 query error DataFusion error: Execution error: Unsupported type 'unknown'\. Must be a supported arrow type name such as 'Int32' or 'Timestamp\(ns\)'\. Error unknown token: unknown


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24133.

## Rationale for this change

Some functions require particular arguments to be literal values. This requirement is currently enforced separately by each function, rather than being declared as part of the function signature.

## What changes are included in this PR?

- Adds `ArgumentConstraint` and `TypeSignature::Constrained`.
- Validates literal constraints while logical expressions are analyzed and typed.
- Declares the required literal arguments for `arrow_cast`, `arrow_try_cast`, and `date_part`.
- Keeps expression constraints separate from `Coercion`.

## Are these changes tested?

Yes.

- Added a unit test covering accepted and rejected literal constraints.
- Ran `./dev/rust_lint.sh`.
- Ran the existing DataFrame `arrow_cast` integration test.

## Are there any user-facing changes?

Calls to constrained functions with non-literal arguments are rejected consistently during planning. This PR also adds public signature API types and therefore may require the `api change` label.