### PR TITLE
fix: log(0.0::float8) should error, not return -inf

### DIFF
--- a/datafusion/core/tests/expr_api/simplification.rs
+++ b/datafusion/core/tests/expr_api/simplification.rs
@@ -611,20 +611,26 @@ fn test_simplify_log() {
         let expr = log(col("c3_non_null"), lit(1));
         test_simplify(expr, lit(0i64));
     }
-    // Log(c3, c3) ===> 1
+    // Log(c3, c3) is not rewritten: c3 is a column, so the logged
+    // value is not known to be a valid (strictly positive) log
+    // argument. Folding to 1 would hide log(0, 0).
     {
         let expr = log(col("c3_non_null"), col("c3_non_null"));
-        let expected = lit(1i64);
-        test_simplify(expr, expected);
+        test_simplify(expr.clone(), expr);
     }
-    // Log(c3, Power(c3, c4)) ===> c4
+    // Log(2, 2) ===> 1 (literal known to be a valid log argument)
+    {
+        let expr = log(lit(2i64), lit(2i64));
+        test_simplify(expr, lit(1i64));
+    }
+    // Log(c3, Power(c3, c4)) is not rewritten for the same reason:
+    // power of two columns is not known to be strictly positive.
     {
         let expr = log(
             col("c3_non_null"),
             power(col("c3_non_null"), col("c4_non_null")),
         );
-        let expected = col("c4_non_null");
-        test_simplify(expr, expected);
+        test_simplify(expr.clone(), expr);
     }
     // Log(c3, c4) ===> Log(c3, c4)
     {

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -345,7 +345,9 @@ impl ScalarUDFImpl for LogFunc {
     /// Simplify the `log` function by the relevant rules:
     /// 1. Log(a, 1) ===> 0
     /// 2. Log(a, Power(a, b)) ===> b
+    ///    (only when `Power(a, b)` is known to be a valid log argument)
     /// 3. Log(a, a) ===> 1
+    ///    (only when `a` is known to be a valid log argument)
     fn simplify(
         &self,
         mut args: Vec<Expr>,
@@ -406,13 +408,18 @@ impl ScalarUDFImpl for LogFunc {
                 if is_pow(&func)
                     && args.len() == 2
                     && base == args[0]
-                    && !base_nullable =>
+                    && !base_nullable
+                    && is_known_positive_power_result(&args[0], &args[1]) =>
             {
                 let b = args.pop().unwrap(); // length checked above
                 Ok(ExprSimplifyResult::Simplified(b))
             }
             number => {
-                if number == base && !base_nullable {
+                // `log(a, a) => 1` is only valid when `a` is known to be a
+                // strictly positive finite value. Zero/negative literals and
+                // non-constant expressions must not be rewritten so the
+                // domain-error check still runs (e.g. `log(0, 0)`).
+                if number == base && !base_nullable && is_known_valid_log_value(&number) {
                     Ok(ExprSimplifyResult::Simplified(lit(ScalarValue::new_one(
                         &number_datatype,
                     )?)))
@@ -436,6 +443,37 @@ impl ScalarUDFImpl for LogFunc {
 /// Returns true if the function is `PowerFunc`
 fn is_pow(func: &ScalarUDF) -> bool {
     func.inner().is::<PowerFunc>()
+}
+
+/// Cast a literal expression to `f64`, if possible.
+fn literal_as_f64(expr: &Expr) -> Option<f64> {
+    let Expr::Literal(value, _) = expr else {
+        return None;
+    };
+    match value.cast_to(&DataType::Float64) {
+        Ok(ScalarValue::Float64(Some(v))) => Some(v),
+        _ => None,
+    }
+}
+
+/// True when `expr` is a literal known to be a valid log argument: finite
+/// and strictly greater than zero. Non-literals, zero, negatives, NaN, and
+/// infinities are not statically safe and must not be rewritten away.
+fn is_known_valid_log_value(expr: &Expr) -> bool {
+    matches!(literal_as_f64(expr), Some(v) if v.is_finite() && v > 0.0)
+}
+
+/// True when `power(base, exponent)` is known to evaluate to a strictly
+/// positive finite value, so `log(base, power(base, exponent))` will not
+/// hit the log-of-zero domain error (or produce 0 via underflow).
+fn is_known_positive_power_result(base: &Expr, exponent: &Expr) -> bool {
+    match (literal_as_f64(base), literal_as_f64(exponent)) {
+        (Some(b), Some(e)) if b.is_finite() && b > 0.0 && e.is_finite() => {
+            let p = b.powf(e);
+            p.is_finite() && p > 0.0
+        }
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -1373,5 +1411,29 @@ mod tests {
             vec![DataType::Float64, DataType::Float64],
         )
         .expect("zero base should not error in this change");
+    }
+
+    #[test]
+    fn test_log_zero_every_physical_type() {
+        let data_types = [
+            DataType::Float16,
+            DataType::Float32,
+            DataType::Float64,
+            DataType::Decimal32(9, 2),
+            DataType::Decimal64(18, 2),
+            DataType::Decimal128(38, 0),
+            DataType::Decimal256(DECIMAL256_MAX_PRECISION, 0),
+        ];
+
+        for data_type in data_types {
+            let zero = ScalarValue::new_zero(&data_type)
+                .unwrap_or_else(|e| panic!("zero for {data_type}: {e}"));
+            let err =
+                invoke_log(vec![ColumnarValue::Scalar(zero)], vec![data_type.clone()])
+                    .expect_err(&format!(
+                        "log(0) as {data_type} should be a domain error"
+                    ));
+            assert_log_of_zero(err);
+        }
     }
 }

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -100,6 +100,27 @@ impl LogFunc {
     }
 }
 
+/// Matches PostgreSQL: `log(0::float8)` is undefined (IEEE 754 would yield -inf).
+const LOG_OF_ZERO_ERROR: &str = "cannot take logarithm of zero";
+
+#[inline]
+fn log_of_zero_error() -> ArrowError {
+    ArrowError::ComputeError(LOG_OF_ZERO_ERROR.to_string())
+}
+
+/// Compute `value.log(base)` after rejecting a zero value.
+///
+/// Only the value (the number being logged) is checked. A zero *base*
+/// (`log(0, x)`) is left as IEEE 754 infinity / NaN; that is a separate
+/// compatibility case from issue #22261.
+#[inline]
+fn compute_float_log<F: Float>(value: F, base: F) -> Result<F, ArrowError> {
+    if value == F::zero() {
+        return Err(log_of_zero_error());
+    }
+    Ok(value.log(base))
+}
+
 /// Checks if the base is valid for the efficient integer logarithm algorithm.
 #[inline]
 fn is_valid_integer_base(base: f64) -> bool {
@@ -110,6 +131,9 @@ fn is_valid_integer_base(base: f64) -> bool {
 /// For integer bases >= 2 with zero scale, return an exact integer log when the
 /// value is a perfect power of the base. Otherwise falls back to f64 computation.
 fn log_decimal32(value: i32, scale: i8, base: f64) -> Result<f64, ArrowError> {
+    if value == 0 {
+        return Err(log_of_zero_error());
+    }
     if scale == 0
         && is_valid_integer_base(base)
         && let Ok(unscaled) = u32::try_from(value)
@@ -128,6 +152,9 @@ fn log_decimal32(value: i32, scale: i8, base: f64) -> Result<f64, ArrowError> {
 /// For integer bases >= 2 with zero scale, return an exact integer log when the
 /// value is a perfect power of the base. Otherwise falls back to f64 computation.
 fn log_decimal64(value: i64, scale: i8, base: f64) -> Result<f64, ArrowError> {
+    if value == 0 {
+        return Err(log_of_zero_error());
+    }
     if scale == 0
         && is_valid_integer_base(base)
         && let Ok(unscaled) = u64::try_from(value)
@@ -146,6 +173,9 @@ fn log_decimal64(value: i64, scale: i8, base: f64) -> Result<f64, ArrowError> {
 /// For integer bases >= 2 with zero scale, return an exact integer log when the
 /// value is a perfect power of the base. Otherwise falls back to f64 computation.
 fn log_decimal128(value: i128, scale: i8, base: f64) -> Result<f64, ArrowError> {
+    if value == 0 {
+        return Err(log_of_zero_error());
+    }
     if scale == 0
         && is_valid_integer_base(base)
         && let Ok(unscaled) = u128::try_from(value)
@@ -171,6 +201,9 @@ fn decimal_to_f64<T: ToPrimitive + Copy>(value: T, scale: i8) -> Result<f64, Arr
 }
 
 fn log_decimal256(value: i256, scale: i8, base: f64) -> Result<f64, ArrowError> {
+    if value == i256::ZERO {
+        return Err(log_of_zero_error());
+    }
     // Try to convert to i128 for the optimized path
     match value.to_i128() {
         Some(v) => log_decimal128(v, scale, base),
@@ -251,27 +284,24 @@ impl ScalarUDFImpl for LogFunc {
         let value = value.to_array(args.number_rows)?;
 
         let output: ArrayRef = match value.data_type() {
-            DataType::Float16 => {
-                calculate_binary_math::<Float16Type, Float16Type, Float16Type, _>(
-                    &value,
-                    &base,
-                    |value, base| Ok(value.log(base)),
-                )?
-            }
-            DataType::Float32 => {
-                calculate_binary_math::<Float32Type, Float32Type, Float32Type, _>(
-                    &value,
-                    &base,
-                    |value, base| Ok(value.log(base)),
-                )?
-            }
-            DataType::Float64 => {
-                calculate_binary_math::<Float64Type, Float64Type, Float64Type, _>(
-                    &value,
-                    &base,
-                    |value, base| Ok(value.log(base)),
-                )?
-            }
+            DataType::Float16 => calculate_binary_math::<
+                Float16Type,
+                Float16Type,
+                Float16Type,
+                _,
+            >(&value, &base, compute_float_log)?,
+            DataType::Float32 => calculate_binary_math::<
+                Float32Type,
+                Float32Type,
+                Float32Type,
+                _,
+            >(&value, &base, compute_float_log)?,
+            DataType::Float64 => calculate_binary_math::<
+                Float64Type,
+                Float64Type,
+                Float64Type,
+                _,
+            >(&value, &base, compute_float_log)?,
             DataType::Decimal32(_, scale) => {
                 calculate_binary_math::<Decimal32Type, Float64Type, Float64Type, _>(
                     &value,
@@ -1212,5 +1242,136 @@ mod tests {
                 panic!("Expected an array value")
             }
         }
+    }
+
+    fn invoke_log(
+        args: Vec<ColumnarValue>,
+        data_types: Vec<DataType>,
+    ) -> Result<ColumnarValue> {
+        let number_rows = args
+            .iter()
+            .map(|a| match a {
+                ColumnarValue::Array(arr) => arr.len(),
+                ColumnarValue::Scalar(_) => 1,
+            })
+            .max()
+            .unwrap_or(1);
+        let arg_fields = data_types
+            .into_iter()
+            .map(|dt| Field::new("a", dt, false).into())
+            .collect();
+        let args = ScalarFunctionArgs {
+            args,
+            arg_fields,
+            number_rows,
+            return_field: Field::new("f", DataType::Float64, true).into(),
+            config_options: Arc::new(ConfigOptions::default()),
+        };
+        LogFunc::new().invoke_with_args(args)
+    }
+
+    fn assert_log_of_zero(err: datafusion_common::DataFusionError) {
+        let message = err.to_string();
+        assert!(
+            message.contains(LOG_OF_ZERO_ERROR),
+            "expected '{LOG_OF_ZERO_ERROR}' in error, got {message}"
+        );
+    }
+
+    #[test]
+    fn test_log_zero_float64_unary_errors() {
+        let err = invoke_log(
+            vec![ColumnarValue::Scalar(ScalarValue::Float64(Some(0.0)))],
+            vec![DataType::Float64],
+        )
+        .expect_err("log(0.0) should be a domain error");
+        assert_log_of_zero(err);
+    }
+
+    #[test]
+    fn test_log_negative_zero_float64_errors() {
+        let err = invoke_log(
+            vec![ColumnarValue::Scalar(ScalarValue::Float64(Some(-0.0)))],
+            vec![DataType::Float64],
+        )
+        .expect_err("log(-0.0) should be a domain error");
+        assert_log_of_zero(err);
+    }
+
+    #[test]
+    fn test_log_zero_float32_unary_errors() {
+        let err = invoke_log(
+            vec![ColumnarValue::Scalar(ScalarValue::Float32(Some(0.0)))],
+            vec![DataType::Float32],
+        )
+        .expect_err("log(0.0f32) should be a domain error");
+        assert_log_of_zero(err);
+    }
+
+    #[test]
+    fn test_log_zero_float64_binary_errors() {
+        let err = invoke_log(
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(10.0))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(0.0))),
+            ],
+            vec![DataType::Float64, DataType::Float64],
+        )
+        .expect_err("log(10, 0.0) should be a domain error");
+        assert_log_of_zero(err);
+    }
+
+    #[test]
+    fn test_log_zero_array_errors() {
+        let err = invoke_log(
+            vec![ColumnarValue::Array(Arc::new(Float64Array::from(vec![
+                10.0, 0.0, 100.0,
+            ])))],
+            vec![DataType::Float64],
+        )
+        .expect_err("log() of an array containing 0 should be a domain error");
+        assert_log_of_zero(err);
+    }
+
+    #[test]
+    fn test_log_zero_decimal128_errors() {
+        let err = invoke_log(
+            vec![ColumnarValue::Scalar(ScalarValue::Decimal128(
+                Some(0),
+                38,
+                0,
+            ))],
+            vec![DataType::Decimal128(38, 0)],
+        )
+        .expect_err("log(0::decimal) should be a domain error");
+        assert_log_of_zero(err);
+    }
+
+    #[test]
+    fn test_log_zero_decimal256_errors() {
+        let err = invoke_log(
+            vec![ColumnarValue::Scalar(ScalarValue::Decimal256(
+                Some(i256::ZERO),
+                DECIMAL256_MAX_PRECISION,
+                0,
+            ))],
+            vec![DataType::Decimal256(DECIMAL256_MAX_PRECISION, 0)],
+        )
+        .expect_err("log(0::decimal256) should be a domain error");
+        assert_log_of_zero(err);
+    }
+
+    #[test]
+    fn test_log_zero_base_is_not_this_issue() {
+        // log(0, 64) takes log of 64 (nonzero). A zero *base* is out of
+        // scope for #22261 and keeps the previous IEEE result.
+        invoke_log(
+            vec![
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(0.0))),
+                ColumnarValue::Scalar(ScalarValue::Float64(Some(64.0))),
+            ],
+            vec![DataType::Float64, DataType::Float64],
+        )
+        .expect("zero base should not error in this change");
     }
 }

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -1162,6 +1162,26 @@ select
 ----
 39.0625 Float64
 
+# log(0::float8) - issue #22261
+query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
+SELECT log(0.0::float8)
+
+# two-arg form: logarithm of zero value
+query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
+SELECT log(10.0::float8, 0.0::float8)
+
+# negative zero is still zero
+query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
+SELECT log((-0.0)::float8)
+
+# column / non-literal path
+query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
+SELECT log(x) FROM (VALUES (0.0::float8)) AS t(x)
+
+# decimal zero
+query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
+SELECT log(0::decimal(10, 2))
+
 # factorial negative (PostgreSQL-compatible domain error)
 query error DataFusion error: Execution error: factorial of a negative number is undefined
 select factorial(-1);

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -1182,6 +1182,18 @@ SELECT log(x) FROM (VALUES (0.0::float8)) AS t(x)
 query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
 SELECT log(0::decimal(10, 2))
 
+# log(0, 0) must not simplify to 1
+query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
+SELECT log(0.0::float8, 0.0::float8)
+
+# log(a, power(a, b)) must not rewrite to b when the power result is zero
+query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
+SELECT log(0.0::float8, power(0.0::float8, 1.0::float8))
+
+# underflow of a positive base still yields a zero power result
+query error DataFusion error: Arrow error: Compute error: cannot take logarithm of zero
+SELECT log(2.0::float8, power(2.0::float8, -2000.0::float8))
+
 # factorial negative (PostgreSQL-compatible domain error)
 query error DataFusion error: Execution error: factorial of a negative number is undefined
 select factorial(-1);
@@ -1233,7 +1245,9 @@ physical_plan
 01)ProjectionExec: expr=[log(column1@0, 1) as l1, log(column1@0, column1@0) as la, power(column1@0, 0) as p0, power(column1@0, log(column1@0, column2@1)) as pl]
 02)--DataSourceExec: partitions=1, partition_sizes=[1]
 
-# Non-nullable bases still use the existing simplifications
+# Non-nullable bases still use simplifications that cannot skip domain checks.
+# log(a, 1) and power(...) are unchanged. log(a, a) is not rewritten because
+# a column is not a known-positive literal.
 query TT
 EXPLAIN SELECT
   log(a, 1) AS l1,
@@ -1243,13 +1257,35 @@ EXPLAIN SELECT
 FROM (VALUES (2.0::double, 3.0::double)) AS t(a, b);
 ----
 logical_plan
-01)Projection: Float64(0) AS l1, Float64(1) AS la, Float64(1) AS p0, t.b AS pl
+01)Projection: Float64(0) AS l1, log(t.a, t.a) AS la, Float64(1) AS p0, t.b AS pl
 02)--SubqueryAlias: t
-03)----Projection: column2 AS b
+03)----Projection: column1 AS a, column2 AS b
 04)------Values: (Float64(2), Float64(3))
 physical_plan
-01)ProjectionExec: expr=[0 as l1, 1 as la, 1 as p0, column2@1 as pl]
+01)ProjectionExec: expr=[0 as l1, log(column1@0, column1@0) as la, 1 as p0, column2@1 as pl]
 02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Known-positive literals still use log(a, a) => 1
