### PR TITLE
fix: preserve NULL semantics in `log` and `power` simplification

### DIFF
--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -362,23 +362,27 @@ impl ScalarUDFImpl for LogFunc {
         } else {
             lit(ScalarValue::new_ten(&number_datatype)?)
         };
+        let base_nullable = info.nullable(&base)?;
 
         match number {
             Expr::Literal(value, _)
-                if value == ScalarValue::new_one(&number_datatype)? =>
+                if value == ScalarValue::new_one(&number_datatype)? && !base_nullable =>
             {
                 Ok(ExprSimplifyResult::Simplified(lit(ScalarValue::new_zero(
                     &info.get_data_type(&base)?,
                 )?)))
             }
             Expr::ScalarFunction(ScalarFunction { func, mut args })
-                if is_pow(&func) && args.len() == 2 && base == args[0] =>
+                if is_pow(&func)
+                    && args.len() == 2
+                    && base == args[0]
+                    && !base_nullable =>
             {
                 let b = args.pop().unwrap(); // length checked above
                 Ok(ExprSimplifyResult::Simplified(b))
             }
             number => {
-                if number == base {
+                if number == base && !base_nullable {
                     Ok(ExprSimplifyResult::Simplified(lit(ScalarValue::new_one(
                         &number_datatype,
                     )?)))

--- a/datafusion/functions/src/math/power.rs
+++ b/datafusion/functions/src/math/power.rs
@@ -140,6 +140,7 @@ impl ScalarUDFImpl for PowerFunc {
         let [base, exponent] = take_function_args("power", args)?;
         let base_type = info.get_data_type(&base)?;
         let exponent_type = info.get_data_type(&exponent)?;
+        let base_nullable = info.nullable(&base)?;
         let return_type =
             self.return_type(&[base_type.clone(), exponent_type.clone()])?;
 
@@ -167,7 +168,7 @@ impl ScalarUDFImpl for PowerFunc {
 
         match exponent {
             Expr::Literal(value, _)
-                if value == ScalarValue::new_zero(&exponent_type)? =>
+                if value == ScalarValue::new_zero(&exponent_type)? && !base_nullable =>
             {
                 Ok(ExprSimplifyResult::Simplified(lit(ScalarValue::new_one(
                     &return_type,
@@ -179,7 +180,10 @@ impl ScalarUDFImpl for PowerFunc {
                 )))
             }
             Expr::ScalarFunction(ScalarFunction { func, mut args })
-                if is_log(&func) && args.len() == 2 && base == args[0] =>
+                if is_log(&func)
+                    && args.len() == 2
+                    && base == args[0]
+                    && !base_nullable =>
             {
                 let b = args.pop().unwrap(); // length checked above
                 let b_type = info.get_data_type(&b)?;

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -1182,6 +1182,55 @@ logical_plan
 02)--TableScan: aggregate_simple projection=[]
 physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/aggregate_simple.csv]]}, projection=[NULL as log(NULL,aggregate_simple.c2)], file_type=csv, has_header=true
 
+# Simplification must preserve NULLs from nullable columns
+query RRRRR rowsort
+SELECT
+  log(a, 1),
+  log(a, a),
+  log(a, power(a, b)),
+  power(a, 0),
+  power(a, log(a, b))
+FROM (VALUES (NULL::double, 2.0::double), (2.0, 3.0)) AS t(a, b);
+----
+0 1 3 1 3
+NULL NULL NULL NULL NULL
+
+# Nullable bases must remain in the optimized plan so they can propagate NULL
+query TT
+EXPLAIN SELECT
+  log(a, 1) AS l1,
+  log(a, a) AS la,
+  power(a, 0) AS p0,
+  power(a, log(a, b)) AS pl
+FROM (VALUES (NULL::double, 2.0::double), (2.0, 3.0)) AS t(a, b);
+----
+logical_plan
+01)Projection: log(t.a, Float64(1)) AS l1, log(t.a, t.a) AS la, power(t.a, Float64(0)) AS p0, power(t.a, log(t.a, t.b)) AS pl
+02)--SubqueryAlias: t
+03)----Projection: column1 AS a, column2 AS b
+04)------Values: (Float64(NULL) AS NULL, Float64(2)), (Float64(2), Float64(3))
+physical_plan
+01)ProjectionExec: expr=[log(column1@0, 1) as l1, log(column1@0, column1@0) as la, power(column1@0, 0) as p0, power(column1@0, log(column1@0, column2@1)) as pl]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Non-nullable bases still use the existing simplifications
+query TT
+EXPLAIN SELECT
+  log(a, 1) AS l1,
+  log(a, a) AS la,
+  power(a, 0) AS p0,
+  power(a, log(a, b)) AS pl
+FROM (VALUES (2.0::double, 3.0::double)) AS t(a, b);
+----
+logical_plan
+01)Projection: Float64(0) AS l1, Float64(1) AS la, Float64(1) AS p0, t.b AS pl
+02)--SubqueryAlias: t
+03)----Projection: column2 AS b
+04)------Values: (Float64(2), Float64(3))
+physical_plan
+01)ProjectionExec: expr=[0 as l1, 1 as la, 1 as p0, column2@1 as pl]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
 # Float 16/32/64 for log
 query RT
 SELECT log(2.5, arrow_cast(10.9, 'Float16')), arrow_typeof(log(2.5, arrow_cast(10.9, 'Float16')));


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Part of #24246.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

`log` and `power` simplifications removed a nullable base expression, which could incorrectly produce a non-NULL result when the base was NULL.

For example:

```sql
SELECT log(a, 1.0), power(a, 0.0)
FROM (VALUES (NULL::DOUBLE)) AS t(a);
```

These expressions should both return NULL, but simplification could replace them with 0.0 and 1.0.

## What changes are included in this PR?

only apply these simplifications when the removed base expression is non-nullable.

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. Added sqllogictests covering results and plans.

## Are there any user-facing changes?

Yes. log and power expressions with nullable bases now correctly preserve NULLs.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
