### PR TITLE
docs: fix signum documentation to say zero returns 0

### DIFF
--- a/datafusion/functions/src/math/signum.rs
+++ b/datafusion/functions/src/math/signum.rs
@@ -34,7 +34,8 @@ use datafusion_macros::user_doc;
     doc_section(label = "Math Functions"),
     description = r#"Returns the sign of a number.
 Negative numbers return `-1`.
-Zero and positive numbers return `1`."#,
+Zero returns `0`.
+Positive numbers return `1`."#,
     syntax_example = "signum(numeric_expression)",
     standard_argument(name = "numeric_expression", prefix = "Numeric"),
     sql_example = r#"```sql

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -796,7 +796,8 @@ round(numeric_expression[, decimal_places])
 
 Returns the sign of a number.
 Negative numbers return `-1`.
-Zero and positive numbers return `1`.
+Zero returns `0`.
+Positive numbers return `1`.
 
 ```sql
 signum(numeric_expression)


### PR DESCRIPTION
## Which issue does this PR close?

N/A — documentation-only correction; no open issue tracks it.

## Rationale for this change

The user guide for `signum` says "Zero and positive numbers return `1`", but
`signum(0)` returns `0` — the documented return value for zero is the opposite
of what the function does. The repository's own tests already pin the real
behavior:

- `datafusion/sqllogictest/test_files/scalar.slt`:
  `select signum(-2), signum(0), signum(2);` → `-1 0 1`
- The unit tests in `signum.rs` assert `signum(±0.0) == 0.0`

That behavior is intentional: it matches PostgreSQL `sign()` and Spark
`signum()`, and was changed on purpose in #11580 (issue #11557). Only the docs
were left describing the pre-#11580 behavior, so this PR updates the docs, not
the code.

## What changes are included in this PR?

Documentation only:

- Update the `#[user_doc]` description in `datafusion/functions/src/math/signum.rs`
  to state that zero returns `0`.
- Regenerate `docs/source/user-guide/sql/scalar_functions.md` via
  `dev/update_function_docs.sh`.

## Are these changes tested?

No new tests: the corrected wording describes behavior the existing tests above
already assert, and those are what it was checked against.

- `cargo test -p datafusion-functions --lib math::signum` → 2 passed
- `cargo fmt --all -- --check` and `./ci/scripts/doc_prettier_check.sh` → clean

## Are there any user-facing changes?

Yes, documentation only. No API or runtime behavior change.

---

Prepared with AI assistance; every claim above was verified locally against the
repository's existing tests before opening this PR.
