### PR TITLE
chore: Expand dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,8 +62,33 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  # dev/depcheck is a standalone crate excluded from the workspace, so it is
+  # not covered by the workspace entry above
+  - package-ecosystem: cargo
+    directory: "/dev/depcheck"
+    schedule:
+      interval: weekly
+    target-branch: main
+    labels: [auto-dependencies]
+  # the wasm test app has its own npm lockfile
+  - package-ecosystem: npm
+    directory: "/datafusion/wasmtest/datafusion-wasm-app"
+    schedule:
+      interval: weekly
+    labels: [auto-dependencies]
+    groups:
+      # minor and patch bumps are grouped into a single PR
+      all-npm-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" covers workflows in .github/workflows; the glob covers composite
+    # actions such as .github/actions/setup-builder
+    directories: ["/", "/.github/actions/*"]
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -72,8 +97,10 @@ updates:
       codeql-actions:
         patterns:
           - "github/codeql-action/*"
-  - package-ecosystem: "pip"
-    directory: "/docs"
+  # Python dependencies are managed as a uv workspace rooted at the top-level
+  # pyproject.toml with a shared uv.lock
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
     labels: [auto-dependencies]


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## Rationale for this change

This PR tweaks the dependabot config to send dependency updates for a few parts of the repo that were previously missed:

- `dev/depcheck` is excluded from the Cargo workspace and has its own `Cargo.lock` (#24289 updates the dependencies manually as an interim fix)
- `datafusion/wasmtest/datafusion-wasm-app` has its own npm `package-lock.json`
- Composite actions under `.github/actions/`
- The Python dependencies are a uv workspace rooted at the top-level `pyproject.toml` with a shared `uv.lock`, but only `docs/` was covered — `dev/` and `benchmarks/` got no version updates.

## What changes are included in this PR?

- Add a `cargo` entry for `/dev/depcheck`
- Add an `npm` entry for `/datafusion/wasmtest/datafusion-wasm-app`
- Change the `github-actions` entry from `directory: "/"` to `directories: ["/", "/.github/actions/*"]` so composite actions are covered
- Replace the `pip` `/docs` entry with a `uv` entry at the repository root, covering the whole uv workspace and `uv.lock`

## Are these changes tested?

Some manual testing, hard to really test exhaustively without letting dependabot run.

## Are there any user-facing changes?

No.
