### PR TITLE
perf: desugar remaining `#[async_trait]` stubs capturing `Expr`/`LogicalPlan`

### DIFF
--- a/datafusion/catalog/src/empty.rs
+++ b/datafusion/catalog/src/empty.rs
@@ -17,6 +17,7 @@
 
 //! [`EmptyTable`] useful for testing.
 
+use std::future::ready;
 use std::sync::Arc;
 
 use arrow::datatypes::*;
@@ -25,6 +26,7 @@ use datafusion_common::{Result, project_schema};
 use datafusion_expr::{Expr, TableType};
 use datafusion_physical_plan::ExecutionPlan;
 use datafusion_physical_plan::empty::EmptyExec;
+use futures::future::BoxFuture;
 
 use crate::Session;
 use crate::TableProvider;
@@ -63,12 +65,30 @@ impl TableProvider for EmptyTable {
         TableType::Base
     }
 
-    async fn scan(
-        &self,
-        _state: &dyn Session,
-        projection: Option<&Vec<usize>>,
-        _filters: &[Expr],
+    // Hand-written `#[async_trait]` expansion to reduce compile time. See
+    // <https://github.com/apache/datafusion/issues/13814#issuecomment-5292709677>
+    fn scan<'life0, 'life1, 'life2, 'life3, 'async_trait>(
+        &'life0 self,
+        _state: &'life1 dyn Session,
+        projection: Option<&'life2 Vec<usize>>,
+        _filters: &'life3 [Expr],
         _limit: Option<usize>,
+    ) -> BoxFuture<'async_trait, Result<Arc<dyn ExecutionPlan>>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+        'life3: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(ready(self.scan_inner(projection)))
+    }
+}
+
+impl EmptyTable {
+    fn scan_inner(
+        &self,
+        projection: Option<&Vec<usize>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // even though there is no data, projections apply
         let projected_schema = project_schema(&self.schema, projection)?;

--- a/datafusion/core/src/test_util/mod.rs
+++ b/datafusion/core/src/test_util/mod.rs
@@ -245,14 +245,25 @@ impl TableProvider for TestTableProvider {
         unimplemented!("TestTableProvider is a stub for testing.")
     }
 
-    async fn scan(
-        &self,
-        _state: &dyn Session,
-        _projection: Option<&Vec<usize>>,
-        _filters: &[Expr],
+    // Hand-written `#[async_trait]` expansion to reduce compile time. See
+    // <https://github.com/apache/datafusion/issues/13814#issuecomment-5292709677>
+    fn scan<'life0, 'life1, 'life2, 'life3, 'async_trait>(
+        &'life0 self,
+        _state: &'life1 dyn Session,
+        _projection: Option<&'life2 Vec<usize>>,
+        _filters: &'life3 [Expr],
         _limit: Option<usize>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        unimplemented!("TestTableProvider is a stub for testing.")
+    ) -> BoxFuture<'async_trait, Result<Arc<dyn ExecutionPlan>>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+        'life3: 'async_trait,
+        Self: 'async_trait,
+    {
+        // The async block captures none of the arguments, so proving it
+        // `Send` is cheap; panics when polled, like the `async fn` it replaces.
+        Box::pin(async { unimplemented!("TestTableProvider is a stub for testing.") })
     }
 }
 

--- a/datafusion/session/src/planner.rs
+++ b/datafusion/session/src/planner.rs
@@ -19,6 +19,7 @@
 
 use std::any::Any;
 use std::fmt::Debug;
+use std::future::ready;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -26,6 +27,7 @@ use datafusion_common::{DFSchema, Result, not_impl_err};
 use datafusion_expr::physical_planning_context::PhysicalPlanningContext;
 use datafusion_expr::{Expr, LogicalPlan, TableScan, UserDefinedLogicalNode};
 use datafusion_physical_plan::{ExecutionPlan, PhysicalExpr};
+use futures::future::BoxFuture;
 
 use crate::Session;
 
@@ -49,12 +51,22 @@ pub struct UnsupportedQueryPlanner;
 
 #[async_trait]
 impl QueryPlanner for UnsupportedQueryPlanner {
-    async fn create_physical_plan(
-        &self,
-        _logical_plan: &LogicalPlan,
-        _session: &dyn Session,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        not_impl_err!("This session does not expose its query planner")
+    // Hand-written `#[async_trait]` expansion to reduce compile time. See
+    // <https://github.com/apache/datafusion/issues/13814#issuecomment-5292709677>
+    fn create_physical_plan<'life0, 'life1, 'life2, 'async_trait>(
+        &'life0 self,
+        _logical_plan: &'life1 LogicalPlan,
+        _session: &'life2 dyn Session,
+    ) -> BoxFuture<'async_trait, Result<Arc<dyn ExecutionPlan>>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(ready(not_impl_err!(
+            "This session does not expose its query planner"
+        )))
     }
 }
 
