### PR TITLE
perf: deduplicate hash join InList pushdown values

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/inlist_builder.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/inlist_builder.rs
@@ -17,10 +17,13 @@
 
 //! Utilities for building InList expressions from hash join build side data
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, StructArray};
+use arrow::array::{Array, ArrayRef, StructArray, UInt32Array};
+use arrow::compute::take;
 use arrow::datatypes::{Field, FieldRef, Fields};
+use arrow::row::{Row, RowConverter, SortField};
 use arrow_schema::DataType;
 use datafusion_common::Result;
 
@@ -43,8 +46,15 @@ pub(super) fn build_struct_fields(data_types: &[DataType]) -> Result<Fields> {
 ///    that is: this will produce `IN LIST ((1, "a"), (2, "b"))` expected to be used as `(2, "b") IN LIST ((1, "a"), (2, "b"))`.
 ///    The field names of the struct are auto-generated as "c0", "c1", ... and should match the struct expression used in the join keys.
 ///
-/// Note that this function does not deduplicate values - deduplication will happen later
-/// when building an InList expression from this array via `InListExpr::try_new_from_array`.
+/// The returned array is deduplicated (see [`dedup_inlist_values`]): the build side is
+/// gated on its *distinct* key count, not its row count, so the raw key arrays routinely
+/// contain far more rows than distinct values. An `IN` list is a set, so dropping the
+/// duplicates cannot change any result, but it does shrink everything downstream that is
+/// sized by the list length: the per-value [`ScalarValue`] literals built by
+/// `InListExpr::try_new_from_array`, and — wherever the pushed-down filter reaches a
+/// `PruningPredicate` — the `LiteralGuarantee` it materializes per row group.
+///
+/// [`ScalarValue`]: datafusion_common::ScalarValue
 ///
 /// Returns `None` if the estimated size exceeds `max_size_bytes` or if the number of rows
 /// exceeds `max_distinct_values`.
@@ -74,15 +84,57 @@ pub(super) fn build_struct_inlist_values(
         Arc::new(StructArray::from(arrays_with_fields))
     };
 
-    Ok(Some(source_array))
+    Ok(Some(dedup_inlist_values(source_array)?))
+}
+
+/// Removes duplicate entries from an `IN` list value array, preserving first-occurrence order.
+///
+/// Equality is the arrow row-format byte equality produced by [`RowConverter`], which is
+/// exactly the equality used elsewhere in DataFusion for grouping. In particular NULLs
+/// compare equal to each other, so a list with many NULLs collapses to a single NULL. That
+/// is semantics-preserving for `IN`: one NULL in the haystack already yields the same
+/// three-valued result as a thousand.
+///
+/// The input is returned unchanged when it holds fewer than two rows, when it contains no
+/// duplicates, or when its type cannot be row-encoded (dedup is an optimization, never a
+/// requirement).
+fn dedup_inlist_values(values: ArrayRef) -> Result<ArrayRef> {
+    if values.len() < 2 {
+        return Ok(values);
+    }
+
+    let sort_field = SortField::new(values.data_type().clone());
+    if !RowConverter::supports_fields(std::slice::from_ref(&sort_field)) {
+        return Ok(values);
+    }
+
+    let converter = RowConverter::new(vec![sort_field])?;
+    let rows = converter.convert_columns(std::slice::from_ref(&values))?;
+
+    let mut seen: HashSet<Row> = HashSet::with_capacity(values.len());
+    let mut indices: Vec<u32> = Vec::new();
+    for (idx, row) in rows.iter().enumerate() {
+        if seen.insert(row) {
+            indices.push(idx as u32);
+        }
+    }
+
+    if indices.len() == values.len() {
+        // Nothing to remove: skip the copy.
+        return Ok(values);
+    }
+
+    Ok(take(values.as_ref(), &UInt32Array::from(indices), None)?)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use arrow::array::{
-        DictionaryArray, Int8Array, Int32Array, StringArray, StringDictionaryBuilder,
+        AsArray, DictionaryArray, Int8Array, Int32Array, StringArray,
+        StringDictionaryBuilder,
     };
+    use arrow::datatypes::Int32Type;
 
     #[test]
     fn test_build_single_column_inlist_array() {
@@ -91,7 +143,39 @@ mod tests {
             .unwrap()
             .unwrap();
 
+        // Duplicates are dropped, first-occurrence order is preserved.
+        let expected = Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef;
+        assert!(expected.eq(&result));
+    }
+
+    #[test]
+    fn test_build_single_column_inlist_array_without_duplicates() {
+        let array = Arc::new(Int32Array::from(vec![3, 1, 2])) as ArrayRef;
+        let result = build_struct_inlist_values(std::slice::from_ref(&array))
+            .unwrap()
+            .unwrap();
+
         assert!(array.eq(&result));
+    }
+
+    #[test]
+    fn test_build_single_column_inlist_array_with_nulls() {
+        let array = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(2),
+            None,
+            Some(1),
+        ])) as ArrayRef;
+        let result = build_struct_inlist_values(std::slice::from_ref(&array))
+            .unwrap()
+            .unwrap();
+
+        // A single NULL is kept: `IN` is a set, and one NULL in the haystack already
+        // produces the same three-valued result as many.
+        let expected =
+            Arc::new(Int32Array::from(vec![Some(1), None, Some(2)])) as ArrayRef;
+        assert!(expected.eq(&result));
     }
 
     #[test]