+query TT
+EXPLAIN SELECT log(2.0::float8, 2.0::float8);
+----
+logical_plan
+01)Projection: Float64(1) AS log(Float64(2),Float64(2))
+02)--EmptyRelation: rows=1
+physical_plan
+01)ProjectionExec: expr=[1 as log(Float64(2),Float64(2))]
+02)--PlaceholderRowExec
+
+# Known-positive power result still uses log(a, power(a, b)) => b
+query TT
+EXPLAIN SELECT log(2.0::float8, power(2.0::float8, 3.0::float8));
+----
+logical_plan
+01)Projection: Float64(3) AS log(Float64(2),power(Float64(2),Float64(3)))
+02)--EmptyRelation: rows=1
+physical_plan
+01)ProjectionExec: expr=[3 as log(Float64(2),power(Float64(2),Float64(3)))]
+02)--PlaceholderRowExec
 
 # Float 16/32/64 for log
 query RT

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -644,10 +644,15 @@ select log(2, 2.0/3) a, log(10, 2.0/3) b;
 
 # log scalar ops with zero edgecases
 # please see https://github.com/apache/datafusion/pull/5245#issuecomment-1426828382
-query RR rowsort
-select log(0) a, log(1, 64) b;
+# log(0) is a domain error (PostgreSQL compatibility, #22261)
+query error cannot take logarithm of zero
+select log(0);
+
+# log(1, 64) remains IEEE infinity (base-1 is a separate issue)
+query R
+select log(1, 64);
 ----
