### PR TITLE
fix: preserve scan order during sort-preserving merge limit pushdown

### DIFF
--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -19,13 +19,16 @@ use std::sync::Arc;
 
 use crate::physical_optimizer::test_utils::{
     coalesce_partitions_exec, global_limit_exec, hash_join_exec, local_limit_exec,
-    sort_exec, sort_preserving_merge_exec, stream_exec,
+    parquet_exec_with_sort, sort_exec, sort_preserving_merge_exec,
+    sort_preserving_merge_exec_with_fetch, stream_exec,
 };
 
 use arrow::compute::SortOptions;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::error::Result;
+use datafusion_datasource::file_scan_config::FileScanConfig;
+use datafusion_datasource::source::DataSourceExec;
 use datafusion_expr::{JoinType, Operator};
 use datafusion_physical_expr::Partitioning;
 use datafusion_physical_expr::expressions::{BinaryExpr, col, lit};
@@ -401,6 +404,33 @@ fn pushes_global_limit_into_multiple_fetch_plans() -> Result<()> {
             StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true
     "
     );
+
+    Ok(())
+}
+
+#[test]
+fn preserves_order_when_pushing_fetch_from_sort_preserving_merge() -> Result<()> {
+    let schema = create_schema();
+    let ordering: LexOrdering = [PhysicalSortExpr {
+        expr: col("c1", &schema)?,
+        options: SortOptions::default(),
+    }]
+    .into();
+    let scan = parquet_exec_with_sort(schema, vec![ordering.clone()]);
+    let plan = sort_preserving_merge_exec_with_fetch(ordering, scan, 5);
+
+    let optimized = LimitPushdown::new().optimize(plan, &ConfigOptions::new())?;
+    let scan = optimized.children().swap_remove(0);
+    let scan = scan
+        .downcast_ref::<DataSourceExec>()
+        .expect("fetch should be pushed into the scan");
+    let config = scan
+        .data_source()
+        .downcast_ref::<FileScanConfig>()
+        .expect("parquet scan should use FileScanConfig");
+
+    assert_eq!(config.limit, Some(5));
+    assert!(config.preserve_order);
 
     Ok(())
 }

--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use crate::physical_optimizer::test_utils::{
     coalesce_partitions_exec, global_limit_exec, hash_join_exec, local_limit_exec,
-    parquet_exec_with_sort, sort_exec, sort_preserving_merge_exec,
+    parquet_exec, parquet_exec_with_sort, sort_exec, sort_preserving_merge_exec,
     sort_preserving_merge_exec_with_fetch, stream_exec,
 };
 
@@ -432,6 +432,36 @@ fn preserves_order_when_pushing_fetch_from_sort_preserving_merge() -> Result<()>
 
     assert_eq!(config.limit, Some(5));
     assert!(config.preserve_order);
+
+    Ok(())
+}
+
+#[test]
+fn does_not_preserve_order_for_independent_limit_below_sort() -> Result<()> {
+    let schema = create_schema();
+    let ordering: LexOrdering = [PhysicalSortExpr {
+        expr: col("c1", &schema)?,
+        options: SortOptions::default(),
+    }]
+    .into();
+    let scan = parquet_exec(schema);
+    let local_limit = local_limit_exec(scan, 10);
+    let sort = sort_exec(ordering.clone(), local_limit);
+    let plan = sort_preserving_merge_exec_with_fetch(ordering, sort, 5);
+
+    let optimized = LimitPushdown::new().optimize(plan, &ConfigOptions::new())?;
+    let sort = optimized.children().swap_remove(0);
+    let scan = sort.children().swap_remove(0);
+    let scan = scan
+        .downcast_ref::<DataSourceExec>()
+        .expect("inner fetch should be pushed into the scan");
+    let config = scan
+        .data_source()
+        .downcast_ref::<FileScanConfig>()
+        .expect("parquet scan should use FileScanConfig");
+
+    assert_eq!(config.limit, Some(10));
+    assert!(!config.preserve_order);
 
     Ok(())
 }

