### PR TITLE
fix: account for Arrow bytes map hash table allocations

### DIFF
--- a/datafusion/physical-expr-common/src/binary_map.rs
+++ b/datafusion/physical-expr-common/src/binary_map.rs
@@ -244,10 +244,12 @@ where
     V: Debug + PartialEq + Eq + Clone + Copy + Default,
 {
     pub fn new(output_type: OutputType) -> Self {
+        let map = hashbrown::hash_table::HashTable::with_capacity(INITIAL_MAP_CAPACITY);
+        let map_size = map.allocation_size();
         Self {
             output_type,
-            map: hashbrown::hash_table::HashTable::with_capacity(INITIAL_MAP_CAPACITY),
-            map_size: 0,
+            map,
+            map_size,
             buffer: Vec::with_capacity(INITIAL_BUFFER_CAPACITY),
             offsets: vec![O::default()], // first offset is always 0
             random_state: RandomState::default(),
@@ -262,6 +264,21 @@ where
         let mut new_self = Self::new(self.output_type);
         swap(self, &mut new_self);
         new_self
+    }
+
+    fn insert_entry(
+        map: &mut hashbrown::hash_table::HashTable<Entry<O, V>>,
+        map_size: &mut usize,
+        entry: Entry<O, V>,
+    ) {
+        let capacity = map.capacity();
+        map.insert_accounted(entry, |entry| entry.hash, map_size);
+
+        // `insert_accounted` estimates growth from capacity. Keep `map_size`
+        // consistent with the exact allocation recorded by `new` after a resize.
+        if map.capacity() != capacity {
+            *map_size = map.allocation_size();
+        }
     }
 
     /// Inserts each value from `values` into the map, invoking `payload_fn` for
@@ -414,11 +431,7 @@ where
                         offset_or_inline: inline,
                         payload,
                     };
-                    self.map.insert_accounted(
-                        new_header,
-                        |header| header.hash,
-                        &mut self.map_size,
-                    );
+                    Self::insert_entry(&mut self.map, &mut self.map_size, new_header);
                     payload
                 }
             }
@@ -456,11 +469,7 @@ where
                         offset_or_inline: offset,
                         payload,
                     };
-                    self.map.insert_accounted(
-                        new_header,
-                        |header| header.hash,
-                        &mut self.map_size,
-                    );
+                    Self::insert_entry(&mut self.map, &mut self.map_size, new_header);
                     payload
                 }
             };
@@ -872,6 +881,33 @@ mod tests {
         let size_after_values2 = set.size();
         assert!(size_after_values2 > size_after_values1);
         assert!(size_after_values2 > total_strings1_len + total_strings2_len);
+    }
+
+    #[test]
+    fn test_size_includes_hash_table_allocation() {
+        fn allocated_size(map: &ArrowBytesMap<i32, ()>) -> usize {
+            map.map.allocation_size()
+                + map.buffer.capacity()
+                + map.offsets.allocated_size()
+                + map.hashes_buffer.allocated_size()
+        }
+
+        let mut set = ArrowBytesSet::<i32>::new(OutputType::Utf8);
+        assert_eq!(set.size(), allocated_size(&set.0));
+
+        let initial_capacity = set.0.map.capacity();
+        let values = (0..=initial_capacity)
+            .map(|index| format!("value-{index}"))
+            .collect::<Vec<_>>();
+        let values: ArrayRef = Arc::new(StringArray::from(values));
+        set.insert(&values);
+
+        assert!(set.0.map.capacity() > initial_capacity);
+        assert_eq!(set.size(), allocated_size(&set.0));
+
+        let populated = set.take();
+        assert_eq!(populated.size(), allocated_size(&populated.0));
+        assert_eq!(set.size(), allocated_size(&set.0));
     }
 
     #[test]

--- a/datafusion/physical-expr-common/src/binary_map.rs
+++ b/datafusion/physical-expr-common/src/binary_map.rs
@@ -884,33 +884,6 @@ mod tests {
     }
 
     #[test]
