### PR TITLE
ci: run extended tests on aggregate and window function changes

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -45,6 +45,9 @@ on:
       - 'datafusion/expr*/**/*.rs'
       - 'datafusion/optimizer/**/*.rs'
       - 'datafusion/sql/**/*.rs'
+      # aggregate_fuzz / window_fuzz exercise these crates
+      - 'datafusion/functions-aggregate/**/*.rs'
+      - 'datafusion/functions-window/**/*.rs'
       - 'datafusion-testing'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24212

## Rationale for this change

The `Datafusion extended tests` workflow is the only CI job that enables `extended_tests`, which is what gates `aggregate_fuzz` and `window_fuzz`. On pull requests the path filter did not include the two crates those fuzzers actually import:

- `aggregate_fuzz.rs` builds queries with `min` / `max` / `sum` / `count` / `median` / `first_value` / `last_value` from `datafusion/functions-aggregate`
- `window_fuzz.rs` imports `datafusion_functions_window` and `datafusion_functions_aggregate`

A PR that only changes those crates (for example #24104, which updated `median.rs`) therefore skipped the suite built to exercise it. The post-merge run on `main` still catches failures, but the cost is a red `main` instead of a red PR.

#24212 measured this as a 4% extra trigger rate on recent PRs (~9.5 minutes wall-clock because the three jobs already run in parallel).

## What changes are included in this PR?

Add the two path globs requested in #24212:

```yaml
- 'datafusion/functions-aggregate/**/*.rs'
- 'datafusion/functions-window/**/*.rs'
```

This is the small, two-line option from the issue. It does not widen the filter to `datasource*` / `catalog*` (those would raise the trigger rate a lot more), and it does not split the path set per job.

## Are these changes tested?

This is a GitHub Actions path-filter change, so there is no unit test to run.

Verified:

- The workflow YAML still parses (`yaml.safe_load`)
- `datafusion/functions-aggregate/` and `datafusion/functions-window/` exist and contain the implementations the fuzzers import
- The new globs match the existing `*.rs` style of the other extended-test path filters

## Are there any user-facing changes?

No.
