### PR TITLE
Minor: avoid a few clones in sum accumulator setup

### DIFF
--- a/datafusion/functions-aggregate-common/src/aggregate/avg_distinct/decimal.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/avg_distinct/decimal.rs
@@ -56,7 +56,7 @@ impl<I: DecimalType + Debug, S: DecimalType + Debug> DecimalDistinctAvgAccumulat
         let data_type = I::TYPE_CONSTRUCTOR(I::MAX_PRECISION, sum_scale);
 
         Self {
-            sum_accumulator: DistinctSumAccumulator::new(&data_type),
+            sum_accumulator: DistinctSumAccumulator::new(data_type),
             sum_scale,
             target_precision,
             target_scale,

--- a/datafusion/functions-aggregate-common/src/aggregate/avg_distinct/numeric.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/avg_distinct/numeric.rs
@@ -36,7 +36,7 @@ impl Default for Float64DistinctAvgAccumulator {
     fn default() -> Self {
         Self {
             sum_accumulator: DistinctSumAccumulator::<Float64Type>::new(
-                &DataType::Float64,
+                DataType::Float64,
             ),
         }
     }

--- a/datafusion/functions-aggregate-common/src/aggregate/sum_distinct/numeric.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/sum_distinct/numeric.rs
@@ -40,10 +40,10 @@ pub struct DistinctSumAccumulator<T: ArrowPrimitiveType> {
 }
 
 impl<T: ArrowPrimitiveType> DistinctSumAccumulator<T> {
-    pub fn new(data_type: &DataType) -> Self {
+    pub fn new(data_type: DataType) -> Self {
         Self {
             values: GenericDistinctBuffer::new(data_type.clone()),
-            data_type: data_type.clone(),
+            data_type,
         }
     }
 

--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -264,14 +264,14 @@ impl AggregateUDFImpl for Sum {
         if args.is_distinct {
             macro_rules! helper {
                 ($t:ty, $dt:expr) => {
-                    Ok(Box::new(DistinctSumAccumulator::<$t>::new(&$dt)))
+                    Ok(Box::new(DistinctSumAccumulator::<$t>::new($dt)))
                 };
             }
             downcast_sum!(args, helper)
         } else {
             macro_rules! helper {
                 ($t:ty, $dt:expr) => {
-                    Ok(Box::new(SumAccumulator::<$t>::new($dt.clone())))
+                    Ok(Box::new(SumAccumulator::<$t>::new($dt)))
                 };
             }
             downcast_sum!(args, helper)


### PR DESCRIPTION
## Which issue does this PR close?

- follow on to https://github.com/apache/datafusion/pull/24035

## Rationale for this change

This is a minor thing I found while doing some performance profiling for https://github.com/apache/datafusion/pull/24035


## What changes are included in this PR?

Avoid a few clone calls

## Are these changes tested?

By CI
## Are there any user-facing changes?

realistically nothing that someone will measure