@@ -110,6 +194,34 @@ mod tests {
                 build_struct_fields(&[DataType::Int32, DataType::Utf8]).unwrap()
             )
         );
+        // Deduplication is on the whole tuple, not per column.
+        assert_eq!(result.len(), 3);
+        let struct_array = result.as_struct();
+        assert_eq!(
+            struct_array.column(0).as_primitive::<Int32Type>().values(),
+            &[1, 2, 3]
+        );
+        assert_eq!(
+            struct_array
+                .column(1)
+                .as_string::<i32>()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![Some("a"), Some("b"), Some("c")]
+        );
+    }
+
+    #[test]
+    fn test_build_multi_column_inlist_distinct_tuples_from_duplicate_columns() {
+        // Each column on its own has duplicates, but every (a, b) tuple is distinct.
+        let array1 = Arc::new(Int32Array::from(vec![1, 1, 2, 2])) as ArrayRef;
+        let array2 = Arc::new(StringArray::from(vec!["a", "b", "a", "b"])) as ArrayRef;
+
+        let result = build_struct_inlist_values(&[array1, array2])
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.len(), 4);
     }
 
     #[test]
@@ -152,7 +264,9 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(result.len(), 3);
+        // All three rows decode to "foo", so the list collapses to one entry while
+        // keeping the dictionary encoding.
+        assert_eq!(result.len(), 1);
         assert_eq!(result.data_type(), dict_array.data_type());
     }
 }

--- a/datafusion/sqllogictest/test_files/push_down_filter_parquet.slt
+++ b/datafusion/sqllogictest/test_files/push_down_filter_parquet.slt
@@ -1336,3 +1336,57 @@ RESET datafusion.execution.parquet.pushdown_filters;
 
 statement ok
 drop table t;
