### PR TITLE
Split and deprecate `and_or`

### DIFF
--- a/datafusion/expr-common/src/sort_properties.rs
+++ b/datafusion/expr-common/src/sort_properties.rs
@@ -99,32 +99,21 @@ impl SortProperties {
             _ => Self::Unordered,
         }
     }
+
+    /// `AND` keeps an ordering only when nulls sort after `true`
+    /// (`ASC NULLS LAST`, `DESC NULLS FIRST`).
     pub fn and(&self, rhs: &Self) -> Self {
-        // `descending == nulls_first` selects ASC NULLS LAST / DESC NULLS FIRST.
         self.kleene(rhs, |opt| opt.descending == opt.nulls_first)
     }
 
+    /// `OR` keeps an ordering only when nulls sort before `false`
+    /// (`ASC NULLS FIRST`, `DESC NULLS LAST`).
     pub fn or(&self, rhs: &Self) -> Self {
-        // `descending != nulls_first` selects ASC NULLS FIRST / DESC NULLS LAST.
         self.kleene(rhs, |opt| opt.descending != opt.nulls_first)
     }
 
-    #[deprecated(
-        since = "55.0.0",
-        note = "`AND` and `OR` propagate orderings differently under three-valued logic; use `and` or `or`"
-    )]
-    pub fn and_or(&self, rhs: &Self) -> Self {
-        // Only the behavior on which `and` and `or` agree survives; their
-        // `Ordered` conditions are mutually exclusive.
-        match (self, rhs) {
-            (Self::Singleton, Self::Singleton) => Self::Singleton,
-            _ => Self::Unordered,
-        }
-    }
-
-    /// Shared logic of [`Self::and`] and [`Self::or`]: `preserves` accepts
-    /// the sort options whose physical order realizes the operator's truth
-    /// ordering.
+    /// `preserves` reports whether the operator keeps data in that ordering.
+    /// A `Singleton` may be a literal NULL, so it carries the same guard.
     fn kleene(&self, rhs: &Self, preserves: fn(&SortOptions) -> bool) -> Self {
         match (self, rhs) {
             (Self::Singleton, Self::Singleton) => Self::Singleton,
@@ -208,13 +197,8 @@ mod sort_properties_test {
                 SINGLETON,
                 SINGLETON,
             ),
-            // `and`/`or` back Kleene `AND`/`OR`, where NULL does not simply
-            // propagate (`NULL AND false = false`). Each operator is monotone
-            // w.r.t. its truth ordering (`false < NULL < true` for `AND`,
-            // `NULL < false < true` for `OR`), so each preserves exactly the
-            // two physical orderings realizing that truth ordering. A
-            // `Singleton` may be a literal NULL, hence the same restriction
-            // with a literal operand. Both are commutative.
+            // `and` keeps ASC NULLS LAST / DESC NULLS FIRST, `or` keeps ASC
+            // NULLS FIRST / DESC NULLS LAST. Both are commutative.
             (
                 "and: ASC NULLS LAST is preserved",
                 SortProperties::and,
@@ -244,7 +228,7 @@ mod sort_properties_test {
                 UNORDERED,
             ),
             (
-                "and: mixed preserving orderings are unordered",
+                "and: mixed directions are unordered",
                 SortProperties::and,
                 ASC_NL,
                 DESC_NF,
@@ -300,7 +284,7 @@ mod sort_properties_test {
                 UNORDERED,
             ),
             (
-                "or: mixed preserving orderings are unordered",
+                "or: mixed directions are unordered",
                 SortProperties::or,
                 ASC_NF,
                 DESC_NL,
@@ -435,8 +419,8 @@ mod sort_properties_test {
             assert_eq!(op(&lhs, &rhs), expected, "case: {name}");
         }
 
-        // `add`, `and` and `or` are commutative, which is what lets the
-        // table above cover only one argument order for them.
+        // `add`, `and` and `or` are commutative, so the table above covers
+        // only one argument order.
         for (lhs, rhs) in [
             (ASC_NF, DESC_NL),
             (ASC_NF, SINGLETON),
@@ -449,28 +433,15 @@ mod sort_properties_test {
         }
     }
 
-    /// The deprecated `and_or` cannot distinguish the operators, whose
-    /// preserved orderings are disjoint, so it keeps only the behavior on
-    /// which `and` and `or` agree.
-    #[test]
-    #[expect(deprecated)]
-    fn deprecated_and_or_is_conservative() {
-        assert_eq!(SINGLETON.and_or(&SINGLETON), SINGLETON);
-        assert_eq!(ASC_NF.and_or(&ASC_NF), UNORDERED);
-        assert_eq!(ASC_NL.and_or(&ASC_NL), UNORDERED);
-        assert_eq!(ASC_NL.and_or(&SINGLETON), UNORDERED);
-    }
-
     /// If two ordered operands disagree on null placement, the result is
     /// always Unordered, no matter which operator or direction is used.
     /// Checked below for every combination.
     ///
-    /// For the arithmetic and comparison operators, nulls propagate: the
+    /// Nulls propagate through the arithmetic and comparison operators: the
     /// result is null wherever either operand is null. `nulls_first` treats
     /// those rows as a prefix, `nulls_last` as a suffix. A set that's both
-    /// can't be described by any `SortOptions`. For `and`/`or` the reason
-    /// differs (Kleene monotonicity requires *identical* preserving
-    /// orderings), but the conclusion is the same.
+    /// can't be described by any `SortOptions`. `and`/`or` keep an ordering
+    /// only when both operands already share it.
     ///
     /// The assertion only checks "not Ordered", not which ordering
     /// results. That keeps the test from just repeating the logic it's

--- a/datafusion/expr-common/src/sort_properties.rs
+++ b/datafusion/expr-common/src/sort_properties.rs
@@ -99,24 +99,44 @@ impl SortProperties {
             _ => Self::Unordered,
         }
     }
+    pub fn and(&self, rhs: &Self) -> Self {
+        // `descending == nulls_first` selects ASC NULLS LAST / DESC NULLS FIRST.
+        self.kleene(rhs, |opt| opt.descending == opt.nulls_first)
+    }
 
+    pub fn or(&self, rhs: &Self) -> Self {
+        // `descending != nulls_first` selects ASC NULLS FIRST / DESC NULLS LAST.
+        self.kleene(rhs, |opt| opt.descending != opt.nulls_first)
+    }
+
+    #[deprecated(
+        since = "55.0.0",
+        note = "`AND` and `OR` propagate orderings differently under three-valued logic; use `and` or `or`"
+    )]
     pub fn and_or(&self, rhs: &Self) -> Self {
+        // Only the behavior on which `and` and `or` agree survives; their
+        // `Ordered` conditions are mutually exclusive.
         match (self, rhs) {
-            (Self::Ordered(lhs), Self::Ordered(rhs))
-                if lhs.descending == rhs.descending
-                    && lhs.nulls_first == rhs.nulls_first =>
-            {
-                Self::Ordered(SortOptions {
-                    descending: lhs.descending,
-                    nulls_first: lhs.nulls_first,
-                })
-            }
-            (Self::Ordered(opt), Self::Singleton)
-            | (Self::Singleton, Self::Ordered(opt)) => Self::Ordered(SortOptions {
-                descending: opt.descending,
-                nulls_first: opt.nulls_first,
-            }),
             (Self::Singleton, Self::Singleton) => Self::Singleton,
+            _ => Self::Unordered,
+        }
+    }
+
+    /// Shared logic of [`Self::and`] and [`Self::or`]: `preserves` accepts
+    /// the sort options whose physical order realizes the operator's truth
+    /// ordering.
+    fn kleene(&self, rhs: &Self, preserves: fn(&SortOptions) -> bool) -> Self {
+        match (self, rhs) {
+            (Self::Singleton, Self::Singleton) => Self::Singleton,
+            (Self::Ordered(opt), Self::Singleton)
+            | (Self::Singleton, Self::Ordered(opt))
+                if preserves(opt) =>
+            {
+                Self::Ordered(*opt)
+            }
+            (Self::Ordered(lhs), Self::Ordered(rhs)) if lhs == rhs && preserves(lhs) => {
+                Self::Ordered(*lhs)
+            }
             _ => Self::Unordered,
         }
     }
@@ -188,39 +208,121 @@ mod sort_properties_test {
                 SINGLETON,
                 SINGLETON,
             ),
-            // `and_or` backs both `AND` and `OR`, whose rules coincide. Same
-            // shape as `add`, and likewise commutative.
+            // `and`/`or` back Kleene `AND`/`OR`, where NULL does not simply
+            // propagate (`NULL AND false = false`). Each operator is monotone
+            // w.r.t. its truth ordering (`false < NULL < true` for `AND`,
+            // `NULL < false < true` for `OR`), so each preserves exactly the
+            // two physical orderings realizing that truth ordering. A
+            // `Singleton` may be a literal NULL, hence the same restriction
+            // with a literal operand. Both are commutative.
             (
-                "and_or: same direction is preserved",
-                SortProperties::and_or,
-                ASC_NF,
-                ASC_NF,
-                ASC_NF,
+                "and: ASC NULLS LAST is preserved",
+                SortProperties::and,
+                ASC_NL,
+                ASC_NL,
+                ASC_NL,
             ),
             (
-                "and_or: nulls_last placement is preserved",
-                SortProperties::and_or,
-                DESC_NL,
-                DESC_NL,
-                DESC_NL,
+                "and: DESC NULLS FIRST is preserved",
+                SortProperties::and,
+                DESC_NF,
+                DESC_NF,
+                DESC_NF,
             ),
             (
-                "and_or: opposing directions are unordered",
-                SortProperties::and_or,
+                "and: ASC NULLS FIRST is unordered",
+                SortProperties::and,
                 ASC_NF,
+                ASC_NF,
+                UNORDERED,
+            ),
+            (
+                "and: DESC NULLS LAST is unordered",
+                SortProperties::and,
+                DESC_NL,
+                DESC_NL,
+                UNORDERED,
+            ),
+            (
+                "and: mixed preserving orderings are unordered",
+                SortProperties::and,
+                ASC_NL,
                 DESC_NF,
                 UNORDERED,
             ),
             (
-                "and_or: literal with ordered",
-                SortProperties::and_or,
+                "and: literal with ASC NULLS LAST",
+                SortProperties::and,
+                SINGLETON,
+                ASC_NL,
+                ASC_NL,
+            ),
+            (
+                "and: literal with ASC NULLS FIRST is unordered",
+                SortProperties::and,
+                SINGLETON,
+                ASC_NF,
+                UNORDERED,
+            ),
+            (
+                "and: two literals stay a literal",
+                SortProperties::and,
+                SINGLETON,
+                SINGLETON,
+                SINGLETON,
+            ),
+            (
+                "or: ASC NULLS FIRST is preserved",
+                SortProperties::or,
+                ASC_NF,
+                ASC_NF,
+                ASC_NF,
+            ),
+            (
+                "or: DESC NULLS LAST is preserved",
+                SortProperties::or,
+                DESC_NL,
+                DESC_NL,
+                DESC_NL,
+            ),
+            (
+                "or: ASC NULLS LAST is unordered",
+                SortProperties::or,
+                ASC_NL,
+                ASC_NL,
+                UNORDERED,
+            ),
+            (
+                "or: DESC NULLS FIRST is unordered",
+                SortProperties::or,
+                DESC_NF,
+                DESC_NF,
+                UNORDERED,
+            ),
+            (
+                "or: mixed preserving orderings are unordered",
+                SortProperties::or,
+                ASC_NF,
+                DESC_NL,
+                UNORDERED,
+            ),
+            (
+                "or: literal with ASC NULLS FIRST",
+                SortProperties::or,
                 SINGLETON,
                 ASC_NF,
                 ASC_NF,
             ),
             (
-                "and_or: two literals stay a literal",
-                SortProperties::and_or,
+                "or: literal with ASC NULLS LAST is unordered",
+                SortProperties::or,
+                SINGLETON,
+                ASC_NL,
+                UNORDERED,
+            ),
+            (
+                "or: two literals stay a literal",
+                SortProperties::or,
                 SINGLETON,
                 SINGLETON,
                 SINGLETON,
@@ -333,21 +435,42 @@ mod sort_properties_test {
             assert_eq!(op(&lhs, &rhs), expected, "case: {name}");
         }
 
-        // `add` and `and_or` are commutative, which is what lets the table
-        // above cover only one argument order for them.
-        for (lhs, rhs) in [(ASC_NF, DESC_NL), (ASC_NF, SINGLETON), (ASC_NL, DESC_NF)] {
+        // `add`, `and` and `or` are commutative, which is what lets the
+        // table above cover only one argument order for them.
+        for (lhs, rhs) in [
+            (ASC_NF, DESC_NL),
+            (ASC_NF, SINGLETON),
+            (ASC_NL, SINGLETON),
+            (ASC_NL, DESC_NF),
+        ] {
             assert_eq!(lhs.add(&rhs), rhs.add(&lhs), "add is commutative");
-            assert_eq!(lhs.and_or(&rhs), rhs.and_or(&lhs), "and_or is commutative");
+            assert_eq!(lhs.and(&rhs), rhs.and(&lhs), "and is commutative");
+            assert_eq!(lhs.or(&rhs), rhs.or(&lhs), "or is commutative");
         }
+    }
+
+    /// The deprecated `and_or` cannot distinguish the operators, whose
+    /// preserved orderings are disjoint, so it keeps only the behavior on
+    /// which `and` and `or` agree.
+    #[test]
+    #[expect(deprecated)]
+    fn deprecated_and_or_is_conservative() {
+        assert_eq!(SINGLETON.and_or(&SINGLETON), SINGLETON);
+        assert_eq!(ASC_NF.and_or(&ASC_NF), UNORDERED);
+        assert_eq!(ASC_NL.and_or(&ASC_NL), UNORDERED);
+        assert_eq!(ASC_NL.and_or(&SINGLETON), UNORDERED);
     }
 
     /// If two ordered operands disagree on null placement, the result is
     /// always Unordered, no matter which operator or direction is used.
     /// Checked below for every combination.
     ///
-    /// Nulls propagate: the result is null wherever either operand is
-    /// null. `nulls_first` treats those rows as a prefix, `nulls_last` as
-    /// a suffix. A set that's both can't be described by any `SortOptions`.
+    /// For the arithmetic and comparison operators, nulls propagate: the
+    /// result is null wherever either operand is null. `nulls_first` treats
+    /// those rows as a prefix, `nulls_last` as a suffix. A set that's both
+    /// can't be described by any `SortOptions`. For `and`/`or` the reason
+    /// differs (Kleene monotonicity requires *identical* preserving
+    /// orderings), but the conclusion is the same.
     ///
     /// The assertion only checks "not Ordered", not which ordering
     /// results. That keeps the test from just repeating the logic it's
@@ -356,7 +479,8 @@ mod sort_properties_test {
     #[case::add("add", SortProperties::add)]
     #[case::sub("sub", SortProperties::sub)]
     #[case::gt_or_gteq("gt_or_gteq", SortProperties::gt_or_gteq)]
-    #[case::and_or("and_or", SortProperties::and_or)]
+    #[case::and("and", SortProperties::and)]
+    #[case::or("or", SortProperties::or)]
     fn conflicting_null_placement_is_never_ordered(
         #[values(false, true)] l_descending: bool,
         #[values(false, true)] r_descending: bool,

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -876,13 +876,13 @@ impl PhysicalExpr for BinaryExpr {
                 strictly_order_preserving: false,
             }),
             Operator::And => Ok(ExprProperties {
-                sort_properties: r_order.and_or(&l_order),
+                sort_properties: l_order.and(&r_order),
                 range: l_range.and(r_range)?,
                 preserves_lex_ordering: false,
                 strictly_order_preserving: false,
             }),
             Operator::Or => Ok(ExprProperties {
-                sort_properties: r_order.and_or(&l_order),
+                sort_properties: l_order.or(&r_order),
                 range: l_range.or(r_range)?,
                 preserves_lex_ordering: false,
                 strictly_order_preserving: false,

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -1591,6 +1591,78 @@ physical_plan
 statement ok
 DROP TABLE mixed_null_placement;
 
+# NULLS FIRST inputs stay sorted through OR but not AND. The full
+# operator-by-ordering matrix is unit-tested in sort_properties.rs; this
+# checks the planner consumes it.
+query I
+COPY (VALUES
+  (CAST(NULL AS BOOLEAN), false),
+  (CAST(NULL AS BOOLEAN), true),
+  (false,                 true),
+  (true,                  true))
+TO 'test_files/scratch/order/kleene_nulls_first.csv'
+OPTIONS ('format.has_header' 'true');
+----
+4
+
+statement ok
+CREATE EXTERNAL TABLE kleene_nulls_first (a BOOLEAN, b BOOLEAN)
+STORED AS CSV
+WITH ORDER (a ASC NULLS FIRST)
+WITH ORDER (b ASC NULLS FIRST)
+LOCATION 'test_files/scratch/order/kleene_nulls_first.csv'
+OPTIONS ('format.has_header' 'true');
+
+# a AND b = (false, NULL, false, true) in scan order: the sort has to happen.
+query B
+SELECT a AND b AS c FROM kleene_nulls_first ORDER BY c ASC NULLS FIRST;
+----
+NULL
+false
+false
+true
+
+# Same at the plan level: AND must not claim ASC NULLS FIRST.
+query TT
+EXPLAIN SELECT a AND b AS c FROM kleene_nulls_first ORDER BY c ASC NULLS FIRST;
+----
+logical_plan
+01)Sort: c ASC NULLS FIRST
+02)--Projection: kleene_nulls_first.a AND kleene_nulls_first.b AS c
+03)----TableScan: kleene_nulls_first projection=[a, b]
+physical_plan
+01)SortPreservingMergeExec: [c@0 ASC]
+02)--SortExec: expr=[c@0 ASC], preserve_partitioning=[true]
+03)----ProjectionExec: expr=[a@0 AND b@1 as c]
+04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1, maintains_sort_order=true
+05)--------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/order/kleene_nulls_first.csv]]}, projection=[a, b], output_orderings=[[a@0 ASC], [b@1 ASC]], file_type=csv, has_header=true
+
+# a OR b = (NULL, true, true, true) in scan order: already sorted, and OR may
+# claim it, so no SortExec.
+query B
+SELECT a OR b AS c FROM kleene_nulls_first ORDER BY c ASC NULLS FIRST;
+----
+NULL
+true
+true
+true
+
+query TT
+EXPLAIN SELECT a OR b AS c FROM kleene_nulls_first ORDER BY c ASC NULLS FIRST;
+----
+logical_plan
+01)Sort: c ASC NULLS FIRST
+02)--Projection: kleene_nulls_first.a OR kleene_nulls_first.b AS c
+03)----TableScan: kleene_nulls_first projection=[a, b]
+physical_plan
+01)SortPreservingMergeExec: [c@0 ASC]
+02)--ProjectionExec: expr=[a@0 OR b@1 as c]
+03)----RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1, maintains_sort_order=true
+04)------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/order/kleene_nulls_first.csv]]}, projection=[a, b], output_orderings=[[a@0 ASC], [b@1 ASC]], file_type=csv, has_header=true
+
+statement ok
+DROP TABLE kleene_nulls_first;
+
 # Union a query with the actual data and one with a constant
 query I
 SELECT (SELECT c from ordered_table ORDER BY c LIMIT 1) UNION ALL (SELECT 23 as c from ordered_table ORDER BY c LIMIT 1) ORDER BY c;

