### PR TITLE
chore: group uv dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -105,11 +105,12 @@ updates:
       interval: "weekly"
     labels: [auto-dependencies]
     groups:
-      # minor and patch bumps are grouped into a single PR
+      # all dependency bumps are grouped into a single PR
       all-uv-deps:
         applies-to: version-updates
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,3 +104,12 @@ updates:
     schedule:
       interval: "weekly"
     labels: [auto-dependencies]
+    groups:
+      # minor and patch bumps are grouped into a single PR
+      all-uv-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #24356.

## Rationale for this change

Dependabot currently opens a separate pull request for each `uv` dependency update. Grouping routine minor and patch updates reduces PR volume while keeping major upgrades separate for focused review.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?

Adds an `all-uv-deps` group to the root `uv` Dependabot configuration. The group matches all `uv` dependencies and applies to minor and patch version updates.

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
