### PR TITLE
perf(build): use line-tables-only debug info in the `dev` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,8 +296,11 @@ unused_qualifications = "deny"
 # To use a profile: `cargo [ build | run | ... ] --profile <profile-name>`
 #
 # Profiles available:
-# - dev: default debug build; fastest to compile, slowest to run, full debug info.
-#     For everyday development; default for "cargo [ build | test | run ]".
+# - dev: default debug build; fastest to compile, slowest to run. Carries line
+#     tables only, so panics and backtraces still name a file and line but a
+#     debugger cannot inspect variables; build with `CARGO_PROFILE_DEV_DEBUG=2`
+#     when you need that. For everyday development; default for
+#     "cargo [ build | test | run ]".
 # - release: fully optimized build; slowest to compile, fastest to run, smallest
 #     binaries. For public releases; default for "cargo [ bench | install ]".
 # - release-nonlto: skips LTO, so it builds much faster while staying close to
@@ -312,6 +315,15 @@ unused_qualifications = "deny"
 #
 # If you want to optimize compilation, the `compile_profile` benchmark can be useful.
 # See `benchmarks/README.md` for more details.
+# `dev` is the profile every `cargo build`/`cargo test` uses, so its debug info
+# is generated over and over. `line-tables-only` keeps file and line numbers --
+# so panics and `RUST_BACKTRACE` output stay useful -- while dropping the
+# variable-level DWARF that only an interactive debugger consumes. Build with
+# `CARGO_PROFILE_DEV_DEBUG=2 cargo build` when you need to step through code in a
+# debugger.
+[profile.dev]
+debug = "line-tables-only"
+
 [profile.release]
 codegen-units = 1
 lto = true


### PR DESCRIPTION
## Which issue does this PR close?

Adresses: https://github.com/apache/datafusion/issues/13814

Found while profiling compile times for #24325 / #24326 / #24329 / #24330,
which removed the trait-solving cost from the four crates on the critical path
and left LLVM as the dominant remaining cost.

## Rationale for this change

`dev` is the profile behind every `cargo build` and `cargo test`, so its debug
info is generated over and over. `debug = "line-tables-only"` keeps file and line
numbers — panics and `RUST_BACKTRACE` output stay just as useful — and drops the
variable-level DWARF that only an interactive debugger consumes.

Measured per crate, **interleaved** with the baseline so machine drift cancels
out. The flag is passed to the crate under test only, so cached dependency
artifacts stay valid and nothing else moves between the two measurements:

| crate | `debug = 2` | `line-tables-only` | |
|---|---|---|---|
| `datafusion-physical-plan` | 8.89s | 7.43s | −16% |
| `datafusion-functions-aggregate` | 5.86s | 4.63s | −21% |
| `datafusion-physical-expr` | 4.57s | 3.59s | −21% |
| `datafusion-functions` | 4.64s | 4.04s | −13% |
| `datafusion-expr` | 4.54s | 3.57s | −21% |
| `datafusion-functions-nested` | 4.37s | 3.06s | −30% |
| `datafusion-optimizer` | 3.91s | 3.12s | −20% |
| `datafusion-common` | 3.73s | 3.10s | −17% |
| `datafusion-sql` | 3.57s | 2.43s | −32% |
| `datafusion-datasource-parquet` | 3.27s | 2.44s | −25% |
| `datafusion-datasource` | 1.90s | 1.42s | −25% |
| `datafusion-physical-optimizer` | 1.22s | 0.99s | −19% |
| **sum** | **50.5s** | **39.8s** | **−21%** |

The saving is codegen-side, as you would expect: `datafusion-catalog`, which
spends its time in the trait solver rather than in LLVM, moves only 7.4s → 7.0s.

Artifacts shrink as well — `libdatafusion_physical_plan.rlib` goes from **141MB
to 100MB**.

## What changes are included in this PR?

One setting on `[profile.dev]`, plus an update to the profile documentation block
above it, which currently advertises "full debug info" for `dev`.

## Are these changes tested?


## Are there any user-facing changes?

For anyone stepping through DataFusion in a debugger, local variable inspection
needs `CARGO_PROFILE_DEV_DEBUG=2 cargo build` (or a local override in
`.cargo/config.toml`); the comment in `Cargo.toml` says so. Everything else —
panic locations, backtraces, `#[test]` failures — is unchanged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)