### PR TITLE
Account for transformer-retained batches in symmetric hash join

### DIFF
--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -528,140 +528,143 @@ mod record_batch_tests {
     }
 
     #[test]
-    fn test_record_batch_memory_counter_deduplicates_recursive_shared_children() {
+    fn test_record_batch_memory_counter_deduplicates_shared_list_child() {
         let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let shared_map_key: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
         let list_field = Arc::new(Field::new_list_field(DataType::Int32, false));
-        let map_fields = Fields::from(vec![
+
+        let first = Arc::new(ListArray::new(
+            Arc::clone(&list_field),
+            OffsetBuffer::new(vec![0, 3].into()),
+            Arc::clone(&shared_child),
+            None,
+        ));
+        let second = Arc::new(ListArray::new(
+            list_field,
+            OffsetBuffer::new(vec![0, 3].into()),
+            Arc::clone(&shared_child),
+            None,
+        ));
+
+        assert_recursive_shared_child_memory(
+            "list",
+            first,
+            second,
+            shared_child.get_array_memory_size(),
+        );
+    }
+
+    fn map_with_shared_children(
+        fields: &Fields,
+        shared_key: &ArrayRef,
+        shared_value: &ArrayRef,
+    ) -> ArrayRef {
+        Arc::new(
+            MapArray::try_new(
+                Arc::new(Field::new(
+                    "entries",
+                    DataType::Struct(fields.clone()),
+                    false,
+                )),
+                OffsetBuffer::new(vec![0, 3].into()),
+                StructArray::new(
+                    fields.clone(),
+                    vec![Arc::clone(shared_key), Arc::clone(shared_value)],
+                    None,
+                ),
+                None,
+                false,
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_deduplicates_shared_map_children() {
+        let shared_key: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
+        let shared_value: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let fields = Fields::from(vec![
             Arc::new(Field::new("key", DataType::Int32, false)),
             Arc::new(Field::new("value", DataType::Int32, false)),
         ]);
-        let union_fields: UnionFields =
+
+        let first = map_with_shared_children(&fields, &shared_key, &shared_value);
+        let second = map_with_shared_children(&fields, &shared_key, &shared_value);
+
+        assert_recursive_shared_child_memory(
+            "map",
+            first,
+            second,
+            shared_key.get_array_memory_size() + shared_value.get_array_memory_size(),
+        );
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_deduplicates_shared_union_child() {
+        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let fields: UnionFields =
             [(0, Arc::new(Field::new("value", DataType::Int32, false)))]
                 .into_iter()
                 .collect();
-
-        let arrays = vec![
-            (
-                "list",
-                Arc::new(ListArray::new(
-                    Arc::clone(&list_field),
-                    OffsetBuffer::new(vec![0, 3].into()),
-                    Arc::clone(&shared_child),
+        let make_union = || {
+            Arc::new(
+                UnionArray::try_new(
+                    fields.clone(),
+                    vec![0, 0, 0].into(),
                     None,
-                )) as ArrayRef,
-                Arc::new(ListArray::new(
-                    list_field,
-                    OffsetBuffer::new(vec![0, 3].into()),
-                    Arc::clone(&shared_child),
-                    None,
-                )) as ArrayRef,
-                shared_child.get_array_memory_size(),
-            ),
-            (
-                "map",
-                Arc::new(
-                    MapArray::try_new(
-                        Arc::new(Field::new(
-                            "entries",
-                            DataType::Struct(map_fields.clone()),
-                            false,
-                        )),
-                        OffsetBuffer::new(vec![0, 3].into()),
-                        StructArray::new(
-                            map_fields.clone(),
-                            vec![Arc::clone(&shared_map_key), Arc::clone(&shared_child)],
-                            None,
-                        ),
-                        None,
-                        false,
-                    )
-                    .unwrap(),
-                ) as ArrayRef,
-                Arc::new(
-                    MapArray::try_new(
-                        Arc::new(Field::new(
-                            "entries",
-                            DataType::Struct(map_fields.clone()),
-                            false,
-                        )),
-                        OffsetBuffer::new(vec![0, 3].into()),
-                        StructArray::new(
-                            map_fields,
-                            vec![Arc::clone(&shared_map_key), Arc::clone(&shared_child)],
-                            None,
-                        ),
-                        None,
-                        false,
-                    )
-                    .unwrap(),
-                ) as ArrayRef,
-                shared_map_key.get_array_memory_size()
-                    + shared_child.get_array_memory_size(),
-            ),
-            (
-                "union",
-                Arc::new(
-                    UnionArray::try_new(
-                        union_fields.clone(),
-                        vec![0, 0, 0].into(),
-                        None,
-                        vec![Arc::clone(&shared_child)],
-                    )
-                    .unwrap(),
-                ) as ArrayRef,
-                Arc::new(
-                    UnionArray::try_new(
-                        union_fields,
-                        vec![0, 0, 0].into(),
-                        None,
-                        vec![Arc::clone(&shared_child)],
-                    )
-                    .unwrap(),
-                ) as ArrayRef,
-                shared_child.get_buffer_memory_size(),
-            ),
-            (
-                "dictionary",
-                Arc::new(
-                    DictionaryArray::<Int32Type>::try_new(
-                        Int32Array::from(vec![0, 1, 2]),
-                        Arc::clone(&shared_child),
-                    )
-                    .unwrap(),
-                ) as ArrayRef,
-                Arc::new(
-                    DictionaryArray::<Int32Type>::try_new(
-                        Int32Array::from(vec![0, 1, 2]),
-                        Arc::clone(&shared_child),
-                    )
-                    .unwrap(),
-                ) as ArrayRef,
-                shared_child.get_array_memory_size(),
-            ),
-            (
-                "run_end_encoded",
-                Arc::new(
-                    RunArray::<Int32Type>::try_new(
-                        &Int32Array::from(vec![1, 2, 3]),
-                        shared_child.as_ref(),
-                    )
-                    .unwrap(),
-                ) as ArrayRef,
-                Arc::new(
-                    RunArray::<Int32Type>::try_new(
-                        &Int32Array::from(vec![1, 2, 3]),
-                        shared_child.as_ref(),
-                    )
-                    .unwrap(),
-                ) as ArrayRef,
-                shared_child.get_buffer_memory_size(),
-            ),
-        ];
+                    vec![Arc::clone(&shared_child)],
+                )
+                .unwrap(),
+            ) as ArrayRef
+        };
 
-        for (name, first, second, shared_memory) in arrays {
-            assert_recursive_shared_child_memory(name, first, second, shared_memory);
-        }
+        assert_recursive_shared_child_memory(
+            "union",
+            make_union(),
+            make_union(),
+            shared_child.get_buffer_memory_size(),
+        );
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_deduplicates_shared_dictionary_child() {
+        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let make_dictionary = || {
+            Arc::new(
+                DictionaryArray::<Int32Type>::try_new(
+                    Int32Array::from(vec![0, 1, 2]),
+                    Arc::clone(&shared_child),
+                )
+                .unwrap(),
+            ) as ArrayRef
+        };
+
+        assert_recursive_shared_child_memory(
+            "dictionary",
+            make_dictionary(),
+            make_dictionary(),
+            shared_child.get_array_memory_size(),
+        );
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_deduplicates_shared_run_end_encoded_child() {
+        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let make_run_array = || {
+            Arc::new(
+                RunArray::<Int32Type>::try_new(
+                    &Int32Array::from(vec![1, 2, 3]),
+                    shared_child.as_ref(),
+                )
+                .unwrap(),
+            ) as ArrayRef
+        };
+
+        assert_recursive_shared_child_memory(
+            "run_end_encoded",
+            make_run_array(),
+            make_run_array(),
+            shared_child.get_buffer_memory_size(),
+        );
     }
 
     #[test]

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -19,7 +19,12 @@
 
 use crate::error::_exec_datafusion_err;
 use crate::{HashSet, Result};
-use arrow::array::{Array, ArrayData};
+use arrow::array::types::{
+    Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type, UInt16Type, UInt32Type,
+    UInt64Type,
+};
+use arrow::array::{Array, ArrayData, ArrayRef, AsArray, RunArray};
+use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use std::mem::size_of;
 use std::num::NonZero;
@@ -192,11 +197,8 @@ impl RecordBatchMemoryCounter {
         let mut array_overhead = 0;
 
         for array in batch.columns() {
-            let array_ptr = Arc::as_ptr(array) as *const () as usize;
-            if self.counted_arrays.insert(array_ptr) {
-                array_overhead +=
-                    array.get_array_memory_size() - array.get_buffer_memory_size();
-            }
+            array_overhead +=
+                count_unique_array_object_memory_size(array, &mut self.counted_arrays);
         }
 
         total_size += array_overhead;
@@ -207,6 +209,90 @@ impl RecordBatchMemoryCounter {
     /// Total memory of all counted allocations.
     pub fn memory_usage(&self) -> usize {
         self.memory_usage
+    }
+}
+
+/// Counts the unique Array object memory retained by `array` and its children.
+fn count_unique_array_object_memory_size(
+    array: &ArrayRef,
+    counted_arrays: &mut HashSet<usize>,
+) -> usize {
+    let array_ptr = Arc::as_ptr(array) as *const () as usize;
+    if !counted_arrays.insert(array_ptr) {
+        return 0;
+    }
+
+    let children = array_children(array);
+    let children_overhead: usize = children
+        .iter()
+        .map(|child| child.get_array_memory_size() - child.get_buffer_memory_size())
+        .sum();
+    let own_overhead = array.get_array_memory_size()
+        - array.get_buffer_memory_size()
+        - children_overhead;
+
+    own_overhead
+        + children
+            .into_iter()
+            .map(|child| count_unique_array_object_memory_size(child, counted_arrays))
+            .sum::<usize>()
+}
+
+/// Returns the `ArrayRef` children whose object allocations may be shared.
+fn array_children(array: &ArrayRef) -> Vec<&ArrayRef> {
+    match array.data_type() {
+        DataType::Struct(_) => array.as_struct().columns().iter().collect(),
+        DataType::List(_) => vec![array.as_list::<i32>().values()],
+        DataType::LargeList(_) => vec![array.as_list::<i64>().values()],
+        DataType::ListView(_) => vec![array.as_list_view::<i32>().values()],
+        DataType::LargeListView(_) => vec![array.as_list_view::<i64>().values()],
+        DataType::FixedSizeList(_, _) => vec![array.as_fixed_size_list().values()],
+        DataType::Map(_, _) => {
+            let map = array.as_map();
+            vec![map.keys(), map.values()]
+        }
+        DataType::Union(_, _) => array
+            .as_union()
+            .fields()
+            .iter()
+            .map(|(type_id, _)| array.as_union().child(type_id))
+            .collect(),
+        DataType::Dictionary(key_type, _) => match key_type.as_ref() {
+            DataType::Int8 => vec![array.as_dictionary::<Int8Type>().values()],
+            DataType::Int16 => vec![array.as_dictionary::<Int16Type>().values()],
+            DataType::Int32 => vec![array.as_dictionary::<Int32Type>().values()],
+            DataType::Int64 => vec![array.as_dictionary::<Int64Type>().values()],
+            DataType::UInt8 => vec![array.as_dictionary::<UInt8Type>().values()],
+            DataType::UInt16 => vec![array.as_dictionary::<UInt16Type>().values()],
+            DataType::UInt32 => vec![array.as_dictionary::<UInt32Type>().values()],
+            DataType::UInt64 => vec![array.as_dictionary::<UInt64Type>().values()],
+            _ => unreachable!("invalid dictionary key type: {key_type}"),
+        },
+        DataType::RunEndEncoded(run_ends, _) => match run_ends.data_type() {
+            DataType::Int16 => vec![
+                array
+                    .as_any()
+                    .downcast_ref::<RunArray<Int16Type>>()
+                    .expect("run-end array data type must match its run-end field")
+                    .values(),
+            ],
+            DataType::Int32 => vec![
+                array
+                    .as_any()
+                    .downcast_ref::<RunArray<Int32Type>>()
+                    .expect("run-end array data type must match its run-end field")
+                    .values(),
+            ],
+            DataType::Int64 => vec![
+                array
+                    .as_any()
+                    .downcast_ref::<RunArray<Int64Type>>()
+                    .expect("run-end array data type must match its run-end field")
+                    .values(),
+            ],
+            _ => unreachable!("invalid run-end type: {run_ends}"),
+        },
+        _ => vec![],
     }
 }
 
@@ -272,8 +358,8 @@ mod tests {
 #[cfg(test)]
 mod record_batch_tests {
     use super::*;
-    use arrow::array::{Float64Array, Int32Array, ListArray};
-    use arrow::datatypes::{DataType, Field, Int32Type, Schema};
+    use arrow::array::{ArrayRef, Float64Array, Int32Array, ListArray, StructArray};
+    use arrow::datatypes::{DataType, Field, Fields, Int32Type, Schema};
     use std::sync::Arc;
 
     #[test]
@@ -383,6 +469,34 @@ mod record_batch_tests {
         );
         assert_eq!(counter.count_batch_with_array_overhead(&batch), 0);
         assert_eq!(counter.memory_usage(), batch.get_array_memory_size());
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_deduplicates_shared_nested_array_overhead() {
+        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let fields =
+            Fields::from(vec![Arc::new(Field::new("value", DataType::Int32, false))]);
+        let first = Arc::new(StructArray::new(
+            fields.clone(),
+            vec![Arc::clone(&shared_child)],
+            None,
+        )) as _;
+        let second = Arc::new(StructArray::new(
+            fields,
+            vec![Arc::clone(&shared_child)],
+            None,
+        )) as _;
+        let batch =
+            RecordBatch::try_from_iter(vec![("first", first), ("second", second)])
+                .unwrap();
+
+        let mut counter = RecordBatchMemoryCounter::new();
+        counter.count_batch_with_array_overhead(&batch);
+
+        assert_eq!(
+            counter.memory_usage(),
+            batch.get_array_memory_size() - shared_child.get_array_memory_size()
+        );
     }
 
     #[test]

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -503,6 +503,30 @@ mod record_batch_tests {
         );
     }
 
+    fn assert_recursive_shared_child_memory(
+        name: &str,
+        first: ArrayRef,
+        second: ArrayRef,
+        shared_memory: usize,
+    ) {
+        let first_memory = first.get_array_memory_size();
+        let second_memory = second.get_array_memory_size();
+        let first_batch = RecordBatch::try_from_iter(vec![(name, first)]).unwrap();
+        let second_batch = RecordBatch::try_from_iter(vec![(name, second)]).unwrap();
+        let mut counter = RecordBatchMemoryCounter::new();
+
+        assert_eq!(
+            counter.count_batch_with_array_overhead(&first_batch),
+            first_memory,
+            "{name}: first batch"
+        );
+        assert_eq!(
+            counter.count_batch_with_array_overhead(&second_batch),
+            second_memory - shared_memory,
+            "{name}: shared child"
+        );
+    }
+
     #[test]
     fn test_record_batch_memory_counter_deduplicates_recursive_shared_children() {
         let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
@@ -636,22 +660,7 @@ mod record_batch_tests {
         ];
 
         for (name, first, second, shared_memory) in arrays {
-            let first_batch =
-                RecordBatch::try_from_iter(vec![(name, first.clone())]).unwrap();
-            let second_batch =
-                RecordBatch::try_from_iter(vec![(name, second.clone())]).unwrap();
-            let mut counter = RecordBatchMemoryCounter::new();
-
-            assert_eq!(
-                counter.count_batch_with_array_overhead(&first_batch),
-                first.get_array_memory_size(),
-                "{name}: first batch"
-            );
-            assert_eq!(
-                counter.count_batch_with_array_overhead(&second_batch),
-                second.get_array_memory_size() - shared_memory,
-                "{name}: shared child"
-            );
+            assert_recursive_shared_child_memory(name, first, second, shared_memory);
         }
     }
 

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -816,8 +816,7 @@ mod record_batch_tests {
     fn test_record_batch_memory_counter_deduplicates_union_slice_child_overhead() {
         let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
         let fields: UnionFields =
-            [(0, Arc::new(Field::new("value", DataType::Int32, false)))]
-                .into_iter()
+            std::iter::once((0, Arc::new(Field::new("value", DataType::Int32, false))))
                 .collect();
         let first = Arc::new(
             UnionArray::try_new(

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -412,14 +412,6 @@ fn array_children(array: &ArrayRef) -> Vec<&ArrayRef> {
             let map = array.as_map();
             vec![map.keys(), map.values()]
         }
-        DataType::Union(_, _) => {
-            let union = array.as_union();
-            union
-                .fields()
-                .iter()
-                .map(|(type_id, _)| union.child(type_id))
-                .collect()
-        }
         DataType::Dictionary(key_type, _) => match key_type.as_ref() {
             DataType::Int8 => vec![array.as_dictionary::<Int8Type>().values()],
             DataType::Int16 => vec![array.as_dictionary::<Int16Type>().values()],
@@ -430,30 +422,6 @@ fn array_children(array: &ArrayRef) -> Vec<&ArrayRef> {
             DataType::UInt32 => vec![array.as_dictionary::<UInt32Type>().values()],
             DataType::UInt64 => vec![array.as_dictionary::<UInt64Type>().values()],
             _ => unreachable!("invalid dictionary key type: {key_type}"),
-        },
-        DataType::RunEndEncoded(run_ends, _) => match run_ends.data_type() {
-            DataType::Int16 => vec![
-                array
-                    .as_any()
-                    .downcast_ref::<RunArray<Int16Type>>()
-                    .expect("run-end array data type must match its run-end field")
-                    .values(),
-            ],
-            DataType::Int32 => vec![
-                array
-                    .as_any()
-                    .downcast_ref::<RunArray<Int32Type>>()
-                    .expect("run-end array data type must match its run-end field")
-                    .values(),
-            ],
-            DataType::Int64 => vec![
-                array
-                    .as_any()
-                    .downcast_ref::<RunArray<Int64Type>>()
-                    .expect("run-end array data type must match its run-end field")
-                    .values(),
-            ],
-            _ => unreachable!("invalid run-end type: {run_ends}"),
         },
         _ => vec![],
     }
@@ -542,7 +510,7 @@ mod record_batch_tests {
     use arrow::array::{
         ArrayData, ArrayRef, BinaryViewArray, DictionaryArray, Float64Array, Int16Array,
         Int32Array, Int64Array, LargeListViewArray, ListArray, ListViewArray, MapArray,
-        RunArray, StringArray, StringViewArray, StructArray, UnionArray, new_null_array,
+        RunArray, StringArray, StringViewArray, StructArray, new_null_array,
     };
     use arrow::buffer::OffsetBuffer;
     use arrow::datatypes::{
@@ -817,33 +785,6 @@ mod record_batch_tests {
     }
 
     #[test]
-    fn test_record_batch_memory_counter_deduplicates_shared_union_child() {
-        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let fields: UnionFields =
-            [(0, Arc::new(Field::new("value", DataType::Int32, false)))]
-                .into_iter()
-                .collect();
-        let make_union = || {
-            Arc::new(
-                UnionArray::try_new(
-                    fields.clone(),
-                    vec![0, 0, 0].into(),
-                    None,
-                    vec![Arc::clone(&shared_child)],
-                )
-                .unwrap(),
-            ) as ArrayRef
-        };
-
-        assert_recursive_shared_child_memory(
-            "union",
-            make_union(),
-            make_union(),
-            shared_child.get_buffer_memory_size(),
-        );
-    }
-
-    #[test]
     fn test_record_batch_memory_counter_deduplicates_shared_dictionary_child() {
         let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
         let make_dictionary = || {
@@ -861,27 +802,6 @@ mod record_batch_tests {
             make_dictionary(),
             make_dictionary(),
             shared_child.get_array_memory_size(),
-        );
-    }
-
-    #[test]
-    fn test_record_batch_memory_counter_deduplicates_shared_run_end_encoded_child() {
-        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let make_run_array = || {
-            Arc::new(
-                RunArray::<Int32Type>::try_new(
-                    &Int32Array::from(vec![1, 2, 3]),
-                    shared_child.as_ref(),
-                )
-                .unwrap(),
-            ) as ArrayRef
-        };
-
-        assert_recursive_shared_child_memory(
-            "run_end_encoded",
-            make_run_array(),
-            make_run_array(),
-            shared_child.get_buffer_memory_size(),
         );
     }
 

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -195,8 +195,10 @@ impl RecordBatchMemoryCounter {
     /// Counts unique buffers and Array objects retained by `batch`.
     ///
     /// This is useful for accounting a sequence of batches at an operator
-    /// boundary. It counts buffers and recursively reachable Arrow array objects
-    /// once, including objects shared by multiple batches.
+    /// boundary. It counts buffers once, including buffers shared by multiple
+    /// batches. Array-object overhead is deduplicated recursively when a shared
+    /// child has the same `ArrayRef` identity; Arrow constructors that rebuild
+    /// child array objects may conservatively count their object overhead again.
     pub fn count_batch_with_array_overhead(&mut self, batch: &RecordBatch) -> usize {
         let mut total_size = self.count_batch(batch);
         let mut array_overhead = 0;
@@ -412,6 +414,14 @@ fn array_children(array: &ArrayRef) -> Vec<&ArrayRef> {
             let map = array.as_map();
             vec![map.keys(), map.values()]
         }
+        DataType::Union(_, _) => {
+            let union = array.as_union();
+            union
+                .fields()
+                .iter()
+                .map(|(type_id, _)| union.child(type_id))
+                .collect()
+        }
         DataType::Dictionary(key_type, _) => match key_type.as_ref() {
             DataType::Int8 => vec![array.as_dictionary::<Int8Type>().values()],
             DataType::Int16 => vec![array.as_dictionary::<Int16Type>().values()],
@@ -422,6 +432,24 @@ fn array_children(array: &ArrayRef) -> Vec<&ArrayRef> {
             DataType::UInt32 => vec![array.as_dictionary::<UInt32Type>().values()],
             DataType::UInt64 => vec![array.as_dictionary::<UInt64Type>().values()],
             _ => unreachable!("invalid dictionary key type: {key_type}"),
+        },
+        DataType::RunEndEncoded(run_ends, _) => match run_ends.data_type() {
+            DataType::Int16 => array
+                .as_any()
+                .downcast_ref::<RunArray<Int16Type>>()
+                .map(|array| vec![array.values()])
+                .unwrap_or_default(),
+            DataType::Int32 => array
+                .as_any()
+                .downcast_ref::<RunArray<Int32Type>>()
+                .map(|array| vec![array.values()])
+                .unwrap_or_default(),
+            DataType::Int64 => array
+                .as_any()
+                .downcast_ref::<RunArray<Int64Type>>()
+                .map(|array| vec![array.values()])
+                .unwrap_or_default(),
+            _ => vec![],
         },
         _ => vec![],
     }
@@ -510,7 +538,7 @@ mod record_batch_tests {
     use arrow::array::{
         ArrayData, ArrayRef, BinaryViewArray, DictionaryArray, Float64Array, Int16Array,
         Int32Array, Int64Array, LargeListViewArray, ListArray, ListViewArray, MapArray,
-        RunArray, StringArray, StringViewArray, StructArray, new_null_array,
+        RunArray, StringArray, StringViewArray, StructArray, UnionArray, new_null_array,
     };
     use arrow::buffer::OffsetBuffer;
     use arrow::datatypes::{
@@ -781,6 +809,82 @@ mod record_batch_tests {
             first,
             second,
             shared_key.get_array_memory_size() + shared_value.get_array_memory_size(),
+        );
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_deduplicates_union_slice_child_overhead() {
+        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let fields: UnionFields =
+            [(0, Arc::new(Field::new("value", DataType::Int32, false)))]
+                .into_iter()
+                .collect();
+        let first = Arc::new(
+            UnionArray::try_new(
+                fields,
+                vec![0, 0, 0].into(),
+                Some(vec![0, 1, 2].into()),
+                vec![Arc::clone(&shared_child)],
+            )
+            .unwrap(),
+        ) as ArrayRef;
+        let second = Arc::new(first.as_union().slice(0, first.len())) as ArrayRef;
+        let first_batch =
+            RecordBatch::try_from_iter(vec![("union", Arc::clone(&first))]).unwrap();
+        let second_batch =
+            RecordBatch::try_from_iter(vec![("union", Arc::clone(&second))]).unwrap();
+        let child_overhead =
+            shared_child.get_array_memory_size() - shared_child.get_buffer_memory_size();
+        let second_parent_overhead = second.get_array_memory_size()
+            - second.get_buffer_memory_size()
+            - child_overhead;
+        let mut counter = RecordBatchMemoryCounter::new();
+
+        assert_eq!(
+            counter.count_batch_with_array_overhead(&first_batch),
+            first.get_array_memory_size()
+        );
+        assert_eq!(
+            counter.count_batch_with_array_overhead(&second_batch),
+            second_parent_overhead
+        );
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_deduplicates_run_end_slice_child_overhead() {
+        let values: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let first = Arc::new(
+            RunArray::<Int32Type>::try_new(
+                &Int32Array::from(vec![1, 2, 3]),
+                values.as_ref(),
+            )
+            .unwrap(),
+        ) as ArrayRef;
+        let second = Arc::new(
+            first
+                .as_any()
+                .downcast_ref::<RunArray<Int32Type>>()
+                .unwrap()
+                .slice(0, first.len()),
+        ) as ArrayRef;
+        let first_batch =
+            RecordBatch::try_from_iter(vec![("run", Arc::clone(&first))]).unwrap();
+        let second_batch =
+            RecordBatch::try_from_iter(vec![("run", Arc::clone(&second))]).unwrap();
+        let child_overhead =
+            values.get_array_memory_size() - values.get_buffer_memory_size();
+        let second_parent_overhead = second.get_array_memory_size()
+            - second.get_buffer_memory_size()
+            - child_overhead;
+        let mut counter = RecordBatchMemoryCounter::new();
+
+        assert_eq!(
+            counter.count_batch_with_array_overhead(&first_batch),
+            first.get_array_memory_size()
+        );
+        assert_eq!(
+            counter.count_batch_with_array_overhead(&second_batch),
+            second_parent_overhead
         );
     }
 

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -251,12 +251,14 @@ fn array_children(array: &ArrayRef) -> Vec<&ArrayRef> {
             let map = array.as_map();
             vec![map.keys(), map.values()]
         }
-        DataType::Union(_, _) => array
-            .as_union()
-            .fields()
-            .iter()
-            .map(|(type_id, _)| array.as_union().child(type_id))
-            .collect(),
+        DataType::Union(_, _) => {
+            let union = array.as_union();
+            union
+                .fields()
+                .iter()
+                .map(|(type_id, _)| union.child(type_id))
+                .collect()
+        }
         DataType::Dictionary(key_type, _) => match key_type.as_ref() {
             DataType::Int8 => vec![array.as_dictionary::<Int8Type>().values()],
             DataType::Int16 => vec![array.as_dictionary::<Int16Type>().values()],

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -190,8 +190,8 @@ impl RecordBatchMemoryCounter {
     /// Counts unique buffers and Array objects retained by `batch`.
     ///
     /// This is useful for accounting a sequence of batches at an operator
-    /// boundary. It counts buffers once, and also avoids double-counting a
-    /// top-level Arrow array shared by multiple batches.
+    /// boundary. It counts buffers and recursively reachable Arrow array objects
+    /// once, including objects shared by multiple batches.
     pub fn count_batch_with_array_overhead(&mut self, batch: &RecordBatch) -> usize {
         let mut total_size = self.count_batch(batch);
         let mut array_overhead = 0;

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -828,7 +828,7 @@ mod record_batch_tests {
             )
             .unwrap(),
         ) as ArrayRef;
-        let second = Arc::new(first.as_union().slice(0, first.len())) as ArrayRef;
+        let second = Arc::new(first.as_union().slice(1, 2)) as ArrayRef;
         let first_batch =
             RecordBatch::try_from_iter(vec![("union", Arc::clone(&first))]).unwrap();
         let second_batch =
@@ -865,7 +865,7 @@ mod record_batch_tests {
                 .as_any()
                 .downcast_ref::<RunArray<Int32Type>>()
                 .unwrap()
-                .slice(0, first.len()),
+                .slice(1, 2),
         ) as ArrayRef;
         let first_batch =
             RecordBatch::try_from_iter(vec![("run", Arc::clone(&first))]).unwrap();

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -358,8 +358,12 @@ mod tests {
 #[cfg(test)]
 mod record_batch_tests {
     use super::*;
-    use arrow::array::{ArrayRef, Float64Array, Int32Array, ListArray, StructArray};
-    use arrow::datatypes::{DataType, Field, Fields, Int32Type, Schema};
+    use arrow::array::{
+        ArrayRef, DictionaryArray, Float64Array, Int32Array, ListArray, MapArray,
+        RunArray, StructArray, UnionArray,
+    };
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, Field, Fields, Int32Type, Schema, UnionFields};
     use std::sync::Arc;
 
     #[test]
@@ -497,6 +501,158 @@ mod record_batch_tests {
             counter.memory_usage(),
             batch.get_array_memory_size() - shared_child.get_array_memory_size()
         );
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_deduplicates_recursive_shared_children() {
+        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let shared_map_key: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
+        let list_field = Arc::new(Field::new_list_field(DataType::Int32, false));
+        let map_fields = Fields::from(vec![
+            Arc::new(Field::new("key", DataType::Int32, false)),
+            Arc::new(Field::new("value", DataType::Int32, false)),
+        ]);
+        let union_fields: UnionFields =
+            [(0, Arc::new(Field::new("value", DataType::Int32, false)))]
+                .into_iter()
+                .collect();
+
+        let arrays = vec![
+            (
+                "list",
+                Arc::new(ListArray::new(
+                    Arc::clone(&list_field),
+                    OffsetBuffer::new(vec![0, 3].into()),
+                    Arc::clone(&shared_child),
+                    None,
+                )) as ArrayRef,
+                Arc::new(ListArray::new(
+                    list_field,
+                    OffsetBuffer::new(vec![0, 3].into()),
+                    Arc::clone(&shared_child),
+                    None,
+                )) as ArrayRef,
+                shared_child.get_array_memory_size(),
+            ),
+            (
+                "map",
+                Arc::new(
+                    MapArray::try_new(
+                        Arc::new(Field::new(
+                            "entries",
+                            DataType::Struct(map_fields.clone()),
+                            false,
+                        )),
+                        OffsetBuffer::new(vec![0, 3].into()),
+                        StructArray::new(
+                            map_fields.clone(),
+                            vec![Arc::clone(&shared_map_key), Arc::clone(&shared_child)],
+                            None,
+                        ),
+                        None,
+                        false,
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+                Arc::new(
+                    MapArray::try_new(
+                        Arc::new(Field::new(
+                            "entries",
+                            DataType::Struct(map_fields.clone()),
+                            false,
+                        )),
+                        OffsetBuffer::new(vec![0, 3].into()),
+                        StructArray::new(
+                            map_fields,
+                            vec![Arc::clone(&shared_map_key), Arc::clone(&shared_child)],
+                            None,
+                        ),
+                        None,
+                        false,
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+                shared_map_key.get_array_memory_size()
+                    + shared_child.get_array_memory_size(),
+            ),
+            (
+                "union",
+                Arc::new(
+                    UnionArray::try_new(
+                        union_fields.clone(),
+                        vec![0, 0, 0].into(),
+                        None,
+                        vec![Arc::clone(&shared_child)],
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+                Arc::new(
+                    UnionArray::try_new(
+                        union_fields,
+                        vec![0, 0, 0].into(),
+                        None,
+                        vec![Arc::clone(&shared_child)],
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+                shared_child.get_buffer_memory_size(),
+            ),
+            (
+                "dictionary",
+                Arc::new(
+                    DictionaryArray::<Int32Type>::try_new(
+                        Int32Array::from(vec![0, 1, 2]),
+                        Arc::clone(&shared_child),
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+                Arc::new(
+                    DictionaryArray::<Int32Type>::try_new(
+                        Int32Array::from(vec![0, 1, 2]),
+                        Arc::clone(&shared_child),
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+                shared_child.get_array_memory_size(),
+            ),
+            (
+                "run_end_encoded",
+                Arc::new(
+                    RunArray::<Int32Type>::try_new(
+                        &Int32Array::from(vec![1, 2, 3]),
+                        shared_child.as_ref(),
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+                Arc::new(
+                    RunArray::<Int32Type>::try_new(
+                        &Int32Array::from(vec![1, 2, 3]),
+                        shared_child.as_ref(),
+                    )
+                    .unwrap(),
+                ) as ArrayRef,
+                shared_child.get_buffer_memory_size(),
+            ),
+        ];
+
+        for (name, first, second, shared_memory) in arrays {
+            let first_batch =
+                RecordBatch::try_from_iter(vec![(name, first.clone())]).unwrap();
+            let second_batch =
+                RecordBatch::try_from_iter(vec![(name, second.clone())]).unwrap();
+            let mut counter = RecordBatchMemoryCounter::new();
+
+            assert_eq!(
+                counter.count_batch_with_array_overhead(&first_batch),
+                first.get_array_memory_size(),
+                "{name}: first batch"
+            );
+            assert_eq!(
+                counter.count_batch_with_array_overhead(&second_batch),
+                second.get_array_memory_size() - shared_memory,
+                "{name}: shared child"
+            );
+        }
     }
 
     #[test]

--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -19,10 +19,11 @@
 
 use crate::error::_exec_datafusion_err;
 use crate::{HashSet, Result};
-use arrow::array::ArrayData;
+use arrow::array::{Array, ArrayData};
 use arrow::record_batch::RecordBatch;
 use std::mem::size_of;
 use std::num::NonZero;
+use std::sync::Arc;
 
 /// Estimates the memory size required for a hash table prior to allocation.
 ///
@@ -152,7 +153,9 @@ pub struct RecordBatchMemoryCounter {
     /// Start addresses of `Buffer`s that have already been counted (instead of
     /// actual used data region's pointer represented by current `Array`)
     counted_buffers: HashSet<NonZero<usize>>,
-    /// Total memory of all unique buffers counted so far
+    /// Array objects already counted by [`Self::count_batch_with_array_overhead`]
+    counted_arrays: HashSet<usize>,
+    /// Total memory of all counted allocations
     memory_usage: usize,
 }
 
@@ -179,7 +182,29 @@ impl RecordBatchMemoryCounter {
         total_size
     }
 
-    /// Total memory of the unique buffers of all batches counted so far.
+    /// Counts unique buffers and Array objects retained by `batch`.
+    ///
+    /// This is useful for accounting a sequence of batches at an operator
+    /// boundary. It counts buffers once, and also avoids double-counting a
+    /// top-level Arrow array shared by multiple batches.
+    pub fn count_batch_with_array_overhead(&mut self, batch: &RecordBatch) -> usize {
+        let mut total_size = self.count_batch(batch);
+        let mut array_overhead = 0;
+
+        for array in batch.columns() {
+            let array_ptr = Arc::as_ptr(array) as *const () as usize;
+            if self.counted_arrays.insert(array_ptr) {
+                array_overhead +=
+                    array.get_array_memory_size() - array.get_buffer_memory_size();
+            }
+        }
+
+        total_size += array_overhead;
+        self.memory_usage += array_overhead;
+        total_size
+    }
+
+    /// Total memory of all counted allocations.
     pub fn memory_usage(&self) -> usize {
         self.memory_usage
     }
@@ -334,6 +359,30 @@ mod record_batch_tests {
         let size_sliced = get_record_batch_memory_size(&batch_sliced);
 
         assert_eq!(size_origin, size_sliced);
+    }
+
+    #[test]
+    fn test_record_batch_memory_counter_array_overhead_shared_across_batches() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("ints", DataType::Int32, false),
+            Field::new("floats", DataType::Float64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5, 6])),
+                Arc::new(Float64Array::from(vec![1., 2., 3., 4., 5., 6.])),
+            ],
+        )
+        .unwrap();
+
+        let mut counter = RecordBatchMemoryCounter::new();
+        assert_eq!(
+            counter.count_batch_with_array_overhead(&batch),
+            batch.get_array_memory_size()
+        );
+        assert_eq!(counter.count_batch_with_array_overhead(&batch), 0);
+        assert_eq!(counter.memory_usage(), batch.get_array_memory_size());
     }
 
     #[test]

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1931,8 +1931,8 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
     /// so count them as one sequence rather than summing individual batch sizes.
     fn size(&self) -> usize {
         let mut batch_memory_counter = RecordBatchMemoryCounter::new();
-        batch_memory_counter.count_batch(&self.left.input_buffer);
-        batch_memory_counter.count_batch(&self.right.input_buffer);
+        batch_memory_counter.count_batch_with_array_overhead(&self.left.input_buffer);
+        batch_memory_counter.count_batch_with_array_overhead(&self.right.input_buffer);
         self.batch_transformer
             .count_memory(&mut batch_memory_counter);
 
@@ -2102,12 +2102,14 @@ mod tests {
         join_expr_tests_fixture_temporal, partitioned_hash_join_with_filter,
         partitioned_sym_join_with_filter, split_record_batches,
     };
+    use crate::test::TestMemoryExec;
 
     use arrow::array::Int32Array;
     use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
     use datafusion_common::ScalarValue;
     use datafusion_execution::config::SessionConfig;
+    use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{Column, binary, col, lit};
     use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
@@ -2165,7 +2167,7 @@ mod tests {
             Arc::new(Int32Array::from_iter_values(0..10)) as _,
         )])
         .unwrap();
-        let expected_size = RecordBatchMemoryCounter::new().count_batch(&batch);
+        let expected_size = batch.get_array_memory_size();
         let mut stream = create_stream(batch_transformer, batch.schema());
 
         let empty_size = stream.size();
@@ -2190,6 +2192,56 @@ mod tests {
     fn stream_accounts_for_transformer_batches_once() {
         assert_stream_accounts_for_transformer(NoopBatchTransformer::new());
         assert_stream_accounts_for_transformer(BatchSplitter::new(3));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn symmetric_hash_join_reserves_transformer_batch(
+        #[values(false, true)] enforce_batch_size_in_joins: bool,
+    ) -> Result<()> {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from_iter_values(0..10))],
+        )?;
+        let left = TestMemoryExec::try_new_exec(
+            &[vec![batch.clone()]],
+            Arc::clone(&schema),
+            None,
+        )?;
+        let right =
+            TestMemoryExec::try_new_exec(&[vec![batch]], Arc::clone(&schema), None)?;
+        let on = vec![(col("id", &schema)?, col("id", &schema)?)];
+        let join = SymmetricHashJoinExec::try_new(
+            left,
+            right,
+            on,
+            None,
+            &JoinType::Inner,
+            NullEquality::NullEqualsNothing,
+            None,
+            None,
+            StreamJoinPartitionMode::Partitioned,
+        )?;
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_limit(2_400, 1.0)
+            .build_arc()?;
+        let context = Arc::new(
+            TaskContext::default()
+                .with_session_config(
+                    SessionConfig::new()
+                        .with_batch_size(1)
+                        .with_enforce_batch_size_in_joins(enforce_batch_size_in_joins),
+                )
+                .with_runtime(runtime),
+        );
+
+        let error = crate::common::collect(join.execute(0, context)?)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("Additional allocation failed"));
+        Ok(())
     }
 
     fn get_or_create_table(

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2103,10 +2103,10 @@ mod tests {
         partitioned_sym_join_with_filter, split_record_batches,
     };
     use crate::test::TestMemoryExec;
-    use arrow::array::{ArrayRef, Int32Array, StructArray};
+    use arrow::array::Int32Array;
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit};
-    use datafusion_common::{DataFusionError, ScalarValue};
+    use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
+    use datafusion_common::ScalarValue;
     use datafusion_execution::config::SessionConfig;
     use datafusion_execution::memory_pool::{
         MemoryLimit, MemoryPool, MemoryReservation, UnboundedMemoryPool,
@@ -2127,173 +2127,10 @@ mod tests {
     static TABLE_CACHE: LazyLock<Mutex<HashMap<TableKey, TableValue>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
 
-    fn create_stream<T: BatchTransformer>(
-        batch_transformer: T,
-        input_schema: SchemaRef,
-    ) -> SymmetricHashJoinStream<T> {
-        let context = TaskContext::default();
-        create_stream_with_context(batch_transformer, input_schema, &context)
-    }
-
-    fn create_stream_with_context<T: BatchTransformer>(
-        batch_transformer: T,
-        input_schema: SchemaRef,
-        context: &TaskContext,
-    ) -> SymmetricHashJoinStream<T> {
-        let metrics = ExecutionPlanMetricsSet::new();
-        SymmetricHashJoinStream {
-            left_stream: Box::pin(EmptyRecordBatchStream::new(Arc::clone(&input_schema))),
-            right_stream: Box::pin(EmptyRecordBatchStream::new(Arc::clone(
-                &input_schema,
-            ))),
-            schema: Arc::clone(&input_schema),
-            filter: None,
-            join_type: JoinType::Inner,
-            left: OneSideHashJoiner::new(
-                JoinSide::Left,
-                vec![],
-                Arc::clone(&input_schema),
-            ),
-            right: OneSideHashJoiner::new(JoinSide::Right, vec![], input_schema),
-            column_indices: vec![],
-            graph: None,
-            left_sorted_filter_expr: None,
-            right_sorted_filter_expr: None,
-            random_state: RandomState::default(),
-            null_equality: NullEquality::NullEqualsNothing,
-            metrics: StreamJoinMetrics::new(0, &metrics),
-            reservation: Arc::new(
-                MemoryConsumer::new("SymmetricHashJoinStream[test]")
-                    .register(context.memory_pool()),
-            ),
-            state: SHJStreamState::PullRight,
-            batch_transformer,
-        }
-    }
-
-    fn assert_stream_accounts_for_transformer<T: BatchTransformer>(batch_transformer: T) {
-        let batch = RecordBatch::try_from_iter(vec![(
-            "a",
-            Arc::new(Int32Array::from_iter_values(0..10)) as _,
-        )])
-        .unwrap();
-        let expected_size = batch.get_array_memory_size();
-        let mut stream = create_stream(batch_transformer, batch.schema());
-
-        let empty_size = stream.size();
-        stream.batch_transformer.set_batch(batch.clone());
-        stream.update_reservation().unwrap();
-        assert_eq!(stream.size() - empty_size, expected_size);
-        assert_eq!(stream.reservation.size(), stream.size());
-
-        while stream.batch_transformer.next().is_some() {}
-        stream.update_reservation().unwrap();
-        assert_eq!(stream.reservation.size(), empty_size);
-
-        stream.left.input_buffer = batch;
-        let size_with_shared_batch = stream.size();
-        stream
-            .batch_transformer
-            .set_batch(stream.left.input_buffer.clone());
-        assert_eq!(stream.size(), size_with_shared_batch);
-    }
-
-    #[test]
-    fn stream_accounts_for_transformer_batches_once() {
-        assert_stream_accounts_for_transformer(NoopBatchTransformer::new());
-        assert_stream_accounts_for_transformer(BatchSplitter::new(3));
-    }
-
-    fn assert_stream_deduplicates_nested_transformer_batch<T: BatchTransformer>(
-        batch_transformer: T,
-    ) {
-        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let fields =
-            Fields::from(vec![Arc::new(Field::new("value", DataType::Int32, false))]);
-        let left_batch = RecordBatch::try_from_iter(vec![(
-            "nested",
-            Arc::new(StructArray::new(
-                fields.clone(),
-                vec![Arc::clone(&shared_child)],
-                None,
-            )) as ArrayRef,
-        )])
-        .unwrap();
-        let transformer_batch = RecordBatch::try_from_iter(vec![(
-            "nested",
-            Arc::new(StructArray::new(
-                fields,
-                vec![Arc::clone(&shared_child)],
-                None,
-            )) as ArrayRef,
-        )])
-        .unwrap();
-        let mut stream = create_stream(batch_transformer, left_batch.schema());
-        stream.left.input_buffer = left_batch;
-        let size_without_transformer = stream.size();
-
-        stream
-            .batch_transformer
-            .set_batch(transformer_batch.clone());
-
-        assert_eq!(
-            stream.size() - size_without_transformer,
-            transformer_batch.get_array_memory_size()
-                - shared_child.get_array_memory_size()
-        );
-    }
-
-    #[test]
-    fn stream_deduplicates_nested_transformer_batches() {
-        assert_stream_deduplicates_nested_transformer_batch(NoopBatchTransformer::new());
-        assert_stream_deduplicates_nested_transformer_batch(BatchSplitter::new(3));
-    }
-
-    fn assert_transformer_reservation_exhausts_pool<T: BatchTransformer>(
-        batch_transformer: T,
-    ) -> Result<()> {
-        let batch = RecordBatch::try_from_iter(vec![(
-            "a",
-            Arc::new(Int32Array::from_iter_values(0..10)) as _,
-        )])?;
-        let empty_size =
-            create_stream(NoopBatchTransformer::new(), batch.schema()).size();
-        let runtime = RuntimeEnvBuilder::new()
-            .with_memory_limit(empty_size + batch.get_array_memory_size() - 1, 1.0)
-            .build_arc()?;
-        let context = TaskContext::default().with_runtime(runtime);
-        let mut stream =
-            create_stream_with_context(batch_transformer, batch.schema(), &context);
-
-        // The empty stream fits, but retaining this batch exceeds the exact
-        // stream reservation boundary by one byte.
-        stream.update_reservation()?;
-        stream.batch_transformer.set_batch(batch);
-        let error = stream.update_reservation().unwrap_err();
-        assert!(
-            matches!(error.find_root(), DataFusionError::ResourcesExhausted(_)),
-            "expected a memory-pool error, got: {error}"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn transformer_reservation_exhausts_pool() -> Result<()> {
-        assert_transformer_reservation_exhausts_pool(NoopBatchTransformer::new())?;
-        assert_transformer_reservation_exhausts_pool(BatchSplitter::new(3))?;
-        Ok(())
-    }
-
-    #[derive(Clone, Debug)]
-    struct RecordedReservationChange {
-        change: isize,
-        reserved: usize,
-    }
-
     #[derive(Debug, Default)]
     struct RecordingMemoryPool {
         inner: UnboundedMemoryPool,
-        symmetric_join_changes: Mutex<Vec<RecordedReservationChange>>,
+        symmetric_join_changes: Mutex<Vec<isize>>,
     }
 
     impl fmt::Display for RecordingMemoryPool {
@@ -2312,27 +2149,15 @@ mod tests {
                 self.symmetric_join_changes
                     .lock()
                     .expect("recording pool mutex is not poisoned")
-                    .push(RecordedReservationChange {
-                        change,
-                        reserved: self.inner.reserved(),
-                    });
+                    .push(change);
             }
-        }
-
-        fn changes(&self) -> Vec<RecordedReservationChange> {
-            self.symmetric_join_changes
-                .lock()
-                .expect("recording pool mutex is not poisoned")
-                .clone()
         }
 
         fn change_deltas(&self) -> Vec<isize> {
             self.symmetric_join_changes
                 .lock()
                 .expect("recording pool mutex is not poisoned")
-                .iter()
-                .map(|change| change.change)
-                .collect()
+                .clone()
         }
     }
 
@@ -2462,64 +2287,6 @@ mod tests {
                 .map(RecordBatch::num_rows)
                 .sum::<usize>();
         assert_eq!(output_rows, 10);
-        Ok(())
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn symmetric_hash_join_transformer_retention_exhausts_bounded_pool(
-        #[values(false, true)] enforce_batch_size_in_joins: bool,
-    ) -> Result<()> {
-        let calibration_pool = Arc::new(RecordingMemoryPool::default());
-        let calibration_runtime = RuntimeEnvBuilder::new()
-            .with_memory_pool(Arc::clone(&calibration_pool) as Arc<dyn MemoryPool>)
-            .build_arc()?;
-        let mut calibration_stream = transformer_lifecycle_test_join()?.execute(
-            0,
-            transformer_lifecycle_test_context(
-                calibration_runtime,
-                enforce_batch_size_in_joins,
-            ),
-        )?;
-
-        let first_batch = calibration_stream.next().await.transpose()?.unwrap();
-        let retained_batch_size = first_batch.get_array_memory_size() as isize;
-        let changes = calibration_pool.changes();
-        // `poll_next_impl` has no reservation operation after transformer `next()`.
-        // Therefore the retain operation is last for a splitter and penultimate
-        // for Noop, whose `next()` immediately releases the retained batch.
-        let retain_index = changes
-            .len()
-            .checked_sub(if enforce_batch_size_in_joins { 1 } else { 2 })
-            .expect("transformer retain must update the stream reservation");
-        let retain_change = &changes[retain_index];
-        assert_eq!(
-            retain_change.change, retained_batch_size,
-            "expected transformer retain reservation update: {changes:?}"
-        );
-        if !enforce_batch_size_in_joins {
-            assert_eq!(
-                changes.last().map(|change| change.change),
-                Some(-retained_batch_size),
-                "Noop must release the retained batch before emitting it: {changes:?}"
-            );
-        }
-
-        // This limit is between the reservation immediately before transformer
-        // retention and the reservation immediately after it. The old accounting
-        // omitted this growth and would emit the first batch instead of failing.
-        let runtime = RuntimeEnvBuilder::new()
-            .with_memory_limit(retain_change.reserved - 1, 1.0)
-            .build_arc()?;
-        let mut stream = transformer_lifecycle_test_join()?.execute(
-            0,
-            transformer_lifecycle_test_context(runtime, enforce_batch_size_in_joins),
-        )?;
-        let error = stream.next().await.transpose().unwrap_err();
-        assert!(
-            matches!(error.find_root(), DataFusionError::ResourcesExhausted(_)),
-            "expected transformer retention to exhaust the pool, got: {error}"
-        );
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2103,10 +2103,10 @@ mod tests {
         partitioned_sym_join_with_filter, split_record_batches,
     };
     use crate::test::TestMemoryExec;
-    use arrow::array::Int32Array;
+    use arrow::array::{ArrayRef, Int32Array, StructArray};
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
-    use datafusion_common::ScalarValue;
+    use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit};
+    use datafusion_common::{DataFusionError, ScalarValue};
     use datafusion_execution::config::SessionConfig;
     use datafusion_execution::memory_pool::{
         MemoryLimit, MemoryPool, MemoryReservation, UnboundedMemoryPool,
@@ -2126,6 +2126,161 @@ mod tests {
     // Cache for storing tables
     static TABLE_CACHE: LazyLock<Mutex<HashMap<TableKey, TableValue>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    fn create_stream<T: BatchTransformer>(
+        batch_transformer: T,
+        input_schema: SchemaRef,
+    ) -> SymmetricHashJoinStream<T> {
+        let context = TaskContext::default();
+        create_stream_with_context(batch_transformer, input_schema, &context)
+    }
+
+    fn create_stream_with_context<T: BatchTransformer>(
+        batch_transformer: T,
+        input_schema: SchemaRef,
+        context: &TaskContext,
+    ) -> SymmetricHashJoinStream<T> {
+        let metrics = ExecutionPlanMetricsSet::new();
+        SymmetricHashJoinStream {
+            left_stream: Box::pin(EmptyRecordBatchStream::new(Arc::clone(&input_schema))),
+            right_stream: Box::pin(EmptyRecordBatchStream::new(Arc::clone(
+                &input_schema,
+            ))),
+            schema: Arc::clone(&input_schema),
+            filter: None,
+            join_type: JoinType::Inner,
+            left: OneSideHashJoiner::new(
+                JoinSide::Left,
+                vec![],
+                Arc::clone(&input_schema),
+            ),
+            right: OneSideHashJoiner::new(JoinSide::Right, vec![], input_schema),
+            column_indices: vec![],
+            graph: None,
+            left_sorted_filter_expr: None,
+            right_sorted_filter_expr: None,
+            random_state: RandomState::default(),
+            null_equality: NullEquality::NullEqualsNothing,
+            metrics: StreamJoinMetrics::new(0, &metrics),
+            reservation: Arc::new(
+                MemoryConsumer::new("SymmetricHashJoinStream[test]")
+                    .register(context.memory_pool()),
+            ),
+            state: SHJStreamState::PullRight,
+            batch_transformer,
+        }
+    }
+
+    fn assert_stream_accounts_for_transformer<T: BatchTransformer>(batch_transformer: T) {
+        let batch = RecordBatch::try_from_iter(vec![(
+            "a",
+            Arc::new(Int32Array::from_iter_values(0..10)) as _,
+        )])
+        .unwrap();
+        let expected_size = batch.get_array_memory_size();
+        let mut stream = create_stream(batch_transformer, batch.schema());
+
+        let empty_size = stream.size();
+        stream.batch_transformer.set_batch(batch.clone());
+        stream.update_reservation().unwrap();
+        assert_eq!(stream.size() - empty_size, expected_size);
+        assert_eq!(stream.reservation.size(), stream.size());
+
+        while stream.batch_transformer.next().is_some() {}
+        stream.update_reservation().unwrap();
+        assert_eq!(stream.reservation.size(), empty_size);
+
+        stream.left.input_buffer = batch;
+        let size_with_shared_batch = stream.size();
+        stream
+            .batch_transformer
+            .set_batch(stream.left.input_buffer.clone());
+        assert_eq!(stream.size(), size_with_shared_batch);
+    }
+
+    #[test]
+    fn stream_accounts_for_transformer_batches_once() {
+        assert_stream_accounts_for_transformer(NoopBatchTransformer::new());
+        assert_stream_accounts_for_transformer(BatchSplitter::new(3));
+    }
+
+    fn assert_stream_deduplicates_nested_transformer_batch<T: BatchTransformer>(
+        batch_transformer: T,
+    ) {
+        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let fields =
+            Fields::from(vec![Arc::new(Field::new("value", DataType::Int32, false))]);
+        let left_batch = RecordBatch::try_from_iter(vec![(
+            "nested",
+            Arc::new(StructArray::new(
+                fields.clone(),
+                vec![Arc::clone(&shared_child)],
+                None,
+            )) as ArrayRef,
+        )])
+        .unwrap();
+        let transformer_batch = RecordBatch::try_from_iter(vec![(
+            "nested",
+            Arc::new(StructArray::new(
+                fields,
+                vec![Arc::clone(&shared_child)],
+                None,
+            )) as ArrayRef,
+        )])
+        .unwrap();
+        let mut stream = create_stream(batch_transformer, left_batch.schema());
+        stream.left.input_buffer = left_batch;
+        let size_without_transformer = stream.size();
+
+        stream
+            .batch_transformer
+            .set_batch(transformer_batch.clone());
+
+        assert_eq!(
+            stream.size() - size_without_transformer,
+            transformer_batch.get_array_memory_size()
+                - shared_child.get_array_memory_size()
+        );
+    }
+
+    #[test]
+    fn stream_deduplicates_nested_transformer_batches() {
+        assert_stream_deduplicates_nested_transformer_batch(NoopBatchTransformer::new());
+        assert_stream_deduplicates_nested_transformer_batch(BatchSplitter::new(3));
+    }
+
+    fn assert_transformer_reservation_exhausts_pool<T: BatchTransformer>(
+        batch_transformer: T,
+    ) -> Result<()> {
+        let batch = RecordBatch::try_from_iter(vec![(
+            "a",
+            Arc::new(Int32Array::from_iter_values(0..10)) as _,
+        )])?;
+        let empty_size =
+            create_stream(NoopBatchTransformer::new(), batch.schema()).size();
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_limit(empty_size + batch.get_array_memory_size() - 1, 1.0)
+            .build_arc()?;
+        let context = TaskContext::default().with_runtime(runtime);
+        let mut stream =
+            create_stream_with_context(batch_transformer, batch.schema(), &context);
+
+        stream.update_reservation()?;
+        stream.batch_transformer.set_batch(batch);
+        let error = stream.update_reservation().unwrap_err();
+        assert!(
+            matches!(error.find_root(), DataFusionError::ResourcesExhausted(_)),
+            "expected a memory-pool error, got: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn transformer_reservation_exhausts_pool() -> Result<()> {
+        assert_transformer_reservation_exhausts_pool(NoopBatchTransformer::new())?;
+        assert_transformer_reservation_exhausts_pool(BatchSplitter::new(3))?;
+        Ok(())
+    }
 
     #[derive(Debug, Default)]
     struct RecordingMemoryPool {
@@ -2287,6 +2442,65 @@ mod tests {
                 .map(RecordBatch::num_rows)
                 .sum::<usize>();
         assert_eq!(output_rows, 10);
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn symmetric_hash_join_transformer_retention_exhausts_bounded_pool(
+        #[values(false, true)] enforce_batch_size_in_joins: bool,
+    ) -> Result<()> {
+        let calibration_pool = Arc::new(RecordingMemoryPool::default());
+        let calibration_runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::clone(&calibration_pool) as Arc<dyn MemoryPool>)
+            .build_arc()?;
+        let mut calibration_stream = transformer_lifecycle_test_join()?.execute(
+            0,
+            transformer_lifecycle_test_context(
+                calibration_runtime,
+                enforce_batch_size_in_joins,
+            ),
+        )?;
+
+        let first_batch = calibration_stream.next().await.transpose()?.unwrap();
+        let retained_size = first_batch.get_array_memory_size() as isize;
+        let changes = calibration_pool.change_deltas();
+        let retain_index = changes
+            .len()
+            .checked_sub(if enforce_batch_size_in_joins { 1 } else { 2 })
+            .expect("transformer retain must update the stream reservation");
+        assert_eq!(
+            changes[retain_index], retained_size,
+            "expected transformer retain reservation update: {changes:?}"
+        );
+        if !enforce_batch_size_in_joins {
+            assert_eq!(
+                changes.last(),
+                Some(&-retained_size),
+                "Noop must release the retained batch before emitting it: {changes:?}"
+            );
+        }
+        let pre_retain_size: isize = changes[..retain_index].iter().sum();
+        assert!(
+            pre_retain_size > 0,
+            "expected a positive reservation before retention: {changes:?}"
+        );
+
+        // This limit is one byte below the independently measured retained
+        // output batch added to the reservation immediately before it.
+        // Without retain-side accounting, the first batch is emitted.
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_limit((pre_retain_size + retained_size) as usize - 1, 1.0)
+            .build_arc()?;
+        let mut stream = transformer_lifecycle_test_join()?.execute(
+            0,
+            transformer_lifecycle_test_context(runtime, enforce_batch_size_in_joins),
+        )?;
+        let error = stream.next().await.transpose().unwrap_err();
+        assert!(
+            matches!(error.find_root(), DataFusionError::ResourcesExhausted(_)),
+            "expected transformer retention to exhaust the pool, got: {error}"
+        );
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1656,6 +1656,8 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
                             final_result: false,
                         } => self.prepare_for_final_results_after_exhaustion(),
                         SHJStreamState::BothExhausted { final_result: true } => {
+                            self.reservation.free();
+                            self.metrics.stream_memory_usage.set(0);
                             return Poll::Ready(None);
                         }
                     };
@@ -2202,6 +2204,18 @@ mod tests {
     fn stream_accounts_for_transformer_batches_once() {
         assert_stream_accounts_for_transformer(NoopBatchTransformer::new());
         assert_stream_accounts_for_transformer(BatchSplitter::new(3));
+    }
+
+    #[tokio::test]
+    async fn symmetric_hash_join_releases_reservation_when_complete() {
+        let schema = Arc::new(Schema::empty());
+        let mut stream = create_stream(NoopBatchTransformer::new(), schema);
+        stream.update_reservation().unwrap();
+        assert_ne!(stream.reservation.size(), 0);
+
+        stream.set_state(SHJStreamState::BothExhausted { final_result: true });
+        assert!(stream.next().await.is_none());
+        assert_eq!(stream.reservation.size(), 0);
     }
 
     fn assert_stream_deduplicates_nested_transformer_batch<T: BatchTransformer>(

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2102,12 +2102,16 @@ mod tests {
         join_expr_tests_fixture_temporal, partitioned_hash_join_with_filter,
         partitioned_sym_join_with_filter, split_record_batches,
     };
+    use crate::test::TestMemoryExec;
     use arrow::array::{ArrayRef, Int32Array, StructArray};
     use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit};
     use datafusion_common::{DataFusionError, ScalarValue};
     use datafusion_execution::config::SessionConfig;
-    use datafusion_execution::runtime_env::RuntimeEnvBuilder;
+    use datafusion_execution::memory_pool::{
+        MemoryLimit, MemoryPool, MemoryReservation, UnboundedMemoryPool,
+    };
+    use datafusion_execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{Column, binary, col, lit};
     use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
@@ -2277,6 +2281,169 @@ mod tests {
     fn transformer_reservation_exhausts_pool() -> Result<()> {
         assert_transformer_reservation_exhausts_pool(NoopBatchTransformer::new())?;
         assert_transformer_reservation_exhausts_pool(BatchSplitter::new(3))?;
+        Ok(())
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingMemoryPool {
+        inner: UnboundedMemoryPool,
+        symmetric_join_changes: Mutex<Vec<isize>>,
+    }
+
+    impl fmt::Display for RecordingMemoryPool {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fmt::Display::fmt(&self.inner, f)
+        }
+    }
+
+    impl RecordingMemoryPool {
+        fn record(&self, reservation: &MemoryReservation, change: isize) {
+            if reservation
+                .consumer()
+                .name()
+                .starts_with("SymmetricHashJoinStream")
+            {
+                self.symmetric_join_changes
+                    .lock()
+                    .expect("recording pool mutex is not poisoned")
+                    .push(change);
+            }
+        }
+
+        fn changes(&self) -> Vec<isize> {
+            self.symmetric_join_changes
+                .lock()
+                .expect("recording pool mutex is not poisoned")
+                .clone()
+        }
+    }
+
+    impl MemoryPool for RecordingMemoryPool {
+        fn name(&self) -> &str {
+            self.inner.name()
+        }
+
+        fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+            self.inner.grow(reservation, additional);
+            self.record(reservation, additional as isize);
+        }
+
+        fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+            self.inner.shrink(reservation, shrink);
+            self.record(reservation, -(shrink as isize));
+        }
+
+        fn try_grow(
+            &self,
+            reservation: &MemoryReservation,
+            additional: usize,
+        ) -> Result<()> {
+            self.inner.try_grow(reservation, additional)?;
+            self.record(reservation, additional as isize);
+            Ok(())
+        }
+
+        fn reserved(&self) -> usize {
+            self.inner.reserved()
+        }
+
+        fn memory_limit(&self) -> MemoryLimit {
+            self.inner.memory_limit()
+        }
+    }
+
+    fn transformer_lifecycle_test_join() -> Result<SymmetricHashJoinExec> {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from_iter_values(0..10))],
+        )?;
+        let left = TestMemoryExec::try_new_exec(
+            &[vec![batch.clone()]],
+            Arc::clone(&schema),
+            None,
+        )?;
+        let right =
+            TestMemoryExec::try_new_exec(&[vec![batch]], Arc::clone(&schema), None)?;
+        let on = vec![(col("id", &schema)?, col("id", &schema)?)];
+        SymmetricHashJoinExec::try_new(
+            left,
+            right,
+            on,
+            None,
+            &JoinType::Inner,
+            NullEquality::NullEqualsNothing,
+            None,
+            None,
+            StreamJoinPartitionMode::Partitioned,
+        )
+    }
+
+    fn transformer_lifecycle_test_context(
+        runtime: Arc<RuntimeEnv>,
+        enforce_batch_size_in_joins: bool,
+    ) -> Arc<TaskContext> {
+        Arc::new(
+            TaskContext::default()
+                .with_session_config(
+                    SessionConfig::new()
+                        .with_batch_size(3)
+                        .with_enforce_batch_size_in_joins(enforce_batch_size_in_joins),
+                )
+                .with_runtime(runtime),
+        )
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn symmetric_hash_join_updates_reservation_while_transforming_output(
+        #[values(false, true)] enforce_batch_size_in_joins: bool,
+    ) -> Result<()> {
+        let pool = Arc::new(RecordingMemoryPool::default());
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::clone(&pool) as Arc<dyn MemoryPool>)
+            .build_arc()?;
+        let mut stream = transformer_lifecycle_test_join()?.execute(
+            0,
+            transformer_lifecycle_test_context(runtime, enforce_batch_size_in_joins),
+        )?;
+
+        let first_batch = stream.next().await.transpose()?.unwrap();
+        let retained_batch_size = first_batch.get_array_memory_size() as isize;
+        let changes_after_first_batch = pool.changes();
+        assert!(
+            changes_after_first_batch.contains(&retained_batch_size),
+            "expected transformer retain reservation update: {changes_after_first_batch:?}"
+        );
+        if enforce_batch_size_in_joins {
+            assert!(
+                !changes_after_first_batch.contains(&-retained_batch_size),
+                "splitter must retain the output batch after a non-final slice: {changes_after_first_batch:?}"
+            );
+        } else {
+            assert!(
+                changes_after_first_batch
+                    .windows(2)
+                    .any(|changes| changes == [retained_batch_size, -retained_batch_size]),
+                "expected Noop transformer release after emission: {changes_after_first_batch:?}"
+            );
+        }
+
+        let remaining_batches = crate::common::collect(stream).await?;
+        let changes_after_completion = pool.changes();
+        if enforce_batch_size_in_joins {
+            assert!(
+                changes_after_completion.contains(&-retained_batch_size),
+                "expected splitter release after final slice: {changes_after_completion:?}"
+            );
+        }
+        let output_rows = first_batch.num_rows()
+            + remaining_batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>();
+        assert_eq!(output_rows, 10);
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2325,6 +2325,13 @@ mod tests {
                 .expect("recording pool mutex is not poisoned")
                 .clone()
         }
+
+        fn change_deltas(&self) -> Vec<isize> {
+            self.changes()
+                .into_iter()
+                .map(|change| change.change)
+                .collect()
+        }
     }
 
     impl MemoryPool for RecordingMemoryPool {
@@ -2420,11 +2427,7 @@ mod tests {
 
         let first_batch = stream.next().await.transpose()?.unwrap();
         let retained_batch_size = first_batch.get_array_memory_size() as isize;
-        let changes_after_first_batch = pool.changes();
-        let changes_after_first_batch: Vec<_> = changes_after_first_batch
-            .iter()
-            .map(|change| change.change)
-            .collect();
+        let changes_after_first_batch = pool.change_deltas();
         assert!(
             changes_after_first_batch.contains(&retained_batch_size),
             "expected transformer retain reservation update: {changes_after_first_batch:?}"
@@ -2444,11 +2447,7 @@ mod tests {
         }
 
         let remaining_batches = crate::common::collect(stream).await?;
-        let changes_after_completion: Vec<_> = pool
-            .changes()
-            .into_iter()
-            .map(|change| change.change)
-            .collect();
+        let changes_after_completion = pool.change_deltas();
         if enforce_batch_size_in_joins {
             assert!(
                 changes_after_completion.contains(&-retained_batch_size),

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1660,8 +1660,6 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
                             final_result: false,
                         } => self.prepare_for_final_results_after_exhaustion(),
                         SHJStreamState::BothExhausted { final_result: true } => {
-                            self.reservation.free();
-                            self.metrics.stream_memory_usage.set(0);
                             return Poll::Ready(None);
                         }
                     };
@@ -2211,15 +2209,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn symmetric_hash_join_releases_reservation_when_complete() {
+    async fn symmetric_hash_join_retains_reservation_until_dropped() -> Result<()> {
+        let pool = Arc::new(RecordingMemoryPool::default());
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::clone(&pool) as Arc<dyn MemoryPool>)
+            .build_arc()?;
+        let context = TaskContext::default().with_runtime(runtime);
         let schema = Arc::new(Schema::empty());
-        let mut stream = create_stream(NoopBatchTransformer::new(), schema);
-        stream.update_reservation().unwrap();
-        assert_ne!(stream.reservation.size(), 0);
+        let mut stream =
+            create_stream_with_context(NoopBatchTransformer::new(), schema, &context);
+        stream.update_reservation()?;
+        let reserved_size = stream.reservation.size();
+        assert_ne!(reserved_size, 0);
 
         stream.set_state(SHJStreamState::BothExhausted { final_result: true });
         assert!(stream.next().await.is_none());
-        assert_eq!(stream.reservation.size(), 0);
+        assert_eq!(stream.reservation.size(), reserved_size);
+        assert_eq!(stream.metrics.stream_memory_usage.value(), reserved_size);
+
+        drop(stream);
+        assert_eq!(pool.reserved(), 0);
+        Ok(())
     }
 
     fn assert_stream_deduplicates_nested_transformer_batch<T: BatchTransformer>(

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2269,6 +2269,8 @@ mod tests {
             None,
             StreamJoinPartitionMode::Partitioned,
         )?;
+        // This limit is intentionally at the regression boundary: accounting that
+        // omits the transformer-held batch succeeds, while corrected accounting fails.
         let runtime = RuntimeEnvBuilder::new()
             .with_memory_limit(2_400, 1.0)
             .build_arc()?;

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2104,12 +2104,15 @@ mod tests {
     };
     use crate::test::TestMemoryExec;
 
-    use arrow::array::{ArrayRef, Int32Array, StructArray};
+    use arrow::array::{ArrayRef, AsArray, Int32Array, StructArray};
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit};
-    use datafusion_common::ScalarValue;
+    use arrow::datatypes::{DataType, Field, Fields, Int32Type, IntervalUnit, TimeUnit};
+    use datafusion_common::{DataFusionError, ScalarValue};
     use datafusion_execution::config::SessionConfig;
-    use datafusion_execution::runtime_env::RuntimeEnvBuilder;
+    use datafusion_execution::memory_pool::{
+        GreedyMemoryPool, MemoryPool, PeakRecordingPool, UnboundedMemoryPool,
+    };
+    use datafusion_execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{Column, binary, col, lit};
     use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
@@ -2256,11 +2259,7 @@ mod tests {
         assert_stream_deduplicates_nested_transformer_batch(BatchSplitter::new(3));
     }
 
-    #[rstest]
-    #[tokio::test]
-    async fn symmetric_hash_join_reserves_transformer_batch(
-        #[values(false, true)] enforce_batch_size_in_joins: bool,
-    ) -> Result<()> {
+    fn transformer_memory_test_join() -> Result<SymmetricHashJoinExec> {
         let schema =
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let batch = RecordBatch::try_new(
@@ -2275,7 +2274,7 @@ mod tests {
         let right =
             TestMemoryExec::try_new_exec(&[vec![batch]], Arc::clone(&schema), None)?;
         let on = vec![(col("id", &schema)?, col("id", &schema)?)];
-        let join = SymmetricHashJoinExec::try_new(
+        SymmetricHashJoinExec::try_new(
             left,
             right,
             on,
@@ -2285,13 +2284,14 @@ mod tests {
             None,
             None,
             StreamJoinPartitionMode::Partitioned,
-        )?;
-        // This limit is intentionally at the regression boundary: accounting that
-        // omits the transformer-held batch succeeds, while corrected accounting fails.
-        let runtime = RuntimeEnvBuilder::new()
-            .with_memory_limit(2_400, 1.0)
-            .build_arc()?;
-        let context = Arc::new(
+        )
+    }
+
+    fn transformer_memory_test_context(
+        runtime: Arc<RuntimeEnv>,
+        enforce_batch_size_in_joins: bool,
+    ) -> Arc<TaskContext> {
+        Arc::new(
             TaskContext::default()
                 .with_session_config(
                     SessionConfig::new()
@@ -2299,12 +2299,72 @@ mod tests {
                         .with_enforce_batch_size_in_joins(enforce_batch_size_in_joins),
                 )
                 .with_runtime(runtime),
-        );
+        )
+    }
 
-        let error = crate::common::collect(join.execute(0, context)?)
-            .await
-            .unwrap_err();
-        assert!(error.to_string().contains("Additional allocation failed"));
+    fn assert_transformer_memory_test_output(batches: &[RecordBatch]) {
+        let actual_rows = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_primitive::<Int32Type>()
+                    .values()
+                    .iter()
+                    .zip(batch.column(1).as_primitive::<Int32Type>().values())
+                    .map(|(&left, &right)| (left, right))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let expected_rows = (0..10).map(|id| (id, id)).collect::<Vec<_>>();
+        assert_eq!(actual_rows, expected_rows);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn symmetric_hash_join_reserves_transformer_batch(
+        #[values(false, true)] enforce_batch_size_in_joins: bool,
+    ) -> Result<()> {
+        let recording_pool = Arc::new(PeakRecordingPool::new(Arc::new(
+            UnboundedMemoryPool::default(),
+        )));
+        let pool: Arc<dyn MemoryPool> = Arc::clone(&recording_pool) as _;
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(pool)
+            .build_arc()?;
+        let batches = crate::common::collect(transformer_memory_test_join()?.execute(
+            0,
+            transformer_memory_test_context(runtime, enforce_batch_size_in_joins),
+        )?)
+        .await?;
+        assert_transformer_memory_test_output(&batches);
+
+        let peak_reservation = recording_pool.peak_reserved();
+        let transformer_batch_memory = batches
+            .iter()
+            .map(RecordBatch::get_array_memory_size)
+            .max()
+            .expect("join emits a transformer batch");
+        let memory_limit = peak_reservation
+            .checked_sub(transformer_batch_memory)
+            .expect("transformer batch is part of the peak reservation")
+            + 1;
+
+        // The direct stream tests prove this batch is the reservation delta. This
+        // limit leaves room for the old accounting but not the retained batch.
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::new(GreedyMemoryPool::new(memory_limit)))
+            .build_arc()?;
+        let error = crate::common::collect(transformer_memory_test_join()?.execute(
+            0,
+            transformer_memory_test_context(runtime, enforce_batch_size_in_joins),
+        )?)
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(error.find_root(), DataFusionError::ResourcesExhausted(_)),
+            "expected a memory-pool error, got: {error}"
+        );
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2102,21 +2102,15 @@ mod tests {
         join_expr_tests_fixture_temporal, partitioned_hash_join_with_filter,
         partitioned_sym_join_with_filter, split_record_batches,
     };
-    use crate::test::TestMemoryExec;
-
-    use arrow::array::{ArrayRef, AsArray, Int32Array, StructArray};
+    use arrow::array::{ArrayRef, Int32Array, StructArray};
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, Fields, Int32Type, IntervalUnit, TimeUnit};
+    use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit};
     use datafusion_common::{DataFusionError, ScalarValue};
     use datafusion_execution::config::SessionConfig;
-    use datafusion_execution::memory_pool::{
-        GreedyMemoryPool, MemoryPool, PeakRecordingPool, UnboundedMemoryPool,
-    };
-    use datafusion_execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+    use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{Column, binary, col, lit};
     use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
-    use std::task::Context as PollContext;
 
     use rstest::*;
 
@@ -2134,6 +2128,14 @@ mod tests {
         input_schema: SchemaRef,
     ) -> SymmetricHashJoinStream<T> {
         let context = TaskContext::default();
+        create_stream_with_context(batch_transformer, input_schema, &context)
+    }
+
+    fn create_stream_with_context<T: BatchTransformer>(
+        batch_transformer: T,
+        input_schema: SchemaRef,
+        context: &TaskContext,
+    ) -> SymmetricHashJoinStream<T> {
         let metrics = ExecutionPlanMetricsSet::new();
         SymmetricHashJoinStream {
             left_stream: Box::pin(EmptyRecordBatchStream::new(Arc::clone(&input_schema))),
@@ -2165,9 +2167,7 @@ mod tests {
         }
     }
 
-    fn assert_stream_accounts_for_transformer<T: BatchTransformer + Unpin + Send>(
-        batch_transformer: T,
-    ) {
+    fn assert_stream_accounts_for_transformer<T: BatchTransformer>(batch_transformer: T) {
         let batch = RecordBatch::try_from_iter(vec![(
             "a",
             Arc::new(Int32Array::from_iter_values(0..10)) as _,
@@ -2181,24 +2181,10 @@ mod tests {
         stream.update_reservation().unwrap();
         assert_eq!(stream.size() - empty_size, expected_size);
         assert_eq!(stream.reservation.size(), stream.size());
-        assert_eq!(stream.metrics.stream_memory_usage.value(), stream.size());
 
-        loop {
-            let poll = stream.poll_next_unpin(&mut PollContext::from_waker(
-                futures::task::noop_waker_ref(),
-            ));
-            match poll {
-                Poll::Ready(Some(Ok(_))) => {}
-                Poll::Ready(None) => break,
-                Poll::Ready(Some(Err(error))) => {
-                    panic!("unexpected stream error: {error}")
-                }
-                Poll::Pending => panic!("empty input streams must not pend"),
-            }
-        }
-        assert_eq!(stream.size(), empty_size);
+        while stream.batch_transformer.next().is_some() {}
+        stream.update_reservation().unwrap();
         assert_eq!(stream.reservation.size(), empty_size);
-        assert_eq!(stream.metrics.stream_memory_usage.value(), empty_size);
 
         stream.left.input_buffer = batch;
         let size_with_shared_batch = stream.size();
@@ -2259,107 +2245,38 @@ mod tests {
         assert_stream_deduplicates_nested_transformer_batch(BatchSplitter::new(3));
     }
 
-    fn transformer_memory_test_join() -> Result<SymmetricHashJoinExec> {
-        let schema =
-            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(Int32Array::from_iter_values(0..10))],
-        )?;
-        let left = TestMemoryExec::try_new_exec(
-            &[vec![batch.clone()]],
-            Arc::clone(&schema),
-            None,
-        )?;
-        let right =
-            TestMemoryExec::try_new_exec(&[vec![batch]], Arc::clone(&schema), None)?;
-        let on = vec![(col("id", &schema)?, col("id", &schema)?)];
-        SymmetricHashJoinExec::try_new(
-            left,
-            right,
-            on,
-            None,
-            &JoinType::Inner,
-            NullEquality::NullEqualsNothing,
-            None,
-            None,
-            StreamJoinPartitionMode::Partitioned,
-        )
-    }
-
-    fn transformer_memory_test_context(
-        runtime: Arc<RuntimeEnv>,
-        enforce_batch_size_in_joins: bool,
-    ) -> Arc<TaskContext> {
-        Arc::new(
-            TaskContext::default()
-                .with_session_config(
-                    SessionConfig::new()
-                        .with_batch_size(1)
-                        .with_enforce_batch_size_in_joins(enforce_batch_size_in_joins),
-                )
-                .with_runtime(runtime),
-        )
-    }
-
-    fn assert_transformer_memory_test_output(batches: &[RecordBatch]) {
-        let actual_rows = batches
-            .iter()
-            .flat_map(|batch| {
-                batch
-                    .column(0)
-                    .as_primitive::<Int32Type>()
-                    .values()
-                    .iter()
-                    .zip(batch.column(1).as_primitive::<Int32Type>().values())
-                    .map(|(&left, &right)| (left, right))
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-        let expected_rows = (0..10).map(|id| (id, id)).collect::<Vec<_>>();
-        assert_eq!(actual_rows, expected_rows);
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn symmetric_hash_join_reserves_transformer_batch(
-        #[values(false, true)] enforce_batch_size_in_joins: bool,
+    fn assert_transformer_reservation_exhausts_pool<T: BatchTransformer>(
+        batch_transformer: T,
     ) -> Result<()> {
-        let recording_pool = Arc::new(PeakRecordingPool::new(Arc::new(
-            UnboundedMemoryPool::default(),
-        )));
-        let pool: Arc<dyn MemoryPool> = Arc::clone(&recording_pool) as _;
+        let batch = RecordBatch::try_from_iter(vec![(
+            "a",
+            Arc::new(Int32Array::from_iter_values(0..10)) as _,
+        )])?;
+        let empty_size =
+            create_stream(NoopBatchTransformer::new(), batch.schema()).size();
         let runtime = RuntimeEnvBuilder::new()
-            .with_memory_pool(pool)
+            .with_memory_limit(empty_size + batch.get_array_memory_size() - 1, 1.0)
             .build_arc()?;
-        let batches = crate::common::collect(transformer_memory_test_join()?.execute(
-            0,
-            transformer_memory_test_context(runtime, enforce_batch_size_in_joins),
-        )?)
-        .await?;
-        assert_transformer_memory_test_output(&batches);
+        let context = TaskContext::default().with_runtime(runtime);
+        let mut stream =
+            create_stream_with_context(batch_transformer, batch.schema(), &context);
 
-        let peak_reservation = recording_pool.peak_reserved();
-        let memory_limit = peak_reservation
-            .checked_sub(1)
-            .expect("join must reserve memory");
-
-        // Direct stream tests prove transformer retain/release accounting and
-        // shared-buffer deduplication. This test verifies the physical plan
-        // enforces its observed peak reservation.
-        let runtime = RuntimeEnvBuilder::new()
-            .with_memory_pool(Arc::new(GreedyMemoryPool::new(memory_limit)))
-            .build_arc()?;
-        let error = crate::common::collect(transformer_memory_test_join()?.execute(
-            0,
-            transformer_memory_test_context(runtime, enforce_batch_size_in_joins),
-        )?)
-        .await
-        .unwrap_err();
+        // The empty stream fits, but retaining this batch exceeds the exact
+        // stream reservation boundary by one byte.
+        stream.update_reservation()?;
+        stream.batch_transformer.set_batch(batch);
+        let error = stream.update_reservation().unwrap_err();
         assert!(
             matches!(error.find_root(), DataFusionError::ResourcesExhausted(_)),
             "expected a memory-pool error, got: {error}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn transformer_reservation_exhausts_pool() -> Result<()> {
+        assert_transformer_reservation_exhausts_pool(NoopBatchTransformer::new())?;
+        assert_transformer_reservation_exhausts_pool(BatchSplitter::new(3))?;
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2327,8 +2327,10 @@ mod tests {
         }
 
         fn change_deltas(&self) -> Vec<isize> {
-            self.changes()
-                .into_iter()
+            self.symmetric_join_changes
+                .lock()
+                .expect("recording pool mutex is not poisoned")
+                .iter()
                 .map(|change| change.change)
                 .collect()
         }

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1455,6 +1455,10 @@ impl OneSideHashJoiner {
         size += size_of_val(&self.deleted_offset);
         size
     }
+
+    fn size_without_input_buffer(&self) -> usize {
+        self.size() - self.input_buffer.get_array_memory_size()
+    }
     pub fn new(
         build_side: JoinSide,
         on: Vec<PhysicalExprRef>,
@@ -1942,8 +1946,8 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
         size += size_of_val(&self.schema);
         size += size_of_val(&self.filter);
         size += size_of_val(&self.join_type);
-        size += self.left.size() - self.left.input_buffer.get_array_memory_size();
-        size += self.right.size() - self.right.input_buffer.get_array_memory_size();
+        size += self.left.size_without_input_buffer();
+        size += self.right.size_without_input_buffer();
         size += size_of_val(&self.column_indices);
         size += self.graph.as_ref().map(|g| g.size()).unwrap_or(0);
         size += size_of_val(&self.left_sorted_filter_expr);
@@ -1957,8 +1961,8 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
     /// Resizes the stream reservation to match all memory retained by the stream.
     fn update_reservation(&mut self) -> Result<()> {
         let capacity = self.size();
-        self.metrics.stream_memory_usage.set(capacity);
         self.reservation.try_resize(capacity)?;
+        self.metrics.stream_memory_usage.set(capacity);
         Ok(())
     }
 
@@ -2280,12 +2284,14 @@ mod tests {
             create_stream_with_context(batch_transformer, batch.schema(), &context);
 
         stream.update_reservation()?;
+        let reserved_size = stream.reservation.size();
         stream.batch_transformer.set_batch(batch);
         let error = stream.update_reservation().unwrap_err();
         assert!(
             matches!(error.find_root(), DataFusionError::ResourcesExhausted(_)),
             "expected a memory-pool error, got: {error}"
         );
+        assert_eq!(stream.metrics.stream_memory_usage.value(), reserved_size);
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2340,18 +2340,13 @@ mod tests {
         assert_transformer_memory_test_output(&batches);
 
         let peak_reservation = recording_pool.peak_reserved();
-        let transformer_batch_memory = batches
-            .iter()
-            .map(RecordBatch::get_array_memory_size)
-            .max()
-            .expect("join emits a transformer batch");
         let memory_limit = peak_reservation
-            .checked_sub(transformer_batch_memory)
-            .expect("transformer batch is part of the peak reservation")
-            + 1;
+            .checked_sub(1)
+            .expect("join must reserve memory");
 
-        // The direct stream tests prove this batch is the reservation delta. This
-        // limit leaves room for the old accounting but not the retained batch.
+        // Direct stream tests prove transformer retain/release accounting and
+        // shared-buffer deduplication. This test verifies the physical plan
+        // enforces its observed peak reservation.
         let runtime = RuntimeEnvBuilder::new()
             .with_memory_pool(Arc::new(GreedyMemoryPool::new(memory_limit)))
             .build_arc()?;

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2104,9 +2104,9 @@ mod tests {
     };
     use crate::test::TestMemoryExec;
 
-    use arrow::array::Int32Array;
+    use arrow::array::{ArrayRef, Int32Array, StructArray};
     use arrow::compute::SortOptions;
-    use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
+    use arrow::datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit};
     use datafusion_common::ScalarValue;
     use datafusion_execution::config::SessionConfig;
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
@@ -2192,6 +2192,51 @@ mod tests {
     fn stream_accounts_for_transformer_batches_once() {
         assert_stream_accounts_for_transformer(NoopBatchTransformer::new());
         assert_stream_accounts_for_transformer(BatchSplitter::new(3));
+    }
+
+    fn assert_stream_deduplicates_nested_transformer_batch<T: BatchTransformer>(
+        batch_transformer: T,
+    ) {
+        let shared_child: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let fields =
+            Fields::from(vec![Arc::new(Field::new("value", DataType::Int32, false))]);
+        let left_batch = RecordBatch::try_from_iter(vec![(
+            "nested",
+            Arc::new(StructArray::new(
+                fields.clone(),
+                vec![Arc::clone(&shared_child)],
+                None,
+            )) as ArrayRef,
+        )])
+        .unwrap();
+        let transformer_batch = RecordBatch::try_from_iter(vec![(
+            "nested",
+            Arc::new(StructArray::new(
+                fields,
+                vec![Arc::clone(&shared_child)],
+                None,
+            )) as ArrayRef,
+        )])
+        .unwrap();
+        let mut stream = create_stream(batch_transformer, left_batch.schema());
+        stream.left.input_buffer = left_batch;
+        let size_without_transformer = stream.size();
+
+        stream
+            .batch_transformer
+            .set_batch(transformer_batch.clone());
+
+        assert_eq!(
+            stream.size() - size_without_transformer,
+            transformer_batch.get_array_memory_size()
+                - shared_child.get_array_memory_size()
+        );
+    }
+
+    #[test]
+    fn stream_deduplicates_nested_transformer_batches() {
+        assert_stream_deduplicates_nested_transformer_batch(NoopBatchTransformer::new());
+        assert_stream_deduplicates_nested_transformer_batch(BatchSplitter::new(3));
     }
 
     #[rstest]

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2284,10 +2284,16 @@ mod tests {
         Ok(())
     }
 
+    #[derive(Clone, Debug)]
+    struct RecordedReservationChange {
+        change: isize,
+        reserved: usize,
+    }
+
     #[derive(Debug, Default)]
     struct RecordingMemoryPool {
         inner: UnboundedMemoryPool,
-        symmetric_join_changes: Mutex<Vec<isize>>,
+        symmetric_join_changes: Mutex<Vec<RecordedReservationChange>>,
     }
 
     impl fmt::Display for RecordingMemoryPool {
@@ -2306,11 +2312,14 @@ mod tests {
                 self.symmetric_join_changes
                     .lock()
                     .expect("recording pool mutex is not poisoned")
-                    .push(change);
+                    .push(RecordedReservationChange {
+                        change,
+                        reserved: self.inner.reserved(),
+                    });
             }
         }
 
-        fn changes(&self) -> Vec<isize> {
+        fn changes(&self) -> Vec<RecordedReservationChange> {
             self.symmetric_join_changes
                 .lock()
                 .expect("recording pool mutex is not poisoned")
@@ -2412,6 +2421,10 @@ mod tests {
         let first_batch = stream.next().await.transpose()?.unwrap();
         let retained_batch_size = first_batch.get_array_memory_size() as isize;
         let changes_after_first_batch = pool.changes();
+        let changes_after_first_batch: Vec<_> = changes_after_first_batch
+            .iter()
+            .map(|change| change.change)
+            .collect();
         assert!(
             changes_after_first_batch.contains(&retained_batch_size),
             "expected transformer retain reservation update: {changes_after_first_batch:?}"
@@ -2431,7 +2444,11 @@ mod tests {
         }
 
         let remaining_batches = crate::common::collect(stream).await?;
-        let changes_after_completion = pool.changes();
+        let changes_after_completion: Vec<_> = pool
+            .changes()
+            .into_iter()
+            .map(|change| change.change)
+            .collect();
         if enforce_batch_size_in_joins {
             assert!(
                 changes_after_completion.contains(&-retained_batch_size),
@@ -2444,6 +2461,64 @@ mod tests {
                 .map(RecordBatch::num_rows)
                 .sum::<usize>();
         assert_eq!(output_rows, 10);
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn symmetric_hash_join_transformer_retention_exhausts_bounded_pool(
+        #[values(false, true)] enforce_batch_size_in_joins: bool,
+    ) -> Result<()> {
+        let calibration_pool = Arc::new(RecordingMemoryPool::default());
+        let calibration_runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::clone(&calibration_pool) as Arc<dyn MemoryPool>)
+            .build_arc()?;
+        let mut calibration_stream = transformer_lifecycle_test_join()?.execute(
+            0,
+            transformer_lifecycle_test_context(
+                calibration_runtime,
+                enforce_batch_size_in_joins,
+            ),
+        )?;
+
+        let first_batch = calibration_stream.next().await.transpose()?.unwrap();
+        let retained_batch_size = first_batch.get_array_memory_size() as isize;
+        let changes = calibration_pool.changes();
+        // `poll_next_impl` has no reservation operation after transformer `next()`.
+        // Therefore the retain operation is last for a splitter and penultimate
+        // for Noop, whose `next()` immediately releases the retained batch.
+        let retain_index = changes
+            .len()
+            .checked_sub(if enforce_batch_size_in_joins { 1 } else { 2 })
+            .expect("transformer retain must update the stream reservation");
+        let retain_change = &changes[retain_index];
+        assert_eq!(
+            retain_change.change, retained_batch_size,
+            "expected transformer retain reservation update: {changes:?}"
+        );
+        if !enforce_batch_size_in_joins {
+            assert_eq!(
+                changes.last().map(|change| change.change),
+                Some(-retained_batch_size),
+                "Noop must release the retained batch before emitting it: {changes:?}"
+            );
+        }
+
+        // This limit is between the reservation immediately before transformer
+        // retention and the reservation immediately after it. The old accounting
+        // omitted this growth and would emit the first batch instead of failing.
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_limit(retain_change.reserved - 1, 1.0)
+            .build_arc()?;
+        let mut stream = transformer_lifecycle_test_join()?.execute(
+            0,
+            transformer_lifecycle_test_context(runtime, enforce_batch_size_in_joins),
+        )?;
+        let error = stream.next().await.transpose().unwrap_err();
+        assert!(
+            matches!(error.find_root(), DataFusionError::ResourcesExhausted(_)),
+            "expected transformer retention to exhaust the pool, got: {error}"
+        );
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2222,8 +2222,13 @@ mod tests {
         let reserved_size = stream.reservation.size();
         assert_ne!(reserved_size, 0);
 
-        stream.set_state(SHJStreamState::BothExhausted { final_result: true });
+        // Empty input streams drive the normal exhaustion/finalization path:
+        // PullRight -> RightExhausted -> BothExhausted(false) -> final_result.
         assert!(stream.next().await.is_none());
+        assert!(matches!(
+            stream.state(),
+            SHJStreamState::BothExhausted { final_result: true }
+        ));
         assert_eq!(stream.reservation.size(), reserved_size);
         assert_eq!(stream.metrics.stream_memory_usage.value(), reserved_size);
 

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -2113,6 +2113,7 @@ mod tests {
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{Column, binary, col, lit};
     use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
+    use std::task::Context as PollContext;
 
     use rstest::*;
 
@@ -2161,7 +2162,9 @@ mod tests {
         }
     }
 
-    fn assert_stream_accounts_for_transformer<T: BatchTransformer>(batch_transformer: T) {
+    fn assert_stream_accounts_for_transformer<T: BatchTransformer + Unpin + Send>(
+        batch_transformer: T,
+    ) {
         let batch = RecordBatch::try_from_iter(vec![(
             "a",
             Arc::new(Int32Array::from_iter_values(0..10)) as _,
@@ -2175,10 +2178,24 @@ mod tests {
         stream.update_reservation().unwrap();
         assert_eq!(stream.size() - empty_size, expected_size);
         assert_eq!(stream.reservation.size(), stream.size());
+        assert_eq!(stream.metrics.stream_memory_usage.value(), stream.size());
 
-        while stream.batch_transformer.next().is_some() {}
-        stream.update_reservation().unwrap();
+        loop {
+            let poll = stream.poll_next_unpin(&mut PollContext::from_waker(
+                futures::task::noop_waker_ref(),
+            ));
+            match poll {
+                Poll::Ready(Some(Ok(_))) => {}
+                Poll::Ready(None) => break,
+                Poll::Ready(Some(Err(error))) => {
+                    panic!("unexpected stream error: {error}")
+                }
+                Poll::Pending => panic!("empty input streams must not pend"),
+            }
+        }
+        assert_eq!(stream.size(), empty_size);
         assert_eq!(stream.reservation.size(), empty_size);
+        assert_eq!(stream.metrics.stream_memory_usage.value(), empty_size);
 
         stream.left.input_buffer = batch;
         let size_with_shared_batch = stream.size();

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -68,6 +68,7 @@ use arrow::record_batch::RecordBatch;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::utils::bisect;
+use datafusion_common::utils::memory::RecordBatchMemoryCounter;
 use datafusion_common::{
     HashSet, JoinSide, JoinType, NullEquality, Result, assert_eq_or_internal_err,
     plan_err,
@@ -1665,11 +1666,14 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
                         }
                         StatefulStreamResult::Ready(Some(batch)) => {
                             self.batch_transformer.set_batch(batch);
+                            self.update_reservation()?;
                         }
                         _ => {}
                     }
                 }
                 Some((batch, _)) => {
+                    // The transformer released this batch before it is emitted.
+                    self.update_reservation()?;
                     return self
                         .metrics
                         .baseline_metrics
@@ -1921,13 +1925,23 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
         self.state.clone()
     }
 
+    /// Returns the memory retained by this stream at its reservation boundary.
+    ///
+    /// Input buffers and a transformer-held output batch can share Arrow buffers,
+    /// so count them as one sequence rather than summing individual batch sizes.
     fn size(&self) -> usize {
-        let mut size = 0;
+        let mut batch_memory_counter = RecordBatchMemoryCounter::new();
+        batch_memory_counter.count_batch(&self.left.input_buffer);
+        batch_memory_counter.count_batch(&self.right.input_buffer);
+        self.batch_transformer
+            .count_memory(&mut batch_memory_counter);
+
+        let mut size = batch_memory_counter.memory_usage();
         size += size_of_val(&self.schema);
         size += size_of_val(&self.filter);
         size += size_of_val(&self.join_type);
-        size += self.left.size();
-        size += self.right.size();
+        size += self.left.size() - self.left.input_buffer.get_array_memory_size();
+        size += self.right.size() - self.right.input_buffer.get_array_memory_size();
         size += size_of_val(&self.column_indices);
         size += self.graph.as_ref().map(|g| g.size()).unwrap_or(0);
         size += size_of_val(&self.left_sorted_filter_expr);
@@ -1936,6 +1950,14 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
         size += size_of_val(&self.null_equality);
         size += size_of_val(&self.metrics);
         size
+    }
+
+    /// Resizes the stream reservation to match all memory retained by the stream.
+    fn update_reservation(&mut self) -> Result<()> {
+        let capacity = self.size();
+        self.metrics.stream_memory_usage.set(capacity);
+        self.reservation.try_resize(capacity)?;
+        Ok(())
     }
 
     /// Performs a join operation for the specified `probe_side` (either left or right).
@@ -2035,9 +2057,7 @@ impl<T: BatchTransformer> SymmetricHashJoinStream<T> {
 
         // Combine results:
         let result = combine_two_batches(&self.schema, equal_result, anti_result)?;
-        let capacity = self.size();
-        self.metrics.stream_memory_usage.set(capacity);
-        self.reservation.try_resize(capacity)?;
+        self.update_reservation()?;
         Ok(result)
     }
 }
@@ -2083,6 +2103,7 @@ mod tests {
         partitioned_sym_join_with_filter, split_record_batches,
     };
 
+    use arrow::array::Int32Array;
     use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
     use datafusion_common::ScalarValue;
@@ -2101,6 +2122,75 @@ mod tests {
     // Cache for storing tables
     static TABLE_CACHE: LazyLock<Mutex<HashMap<TableKey, TableValue>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    fn create_stream<T: BatchTransformer>(
+        batch_transformer: T,
+        input_schema: SchemaRef,
+    ) -> SymmetricHashJoinStream<T> {
+        let context = TaskContext::default();
+        let metrics = ExecutionPlanMetricsSet::new();
+        SymmetricHashJoinStream {
+            left_stream: Box::pin(EmptyRecordBatchStream::new(Arc::clone(&input_schema))),
+            right_stream: Box::pin(EmptyRecordBatchStream::new(Arc::clone(
+                &input_schema,
+            ))),
+            schema: Arc::clone(&input_schema),
+            filter: None,
+            join_type: JoinType::Inner,
+            left: OneSideHashJoiner::new(
+                JoinSide::Left,
+                vec![],
+                Arc::clone(&input_schema),
+            ),
+            right: OneSideHashJoiner::new(JoinSide::Right, vec![], input_schema),
+            column_indices: vec![],
+            graph: None,
+            left_sorted_filter_expr: None,
+            right_sorted_filter_expr: None,
+            random_state: RandomState::default(),
+            null_equality: NullEquality::NullEqualsNothing,
+            metrics: StreamJoinMetrics::new(0, &metrics),
+            reservation: Arc::new(
+                MemoryConsumer::new("SymmetricHashJoinStream[test]")
+                    .register(context.memory_pool()),
+            ),
+            state: SHJStreamState::PullRight,
+            batch_transformer,
+        }
+    }
+
+    fn assert_stream_accounts_for_transformer<T: BatchTransformer>(batch_transformer: T) {
+        let batch = RecordBatch::try_from_iter(vec![(
+            "a",
+            Arc::new(Int32Array::from_iter_values(0..10)) as _,
+        )])
+        .unwrap();
+        let expected_size = RecordBatchMemoryCounter::new().count_batch(&batch);
+        let mut stream = create_stream(batch_transformer, batch.schema());
+
+        let empty_size = stream.size();
+        stream.batch_transformer.set_batch(batch.clone());
+        stream.update_reservation().unwrap();
+        assert_eq!(stream.size() - empty_size, expected_size);
+        assert_eq!(stream.reservation.size(), stream.size());
+
+        while stream.batch_transformer.next().is_some() {}
+        stream.update_reservation().unwrap();
+        assert_eq!(stream.reservation.size(), empty_size);
+
+        stream.left.input_buffer = batch;
+        let size_with_shared_batch = stream.size();
+        stream
+            .batch_transformer
+            .set_batch(stream.left.input_buffer.clone());
+        assert_eq!(stream.size(), size_with_shared_batch);
+    }
+
+    #[test]
+    fn stream_accounts_for_transformer_batches_once() {
+        assert_stream_accounts_for_transformer(NoopBatchTransformer::new());
+        assert_stream_accounts_for_transformer(BatchSplitter::new(3));
+    }
 
     fn get_or_create_table(
         cardinality: (i32, i32),

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -4404,34 +4404,6 @@ mod tests {
         }
     }
 
-    fn assert_transformer_memory(
-        transformer: &impl BatchTransformer,
-        expected_size: usize,
-    ) {
-        let mut counter = RecordBatchMemoryCounter::new();
-        transformer.count_memory(&mut counter);
-        assert_eq!(counter.memory_usage(), expected_size);
-    }
-
-    #[test]
-    fn batch_transformers_count_retained_batch_memory() {
-        let batch = create_test_batch(10);
-        let expected_size = batch.get_array_memory_size();
-
-        let mut noop = NoopBatchTransformer::new();
-        noop.set_batch(batch.clone());
-        assert_transformer_memory(&noop, expected_size);
-
-        let mut splitter = BatchSplitter::new(3);
-        splitter.set_batch(batch.clone());
-        assert_transformer_memory(&splitter, expected_size);
-
-        let mut shared_buffer_counter = RecordBatchMemoryCounter::new();
-        shared_buffer_counter.count_batch_with_array_overhead(&batch);
-        splitter.count_memory(&mut shared_buffer_counter);
-        assert_eq!(shared_buffer_counter.memory_usage(), expected_size);
-    }
-
     #[rstest]
     #[test]
     fn test_batch_splitter(

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -4404,6 +4404,15 @@ mod tests {
         }
     }
 
+    fn assert_transformer_memory(
+        transformer: &impl BatchTransformer,
+        expected_size: usize,
+    ) {
+        let mut counter = RecordBatchMemoryCounter::new();
+        transformer.count_memory(&mut counter);
+        assert_eq!(counter.memory_usage(), expected_size);
+    }
+
     #[test]
     fn batch_transformers_count_retained_batch_memory() {
         let batch = create_test_batch(10);
@@ -4411,15 +4420,11 @@ mod tests {
 
         let mut noop = NoopBatchTransformer::new();
         noop.set_batch(batch.clone());
-        let mut noop_counter = RecordBatchMemoryCounter::new();
-        noop.count_memory(&mut noop_counter);
-        assert_eq!(noop_counter.memory_usage(), expected_size);
+        assert_transformer_memory(&noop, expected_size);
 
         let mut splitter = BatchSplitter::new(3);
         splitter.set_batch(batch.clone());
-        let mut splitter_counter = RecordBatchMemoryCounter::new();
-        splitter.count_memory(&mut splitter_counter);
-        assert_eq!(splitter_counter.memory_usage(), expected_size);
+        assert_transformer_memory(&splitter, expected_size);
 
         let mut shared_buffer_counter = RecordBatchMemoryCounter::new();
         shared_buffer_counter.count_batch_with_array_overhead(&batch);

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -64,6 +64,7 @@ use datafusion_common::cast::as_boolean_array;
 use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::stats::Precision;
+use datafusion_common::utils::memory::RecordBatchMemoryCounter;
 use datafusion_common::utils::normalize_float_zero;
 use datafusion_common::{
     DataFusionError, JoinSide, JoinType, NullEquality, Result, SharedResult,
@@ -1953,6 +1954,9 @@ pub(crate) trait BatchTransformer: Debug + Clone {
     /// Returns `None` if all batches have been produced.
     /// The boolean flag indicates whether the batch is the last one.
     fn next(&mut self) -> Option<(RecordBatch, bool)>;
+
+    /// Counts buffers retained by this transformer.
+    fn count_memory(&self, counter: &mut RecordBatchMemoryCounter);
 }
 
 #[derive(Debug, Clone)]
@@ -1975,6 +1979,12 @@ impl BatchTransformer for NoopBatchTransformer {
 
     fn next(&mut self) -> Option<(RecordBatch, bool)> {
         self.batch.take().map(|batch| (batch, true))
+    }
+
+    fn count_memory(&self, counter: &mut RecordBatchMemoryCounter) {
+        if let Some(batch) = &self.batch {
+            counter.count_batch(batch);
+        }
     }
 }
 
@@ -2023,6 +2033,12 @@ impl BatchTransformer for BatchSplitter {
         }
 
         Some((sliced_batch, last))
+    }
+
+    fn count_memory(&self, counter: &mut RecordBatchMemoryCounter) {
+        if let Some(batch) = &self.batch {
+            counter.count_batch(batch);
+        }
     }
 }
 
@@ -4378,6 +4394,29 @@ mod tests {
             row_count += batch.num_rows();
             assert_eq!(last, row_count == num_rows);
         }
+    }
+
+    #[test]
+    fn batch_transformers_count_retained_batch_memory() {
+        let batch = create_test_batch(10);
+        let expected_size = RecordBatchMemoryCounter::new().count_batch(&batch);
+
+        let mut noop = NoopBatchTransformer::new();
+        noop.set_batch(batch.clone());
+        let mut noop_counter = RecordBatchMemoryCounter::new();
+        noop.count_memory(&mut noop_counter);
+        assert_eq!(noop_counter.memory_usage(), expected_size);
+
+        let mut splitter = BatchSplitter::new(3);
+        splitter.set_batch(batch.clone());
+        let mut splitter_counter = RecordBatchMemoryCounter::new();
+        splitter.count_memory(&mut splitter_counter);
+        assert_eq!(splitter_counter.memory_usage(), expected_size);
+
+        let mut shared_buffer_counter = RecordBatchMemoryCounter::new();
+        shared_buffer_counter.count_batch(&batch);
+        splitter.count_memory(&mut shared_buffer_counter);
+        assert_eq!(shared_buffer_counter.memory_usage(), expected_size);
     }
 
     #[rstest]

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1955,7 +1955,10 @@ pub(crate) trait BatchTransformer: Debug + Clone {
     /// The boolean flag indicates whether the batch is the last one.
     fn next(&mut self) -> Option<(RecordBatch, bool)>;
 
-    /// Counts memory retained by this transformer.
+    /// Adds all memory retained by this transformer to `counter`.
+    ///
+    /// The stream shares this counter with its other retained batches, so
+    /// implementations must let it deduplicate shared Arrow buffers and array objects.
     fn count_memory(&self, counter: &mut RecordBatchMemoryCounter);
 }
 

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1955,7 +1955,7 @@ pub(crate) trait BatchTransformer: Debug + Clone {
     /// The boolean flag indicates whether the batch is the last one.
     fn next(&mut self) -> Option<(RecordBatch, bool)>;
 
-    /// Counts buffers retained by this transformer.
+    /// Counts memory retained by this transformer.
     fn count_memory(&self, counter: &mut RecordBatchMemoryCounter);
 }
 
@@ -1964,7 +1964,7 @@ fn count_retained_batch_memory(
     counter: &mut RecordBatchMemoryCounter,
 ) {
     if let Some(batch) = batch {
-        counter.count_batch(batch);
+        counter.count_batch_with_array_overhead(batch);
     }
 }
 
@@ -4404,7 +4404,7 @@ mod tests {
     #[test]
     fn batch_transformers_count_retained_batch_memory() {
         let batch = create_test_batch(10);
-        let expected_size = RecordBatchMemoryCounter::new().count_batch(&batch);
+        let expected_size = batch.get_array_memory_size();
 
         let mut noop = NoopBatchTransformer::new();
         noop.set_batch(batch.clone());
@@ -4419,7 +4419,7 @@ mod tests {
         assert_eq!(splitter_counter.memory_usage(), expected_size);
 
         let mut shared_buffer_counter = RecordBatchMemoryCounter::new();
-        shared_buffer_counter.count_batch(&batch);
+        shared_buffer_counter.count_batch_with_array_overhead(&batch);
         splitter.count_memory(&mut shared_buffer_counter);
         assert_eq!(shared_buffer_counter.memory_usage(), expected_size);
     }

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -1959,6 +1959,15 @@ pub(crate) trait BatchTransformer: Debug + Clone {
     fn count_memory(&self, counter: &mut RecordBatchMemoryCounter);
 }
 
+fn count_retained_batch_memory(
+    batch: &Option<RecordBatch>,
+    counter: &mut RecordBatchMemoryCounter,
+) {
+    if let Some(batch) = batch {
+        counter.count_batch(batch);
+    }
+}
+
 #[derive(Debug, Clone)]
 /// A batch transformer that does nothing.
 pub(crate) struct NoopBatchTransformer {
@@ -1982,9 +1991,7 @@ impl BatchTransformer for NoopBatchTransformer {
     }
 
     fn count_memory(&self, counter: &mut RecordBatchMemoryCounter) {
-        if let Some(batch) = &self.batch {
-            counter.count_batch(batch);
-        }
+        count_retained_batch_memory(&self.batch, counter);
     }
 }
 
@@ -2036,9 +2043,7 @@ impl BatchTransformer for BatchSplitter {
     }
 
     fn count_memory(&self, counter: &mut RecordBatchMemoryCounter) {
-        if let Some(batch) = &self.batch {
-            counter.count_batch(batch);
-        }
+        count_retained_batch_memory(&self.batch, counter);
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #23393

## Rationale for this change

`SymmetricHashJoinStream` did not include the `RecordBatch` retained by its `BatchTransformer` in the stream's memory reservation. As a result, the symmetric hash join could under-account memory while either `NoopBatchTransformer` or `BatchSplitter` held an output batch.

Transformer-held batches can also share Arrow buffers or nested array objects with other batches retained by the stream, so independently summing batch memory would double-count shared allocations.

This change makes the stream reservation reflect the memory retained at that boundary exactly once. Corrected accounting can increase reservation pressure and may cause a bounded memory pool to report resource exhaustion earlier, without changing join results.

## What changes are included in this PR?

* Adds `RecordBatchMemoryCounter::count_batch_with_array_overhead` to count unique Arrow buffers and recursively reachable array-object allocations across a sequence of batches.
* Deduplicates shared nested array objects for struct, list/list-view, fixed-size-list, map, union, dictionary, and run-end encoded arrays.
* Adds `BatchTransformer::count_memory` and implements it for both `NoopBatchTransformer` and `BatchSplitter`.
* Updates `SymmetricHashJoinStream::size()` to account for its input buffers and transformer-retained batch through one shared `RecordBatchMemoryCounter`, avoiding duplicate accounting of shared allocations.
* Updates the stream reservation when a transformer retains or releases a batch.
* Releases the stream reservation and resets the stream memory metric when the stream reaches its completed state.
* Leaves the existing `OneSideHashJoiner` accounting formulas otherwise unchanged.

## Are these changes tested?

Yes. The patch adds regression coverage for:

* `test_record_batch_memory_counter_array_overhead_shared_across_batches`
* `test_record_batch_memory_counter_deduplicates_shared_nested_array_overhead`
* `test_record_batch_memory_counter_deduplicates_shared_list_child`
* `test_record_batch_memory_counter_deduplicates_shared_map_children`
* `test_record_batch_memory_counter_deduplicates_shared_union_child`
* `test_record_batch_memory_counter_deduplicates_shared_dictionary_child`
* `test_record_batch_memory_counter_deduplicates_shared_run_end_encoded_child`
* `stream_accounts_for_transformer_batches_once`
* `symmetric_hash_join_releases_reservation_when_complete`
* `stream_deduplicates_nested_transformer_batches`
* `transformer_reservation_exhausts_pool`
* `symmetric_hash_join_updates_reservation_while_transforming_output`, for both `NoopBatchTransformer` and `BatchSplitter`
* `symmetric_hash_join_transformer_retention_exhausts_bounded_pool`, for both `NoopBatchTransformer` and `BatchSplitter`

The patch shown does not establish that the full `cargo test -p datafusion-physical-plan`, clippy, repository lint, or extended test suites have been run.

## Are there any user-facing changes?

There are no intended changes to join results or query semantics.

Memory accounting for symmetric hash joins is more accurate. In bounded-memory configurations, a join that previously under-accounted transformer-retained output may now reach the configured memory limit and report resource exhaustion earlier.

No public API breaking change is introduced by this patch.

## LLM-generated code disclosure

This PR includes LLM-generated code and comments. All LLM-generated content has been manually reviewed.
