### PR TITLE
docs: update proto-models README for the datafusion-common dependency

### DIFF
--- a/datafusion/proto-models/README.md
+++ b/datafusion/proto-models/README.md
@@ -22,9 +22,17 @@
 [Apache DataFusion] is an extensible query execution framework, written in Rust, that uses [Apache Arrow] as its in-memory format.
 
 This crate contains the [prost]-generated Rust types for DataFusion's logical
-and physical plan protobuf schemas. It is intentionally kept narrow: it has no
-DataFusion dependencies beyond [`datafusion-proto-common`] and exposes only the
-generated structs (and optional [pbjson]/[serde] support).
+and physical plan protobuf schemas, plus the `From` / `TryFrom` conversions
+between those types and the [`datafusion-common`] types they mirror. The
+conversions live here because their DataFusion side sits _below_ this crate in
+the dependency graph and so cannot host the impls itself — the same arrangement
+[`datafusion-proto-common`] uses for `ScalarValue` and `Statistics`.
+
+It is otherwise intentionally kept narrow: its only DataFusion dependencies are
+[`datafusion-common`] and [`datafusion-proto-common`], and apart from those
+conversions it exposes only the generated structs (and optional
+[pbjson]/[serde] support). In particular it does not depend on
+`datafusion-expr` or on any of the execution crates.
 
 This crate is consumed by [`datafusion-proto`] and may also be depended on
 directly by other DataFusion crates that need to refer to the proto schema
@@ -39,5 +47,6 @@ crate, there is no reason to use this crate directly in your project as well.
 [prost]: https://docs.rs/prost/latest/prost/
 [pbjson]: https://docs.rs/pbjson/latest/pbjson/
 [serde]: https://serde.rs/
+[`datafusion-common`]: https://crates.io/crates/datafusion-common
 [`datafusion-proto`]: https://crates.io/crates/datafusion-proto
 [`datafusion-proto-common`]: https://crates.io/crates/datafusion-proto-common

--- a/datafusion/proto-models/README.md
+++ b/datafusion/proto-models/README.md
@@ -26,7 +26,7 @@ and physical plan protobuf schemas, plus the `From` / `TryFrom` conversions
 between those types and the [`datafusion-common`] types they mirror. The
 conversions live here because their DataFusion side sits _below_ this crate in
 the dependency graph and so cannot host the impls itself — the same arrangement
-[`datafusion-proto-common`] uses for `ScalarValue` and `Statistics`.
+[`datafusion-proto-common`] uses for [`ScalarValue`] and [`Statistics`].
 
 It is otherwise intentionally kept narrow: its only DataFusion dependencies are
 [`datafusion-common`] and [`datafusion-proto-common`], and apart from those
@@ -50,3 +50,5 @@ crate, there is no reason to use this crate directly in your project as well.
 [`datafusion-common`]: https://crates.io/crates/datafusion-common
 [`datafusion-proto`]: https://crates.io/crates/datafusion-proto
 [`datafusion-proto-common`]: https://crates.io/crates/datafusion-proto-common
+[`scalarvalue`]: https://docs.rs/datafusion-common/latest/datafusion_common/scalar/enum.ScalarValue.html
+[`statistics`]: https://docs.rs/datafusion-common/latest/datafusion_common/stats/struct.Statistics.html


### PR DESCRIPTION
`datafusion-proto-models` now depends on `datafusion-common` and hosts the `From` / `TryFrom` conversions between the generated proto types and their `datafusion-common` counterparts, but the crate README still claimed it had no DataFusion dependencies beyond `datafusion-proto-common` and exposed only the generated structs.

Describe the conversions and why they live in this crate, and spell out the narrowness that still holds: `datafusion-common` and `datafusion-proto-common` are the only DataFusion dependencies.