@@ -186,13 +198,23 @@ pub trait ExtensionPlanner {
     /// ```
     ///
     /// [`TableSource`]: datafusion_expr::TableSource
-    async fn plan_table_scan(
-        &self,
-        _planner: &dyn PhysicalPlanner,
-        _scan: &TableScan,
-        _session: &dyn Session,
-        _planning_ctx: &PhysicalPlanningContext,
-    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
-        Ok(None)
+    // Hand-written `#[async_trait]` expansion to reduce compile time. See
+    // <https://github.com/apache/datafusion/issues/13814#issuecomment-5292709677>
+    fn plan_table_scan<'life0, 'life1, 'life2, 'life3, 'life4, 'async_trait>(
+        &'life0 self,
+        _planner: &'life1 dyn PhysicalPlanner,
+        _scan: &'life2 TableScan,
+        _session: &'life3 dyn Session,
+        _planning_ctx: &'life4 PhysicalPlanningContext,
+    ) -> BoxFuture<'async_trait, Result<Option<Arc<dyn ExecutionPlan>>>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+        'life3: 'async_trait,
+        'life4: 'async_trait,
+        Self: Sync + 'async_trait,
+    {
+        Box::pin(ready(Ok(None)))
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Addresses https://github.com/apache/datafusion/issues/13814
- Follow on to #24325, #24326, #24329 and #24330

## Rationale for this change

Applies the same rewrite as the four PRs above to the remaining `#[async_trait]` methods on the serial build path whose futures capture `Expr`/`LogicalPlan`-reaching types (so their `Send`/`Sync` proofs are re-proved per method in a non-empty `ParamEnv`):

- `UnsupportedQueryPlanner::create_physical_plan` (`datafusion-session`) — captures `&LogicalPlan`
- `ExtensionPlanner::plan_table_scan` default body (`datafusion-session`) — captures `&TableScan`, which holds `Vec<Expr>`
- `EmptyTable::scan` (`datafusion-catalog`) — captures `&[Expr]`
- `TestTableProvider::scan` (`datafusion` core; `test_util` compiles into the lib unconditionally) — captures `&[Expr]`

## What changes are included in this PR?

Each method becomes the hand-written desugaring of what `#[async_trait]` generates (verified against `-Zunpretty=expanded` output), with no coroutine capturing the arguments:

- The stubs (`create_physical_plan`, `plan_table_scan`, `TestTableProvider::scan`) return `ready(..)` or a captureless `async` block directly.
- `EmptyTable::scan` has no `.await`, so its body moves verbatim to a plain inherent fn wrapped in `ready(..)` (same as `TestTableFactory::create_inner` in #24329).
- `plan_table_scan` keeps its `Self: Sync + 'async_trait` bound so the public trait signature is unchanged.

Each converted method carries the explanatory comment from #24362.

## Are these changes tested?

Functionally: `cargo fmt --check`, `cargo clippy -p datafusion-catalog -p datafusion-session --all-targets`, `cargo clippy -p datafusion --lib`, `cargo test -p datafusion-catalog -p datafusion-session`, and `cargo test -p datafusion --lib` all pass. The compiler checks each rewritten signature against its trait declaration.

Compile-time impact is **not yet measured** (my machine is too noisy); this PR is a draft until the numbers below are collected.

<details>
<summary>Compile-time measurements to run (on a quiet machine)</summary>

Interleaved A/B of each affected crate's unit, alternating `main` and this branch at least 3 times each so machine drift cancels out (the methodology from #24325–#24330):

```bash
# once per checkout: warm the dependency graph
cargo build -p datafusion

# one round (repeat >=3x, alternating branches):
cargo clean -p datafusion-session -p datafusion-catalog -p datafusion
time cargo rustc -p datafusion-session --lib
time cargo rustc -p datafusion-catalog --lib
time cargo rustc -p datafusion --lib
```

Expected: a drop in `datafusion-session` (which had ~0.65s of `evaluate_obligation` remaining after #24326 in the standalone build, several times more in the feature-unified build) and a smaller drop in `datafusion-catalog` and core. `EmptyTable`/`TestTableProvider` are unproven — they did not appear in the per-impl profiles of #24325/#24329 — so it is worth confirming their marginal contribution before merging, e.g. by reverting one file at a time.

To attribute the change to the trait solver rather than noise:

```bash
# cargo install --git https://github.com/rust-lang/measureme summarize
RUSTFLAGS="-Zself-profile=/tmp/self-profile" cargo +nightly rustc -p datafusion-session --lib
summarize summarize $(ls -t /tmp/self-profile/*.mm_profdata | head -1) | grep -E "evaluate_obligation|Total"
```

</details>

## Are there any user-facing changes?

No. After macro expansion the method signatures are identical to before, including `plan_table_scan`'s `Self: Sync` bound.