-    fn test_size_includes_hash_table_allocation() {
-        fn allocated_size(map: &ArrowBytesMap<i32, ()>) -> usize {
-            map.map.allocation_size()
-                + map.buffer.capacity()
-                + map.offsets.allocated_size()
-                + map.hashes_buffer.allocated_size()
-        }
-
-        let mut set = ArrowBytesSet::<i32>::new(OutputType::Utf8);
-        assert_eq!(set.size(), allocated_size(&set.0));
-
-        let initial_capacity = set.0.map.capacity();
-        let values = (0..=initial_capacity)
-            .map(|index| format!("value-{index}"))
-            .collect::<Vec<_>>();
-        let values: ArrayRef = Arc::new(StringArray::from(values));
-        set.insert(&values);
-
-        assert!(set.0.map.capacity() > initial_capacity);
-        assert_eq!(set.size(), allocated_size(&set.0));
-
-        let populated = set.take();
-        assert_eq!(populated.size(), allocated_size(&populated.0));
-        assert_eq!(set.size(), allocated_size(&set.0));
-    }
-
-    #[test]
     fn test_map() {
         let input = vec![
             // Note mix of short/long strings

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -731,39 +731,6 @@ mod tests {
         assert_eq!(set.len(), 10);
     }
 
-    #[test]
-    fn test_size_includes_hash_table_allocation() {
-        fn allocated_size(map: &ArrowBytesViewMap<()>) -> usize {
-            map.map.allocation_size()
-                + map.views.len() * size_of::<u128>()
-                + map.in_progress.capacity()
-                + map
-                    .completed
-                    .iter()
-                    .map(|buffer| buffer.len())
-                    .sum::<usize>()
-                + map.nulls.allocated_size()
-                + map.hashes_buffer.allocated_size()
-        }
-
-        let mut set = ArrowBytesViewSet::new(OutputType::Utf8View);
-        assert_eq!(set.size(), allocated_size(&set.0));
-
-        let initial_capacity = set.0.map.capacity();
-        let values = (0..=initial_capacity)
-            .map(|index| format!("value-{index}"))
-            .collect::<Vec<_>>();
-        let values: ArrayRef = Arc::new(StringViewArray::from(values));
-        set.insert(&values);
-
-        assert!(set.0.map.capacity() > initial_capacity);
-        assert_eq!(set.size(), allocated_size(&set.0));
-
-        let populated = set.take();
-        assert_eq!(populated.size(), allocated_size(&populated.0));
-        assert_eq!(set.size(), allocated_size(&set.0));
-    }
-
     #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
     struct TestPayload {
         // store the string value to check against input

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -155,10 +155,12 @@ where
     V: Debug + PartialEq + Eq + Clone + Copy + Default,
 {
     pub fn new(output_type: OutputType) -> Self {
+        let map = hashbrown::hash_table::HashTable::with_capacity(INITIAL_MAP_CAPACITY);
+        let map_size = map.allocation_size();
         Self {
             output_type,
-            map: hashbrown::hash_table::HashTable::with_capacity(INITIAL_MAP_CAPACITY),
-            map_size: 0,
+            map,
+            map_size,
             views: Vec::new(),
             in_progress: Vec::new(),
             completed: Vec::new(),
@@ -175,6 +177,21 @@ where
         let mut new_self = Self::new(self.output_type);
         std::mem::swap(self, &mut new_self);
         new_self
+    }
+
+    fn insert_entry(
+        map: &mut hashbrown::hash_table::HashTable<Entry<V>>,
+        map_size: &mut usize,
+        entry: Entry<V>,
+    ) {
+        let capacity = map.capacity();
+        map.insert_accounted(entry, |entry| entry.hash, map_size);
+
+        // `insert_accounted` estimates growth from capacity. Keep `map_size`
+        // consistent with the exact allocation recorded by `new` after a resize.
+        if map.capacity() != capacity {
+            *map_size = map.allocation_size();
+        }
     }
 
     /// Inserts each value from `values` into the map, invoking `payload_fn` for
@@ -367,8 +384,7 @@ where
                     payload,
                 };
 
-                self.map
-                    .insert_accounted(new_header, |h| h.hash, &mut self.map_size);
+                Self::insert_entry(&mut self.map, &mut self.map_size, new_header);
                 payload
             };
             observe_payload_fn(payload);
@@ -713,6 +729,39 @@ mod tests {
         assert!(size_after_values2 > size_after_values1);
 
         assert_eq!(set.len(), 10);
+    }
+
+    #[test]
+    fn test_size_includes_hash_table_allocation() {
+        fn allocated_size(map: &ArrowBytesViewMap<()>) -> usize {
+            map.map.allocation_size()
+                + map.views.len() * size_of::<u128>()
+                + map.in_progress.capacity()
+                + map
+                    .completed
+                    .iter()
+                    .map(|buffer| buffer.len())
+                    .sum::<usize>()
+                + map.nulls.allocated_size()
+                + map.hashes_buffer.allocated_size()
+        }
+
+        let mut set = ArrowBytesViewSet::new(OutputType::Utf8View);
+        assert_eq!(set.size(), allocated_size(&set.0));
+
+        let initial_capacity = set.0.map.capacity();
+        let values = (0..=initial_capacity)
+            .map(|index| format!("value-{index}"))
+            .collect::<Vec<_>>();
+        let values: ArrayRef = Arc::new(StringViewArray::from(values));
+        set.insert(&values);
+
+        assert!(set.0.map.capacity() > initial_capacity);
+        assert_eq!(set.size(), allocated_size(&set.0));
+
+        let populated = set.take();
+        assert_eq!(populated.size(), allocated_size(&populated.0));
+        assert_eq!(set.size(), allocated_size(&set.0));
     }
 
     #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]

--- a/datafusion/physical-expr-common/tests/memory_accounting.rs
+++ b/datafusion/physical-expr-common/tests/memory_accounting.rs
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, StringArray, StringViewArray};
+use datafusion_physical_expr_common::binary_map::{ArrowBytesMap, OutputType};
+use datafusion_physical_expr_common::binary_view_map::ArrowBytesViewMap;
+
+type LargePayload = [u8; 32];
+
+#[test]
+fn arrow_bytes_map_size_accounts_for_hash_table_allocations() {
+    let mut unit_map = ArrowBytesMap::<i32, ()>::new(OutputType::Utf8);
+    let mut payload_map = ArrowBytesMap::<i32, LargePayload>::new(OutputType::Utf8);
+
+    let initial_allocation_difference = payload_map.size() - unit_map.size();
+    assert!(initial_allocation_difference > 0);
+
+    let values: ArrayRef = Arc::new(StringArray::from_iter_values(
+        (0..1024).map(|index| format!("value-{index}")),
+    ));
+    unit_map.insert_if_new(&values, |_| (), |_| {});
+    payload_map.insert_if_new(&values, |_| LargePayload::default(), |_| {});
+
+    let grown_allocation_difference = payload_map.size() - unit_map.size();
+    assert!(grown_allocation_difference > initial_allocation_difference);
+
+    let populated_unit_map = unit_map.take();
+    let populated_payload_map = payload_map.take();
+    assert_eq!(
+        populated_payload_map.size() - populated_unit_map.size(),
+        grown_allocation_difference
+    );
+    assert_eq!(
+        payload_map.size() - unit_map.size(),
+        initial_allocation_difference
+    );
+}
+
+#[test]
+fn arrow_bytes_view_map_size_accounts_for_hash_table_allocations() {
+    let mut unit_map = ArrowBytesViewMap::<()>::new(OutputType::Utf8View);
+    let mut payload_map = ArrowBytesViewMap::<LargePayload>::new(OutputType::Utf8View);
+
+    let initial_allocation_difference = payload_map.size() - unit_map.size();
+    assert!(initial_allocation_difference > 0);
+
+    let values: ArrayRef = Arc::new(StringViewArray::from_iter_values(
+        (0..1024).map(|index| format!("value-{index}")),
+    ));
+    unit_map.insert_if_new(&values, |_| (), |_| {});
+    payload_map.insert_if_new(&values, |_| LargePayload::default(), |_| {});
+
+    let grown_allocation_difference = payload_map.size() - unit_map.size();
+    assert!(grown_allocation_difference > initial_allocation_difference);
+
+    let populated_unit_map = unit_map.take();
+    let populated_payload_map = payload_map.take();
+    assert_eq!(
+        populated_payload_map.size() - populated_unit_map.size(),
+        grown_allocation_difference
+    );
+    assert_eq!(
+        payload_map.size() - unit_map.size(),
+        initial_allocation_difference
+    );
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21248.

## Rationale for this change

`ArrowBytesMap::size()` and `ArrowBytesViewMap::size()` undercount memory because their hash tables are preallocated, while `map_size` starts at zero. This makes aggregate memory accounting inaccurate before the first resize and can also leave it out of sync after table growth.

## What changes are included in this PR?

- Initialize `map_size` from the hash table's `allocation_size()` in both constructors.
- After an insertion changes the table capacity, resynchronize `map_size` from `allocation_size()` so exact allocation accounting is not mixed with incremental capacity estimates.
- Use the same insertion path throughout both map implementations.
- Add regression coverage for construction, capacity growth, populated `take()`, and the reset map returned by `take()`.

## Are these changes tested?

Yes.

- `cargo test -p datafusion-physical-expr-common` — 75 unit tests, 2 integration tests, and 8 doc tests passed.
- `cargo fmt --all -- --check` — passed.
- Workspace `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `./dev/rust_lint.sh` — passed, including the workspace lint, formatting, documentation, license, typo, and workflow checks.

I also ran the repository's extended workspace test command. It completed with 1,084 passed, 2 failed, and 1 ignored. Both failures were process RSS ceiling checks: the sort check used about 207 MB against a 190.7 MB limit, and the sort-merge join check initially used about 153.9 MB against a 152.6 MB limit. The sort-merge join check passed when rerun in isolation; an independent rerun reproduced only the sort RSS failure at about 206 MB. These checks exercise process-level integer sort and sort-merge join memory limits and do not execute the modified Arrow byte map paths, so the remaining failure appears environment-dependent.

## Are there any user-facing changes?

There are no API changes. Memory estimates reported by these two byte maps now include the hash table allocation at construction and remain synchronized after growth and `take()`.

## AI-assisted contribution disclosure

OpenAI Codex assisted with this change. I reviewed the constructor, growth, and `take()` paths and can explain how the accounting changes across them. The commit records `Generated-by: OpenAI Codex`.