--- a/datafusion/sqllogictest/test_files/order.slt
+++ b/datafusion/sqllogictest/test_files/order.slt
@@ -1591,9 +1591,8 @@ physical_plan
 statement ok
 DROP TABLE mixed_null_placement;
 
-# NULLS FIRST inputs stay sorted through OR but not AND. The full
-# operator-by-ordering matrix is unit-tested in sort_properties.rs; this
-# checks the planner consumes it.
+# ASC NULLS FIRST survives OR but not AND. The per-operator rules are
+# unit-tested in sort_properties.rs; this checks the planner uses them.
 query I
 COPY (VALUES
   (CAST(NULL AS BOOLEAN), false),
@@ -1613,7 +1612,7 @@ WITH ORDER (b ASC NULLS FIRST)
 LOCATION 'test_files/scratch/order/kleene_nulls_first.csv'
 OPTIONS ('format.has_header' 'true');
 
-# a AND b = (false, NULL, false, true) in scan order: the sort has to happen.
+# a AND b is (false, NULL, false, true) in scan order, so it needs sorting.
 query B
 SELECT a AND b AS c FROM kleene_nulls_first ORDER BY c ASC NULLS FIRST;
 ----
@@ -1622,7 +1621,7 @@ false
 false
 true
 
-# Same at the plan level: AND must not claim ASC NULLS FIRST.
+# AND must not claim ASC NULLS FIRST.
 query TT
 EXPLAIN SELECT a AND b AS c FROM kleene_nulls_first ORDER BY c ASC NULLS FIRST;
 ----
@@ -1637,8 +1636,8 @@ physical_plan
 04)------RepartitionExec: partitioning=RoundRobinBatch(2), input_partitions=1, maintains_sort_order=true
 05)--------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/order/kleene_nulls_first.csv]]}, projection=[a, b], output_orderings=[[a@0 ASC], [b@1 ASC]], file_type=csv, has_header=true
 
