### PR TITLE
Add focused benchmark for Parquet pruning setup cache

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -44,7 +44,7 @@ arrow = { workspace = true }
 async-trait = "0.1"
 bytes = { workspace = true }
 clap = { version = "4.6.0", features = ["derive", "env", "string"] }
-criterion = { workspace = true, features = ["html_reports"] }
+criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 datafusion = { workspace = true, default-features = true }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-common-runtime = { workspace = true }
@@ -71,3 +71,7 @@ tempfile = { workspace = true }
 [[bench]]
 harness = false
 name = "sql"
+
+[[bench]]
+harness = false
+name = "parquet_pruning_setup_cache"

--- a/benchmarks/benches/parquet_pruning_setup_cache.rs
+++ b/benchmarks/benches/parquet_pruning_setup_cache.rs
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmarks reusable Parquet pruning setup across same-schema files.
+//!
+//! The predicate matches every file so each scan must adapt the predicate and
+//! build (or reuse) the pruning setup for all files.
+
+use std::{fs::File, sync::Arc};
+
+use arrow::{
+    array::Int64Array,
+    datatypes::{DataType, Field, Schema},
+    record_batch::RecordBatch,
+};
+use criterion::{Criterion, criterion_group, criterion_main};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use parquet::arrow::ArrowWriter;
+use tempfile::TempDir;
+
+const FILES: usize = 128;
+const ROWS_PER_FILE: usize = 128;
+
+fn write_files() -> TempDir {
+    let directory = tempfile::tempdir().unwrap();
+    let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+
+    for file_index in 0..FILES {
+        let start = i64::try_from(file_index * ROWS_PER_FILE).unwrap();
+        let values = Int64Array::from_iter_values(
+            start..start + i64::try_from(ROWS_PER_FILE).unwrap(),
+        );
+        let batch =
+            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(values)]).unwrap();
+        let file =
+            File::create(directory.path().join(format!("{file_index}.parquet"))).unwrap();
+        let mut writer = ArrowWriter::try_new(file, Arc::clone(&schema), None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    directory
+}
+
+fn criterion_benchmark(criterion: &mut Criterion) {
+    let directory = write_files();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let context = runtime.block_on(async {
+        let context = SessionContext::new_with_config(
+            SessionConfig::new().with_target_partitions(1),
+        );
+        context
+            .register_parquet("t", directory.path().to_str().unwrap(), Default::default())
+            .await
+            .unwrap();
+        context
+    });
+
+    runtime.block_on(async {
+        let batches = context
+            .sql("SELECT id FROM t WHERE id >= 0")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+            FILES * ROWS_PER_FILE
+        );
+    });
+
+    criterion.bench_function(
+        "parquet_pruning_setup_cache/same_schema_files",
+        |bencher| {
+            bencher.to_async(&runtime).iter(|| async {
+                context
+                    .sql("SELECT id FROM t WHERE id >= 0")
+                    .await
+                    .unwrap()
+                    .collect()
+                    .await
+                    .unwrap()
+            });
+        },
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benchmarks/benches/parquet_pruning_setup_cache.rs
+++ b/benchmarks/benches/parquet_pruning_setup_cache.rs
@@ -15,10 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Benchmarks reusable Parquet pruning setup across same-schema files.
+//! Benchmarks end-to-end Parquet scan cost for a cache-favourable workload.
 //!
-//! The predicate matches every file so each scan must adapt the predicate and
-//! build (or reuse) the pruning setup for all files.
+//! The 128 files share one physical schema and use the same predicate and target
+//! partition count, so pruning setup is reusable in a cache-enabled comparison
+//! branch. The predicate matches every file, so each scan must adapt the
+//! predicate and build (or reuse) pruning setup for all files.
+//!
+//! This is a focused baseline for comparing cache-disabled and cache-enabled
+//! branches. It is not a general DataFusion benchmark and must not be
+//! interpreted as a ClickBench performance result.
 
 use std::{fs::File, sync::Arc};
 


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #21554

## Rationale for this change

`ParquetPruningSetupCache` in #21566 needs a focused benchmark that exercises it under deliberately cache-favourable conditions.

This benchmark provides a workload where many Parquet files share the same physical schema and use the same predicate, target partition count, and query, creating repeated opportunities to reuse pruning setup. It is intended to measure end-to-end scan cost for this specific workload shape, rather than represent general DataFusion performance or predict improvements in broader benchmarks such as ClickBench.

## What changes are included in this PR?

* Adds a Criterion benchmark that creates 128 Parquet files sharing one physical schema and repeatedly executes `SELECT id FROM t WHERE id >= 0`.
* Keeps file generation, runtime creation, table registration, and initial correctness validation outside the timed Criterion loop.
* Validates that the query returns all 16,384 expected rows before benchmarking.
* Enables Criterion's `async_tokio` feature so the asynchronous query execution can be benchmarked with the Tokio runtime.
* Registers the new `parquet_pruning_setup_cache` benchmark target.
* Documents that the benchmark is intentionally cache-favourable and that its results should not be interpreted as general DataFusion or ClickBench performance results.

## Are these changes tested?

The benchmark includes a correctness check that verifies the query returns `128 × 128 = 16,384` rows before the timed benchmark begins.

No additional tests are included in this patch.

## Are there any user-facing changes?

No. This PR adds a focused benchmark and benchmark configuration only; it does not change user-facing DataFusion behavior or public APIs.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed.