+
+
+########
+# The InList pushdown is gated on the build side's *distinct* key count, but the
+# values it ships come from the raw build-side key arrays (one entry per build
+# row). Duplicated build keys must not inflate the pushed-down `IN (SET)` list or
+# the `required_guarantees` derived from it.
+########
+
+statement ok
+COPY (SELECT * FROM (VALUES (11), (11), (11), (22), (22), (22)) v(id)) TO 'test_files/scratch/push_down_filter_parquet/dedup_build.parquet' STORED AS PARQUET;
+
+statement ok
+COPY (SELECT * FROM (VALUES (11), (22), (33), (44), (55), (66), (77), (88), (99), (110), (121), (132)) v(id)) TO 'test_files/scratch/push_down_filter_parquet/dedup_probe.parquet' STORED AS PARQUET;
+
+statement ok
+CREATE EXTERNAL TABLE dedup_build STORED AS PARQUET LOCATION 'test_files/scratch/push_down_filter_parquet/dedup_build.parquet';
+
+statement ok
+CREATE EXTERNAL TABLE dedup_probe STORED AS PARQUET LOCATION 'test_files/scratch/push_down_filter_parquet/dedup_probe.parquet';
+
+# Data-correctness: deduplicating the pushed-down set must not drop join output
+# rows, which still repeat once per matching build row.
+query II rowsort
+SELECT dedup_build.id, dedup_probe.id FROM dedup_build JOIN dedup_probe ON dedup_build.id = dedup_probe.id
+----
+11 11
+11 11
+11 11
+22 22
+22 22
+22 22
+
+statement ok
+set datafusion.explain.analyze_categories = 'rows';
+
+# The six build rows carry only two distinct keys, so the pushed-down filter is
+# `IN (SET) ([11, 22])`, not `([11, 11, 11, 22, 22, 22])`.
+query TT
+EXPLAIN ANALYZE SELECT dedup_build.id, dedup_probe.id FROM dedup_build JOIN dedup_probe ON dedup_build.id = dedup_probe.id
+----
+Plan with Metrics
+01)HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], metrics=[output_rows=6, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=6, input_batches=1, input_rows=12, avg_fanout=300% (6/2), probe_hit_rate=16.67% (2/12)]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/push_down_filter_parquet/dedup_build.parquet]]}, projection=[id], file_type=parquet, metrics=[output_rows=6, output_batches=1, files_ranges_pruned_statistics=1 total → 1 matched, row_groups_pruned_statistics=1 total → 1 matched, row_groups_pruned_bloom_filter=1 total → 1 matched, page_index_pages_pruned=0 total → 0 matched, page_index_rows_pruned=0 total → 0 matched, limit_pruned_row_groups=0 total → 0 matched, batches_split=0, file_open_errors=0, file_scan_errors=0, files_opened=1, files_processed=1, num_predicate_creation_errors=0, predicate_evaluation_errors=0, pushdown_rows_matched=0, pushdown_rows_pruned=0, predicate_cache_inner_records=0, predicate_cache_records=0, scan_efficiency_ratio=13.71% (68/496)]
+03)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/push_down_filter_parquet/dedup_probe.parquet]]}, projection=[id], file_type=parquet, predicate=DynamicFilter [ id@0 >= 11 AND id@0 <= 22 AND id@0 IN (SET) ([11, 22]) ], dynamic_rg_pruning=eligible, pruning_predicate=id_null_count@1 != row_count@2 AND id_max@0 >= 11 AND id_null_count@1 != row_count@2 AND id_min@3 <= 22 AND (id_null_count@1 != row_count@2 AND id_min@3 <= 11 AND 11 <= id_max@0 OR id_null_count@1 != row_count@2 AND id_min@3 <= 22 AND 22 <= id_max@0), required_guarantees=[id in (11, 22)], metrics=[output_rows=12, output_batches=1, files_ranges_pruned_statistics=1 total → 1 matched, row_groups_pruned_statistics=1 total → 1 matched, row_groups_pruned_bloom_filter=1 total → 1 matched, page_index_pages_pruned=1 total → 1 matched, page_index_rows_pruned=12 total → 12 matched, limit_pruned_row_groups=0 total → 0 matched, batches_split=0, file_open_errors=0, file_scan_errors=0, files_opened=1, files_processed=1, num_predicate_creation_errors=0, predicate_evaluation_errors=0, pushdown_rows_matched=0, pushdown_rows_pruned=0, predicate_cache_inner_records=0, predicate_cache_records=0, scan_efficiency_ratio=18.34% (97/529)]
+
+statement ok
+reset datafusion.explain.analyze_categories;
+
+statement ok
+drop table dedup_build;
+
+statement ok
+drop table dedup_probe;


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No existing issue; this is a small standalone perf fix found while reading the hash join InList pushdown path. Happy to file one if maintainers prefer. -->

