### PR TITLE
fix: roll back DiskManager usage when spill write I/O fails

### DIFF
--- a/datafusion/execution/src/disk_manager.rs
+++ b/datafusion/execution/src/disk_manager.rs
@@ -502,7 +502,17 @@ impl std::io::Write for FileSpillWriter {
             )));
         }
 
-        self.file.write_all(buf).map_err(DataFusionError::IoError)?;
+        // Charge the global counter before the OS write so concurrent writers
+        // cannot collectively exceed the quota. If the write fails, roll that
+        // reservation back: `current_file_disk_usage` is only updated on
+        // success, so `Drop` would otherwise subtract too little and the
+        // leaked bytes would permanently shrink spill capacity (#24230).
+        if let Err(e) = self.file.write_all(buf) {
+            self.disk_manager
+                .used_disk_space
+                .fetch_sub(len, Ordering::Relaxed);
+            return Err(e);
+        }
 
         self.current_file_disk_usage
             .fetch_add(len, Ordering::Relaxed);
@@ -1171,6 +1181,61 @@ mod tests {
         drop(file);
 
         // After drop: used_disk_space must be zero (no leak)
+        assert_eq!(dm.used_disk_space(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_io_error_rolls_back_disk_usage() -> Result<()> {
+        // FileSpillWriter::write reserves `len` on the global counter before
+        // the OS write. If that write fails, the reservation must be released.
+        // Otherwise Drop only subtracts the last successful size and the
+        // leaked bytes shrink future spill capacity (issue #24230).
+        let cap = 1000u64;
+        let dm = Arc::new(
+            DiskManagerBuilder::default()
+                .with_max_temp_directory_size(cap)
+                .build()?,
+        );
+
+        let file = dm.create_tmp_file("write_io_error")?;
+        {
+            let mut writer = file.open_writer()?;
+            writer.write_all(&[0u8; 400])?;
+        }
+        assert_eq!(dm.used_disk_space(), 400);
+
+        // Read-only handle: the quota reservation succeeds (400 + 600 == cap)
+        // but the OS write fails. Use a dummy per-file counter so this writer
+        // cannot accidentally "fix" Drop accounting on the real file.
+        let mut failing = FileSpillWriter {
+            file: std::fs::File::open(file.path().unwrap())?,
+            disk_manager: Arc::clone(&dm),
+            current_file_disk_usage: Arc::new(AtomicU64::new(0)),
+        };
+
+        for _ in 0..2 {
+            let err = std::io::Write::write_all(&mut failing, &[1u8; 600]).unwrap_err();
+            // Without the rollback, the first leak fills the cap and the
+            // second attempt fails the quota check instead of the OS write.
+            assert!(
+                !err.to_string().contains("exceeded the allowable limit"),
+                "expected an OS write error, not a quota error: {err}"
+            );
+            assert_eq!(dm.used_disk_space(), 400);
+        }
+        drop(failing);
+
+        // 500 bytes still fits (used 400, cap 1000). A leaked 600-byte
+        // reservation would make this fail the quota check.
+        {
+            let mut writer = file.open_writer()?;
+            writer.write_all(&[2u8; 500])?;
+        }
+        assert_eq!(dm.used_disk_space(), 900);
+
+        drop(file);
         assert_eq!(dm.used_disk_space(), 0);
 
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24230.

## Rationale for this change

`DiskManager` charges `used_disk_space` before writing a spill file so concurrent writers cannot collectively exceed `max_temp_directory_size`. On a quota miss, `FileSpillWriter::write` already rolls that reservation back.

The OS `write_all` error path did not. The global counter stayed charged, `current_file_disk_usage` was left at the last successful size, and `RefCountedTempFile::Drop` subtracted too little. After one I/O error the leaked bytes stay until process exit, so later spills that fit on disk are rejected.

#21882 already fixed the quota path on `main`. This is the remaining `write_all` error path called out in #24230.

## What changes are included in this PR?

- If the OS write fails after the reservation, subtract the reserved bytes from `used_disk_space` before returning the I/O error.
- Add a regression test that writes 400 bytes into a 1000-byte cap, then forces two 600-byte writes through a read-only handle. Without the rollback the first leak fills the cap (so the second attempt is a quota error, and a later 500-byte spill is rejected). With the fix the counter stays at 400, the 500-byte write succeeds, and dropping the file returns the counter to 0.

## Are these changes tested?

Yes.

- New `test_write_io_error_rolls_back_disk_usage` in `datafusion/execution/src/disk_manager.rs`.
- Existing `test_rollback_on_limit_exceeded_then_drop_returns_to_zero` still covers the quota path.

Ran:

- `cargo test -p datafusion-execution --lib disk_manager`
- `cargo clippy -p datafusion-execution --lib --all-targets -- -D warnings`

## Are there any user-facing changes?

A failed spill write no longer permanently reduces remaining spill capacity. There is no API change.