### PR TITLE
fix: support RANGE window frames with binary ORDER BY (#24327)

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1069,6 +1069,8 @@ fn extract_window_frame_target_type(col_type: &DataType) -> Result<DataType> {
     if col_type.is_numeric()
         || col_type.is_string()
         || col_type.is_null()
+        || col_type.is_binary()
+        || col_type.is_fixed_size_binary()
         || matches!(
             col_type,
             DataType::List(_)
@@ -1109,10 +1111,31 @@ fn coerce_window_frame(
         }
         WindowFrameUnits::Rows | WindowFrameUnits::Groups => DataType::UInt64,
     };
+    // For RANGE frames on binary types, finite offsets (e.g. RANGE BETWEEN 1
+    // PRECEDING) are not supported because they require arithmetic on the
+    // order key. Free RANGE frames (only UNBOUNDED / CURRENT ROW) are fine.
+    if window_frame.units == WindowFrameUnits::Range
+        && (target_type.is_binary() || target_type.is_fixed_size_binary())
+        && (has_finite_offset(&window_frame.start_bound)
+            || has_finite_offset(&window_frame.end_bound))
+    {
+        return plan_err!(
+            "RANGE frame with finite offset is not supported for binary ORDER BY type: {target_type}"
+        );
+    }
     window_frame.start_bound =
         coerce_frame_bound(&target_type, window_frame.start_bound)?;
     window_frame.end_bound = coerce_frame_bound(&target_type, window_frame.end_bound)?;
     Ok(window_frame)
+}
+
+/// Returns true if the window frame bound is a finite offset (not UNBOUNDED
+/// or CURRENT ROW).
+fn has_finite_offset(bound: &WindowFrameBound) -> bool {
+    match bound {
+        WindowFrameBound::Preceding(v) | WindowFrameBound::Following(v) => !v.is_null(),
+        WindowFrameBound::CurrentRow => false,
+    }
 }
 
 // Support the `IsTrue` `IsNotTrue` `IsFalse` `IsNotFalse` type coercion.


### PR DESCRIPTION
## Which issue does this PR close?

Closes #24327.

## What changes are included in this PR?

Allow RANGE window frames whose ORDER BY column is of type Binary, LargeBinary, BinaryView, or FixedSizeBinary. Free RANGE frames (only UNBOUNDED / CURRENT ROW bounds) are now supported; finite-offset RANGE frames emit a planning error.

## Why are these changes needed?

The default window frame for `OVER (ORDER BY x)` is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`. When `x` is a binary type, this incorrectly produces an internal error "Cannot run range queries on datatype: Binary" during type coercion, even though the frame has no finite offsets and only needs ordering comparisons (which Binary supports).

## What changes were made?

1. **`extract_window_frame_target_type`**: Added `col_type.is_binary()` and `col_type.is_fixed_size_binary()` to the allowed type list, so binary ORDER BY columns are accepted for RANGE window frames.

2. **`coerce_window_frame`**: Added a check that rejects finite-offset RANGE frames on binary types with a planning error, since binary types don't support the arithmetic needed for offset computation.

3. **`has_finite_offset` helper**: A new function that checks whether a window frame bound is a finite offset (not UNBOUNDED or CURRENT ROW).

## Are there any user-facing changes?

- Queries like `SELECT x, COUNT(*) OVER (ORDER BY x) FROM t` where `x` is Binary now succeed (was: internal error).
- Queries like `RANGE BETWEEN 1 PRECEDING AND CURRENT ROW` on a binary column now produce a clear planning error instead of an internal error.
- Explicit `ROWS` frame (e.g., `ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`) already worked and continues to work.