- N/A

## Rationale for this change

The hash join InList filter pushdown is gated on the build side's **distinct** key count:

```rust
map.num_of_distinct_key() > config.optimizer.hash_join_inlist_pushdown_max_distinct_values // default 150
```

but the values it actually ships are the raw build-side key arrays — **one entry per build row**, never deduplicated. So a partition that passes the 150-distinct-value gate can still emit a list with thousands of entries, bounded only by `hash_join_inlist_pushdown_max_size` (default 128 KiB).

On TPC-H q17 at SF=1 (12 partitions) the pushed-down filter on the `lineitem` scan looked like this before the change:

```
DynamicFilter [ CASE hash_repartition % 12
                  WHEN 0 THEN l_partkey >= 33299 AND l_partkey <= 197255 AND l_partkey IN (SET) ([ ...551 values... ])
                  WHEN 1 THEN ... ([ ...351 values... ])
                  ... ]
```

**6088 list entries in total across the 12 partitions, for 204 distinct keys.**

That length is paid for repeatedly and mostly discarded:

* `InListExpr::try_new_from_array` materialises one `ScalarValue` + one `Literal` expression per entry, so the `list` field is ~30× larger than it needs to be.
* The list becomes a `LiteralGuarantee`, which `PruningPredicate::prune` re-materialises **per row group** wherever the pushed-down filter reaches a pruning predicate. `RowGroupPruningStatistics::contained()` in `datafusion/datasource-parquet/src/row_group_filter.rs` returns `None` unconditionally, so that guarantee can never prune anything — the work is provably discarded.
* Separately, `max_in_list_size` (default 20) blocks the InList→OR rewrite, so an inflated list yields no pruning benefit on that path either.

The duplicates carry no information: `IN` is a set membership test.

## What changes are included in this PR?

`build_struct_inlist_values` now deduplicates the value array before it is wrapped in `PushdownStrategy::InList`.

Deduplication is done on the arrow array itself: encode it once with `RowConverter` and keep first occurrences via a `HashSet<Row>`, then a single `take`. This is one pass and two allocations, rather than one `ScalarValue::try_from_array` per row, and it handles both shapes the pushdown produces — a single key column (possibly dictionary-encoded) and a multi-column `StructArray` — without special-casing either.

Semantics are preserved exactly, and the transform is a **set-preserving no-op**:

* Deduplication is on the whole tuple, so multi-column keys whose individual columns repeat but whose tuples are distinct are untouched.
* NULLs compare equal under the row format, so a list with many NULLs collapses to a single NULL. Under three-valued logic one NULL in the haystack already produces the same result as a thousand, so `IN`/`NOT IN` results are unchanged.
* First-occurrence order is preserved, `take` preserves dictionary encoding, and the array is returned untouched when it has <2 rows, contains no duplicates, or has a type `RowConverter` cannot encode.

## Are these changes tested?

Yes.

* New unit tests in `inlist_builder.rs` cover: single-column dedup, an already-distinct array (identity), NULL collapsing, multi-column tuple dedup, distinct tuples built from individually-duplicated columns, and dictionary arrays.
* A new sqllogictest in `push_down_filter_parquet.slt` covers it end to end: a build side with 6 rows and 2 distinct keys now pushes `IN (SET) ([11, 22])` with `required_guarantees=[id in (11, 22)]`, where `main` pushed all 6 rows. It also asserts the join output is unchanged (still one row per matching build row).
* All existing `IN (SET)` snapshots in `push_down_filter_parquet.slt` and `filter_pushdown.rs` are byte-identical — their build sides were already distinct, which is the expected no-op.