--Infinity Infinity
+Infinity
 
 # log with columns #1
 query RRR rowsort

--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -151,17 +151,14 @@ but these operators always return a `bool` which makes them not work with the ex
 | trunc(x)              | truncate toward zero                              |
 
 :::{note}
-Unlike to some databases the math functions in Datafusion works the same way as Rust math functions, avoiding failing on corner cases e.g.
+Most math functions in DataFusion follow Rust / IEEE 754 semantics for
+corner cases. For example `log(-1)` returns `NaN`. Some domain errors
+match PostgreSQL instead and fail the query:
 
-```sql
-select log(-1), log(0), sqrt(-1);
-+----------------+---------------+-----------------+
-| log(Int64(-1)) | log(Int64(0)) | sqrt(Int64(-1)) |
-+----------------+---------------+-----------------+
-| NaN            | -inf          | NaN             |
-+----------------+---------------+-----------------+
-```
-
+* `log(0)` / `log(0.0::float8)` — cannot take logarithm of zero
+* `sqrt` of a negative number
+* `power(0, negative)`
+* `factorial` of a negative number
 :::
 
 ## Conditional Expressions

--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -155,10 +155,11 @@ Most math functions in DataFusion follow Rust / IEEE 754 semantics for
 corner cases. For example `log(-1)` returns `NaN`. Some domain errors
 match PostgreSQL instead and fail the query:
 