--- a/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/limit_pushdown.rs
@@ -417,7 +417,8 @@ fn preserves_order_when_pushing_fetch_from_sort_preserving_merge() -> Result<()>
     }]
     .into();
     let scan = parquet_exec_with_sort(schema, vec![ordering.clone()]);
-    let plan = sort_preserving_merge_exec_with_fetch(ordering, scan, 5);
+    let local_limit = local_limit_exec(scan, 10);
+    let plan = sort_preserving_merge_exec_with_fetch(ordering, local_limit, 5);
 
     let optimized = LimitPushdown::new().optimize(plan, &ConfigOptions::new())?;
     let scan = optimized.children().swap_remove(0);

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -197,8 +197,10 @@ pub fn pushdown_limit_helper(
     }
 
     // If we have a non-limit operator with fetch capability, update global
-    // state as necessary:
+    // state as necessary. A fetched ordered merge selects the leading rows in
+    // its ordering, so preserve that ordering when pushing the fetch down.
     if pushdown_plan.fetch().is_some() {
+        global_state.preserve_order |= pushdown_plan.is::<SortPreservingMergeExec>();
         if global_state.skip == 0 {
             global_state.satisfied = true;
         }

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -161,7 +161,7 @@ pub fn pushdown_limit_helper(
         );
         global_state.skip = skip;
         global_state.fetch = fetch;
-        global_state.preserve_order = limit_info.preserve_order;
+        global_state.preserve_order |= limit_info.preserve_order;
         global_state.satisfied = false;
 
         if let Some(fetch) = fetch

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -272,36 +272,33 @@ pub fn pushdown_limit_helper(
         // to add a limit or a fetch. If the plan is already satisfied, we will try
         // to add the fetch info and return the plan.
 
-        // There's no push down, change fetch & skip to default values:
+        // This operator materializes the current fetch. Clear its requirements before
+        // descending so they are not combined with an independent limit below.
         let global_skip = global_state.skip;
+        let global_preserve_order = std::mem::take(&mut global_state.preserve_order);
         global_state.fetch = None;
         global_state.skip = 0;
 
-        let maybe_fetchable = pushdown_plan.with_fetch(skip_and_fetch);
+        let maybe_fetchable = pushdown_plan.with_fetch(skip_and_fetch).map(|plan| {
+            if global_preserve_order {
+                plan.with_preserve_order(true).unwrap_or(plan)
+            } else {
+                plan
+            }
+        });
         if global_state.satisfied {
             if let Some(plan_with_fetch) = maybe_fetchable {
-                let plan_with_preserve_order = plan_with_fetch
-                    .with_preserve_order(global_state.preserve_order)
-                    .unwrap_or(plan_with_fetch);
-                Ok((Transformed::yes(plan_with_preserve_order), global_state))
+                Ok((Transformed::yes(plan_with_fetch), global_state))
             } else {
                 Ok((Transformed::no(pushdown_plan), global_state))
             }
         } else {
             global_state.satisfied = true;
             pushdown_plan = if let Some(plan_with_fetch) = maybe_fetchable {
-                let plan_with_preserve_order = plan_with_fetch
-                    .with_preserve_order(global_state.preserve_order)
-                    .unwrap_or(plan_with_fetch);
-
                 if global_skip > 0 {
-                    add_global_limit(
-                        plan_with_preserve_order,
-                        global_skip,
-                        Some(global_fetch),
-                    )
+                    add_global_limit(plan_with_fetch, global_skip, Some(global_fetch))
                 } else {
-                    plan_with_preserve_order
+                    plan_with_fetch
                 }
             } else {
                 add_limit(pushdown_plan, global_skip, global_fetch)

--- a/datafusion/sqllogictest/test_files/limit_pruning.slt
+++ b/datafusion/sqllogictest/test_files/limit_pruning.slt
@@ -113,6 +113,79 @@ select a from fully_matched_limit where a >= 3 order by a limit 4;
 statement ok
 drop table fully_matched_limit;
 
+# A fetched SortPreservingMergeExec must preserve scan order when pushing down
+# its limit. Otherwise, limit pruning can skip the first partially matched row
+# group in favor of the following fully matched row group.
+statement ok
+CREATE TABLE ordered_limit_source(id INT, passes INT) AS VALUES
+  (1, 0),
+  (2, 1),
+  (3, 1),
+  (4, 1),
+  (5, 1),
+  (6, 1),
+  (101, 1),
+  (102, 1),
+  (103, 1);
+
+query I
+COPY (SELECT * FROM ordered_limit_source WHERE id < 100 ORDER BY id)
+TO 'test_files/scratch/limit_pruning/ordered_limit/a.parquet'
+STORED AS PARQUET
+OPTIONS (
+  'format.max_row_group_size' '3'
+);
+----
+6
+
+query I
+COPY (SELECT * FROM ordered_limit_source WHERE id >= 100 ORDER BY id)
+TO 'test_files/scratch/limit_pruning/ordered_limit/b.parquet'
+STORED AS PARQUET
+OPTIONS (
+  'format.max_row_group_size' '3'
+);
+----
+3
+
+statement ok
+drop table ordered_limit_source;
+
+statement ok
+set datafusion.execution.target_partitions = 2;
+
+statement ok
+CREATE EXTERNAL TABLE ordered_limit(id INT, passes INT)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/limit_pruning/ordered_limit/'
+WITH ORDER (id ASC);
+
+statement ok
+set datafusion.explain.physical_plan_only = true;
+
+query TT
+explain select * from ordered_limit where passes = 1 order by id limit 3;
+----
+physical_plan
+01)SortPreservingMergeExec: [id@0 ASC NULLS LAST], fetch=3
+02)--DataSourceExec: <slt:ignore>limit=3, output_ordering=[id@0 ASC NULLS LAST], file_type=parquet<slt:ignore>
+
+query II
+select * from ordered_limit where passes = 1 order by id limit 3;
+----
+2 1
+3 1
+4 1
+
+statement ok
+drop table ordered_limit;
+
+statement ok
+reset datafusion.explain.physical_plan_only;
+
+statement ok
+set datafusion.execution.target_partitions = 4;
+
 # limit_pruned_row_groups=0 total → 0 matched
 # because of order by, scan needs to preserve sort, so limit pruning is disabled
 query TT


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24272.

## Rationale for this change

Queries that filter ordered data and apply `ORDER BY ... LIMIT` can return incorrect rows when the physical plan contains a fetched `SortPreservingMergeExec`.

When the fetch is pushed into an ordered Parquet scan, `LimitPushdown` currently treats it as order-insensitive. This allows Parquet's limit-based row-group pruning to discard an earlier partially matched row group in favor of a later fully matched row group. The scan can therefore return later rows instead of the first rows in the requested ordering.

For example, a query shaped like:

```sql
SELECT key
FROM table
WHERE key >= 1
ORDER BY key ASC
LIMIT 5;
```

may skip the row group containing the lowest matching values and return values from a later row group.

## What changes are included in this PR?

- Treat a fetched `SortPreservingMergeExec` as order-sensitive during limit pushdown.
- Propagate `preserve_order = true` when pushing its fetch into the underlying scan.
- Add a regression test verifying that an ordered Parquet scan receives both `limit = Some(5)` and `preserve_order = true`.
- Clear the order-preservation requirement after the ordered fetch is applied so it does not affect independent limits below a pushdown boundary.

This prevents order-insensitive Parquet limit pruning from changing which rows are eligible for an ordered limit.

## Are these changes tested?

Yes. The new `preserves_order_when_pushing_fetch_from_sort_preserving_merge` regression test fails without this change because limit pushdown resets the scan's `preserve_order` flag to `false`.

## Are there any user-facing changes?

Yes. Regression tests verify that order is preserved when pushing a fetched `SortPreservingMergeExec` into a scan and that this requirement does not leak into an independent limit below a `SortExec`.

There are no public API changes.