### PR TITLE
bench: Add benchmarks for ordered `ARRAY_AGG` and `STRING_AGG`

### DIFF
--- a/benchmarks/sql_benchmarks/README.md
+++ b/benchmarks/sql_benchmarks/README.md
@@ -29,6 +29,7 @@ in the community:
 
 | Benchmark Suite       | Description                                                        |
 |-----------------------|--------------------------------------------------------------------|
+| `aggregate`           | Aggregate function benchmarks                                      |
 | `clickbench`          | ClickBench benchmark                                               |
 | `clickbench extended` | 12 additional, more complex queries against the Clickbench dataset |
 | `clickbench_sorted`   | ClickBench benchmark using a pre-sorted hits file.                 |
@@ -169,6 +170,7 @@ Some benchmarks use custom environment variables as outlined below:
 | BENCH_SORTED                 | Used in the sort_tpch benchmark to indicate whether the lineitem table should be sorted.                                 | false         |
 | SORTED_BY                    | Used in the clickbench_sorted benchmark to indicate the column to sort by.                                               | `EventTime`   |
 | SORTED_ORDER                 | Used in the clickbench_sorted benchmark to indicate the sort order of the column.                                        | `ASC`         |
+| AGGREGATE_ROWS               | Used in the aggregate benchmark to size the generated aggregate datasets.                                                | `1000000`     |
 | PRED_ROWS                    | Used in the predicate_eval benchmark to size the synthetic table (the `scale` subgroup overrides this per query), and in the parquet_row_filter_skip benchmark to size the generated Parquet datasets (default `10000000` there). | `1000000`     |
 | PRED_FILL                    | Used in the predicate_eval benchmark as the string-column width knob (filler chars per marker).                          | `30`          |
 | RG_SIZE                      | Used in the parquet_row_filter_skip benchmark as the Parquet `max_row_group_size` for the generated datasets.            | `1000000`     |

--- a/benchmarks/sql_benchmarks/aggregate/aggregate.benchmark.template
+++ b/benchmarks/sql_benchmarks/aggregate/aggregate.benchmark.template
@@ -1,0 +1,13 @@
+load sql_benchmarks/aggregate/init/load.sql
+
+name ${NAME}
+group aggregate
+
+assert B
+SELECT COUNT(*) = ${AGGREGATE_ROWS:-1000000} FROM aggregate_data;
+----
+true
+
+run sql_benchmarks/aggregate/queries/${SUBGROUP}/q${QPAD}.sql
+
+cleanup sql_benchmarks/aggregate/init/cleanup.sql

--- a/benchmarks/sql_benchmarks/aggregate/aggregate.suite
+++ b/benchmarks/sql_benchmarks/aggregate/aggregate.suite
@@ -1,0 +1,23 @@
+description = "Focused aggregate function benchmarks"
+
+query_pattern = "q{QUERY_ID_PADDED}.benchmark"
+
+[[options]]
+name = "rows"
+short = "r"
+env = "AGGREGATE_ROWS"
+default = "1000000"
+values = ["1000000", "..."]
+help = "Sets the number of rows in generated aggregate datasets."
+
+[[examples]]
+command = "cargo run --release --bin benchmark_runner -- aggregate --subgroup array_agg --query 1"
+description = "Run the ordered ARRAY_AGG benchmark."
+
+[[examples]]
+command = "cargo run --release --bin benchmark_runner -- aggregate --subgroup array_agg --query 2"
+description = "Run the conflicting-order ARRAY_AGG benchmark."
+
+[[examples]]
+command = "cargo run --release --bin benchmark_runner -- aggregate --subgroup string_agg --query 1"
+description = "Run the ordered STRING_AGG benchmark."

--- a/benchmarks/sql_benchmarks/aggregate/benchmarks/array_agg/q01.benchmark
+++ b/benchmarks/sql_benchmarks/aggregate/benchmarks/array_agg/q01.benchmark
@@ -1,0 +1,6 @@
+subgroup array_agg
+
+template sql_benchmarks/aggregate/aggregate.benchmark.template
+SUBGROUP=array_agg
+QPAD=01
+NAME=Q01_array_agg_ordered