-* `log(0)` / `log(0.0::float8)` — cannot take logarithm of zero
-* `sqrt` of a negative number
-* `power(0, negative)`
-* `factorial` of a negative number
+- `log(0)` / `log(0.0::float8)` — cannot take logarithm of zero
+- `sqrt` of a negative number
+- `power(0, negative)`
+- `factorial` of a negative number
+
 :::
 
 ## Conditional Expressions


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #22261.

## Rationale for this change

`SELECT log(0.0::float8)` currently returns `-inf`. PostgreSQL raises `ERROR: cannot take logarithm of zero`.

This is the same class of domain error already accepted for `sqrt` of a negative number (#22260 / #22308), `power(0, negative)` (#22272), and `factorial` of a negative number (#22270). IEEE 754 would yield `-inf`; PostgreSQL treats it as undefined.

A previous attempt (#22564) grew into a log-function refactor and was closed. This PR stays scoped to the zero-value invariant: reject a **zero value** at evaluation time, and do not let planner simplifications bypass that check.

## What changes are included in this PR?

- `log` now returns `cannot take logarithm of zero` when the number being logged is zero (including `-0.0`, float32/float64, and decimal zeros).
- A zero *base* (`log(0, 64)`) and `log(1, 64)` are unchanged. Those are separate compatibility cases.
- Simplifications are guarded so they cannot skip the domain check:
  - `log(a, a) => 1` only when `a` is a known strictly positive finite literal (so `log(0, 0)` still errors).
  - `log(a, power(a, b)) => b` only when `power(a, b)` is known strictly positive and finite (so an underflow-to-zero power still errors).
  - `log(a, 1) => 0` is unchanged (the logged value is 1).
- User-guide note updated: it still claimed `log(0)` returns `-inf` and `sqrt(-1)` returns `NaN`, both of which are now domain errors.

## Are these changes tested?

Yes.

- Unit tests in `datafusion/functions/src/math/log.rs` cover unary/binary float64, float32, `-0.0`, array input, decimal128/256, and a table-driven log-of-zero case for Float16/32/64 and Decimal32/64/128/256.
- `math.slt` adds the issue query plus two-arg, negative-zero, column, and decimal cases, matching the style of the `power(0, -1)` tests.
- Planner-level SLT cases cover `log(0, 0)`, `log(0, power(0, 1))`, and `log(2, power(2, -2000))` as domain errors, and still fold `log(2, 2)` / `log(2, power(2, 3))`.
- `scalar.slt` updates the previous `log(0) => -Infinity` expectation to the domain error, and keeps `log(1, 64) => Infinity`.

## Are there any user-facing changes?

Yes. `log(0)`, `log(0.0::float8)`, and other zero values now fail the query with `cannot take logarithm of zero` instead of returning `-inf`. Queries that relied on the IEEE result need to filter zeros first.
