### PR TITLE
fix: scope HashJoinExec build_time to hash-table construction only

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -2249,6 +2249,10 @@ async fn collect_left_input(
         memory_counter: _,
     } = state;
 
+    // Only time hash-table construction, not the `try_fold` above (that's the
+    // child's own compute).
+    let _build_timer = metrics.build_time.timer();
+
     // Compute bounds
     let mut bounds = match bounds_accumulators {
         Some(accumulators) if num_rows > 0 => {

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -660,7 +660,6 @@ impl HashJoinStream {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<StatefulStreamResult<Option<RecordBatch>>>> {
-        let build_timer = self.join_metrics.build_time.timer();
         // build hash table from left (build) side, if not yet done
         let left_data = ready!(
             self.build_side
@@ -668,7 +667,6 @@ impl HashJoinStream {
                 .left_fut
                 .get_shared(cx)
         )?;
-        build_timer.done();
 
         // Note: For null-aware anti join, we need to check the probe side (right) for NULLs,
         // not the build side (left). The probe-side NULL check happens during process_probe_batch.


### PR DESCRIPTION
## Rationale for this change

HashJoinExec's elapsed_compute metric (as reported by EXPLAIN ANALYZE and ExecutionPlanMetricsSet) includes time spent executing the entire build-side subtree, not just the join's own work. Any tool that sums elapsed_compute across a physical plan to estimate total CPU time (e.g. to build a cost/telemetry model) will double-count that subtree's compute: once under the child operator(s) that did the work, and again under HashJoinExec.

## What changes are included in this PR?

build_time was previously timed around the entire collect_left_input future (via left_fut.get_shared(cx) in collect_build_side). That future both drains the build-side child's stream and builds the hash table, so the child's own compute got billed to build_time whenever the driving partition executed both phases inline.

  - Scoped the build_time timer inside collect_left_input to start only after the build-side stream has been fully folded, covering just the synchronous bounds/hash-map construction.
  - Removed the now-redundant wrapping timer in collect_build_side.

## Are these changes tested?

Covered by the existing hash_join test suite (correctness of join output and other metrics is unaffected). No new test was added to assert the exact build_time/elapsed_compute value, since there isn't currently a way to attribute deterministic wall-clock cost to a specific subtree in a unit test.

## Are there any user-facing changes?

elapsed_compute reported for HashJoinExec (e.g. via EXPLAIN ANALYZE) will be smaller and more accurate, reflecting only the join's own compute rather than including its build-side subtree. No public API changes.