### PR TITLE
Add branch-55 protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -104,6 +104,9 @@ github:
     branch-54:
       required_pull_request_reviews:
         required_approving_review_count: 1
+    branch-55:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
   pull_requests:
     # enable updating head branches of pull requests
     allow_update_branch: true


### PR DESCRIPTION
To prepare for the 55 release, add protection to the `branch-55` branch.