--- a/benchmarks/sql_benchmarks/aggregate/benchmarks/array_agg/q02.benchmark
+++ b/benchmarks/sql_benchmarks/aggregate/benchmarks/array_agg/q02.benchmark
@@ -1,0 +1,6 @@
+subgroup array_agg
+
+template sql_benchmarks/aggregate/aggregate.benchmark.template
+SUBGROUP=array_agg
+QPAD=02
+NAME=Q02_array_agg_conflicting_order

--- a/benchmarks/sql_benchmarks/aggregate/benchmarks/string_agg/q01.benchmark
+++ b/benchmarks/sql_benchmarks/aggregate/benchmarks/string_agg/q01.benchmark
@@ -1,0 +1,6 @@
+subgroup string_agg
+
+template sql_benchmarks/aggregate/aggregate.benchmark.template
+SUBGROUP=string_agg
+QPAD=01
+NAME=Q01_string_agg_ordered

--- a/benchmarks/sql_benchmarks/aggregate/init/cleanup.sql
+++ b/benchmarks/sql_benchmarks/aggregate/init/cleanup.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS aggregate_data;

--- a/benchmarks/sql_benchmarks/aggregate/init/load.sql
+++ b/benchmarks/sql_benchmarks/aggregate/init/load.sql
@@ -1,0 +1,26 @@
+CREATE TABLE aggregate_data AS
+SELECT
+  -- Keep this key high-cardinality and stable when AGGREGATE_ROWS changes.
+  CASE
+    WHEN value % 97 = 0 THEN NULL
+    ELSE (value * 8191 + 104729) % 2147483647
+  END AS i64_high_cardinality,
+  -- Derive the low-cardinality key from each lane's ordinal so every key
+  -- occurs in all four UNION ALL partitions.
+  'key-' || LPAD(
+    CAST(
+      ((((value - 1) / 4) * 13 + (value - 1) % 4) % 32) AS VARCHAR
+    ),
+    2,
+    '0'
+  ) AS utf8_low_cardinality,
+  'employee-' || CAST(value AS VARCHAR) AS utf8_value
+FROM (
+  SELECT value FROM generate_series(1, ${AGGREGATE_ROWS:-1000000}, 4)
+  UNION ALL
+  SELECT value FROM generate_series(2, ${AGGREGATE_ROWS:-1000000}, 4)
+  UNION ALL
+  SELECT value FROM generate_series(3, ${AGGREGATE_ROWS:-1000000}, 4)
+  UNION ALL
+  SELECT value FROM generate_series(4, ${AGGREGATE_ROWS:-1000000}, 4)
+) partitioned_data;

--- a/benchmarks/sql_benchmarks/aggregate/queries/array_agg/q01.sql
+++ b/benchmarks/sql_benchmarks/aggregate/queries/array_agg/q01.sql
@@ -1,0 +1,5 @@
+SELECT array_agg(
+  utf8_value
+  ORDER BY i64_high_cardinality ASC NULLS LAST, utf8_low_cardinality DESC
+)
+FROM aggregate_data;

--- a/benchmarks/sql_benchmarks/aggregate/queries/array_agg/q02.sql
+++ b/benchmarks/sql_benchmarks/aggregate/queries/array_agg/q02.sql
@@ -1,0 +1,7 @@
+SELECT
+  array_agg(utf8_value ORDER BY i64_high_cardinality ASC NULLS LAST),
+  array_agg(
+    utf8_value
+    ORDER BY utf8_low_cardinality DESC, i64_high_cardinality DESC NULLS FIRST
+  )
+FROM aggregate_data;

--- a/benchmarks/sql_benchmarks/aggregate/queries/string_agg/q01.sql
+++ b/benchmarks/sql_benchmarks/aggregate/queries/string_agg/q01.sql
@@ -1,0 +1,5 @@
+SELECT string_agg(
+  utf8_value,
+  ',' ORDER BY i64_high_cardinality ASC NULLS LAST, utf8_low_cardinality DESC
+)
+FROM aggregate_data;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related to #20788.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

Add benchmarks for ordered aggregate functions, including the ordered `ARRAY_AGG` workload

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR adds a reusable SQL benchmark suite for aggregate functions.

The initial cases cover:

- `ARRAY_AGG` with multiple ordering expressions.
- Two `ARRAY_AGG` expressions with different ordering requirements.
- `STRING_AGG` with multiple ordering expressions.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

No. This PR only adds benchmarks.