### PR TITLE
Fix ArrowBytesViewMap retained capacity accounting

### DIFF
--- a/datafusion/common/src/heap_size.rs
+++ b/datafusion/common/src/heap_size.rs
@@ -445,6 +445,7 @@ impl_zero_heap_size!(
     i32,
     i64,
     i128,
+    u128,
     i256,
     f16,
     f32,
@@ -548,6 +549,7 @@ mod tests {
         assert_eq!(size(&0i32), 0);
         assert_eq!(size(&0i64), 0);
         assert_eq!(size(&0i128), 0);
+        assert_eq!(size(&0u128), 0);
         assert_eq!(size(&i256::ZERO), 0);
         assert_eq!(size(&0f32), 0);
         assert_eq!(size(&0f64), 0);
@@ -603,6 +605,14 @@ mod tests {
 
         let empty: Vec<i32> = Vec::new();
         assert_eq!(size(&empty), 0);
+    }
+
+    #[test]
+    fn test_vec_u128() {
+        let mut values = Vec::with_capacity(4);
+        values.push(0u128);
+
+        assert_eq!(size(&values), values.capacity() * size_of::<u128>());
     }
 
     #[test]

--- a/datafusion/common/src/heap_size.rs
+++ b/datafusion/common/src/heap_size.rs
@@ -445,7 +445,6 @@ impl_zero_heap_size!(
     i32,
     i64,
     i128,
-    u128,
     i256,
     f16,
     f32,
@@ -549,7 +548,6 @@ mod tests {
         assert_eq!(size(&0i32), 0);
         assert_eq!(size(&0i64), 0);
         assert_eq!(size(&0i128), 0);
-        assert_eq!(size(&0u128), 0);
         assert_eq!(size(&i256::ZERO), 0);
         assert_eq!(size(&0f32), 0);
         assert_eq!(size(&0f64), 0);
@@ -605,14 +603,6 @@ mod tests {
 
         let empty: Vec<i32> = Vec::new();
         assert_eq!(size(&empty), 0);
-    }
-
-    #[test]
-    fn test_vec_u128() {
-        let mut values = Vec::with_capacity(4);
-        values.push(0u128);
-
-        assert_eq!(size(&values), values.capacity() * size_of::<u128>());
     }
 
     #[test]

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -756,6 +756,23 @@ mod tests {
             + map.hashes_buffer.allocated_size();
         assert_eq!(map.size(), expected_size);
 
+        // Verify the retained-capacity delta independently from the production formula.
+        let legacy_size = map.map_size
+            + map.views.len() * size_of::<u128>()
+            + map.in_progress.capacity()
+            + map.completed.iter().map(Buffer::len).sum::<usize>()
+            + map.nulls.allocated_size()
+            + map.hashes_buffer.allocated_size();
+        let retained_capacity_delta = (map.views.capacity() - map.views.len())
+            * size_of::<u128>()
+            + map.completed.capacity() * size_of::<Buffer>()
+            + map
+                .completed
+                .iter()
+                .map(|buffer| buffer.capacity() - buffer.len())
+                .sum::<usize>();
+        assert_eq!(map.size() - legacy_size, retained_capacity_delta);
+
         let size_after_insert = map.size();
         map.insert_if_new(&values, |_| (), |_| {});
         assert_eq!(map.size(), size_after_insert);

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -25,7 +25,6 @@ use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::{BinaryViewType, ByteViewType, DataType, StringViewType};
 use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
-use datafusion_common::heap_size::{DFHeapSize, DFHeapSizeCtx};
 use datafusion_common::utils::proxy::{HashTableAllocExt, VecAllocExt};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -473,7 +472,7 @@ where
     pub fn size(&self) -> usize {
         // All fields below own their allocations. Count retained capacity rather
         // than used length because this value drives memory accounting.
-        let views_size = self.views.heap_size(&mut DFHeapSizeCtx::default());
+        let views_size = self.views.allocated_size();
         let in_progress_size = self.in_progress.allocated_size();
         let completed_size = self.completed.allocated_size()
             + self.completed.iter().map(Buffer::capacity).sum::<usize>();
@@ -530,6 +529,7 @@ where
 mod tests {
     use arrow::array::{GenericByteViewArray, StringViewArray};
     use datafusion_common::HashMap;
+    use std::mem::size_of;
 
     use super::*;
 

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -25,6 +25,7 @@ use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::{BinaryViewType, ByteViewType, DataType, StringViewType};
 use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
+use datafusion_common::heap_size::{DFHeapSize, DFHeapSizeCtx};
 use datafusion_common::utils::proxy::{HashTableAllocExt, VecAllocExt};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -472,7 +473,7 @@ where
     pub fn size(&self) -> usize {
         // All fields below own their allocations. Count retained capacity rather
         // than used length because this value drives memory accounting.
-        let views_size = self.views.allocated_size();
+        let views_size = self.views.heap_size(&mut DFHeapSizeCtx::default());
         let in_progress_size = self.in_progress.allocated_size();
         let completed_size = self.completed.allocated_size()
             + self.completed.iter().map(Buffer::capacity).sum::<usize>();

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -469,11 +469,14 @@ where
     }
 
     /// Return the total size, in bytes, of memory used to store the data in
-    /// this set, not including `self`
+    /// this set, not including `self` or input-array buffers.
     pub fn size(&self) -> usize {
-        let views_size = self.views.len() * size_of::<u128>();
+        // All fields below own their allocations. Count retained capacity rather
+        // than used length because this value drives memory accounting.
+        let views_size = self.views.capacity() * size_of::<u128>();
         let in_progress_size = self.in_progress.capacity();
-        let completed_size: usize = self.completed.iter().map(|b| b.len()).sum();
+        let completed_size = self.completed.capacity() * size_of::<Buffer>()
+            + self.completed.iter().map(Buffer::capacity).sum::<usize>();
         let nulls_size = self.nulls.allocated_size();
 
         self.map_size
@@ -713,6 +716,50 @@ mod tests {
         assert!(size_after_values2 > size_after_values1);
 
         assert_eq!(set.len(), 10);
+    }
+
+    #[test]
+    fn test_size_counts_retained_buffer_capacities() {
+        let first = "a".repeat(BYTE_VIEW_MAX_BLOCK_SIZE / 2 + 1);
+        let second = "b".repeat(BYTE_VIEW_MAX_BLOCK_SIZE / 2 + 1);
+        let third = "c".repeat(BYTE_VIEW_MAX_BLOCK_SIZE / 2 + 1);
+        let values: ArrayRef = Arc::new(StringViewArray::from(vec![
+            first.as_str(),
+            second.as_str(),
+            third.as_str(),
+        ]));
+
+        let mut map = ArrowBytesViewMap::new(OutputType::Utf8View);
+        map.insert_if_new(&values, |_| (), |_| {});
+
+        // Make unused vector capacity explicit; the completed buffers were created
+        // by the map's flush path.
+        map.views.shrink_to_fit();
+        map.views.reserve_exact(1);
+        map.completed.shrink_to_fit();
+        map.completed.reserve_exact(1);
+
+        // The map owns these allocations; `values` and its Arrow buffers remain external.
+        assert!(map.views.capacity() > map.views.len());
+        assert!(map.completed.capacity() > map.completed.len());
+        assert!(
+            map.completed
+                .iter()
+                .any(|buffer| buffer.capacity() > buffer.len())
+        );
+
+        let expected_size = map.map_size
+            + map.views.capacity() * size_of::<u128>()
+            + map.in_progress.capacity()
+            + map.completed.capacity() * size_of::<Buffer>()
+            + map.completed.iter().map(Buffer::capacity).sum::<usize>()
+            + map.nulls.allocated_size()
+            + map.hashes_buffer.allocated_size();
+        assert_eq!(map.size(), expected_size);
+
+        let size_after_insert = map.size();
+        map.insert_if_new(&values, |_| (), |_| {});
+        assert_eq!(map.size(), size_after_insert);
     }
 
     #[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -27,6 +27,7 @@ use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::utils::proxy::{HashTableAllocExt, VecAllocExt};
 use std::fmt::Debug;
+use std::mem::size_of;
 use std::sync::Arc;
 
 /// HashSet optimized for storing string or binary values that can produce that
@@ -154,10 +155,13 @@ where
     V: Debug + PartialEq + Eq + Clone + Copy + Default,
 {
     pub fn new(output_type: OutputType) -> Self {
+        let map = hashbrown::hash_table::HashTable::with_capacity(INITIAL_MAP_CAPACITY);
+        let map_size = map.capacity() * size_of::<Entry<V>>();
+
         Self {
             output_type,
-            map: hashbrown::hash_table::HashTable::with_capacity(INITIAL_MAP_CAPACITY),
-            map_size: 0,
+            map,
+            map_size,
             views: Vec::new(),
             in_progress: Vec::new(),
             completed: Vec::new(),
@@ -529,7 +533,6 @@ where
 mod tests {
     use arrow::array::{GenericByteViewArray, StringViewArray};
     use datafusion_common::HashMap;
-    use std::mem::size_of;
 
     use super::*;
 
@@ -716,6 +719,13 @@ mod tests {
         assert!(size_after_values2 > size_after_values1);
 
         assert_eq!(set.len(), 10);
+    }
+
+    #[test]
+    fn test_size_counts_initial_hash_table_capacity() {
+        let map = ArrowBytesViewMap::<()>::new(OutputType::Utf8View);
+
+        assert_eq!(map.size(), map.map.capacity() * size_of::<Entry<()>>());
     }
 
     #[test]

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -27,7 +27,6 @@ use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::utils::proxy::{HashTableAllocExt, VecAllocExt};
 use std::fmt::Debug;
-use std::mem::size_of;
 use std::sync::Arc;
 
 /// HashSet optimized for storing string or binary values that can produce that
@@ -473,9 +472,9 @@ where
     pub fn size(&self) -> usize {
         // All fields below own their allocations. Count retained capacity rather
         // than used length because this value drives memory accounting.
-        let views_size = self.views.capacity() * size_of::<u128>();
-        let in_progress_size = self.in_progress.capacity();
-        let completed_size = self.completed.capacity() * size_of::<Buffer>()
+        let views_size = self.views.allocated_size();
+        let in_progress_size = self.in_progress.allocated_size();
+        let completed_size = self.completed.allocated_size()
             + self.completed.iter().map(Buffer::capacity).sum::<usize>();
         let nulls_size = self.nulls.allocated_size();
 
@@ -749,9 +748,9 @@ mod tests {
         );
 
         let expected_size = map.map_size
-            + map.views.capacity() * size_of::<u128>()
-            + map.in_progress.capacity()
-            + map.completed.capacity() * size_of::<Buffer>()
+            + map.views.allocated_size()
+            + map.in_progress.allocated_size()
+            + map.completed.allocated_size()
             + map.completed.iter().map(Buffer::capacity).sum::<usize>()
             + map.nulls.allocated_size()
             + map.hashes_buffer.allocated_size();


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #23393

## Rationale for this change

`ArrowBytesViewMap::size()` can underreport memory retained by the map. It previously omitted the initial allocation of the hash table, counted `views` by length rather than capacity, counted completed buffers by used length rather than retained capacity, and did not include the backing allocation of the `completed` vector.

Because this value is used for memory accounting, it should reflect heap allocations owned by the map while continuing to exclude `self` and external input-array buffers.

## What changes are included in this PR?

* Initialize `map_size` from the hash table's initial allocated capacity.
* Account for `views` and the in-progress buffer using their allocated sizes.
* Include the allocation backing the `completed` vector.
* Account for each completed Arrow `Buffer` by retained capacity rather than used length.
* Clarify that `size()` excludes both `self` and input-array buffers.

## Are these changes tested?

Yes. This PR adds:

* `test_size_counts_initial_hash_table_capacity`, which verifies that a newly created map reports the initial hash table allocation.
* `test_size_counts_retained_buffer_capacities`, which verifies unused `views` capacity, `completed` vector storage, retained completed-buffer capacity, and that re-inserting duplicate values does not increase the reported size.

## Are there any user-facing changes?

No public API or query-result behavior changes. This fixes internal memory accounting so `ArrowBytesViewMap::size()` more accurately reports allocations retained by the map.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed.
