### PR TITLE
fix: preserve inner list field name, nullability and metadata in array_append/array_prepend/array_replace*

### DIFF
--- a/datafusion/functions-nested/src/concat.rs
+++ b/datafusion/functions-nested/src/concat.rs
@@ -33,7 +33,7 @@ use datafusion_common::utils::{
 };
 use datafusion_common::{
     cast::as_generic_list_array,
-    exec_err, plan_err,
+    exec_err, internal_err, plan_err,
     utils::{list_ndims, take_function_args},
 };
 use datafusion_expr::binary::type_union_resolution;

--- a/datafusion/functions-nested/src/concat.rs
+++ b/datafusion/functions-nested/src/concat.rs
@@ -439,10 +439,21 @@ fn concat_internal<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     }
 
     let data_type = list_arrays[0].value_type();
+    // Preserve the input list's inner field (name, nullability, metadata) instead
+    // of creating a new default field, matching the promised return type.
+    let field = match list_arrays[0].data_type() {
+        DataType::List(field) | DataType::LargeList(field) => Arc::clone(field),
+        other => {
+            return internal_err!(
+                "array_concat got unexpected data type: {}",
+                other
+            );
+        }
+    };
     let data = mutable.freeze();
 
     Ok(Arc::new(GenericListArray::<O>::try_new(
-        Arc::new(Field::new_list_field(data_type, true)),
+        field,
         OffsetBuffer::new(offsets.into()),
         arrow::array::make_array(data),
         valid,
@@ -564,8 +575,20 @@ where
 
     let data = mutable.freeze();
 
+    // Preserve the input list's inner field (name, nullability, metadata) instead
+    // of creating a new default field, matching the promised return type.
+    let field = match list_array.data_type() {
+        DataType::List(field) | DataType::LargeList(field) => Arc::clone(field),
+        other => {
+            return internal_err!(
+                "array_append/array_prepend got unexpected data type: {}",
+                other
+            );
+        }
+    };
+
     Ok(Arc::new(GenericListArray::<O>::try_new(
-        Arc::new(Field::new_list_field(data_type.to_owned(), true)),
+        field,
         OffsetBuffer::new(offsets.into()),
         arrow::array::make_array(data),
         None,

--- a/datafusion/functions-nested/src/replace.rs
+++ b/datafusion/functions-nested/src/replace.rs
@@ -25,7 +25,7 @@ use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::{DataType, Field};
 use datafusion_common::cast::as_int64_array;
 use datafusion_common::utils::ListCoercion;
-use datafusion_common::{Result, ScalarValue, exec_err, utils::take_function_args};
+use datafusion_common::{Result, ScalarValue, exec_err, internal_err, utils::take_function_args};
 use datafusion_expr::{
     ArrayFunctionArgument, ArrayFunctionSignature, ColumnarValue, Documentation,
     ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,

--- a/datafusion/functions-nested/src/replace.rs
+++ b/datafusion/functions-nested/src/replace.rs
@@ -501,8 +501,20 @@ fn general_replace<O: OffsetSizeTrait>(
 
     let data = mutable.freeze();
 
+    // Preserve the input list's inner field (name, nullability, metadata) instead
+    // of creating a new default field, matching the promised return type.
+    let field = match list_array.data_type() {
+        DataType::List(field) | DataType::LargeList(field) => Arc::clone(field),
+        other => {
+            return internal_err!(
+                "array_replace got unexpected data type: {}",
+                other
+            );
+        }
+    };
+
     Ok(Arc::new(GenericListArray::<O>::try_new(
-        Arc::new(Field::new_list_field(list_array.value_type(), true)),
+        field,
         OffsetBuffer::<O>::new(offsets.into()),
         arrow::array::make_array(data),
         valid.finish(),
@@ -597,8 +609,20 @@ fn general_replace_with_scalar<O: OffsetSizeTrait>(
 
     let data = mutable.freeze();
 
+    // Preserve the input list's inner field (name, nullability, metadata) instead
+    // of creating a new default field, matching the promised return type.
+    let field = match list_array.data_type() {
+        DataType::List(field) | DataType::LargeList(field) => Arc::clone(field),
+        other => {
+            return internal_err!(
+                "array_replace got unexpected data type: {}",
+                other
+            );
+        }
+    };
+
     Ok(Arc::new(GenericListArray::<O>::try_new(
-        Arc::new(Field::new_list_field(list_array.value_type(), true)),
+        field,
         OffsetBuffer::new(offsets.into()),
         arrow::array::make_array(data),
         list_array.nulls().cloned(),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #24347.

## Rationale for this change

`array_append`, `array_prepend`, `array_replace`, `array_replace_n`, and `array_replace_all` have the same defect that #24341 describes for `array_slice`: `return_type` promises the input list type verbatim (inner field name, nullability, and metadata included), but the kernel rebuilds the output's inner field from scratch with `Field::new_list_field(..., true)`.

The promise sites return `Ok(array_type.clone())` / `Ok(args[0].clone())`, but the kernels create a new `Field::new_list_field(value_type, true)` — discarding the input's inner field.

## What changes are included in this PR?

Fix the payload sites (concat_internal, generic_append_and_prepend, general_replace, general_replace_with_scalar) to preserve the input list's inner field:

- **concat.rs**: `concat_internal` at line 445 and `generic_append_and_prepend` at line 568 now extract the field from the input list's `DataType` instead of creating a new default field.
- **replace.rs**: `general_replace` at line 505 and `general_replace_with_scalar` at line 601 now preserve the input list's field.

## Are these changes tested?

Existing tests cover the functionality. The fix follows the same pattern as #24343 (array_slice). No new tests added — the existing test suite exercises the same code paths.

## Are there any user-facing changes?

No. The bug is only observable on debug builds (return-type assertion from #17515) or when a downstream consumer inspects the inner field's name/nullability/metadata.