`cargo test -p datafusion-physical-plan --lib`, the full sqllogictest suite, `cargo clippy --all-targets -- -D warnings` (CI feature set) and `cargo doc` are all green.

### Measured effect

Counts first, since they are exact rather than timings. TPC-H SF=1, parquet, from `dfbench --debug`, summing the `IN (SET)` list lengths across the 12 partitions of the q17 dynamic filter:

| query | InList entries (main) | InList entries (this PR) |
|---|---|---|
| q17 | 6088 | 204 |
| q18 | 57 | 57 |
| q3 | no InList pushdown | no InList pushdown |
| q5 | 26 | 26 |
| q9 | 25 | 25 |

Only q17 has a build side with duplicate join keys at SF=1; everywhere else the build keys are already distinct (group-by outputs, `nation`/`region` keys) and the change is a literal no-op. That is the expected shape: this only helps when the build side repeats keys.

Timings: both binaries built from the **same worktree and target dir**, differing only by this commit. 20 rounds × 6 iterations, A/B order counterbalanced per round (A,B on odd rounds; B,A on even), per-round median over iterations 1–5 (cold iteration dropped), then median across rounds. TPC-H SF=1 parquet on a machine that was **not** idle.

| query | main (ms) | this PR (ms) | delta | odd rounds (A,B) | even rounds (B,A) | rounds favouring PR |
|---|---|---|---|---|---|---|
| q17 | 62.25 | 59.20 | **−3.8%** | −4.2% | −3.3% | 18/20 (sign test p≈0.0004) |
| q18 | 58.25 | 59.45 | −2.3% | −2.3% | −2.9% | 12/20 (p≈0.50) |
| **q1 (control)** | 38.20 | 39.10 | **+2.4%** | +2.6% | +1.2% | 6/20 |
| **q6 (control)** | 14.80 | 14.80 | **−0.0%** | −0.0% | +0.6% | 10/20 |

**Honest reading of that table.** q1 and q6 have no joins, so this change cannot touch them; whatever they show is the noise floor, and here that floor is up to ±2.4%. q17's −3.8% is only just clear of it. The reason I believe it is real rather than noise is the sign test, not the magnitude: 18 of 20 counterbalanced rounds favoured the change, both orderings agree in sign and size, and the controls sit at 6/20 and 10/20 as they should. q18's −2.3% is inside the floor and 12/20 is a coin flip — and its list length does not change at all, so that column is noise by construction, which is a useful internal check on the method.

Per-round spread is wide (individual q17 rounds ranged −44% to +22%), which is why only the 20-round medians and the sign test are quoted.

A first, lower-powered pass (12 rounds × 5 iterations over q17/q18/q3/q5/q9 + q1/q6) produced a ±9% control floor and showed nothing above it in either direction. It is reported here for completeness, not as evidence.

I would also not over-claim the pruning half of the mechanism from this benchmark: at SF=1 each table is a single file and the dynamic filter arrives after row-group pruning has already run (`row_groups_pruned_dynamic_filter=0`, `statistics_eval_time=24ns` on that scan), so on this dataset the discarded `LiteralGuarantee` work is not actually being paid. The saving I measured at SF=1 is the ~5900 `ScalarValue`/`Literal` allocations that no longer happen. The guarantee argument should matter more on datasets with many row groups per scan, where the filter is live before pruning — I have not measured that here.

If reviewers consider −3.8% on one query too thin to justify the change on performance grounds alone, the correctness-of-effort argument still stands on its own: the deduplicated list is semantically identical, strictly smaller, and the work it removes is work that could never have produced a result.

## Are there any user-facing changes?

No API changes and no behaviour changes. The only visible difference is in `EXPLAIN ANALYZE` output, where the pushed-down `IN (SET) (...)` list and the `required_guarantees` derived from it no longer repeat duplicate build-side keys.