-# a OR b = (NULL, true, true, true) in scan order: already sorted, and OR may
-# claim it, so no SortExec.
+# a OR b is (NULL, true, true, true) in scan order, already ASC NULLS FIRST,
+# so no SortExec.
 query B
 SELECT a OR b AS c FROM kleene_nulls_first ORDER BY c ASC NULLS FIRST;
 ----

--- a/docs/source/library-user-guide/upgrading/55.0.0.md
+++ b/docs/source/library-user-guide/upgrading/55.0.0.md
@@ -1341,6 +1341,35 @@ following the pattern in [`parquet/examples/object_store.rs`]
 
 See [PR #24030](https://github.com/apache/datafusion/pull/24030) for details.
 
+### `SortProperties::and_or` split into `and` and `or`
+
+`AND` and `OR` do not propagate the same sort orders. Under three-valued logic
+`AND` preserves an ordering only when nulls sort after `true` (`ASC NULLS LAST`
+or `DESC NULLS FIRST`). `OR` preserves one only when nulls sort before
+`false` (`ASC NULLS FIRST` or `DESC NULLS LAST`). A single shared method could
+not be correct for both.
+
+`datafusion_expr_common::sort_properties::SortProperties::and_or` is deprecated
+in favor of `and` and `or`. Both operators agree on: `Singleton` for two `Singleton`
+operands, `Unordered` otherwise.
+
+**Who is affected:**
+
+- Users who call `SortProperties::and_or` directly.
+
+**Migration guide:**
+
+```rust,ignore
+// Before
+let props = lhs.and_or(&rhs);
+
+// After
+let props = lhs.and(&rhs);   // for AND
+let props = lhs.or(&rhs);    // for OR
+```
+
+See [PR](https://github.com/apache/datafusion/pull/24276) #24276 for details.
+
 [`parquet` crate]: https://crates.io/crates/parquet
 [`parquetobjectreader`]: https://docs.rs/parquet/59.1.0/parquet/arrow/async_reader/struct.ParquetObjectReader.html
 [`parquetobjectwriter`]: https://docs.rs/parquet/59.1.0/parquet/arrow/async_writer/struct.ParquetObjectWriter.html

--- a/docs/source/library-user-guide/upgrading/55.0.0.md
+++ b/docs/source/library-user-guide/upgrading/55.0.0.md
@@ -1341,34 +1341,27 @@ following the pattern in [`parquet/examples/object_store.rs`]
 
 See [PR #24030](https://github.com/apache/datafusion/pull/24030) for details.
 
-### `SortProperties::and_or` split into `and` and `or`
+### `SortProperties::and_or` replaced by `and` and `or`
 
-`AND` and `OR` do not propagate the same sort orders. Under three-valued logic
-`AND` preserves an ordering only when nulls sort after `true` (`ASC NULLS LAST`
-or `DESC NULLS FIRST`). `OR` preserves one only when nulls sort before
-`false` (`ASC NULLS FIRST` or `DESC NULLS LAST`). A single shared method could
-not be correct for both.
-
-`datafusion_expr_common::sort_properties::SortProperties::and_or` is deprecated
-in favor of `and` and `or`. Both operators agree on: `Singleton` for two `Singleton`
-operands, `Unordered` otherwise.
-
-**Who is affected:**
-
-- Users who call `SortProperties::and_or` directly.
-
-**Migration guide:**
+`datafusion_expr_common::sort_properties::SortProperties::and_or` has been
+removed. Call `and` for `AND` and `or` for `OR`:
 
 ```rust,ignore
-// Before
+// Before (54.0.0)
 let props = lhs.and_or(&rhs);
 
-// After
-let props = lhs.and(&rhs);   // for AND
-let props = lhs.or(&rhs);    // for OR
+// After (55.0.0)
+let props = lhs.and(&rhs); // for AND
+let props = lhs.or(&rhs);  // for OR
 ```
 
-See [PR](https://github.com/apache/datafusion/pull/24276) #24276 for details.
+The two operators do not preserve the same sort orders. `AND` keeps an ordering
+only when nulls sort after `true` (`ASC NULLS LAST` or `DESC NULLS FIRST`), and
+`OR` only when nulls sort before `false` (`ASC NULLS FIRST` or
+`DESC NULLS LAST`). `and_or` did not say which operator the caller meant, so it
+could not be right for both.
+
+See [PR #24276](https://github.com/apache/datafusion/pull/24276) for details.
 
 [`parquet` crate]: https://crates.io/crates/parquet
 [`parquetobjectreader`]: https://docs.rs/parquet/59.1.0/parquet/arrow/async_reader/struct.ParquetObjectReader.html


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #24208.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

Under Kleene logic, the behavior of `and` and `or` is inconsistent with respect to transitivity of ordered.

See #24208 for the counterexamples and the full rules. 


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Split `SortProperties::and_or` into `and` / `or` .  `BinaryExpr::get_properties` now calls the matching method per operator.
- Deprecate `and_or` and narrow it to what `and` and `or` agree on  (`Singleton`/`Singleton` → `Singleton`, everything else `Unordered`). A caller of `and_or` does not say which operator it means, so any stronger claim is wrong for one of them. The previous behavior is this bug.


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
Yes.  Split and deprecate `and_or`