### PR TITLE
Docs: Add community showcase to the docs page

### DIFF
--- a/docs/source/user-guide/concepts-readings-events.md
+++ b/docs/source/user-guide/concepts-readings-events.md
@@ -200,6 +200,15 @@ This is a list of DataFusion related blog posts, articles, and other resources. 
 - **2025-02-02** [Apache DataFusion Ballista 43.0.0 Released](https://datafusion.apache.org/blog/2025/02/02/datafusion-ballista-43.0.0)
 - **2025-01-17** [Apache DataFusion Comet 0.5.0 Release](https://datafusion.apache.org/blog/2025/01/17/datafusion-comet-0.5.0)
 
+# 🎥 Community Showcase
+
+The [DataFusion Community Showcase](https://github.com/apache/datafusion/issues/22963) is a
+regular virtual event where community members share what they are building with DataFusion.
+
+- **2026-08-06** [Vol. 3: ASAPQuery (Milind Srivastava) & Streamling (Yaroslav Tkachenko)](https://www.youtube.com/watch?v=0-BIHyzODH8)
+- **2026-07-23** [Vol. 2: DataFusion Comet (Jordan Epstein) & DataFusion Ballista (Phillip LeBlanc)](https://www.youtube.com/watch?v=G8In--2RUwI)
+- **2026-07-09** [Vol. 1: SedonaDB (Dewey Dunnington) & Xarray-SQL (Alex Merose)](https://www.youtube.com/watch?v=5o-4hL8vGPw)
+
 # 🌎 Community Events
 
 - **2026-09-03** [Boston Apache DataFusion Meetup](https://github.com/apache/datafusion/discussions/21541) - [RSVP](https://luma.com/yexgqifv)


### PR DESCRIPTION
## Which issue does this PR close?

- part of #7013 
- related to #22963 

## Rationale for this change

@wyattwenzel is running a great set of community show cases about what people are doing with DataFusion (see #22963). I think these talks are a great way for people to understand what can be done with DataFusion. 

Also, in general the more we tell people about DataFusion the better. Also, making it easier to find DataFusion related content makes it more likely people (and maybe agents) will be able to find it when needed

## What changes are included in this PR?

Add the first three events to the https://datafusion.apache.org/user-guide/concepts-readings-events.html page

<img width="838" height="315" alt="Screenshot 2026-08-10 at 7 21 21 AM" src="https://github.com/user-attachments/assets/86b8a480-2144-4db1-b759-5c0a37d247a3" />

## Are these changes tested?
by CI

## Are there any user-facing changes?
Docs only