### PR TITLE
fix(spark): derive pmod's decimal result type from the declared arguments

### DIFF
--- a/datafusion/spark/src/function/math/modulus.rs
+++ b/datafusion/spark/src/function/math/modulus.rs
@@ -136,7 +136,6 @@ pub fn spark_pmod(
     // A null argument is passed through uncoerced by `Coercible` (#19458), so
     // it still carries `DataType::Null` here. Every operation below needs a
     // concrete numeric type, and the answer is null regardless.
-    // Need to handle nulls separately as they are pass through by the signature
     if args.iter().any(|arg| arg.data_type() == &DataType::Null) {
         return Ok(ColumnarValue::Scalar(ScalarValue::try_new_null(
             result_type,

--- a/datafusion/spark/src/function/math/modulus.rs
+++ b/datafusion/spark/src/function/math/modulus.rs
@@ -28,13 +28,10 @@ use arrow::compute::kernels::{
 };
 use arrow::datatypes::{DECIMAL128_MAX_PRECISION, DataType};
 use arrow::error::ArrowError;
-use datafusion_common::types::NativeType;
-use datafusion_common::{
-    Result, ScalarValue, assert_eq_or_internal_err, exec_err, plan_err,
-};
+use datafusion_common::{Result, ScalarValue, assert_eq_or_internal_err, exec_err};
 use datafusion_expr::{
-    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
-    binary::binary_numeric_coercion,
+    Coercion, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
+    TypeSignatureClass, Volatility, binary::binary_numeric_coercion,
 };
 
 /// Returns a one element array holding negative zero, for the floating point
@@ -141,43 +138,6 @@ fn pmod_computation_type(lhs: &DataType, rhs: &DataType) -> Result<DataType> {
     }
 }
 
-/// The coercion `Signature::numeric` applied before `pmod` moved to
-/// [`Signature::user_defined`], reproduced so that only the decimal pair below
-/// changes behaviour.
-///
-/// A null argument is skipped rather than coerced, and a call still typed null
-/// afterwards falls back to `Float64`; both match `TypeSignature::Numeric` in
-/// `datafusion_expr::type_coercion::functions`.
-fn pmod_numeric_coercion(lhs: &DataType, rhs: &DataType) -> Result<Vec<DataType>> {
-    let mut valid_type = lhs.clone();
-
-    let rhs_native: NativeType = rhs.into();
-    if rhs_native != NativeType::Null {
-        if !rhs_native.is_numeric() {
-            return plan_err!(
-                "Function 'pmod' expects Numeric but received {rhs_native}"
-            );
-        }
-        match binary_numeric_coercion(&valid_type, rhs) {
-            Some(coerced_type) => valid_type = coerced_type,
-            None => {
-                return plan_err!(
-                    "For function 'pmod' {valid_type} and {rhs} are not coercible to a common numeric type"
-                );
-            }
-        }
-    }
-
-    let valid_native: NativeType = valid_type.clone().into();
-    if valid_native == NativeType::Null {
-        valid_type = DataType::Float64;
-    } else if !valid_native.is_numeric() {
-        return plan_err!("Function 'pmod' expects Numeric but received {valid_native}");
-    }
-
-    Ok(vec![valid_type.clone(), valid_type])
-}
-
 /// Spark-compatible `pmod` function
 /// In ANSI mode, division by zero throws an error.
 /// In legacy mode, division by zero returns NULL (Spark behavior).
@@ -188,6 +148,16 @@ pub fn spark_pmod(
 ) -> Result<ColumnarValue> {
     assert_eq_or_internal_err!(args.len(), 2, "pmod expects exactly two arguments");
     let args = ColumnarValue::values_to_arrays(args)?;
+
+    // A null argument is passed through uncoerced by `Coercible` (#19458), so
+    // it still carries `DataType::Null` here. Every operation below needs a
+    // concrete numeric type, and the answer is null regardless.
+    if args.iter().any(|arg| arg.data_type() == &DataType::Null) {
+        return Ok(ColumnarValue::Array(new_null_array(
+            result_type,
+            args[0].len(),
+        )));
+    }
 
     let (left, right): (ArrayRef, ArrayRef) =
         if args[0].data_type() == args[1].data_type() {
@@ -295,7 +265,19 @@ impl Default for SparkPmod {
 impl SparkPmod {
     pub fn new() -> Self {
         Self {
-            signature: Signature::user_defined(Volatility::Immutable),
+            signature: Signature::one_of(
+                vec![
+                    // A decimal pair must reach `return_type` with the
+                    // precision and scale as written, since Spark defines
+                    // `Pmod.resultDecimalType` on the declared arguments.
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Decimal),
+                        Coercion::new_exact(TypeSignatureClass::Decimal),
+                    ]),
+                    TypeSignature::Numeric(2),
+                ],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -320,26 +302,15 @@ impl ScalarUDFImpl for SparkPmod {
             (DataType::Decimal128(p1, s1), DataType::Decimal128(p2, s2)) => {
                 Ok(pmod_decimal_result_type(*p1, *s1, *p2, *s2))
             }
+            // `Coercible` matches a null argument and passes it through
+            // uncoerced (#19458), so an untyped NULL reaches here rather than
+            // being folded by `Numeric(2)`. `mod` answers `Float64` for two
+            // untyped nulls and the other side's type when only one is null;
+            // `pmod` did too, so that behaviour is kept explicitly here.
+            (DataType::Null, DataType::Null) => Ok(DataType::Float64),
+            (DataType::Null, other) | (other, DataType::Null) => Ok(other.clone()),
             // Arrow's rem function handles type promotion for the rest
             _ => Ok(arg_types[0].clone()),
-        }
-    }
-
-    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        if arg_types.len() != 2 {
-            return plan_err!(
-                "Function 'pmod' expects 2 arguments but received {}",
-                arg_types.len()
-            );
-        }
-
-        match (&arg_types[0], &arg_types[1]) {
-            // Spark applies resultDecimalType to the declared argument types, so
-            // these are left alone; spark_pmod widens them for the computation.
-            (DataType::Decimal128(_, _), DataType::Decimal128(_, _)) => {
-                Ok(arg_types.to_vec())
-            }
-            (lhs, rhs) => pmod_numeric_coercion(lhs, rhs),
         }
     }
 

--- a/datafusion/spark/src/function/math/modulus.rs
+++ b/datafusion/spark/src/function/math/modulus.rs
@@ -147,8 +147,6 @@ pub fn spark_pmod(
         if args[0].data_type() == args[1].data_type() {
             (Arc::clone(&args[0]), Arc::clone(&args[1]))
         } else {
-            // Only a decimal pair reaches here: `Numeric(2)` already gives
-            // the other types a common type.
             let Some(computation_type) =
                 decimal_coercion(args[0].data_type(), args[1].data_type())
             else {

--- a/datafusion/spark/src/function/math/modulus.rs
+++ b/datafusion/spark/src/function/math/modulus.rs
@@ -184,18 +184,10 @@ fn pmod_numeric_coercion(lhs: &DataType, rhs: &DataType) -> Result<Vec<DataType>
 pub fn spark_pmod(
     args: &[ColumnarValue],
     enable_ansi_mode: bool,
+    result_type: &DataType,
 ) -> Result<ColumnarValue> {
     assert_eq_or_internal_err!(args.len(), 2, "pmod expects exactly two arguments");
     let args = ColumnarValue::values_to_arrays(args)?;
-
-    // Decimal arguments reach here with their declared types intact, so the
-    // Spark result type is derived before they are widened for the computation.
-    let result_type = match (args[0].data_type(), args[1].data_type()) {
-        (DataType::Decimal128(p1, s1), DataType::Decimal128(p2, s2)) => {
-            Some(pmod_decimal_result_type(*p1, *s1, *p2, *s2))
-        }
-        _ => None,
-    };
 
     let (left, right): (ArrayRef, ArrayRef) =
         if args[0].data_type() == args[1].data_type() {
@@ -230,15 +222,14 @@ pub fn spark_pmod(
     // divisor wider than the dividend does not always fit. Spark wraps decimal
     // arithmetic in `CheckOverflow(nullOnOverflow = !ansiEnabled)`, so an
     // overflow here is NULL in legacy mode and an error under ANSI.
-    let result = match result_type {
-        Some(result_type) if result.data_type() != &result_type => {
-            let narrow = CastOptions {
-                safe: !enable_ansi_mode,
-                ..Default::default()
-            };
-            cast_with_options(&result, &result_type, &narrow)?
-        }
-        _ => result,
+    let result = if result.data_type() == result_type {
+        result
+    } else {
+        let narrow = CastOptions {
+            safe: !enable_ansi_mode,
+            ..Default::default()
+        };
+        cast_with_options(&result, result_type, &narrow)?
     };
     Ok(ColumnarValue::Array(result))
 }
@@ -353,7 +344,13 @@ impl ScalarUDFImpl for SparkPmod {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        spark_pmod(&args.args, args.config_options.execution.enable_ansi_mode)
+        // The Spark result type was already derived in `return_type`, so it is
+        // read back here rather than recomputed from the argument arrays.
+        spark_pmod(
+            &args.args,
+            args.config_options.execution.enable_ansi_mode,
+            args.return_type(),
+        )
     }
 }
 
@@ -702,7 +699,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_int32 =
@@ -725,7 +723,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_int64 =
@@ -769,7 +768,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_float64 = result_array
@@ -827,7 +827,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_float32 = result_array
@@ -862,7 +863,8 @@ mod test {
 
         let left_value = ColumnarValue::Array(Arc::new(left));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_int32 =
@@ -881,7 +883,8 @@ mod test {
         let left = Int32Array::from(vec![Some(10)]);
         let left_value = ColumnarValue::Array(Arc::new(left));
 
-        let result = spark_pmod(&[left_value], false);
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value], false, &return_type);
         assert!(result.is_err());
     }
 
@@ -894,7 +897,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_int32 =
@@ -916,7 +920,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], true);
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], true, &return_type);
         assert!(result.is_err());
     }
 
@@ -932,7 +937,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], true);
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], true, &return_type);
         assert!(result.is_err());
     }
 
@@ -946,7 +952,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_float64 = result_array
@@ -969,7 +976,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], true);
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], true, &return_type);
         assert!(result.is_err());
     }
 
@@ -984,7 +992,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], true).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], true, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_int32 =
@@ -1002,7 +1011,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], true).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], true, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_float64 = result_array
@@ -1025,7 +1035,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_int32 =
@@ -1063,7 +1074,8 @@ mod test {
         let left_value = ColumnarValue::Array(Arc::new(left));
         let right_value = ColumnarValue::Array(Arc::new(right));
 
-        let result = spark_pmod(&[left_value, right_value], false).unwrap();
+        let return_type = left_value.data_type();
+        let result = spark_pmod(&[left_value, right_value], false, &return_type).unwrap();
 
         if let ColumnarValue::Array(result_array) = result {
             let result_int32 =

--- a/datafusion/spark/src/function/math/modulus.rs
+++ b/datafusion/spark/src/function/math/modulus.rs
@@ -31,7 +31,7 @@ use arrow::error::ArrowError;
 use datafusion_common::{Result, ScalarValue, assert_eq_or_internal_err, exec_err};
 use datafusion_expr::{
     Coercion, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
-    TypeSignatureClass, Volatility, binary::binary_numeric_coercion,
+    TypeSignatureClass, Volatility, binary::decimal_coercion,
 };
 
 /// Returns a one element array holding negative zero, for the floating point
@@ -113,29 +113,13 @@ pub fn spark_mod(
 /// precision = min(p1 - s1, p2 - s2) + scale
 /// ```
 ///
-/// The rule is applied to the *declared* argument types. Collapsing both
-/// arguments to a common decimal first would make the two precisions equal and
-/// the rule would degenerate to the input precision, which is why
-/// [`SparkPmod::coerce_types`] leaves decimal arguments intact.
+/// The rule is applied to the input argument types.
 fn pmod_decimal_result_type(p1: u8, s1: i8, p2: u8, s2: i8) -> DataType {
     let scale = s1.max(s2);
     let whole_digits = (i32::from(p1) - i32::from(s1)).min(i32::from(p2) - i32::from(s2));
     let precision =
         (whole_digits + i32::from(scale)).clamp(1, i32::from(DECIMAL128_MAX_PRECISION));
     DataType::Decimal128(precision as u8, scale)
-}
-
-/// The type `pmod` computes in, which is not always the type it returns.
-///
-/// Spark's result type is narrower than the dividend, so the operands cannot be
-/// cast to it before the remainder is taken without overflowing the dividend.
-/// The computation therefore runs in a common type wide enough for both, and
-/// the result is narrowed afterwards.
-fn pmod_computation_type(lhs: &DataType, rhs: &DataType) -> Result<DataType> {
-    match binary_numeric_coercion(lhs, rhs) {
-        Some(computation_type) => Ok(computation_type),
-        None => exec_err!("pmod does not support ({lhs}, {rhs})"),
-    }
 }
 
 /// Spark-compatible `pmod` function
@@ -152,22 +136,28 @@ pub fn spark_pmod(
     // A null argument is passed through uncoerced by `Coercible` (#19458), so
     // it still carries `DataType::Null` here. Every operation below needs a
     // concrete numeric type, and the answer is null regardless.
+    // Need to handle nulls separately as they are pass through by the signature
     if args.iter().any(|arg| arg.data_type() == &DataType::Null) {
-        return Ok(ColumnarValue::Array(new_null_array(
+        return Ok(ColumnarValue::Scalar(ScalarValue::try_new_null(
             result_type,
-            args[0].len(),
-        )));
+        )?));
     }
 
     let (left, right): (ArrayRef, ArrayRef) =
         if args[0].data_type() == args[1].data_type() {
             (Arc::clone(&args[0]), Arc::clone(&args[1]))
         } else {
-            let computation_type =
-                pmod_computation_type(args[0].data_type(), args[1].data_type())?;
-            // The computation type is wide enough for both operands by
-            // construction, so widening must not silently null on overflow the
-            // way arrow's default (`safe: true`) cast would.
+            // Only a decimal pair reaches here: `Numeric(2)` already gives
+            // the other types a common type.
+            let Some(computation_type) =
+                decimal_coercion(args[0].data_type(), args[1].data_type())
+            else {
+                return exec_err!(
+                    "pmod does not support ({}, {})",
+                    args[0].data_type(),
+                    args[1].data_type()
+                );
+            };
             let widen = CastOptions {
                 safe: false,
                 ..Default::default()
@@ -302,21 +292,15 @@ impl ScalarUDFImpl for SparkPmod {
             (DataType::Decimal128(p1, s1), DataType::Decimal128(p2, s2)) => {
                 Ok(pmod_decimal_result_type(*p1, *s1, *p2, *s2))
             }
-            // `Coercible` matches a null argument and passes it through
-            // uncoerced (#19458), so an untyped NULL reaches here rather than
-            // being folded by `Numeric(2)`. `mod` answers `Float64` for two
-            // untyped nulls and the other side's type when only one is null;
-            // `pmod` did too, so that behaviour is kept explicitly here.
+            // Need to handle nulls explicitly, see: https://github.com/apache/datafusion/issues/19458
+            // We align with the behaviour of `mod`
             (DataType::Null, DataType::Null) => Ok(DataType::Float64),
             (DataType::Null, other) | (other, DataType::Null) => Ok(other.clone()),
-            // Arrow's rem function handles type promotion for the rest
             _ => Ok(arg_types[0].clone()),
         }
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        // The Spark result type was already derived in `return_type`, so it is
-        // read back here rather than recomputed from the argument arrays.
         spark_pmod(
             &args.args,
             args.config_options.execution.enable_ansi_mode,

--- a/datafusion/spark/src/function/math/modulus.rs
+++ b/datafusion/spark/src/function/math/modulus.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use arrow::array::{ArrayRef, BooleanArray, Scalar, new_null_array};
+use arrow::compute::kernels::cast::{CastOptions, cast_with_options};
 use arrow::compute::kernels::numeric::add;
 use arrow::compute::kernels::{
     boolean::{and, is_not_null, or},
@@ -23,11 +26,15 @@ use arrow::compute::kernels::{
     numeric::{neg, rem},
     zip::zip,
 };
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DECIMAL128_MAX_PRECISION, DataType};
 use arrow::error::ArrowError;
-use datafusion_common::{Result, ScalarValue, assert_eq_or_internal_err};
+use datafusion_common::types::NativeType;
+use datafusion_common::{
+    Result, ScalarValue, assert_eq_or_internal_err, exec_err, plan_err,
+};
 use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+    binary::binary_numeric_coercion,
 };
 
 /// Returns a one element array holding negative zero, for the floating point
@@ -101,6 +108,76 @@ pub fn spark_mod(
     Ok(ColumnarValue::Array(result))
 }
 
+/// Spark derives the decimal result type of `pmod` with `Pmod.resultDecimalType`,
+/// which follows the `Remainder` rule:
+///
+/// ```text
+/// scale     = max(s1, s2)
+/// precision = min(p1 - s1, p2 - s2) + scale
+/// ```
+///
+/// The rule is applied to the *declared* argument types. Collapsing both
+/// arguments to a common decimal first would make the two precisions equal and
+/// the rule would degenerate to the input precision, which is why
+/// [`SparkPmod::coerce_types`] leaves decimal arguments intact.
+fn pmod_decimal_result_type(p1: u8, s1: i8, p2: u8, s2: i8) -> DataType {
+    let scale = s1.max(s2);
+    let whole_digits = (i32::from(p1) - i32::from(s1)).min(i32::from(p2) - i32::from(s2));
+    let precision =
+        (whole_digits + i32::from(scale)).clamp(1, i32::from(DECIMAL128_MAX_PRECISION));
+    DataType::Decimal128(precision as u8, scale)
+}
+
+/// The type `pmod` computes in, which is not always the type it returns.
+///
+/// Spark's result type is narrower than the dividend, so the operands cannot be
+/// cast to it before the remainder is taken without overflowing the dividend.
+/// The computation therefore runs in a common type wide enough for both, and
+/// the result is narrowed afterwards.
+fn pmod_computation_type(lhs: &DataType, rhs: &DataType) -> Result<DataType> {
+    match binary_numeric_coercion(lhs, rhs) {
+        Some(computation_type) => Ok(computation_type),
+        None => exec_err!("pmod does not support ({lhs}, {rhs})"),
+    }
+}
+
+/// The coercion `Signature::numeric` applied before `pmod` moved to
+/// [`Signature::user_defined`], reproduced so that only the decimal pair below
+/// changes behaviour.
+///
+/// A null argument is skipped rather than coerced, and a call still typed null
+/// afterwards falls back to `Float64`; both match `TypeSignature::Numeric` in
+/// `datafusion_expr::type_coercion::functions`.
+fn pmod_numeric_coercion(lhs: &DataType, rhs: &DataType) -> Result<Vec<DataType>> {
+    let mut valid_type = lhs.clone();
+
+    let rhs_native: NativeType = rhs.into();
+    if rhs_native != NativeType::Null {
+        if !rhs_native.is_numeric() {
+            return plan_err!(
+                "Function 'pmod' expects Numeric but received {rhs_native}"
+            );
+        }
+        match binary_numeric_coercion(&valid_type, rhs) {
+            Some(coerced_type) => valid_type = coerced_type,
+            None => {
+                return plan_err!(
+                    "For function 'pmod' {valid_type} and {rhs} are not coercible to a common numeric type"
+                );
+            }
+        }
+    }
+
+    let valid_native: NativeType = valid_type.clone().into();
+    if valid_native == NativeType::Null {
+        valid_type = DataType::Float64;
+    } else if !valid_native.is_numeric() {
+        return plan_err!("Function 'pmod' expects Numeric but received {valid_native}");
+    }
+
+    Ok(vec![valid_type.clone(), valid_type])
+}
+
 /// Spark-compatible `pmod` function
 /// In ANSI mode, division by zero throws an error.
 /// In legacy mode, division by zero returns NULL (Spark behavior).
@@ -110,14 +187,59 @@ pub fn spark_pmod(
 ) -> Result<ColumnarValue> {
     assert_eq_or_internal_err!(args.len(), 2, "pmod expects exactly two arguments");
     let args = ColumnarValue::values_to_arrays(args)?;
-    let left = &args[0];
-    let right = &args[1];
+
+    // Decimal arguments reach here with their declared types intact, so the
+    // Spark result type is derived before they are widened for the computation.
+    let result_type = match (args[0].data_type(), args[1].data_type()) {
+        (DataType::Decimal128(p1, s1), DataType::Decimal128(p2, s2)) => {
+            Some(pmod_decimal_result_type(*p1, *s1, *p2, *s2))
+        }
+        _ => None,
+    };
+
+    let (left, right): (ArrayRef, ArrayRef) =
+        if args[0].data_type() == args[1].data_type() {
+            (Arc::clone(&args[0]), Arc::clone(&args[1]))
+        } else {
+            let computation_type =
+                pmod_computation_type(args[0].data_type(), args[1].data_type())?;
+            // The computation type is wide enough for both operands by
+            // construction, so widening must not silently null on overflow the
+            // way arrow's default (`safe: true`) cast would.
+            let widen = CastOptions {
+                safe: false,
+                ..Default::default()
+            };
+            (
+                cast_with_options(&args[0], &computation_type, &widen)?,
+                cast_with_options(&args[1], &computation_type, &widen)?,
+            )
+        };
+
+    let left = &left;
+    let right = &right;
     let zero = ScalarValue::new_zero(left.data_type())?.to_array_of_size(left.len())?;
     let result = try_rem(left, right, enable_ansi_mode)?;
     let neg = lt(&result, &zero)?;
     let plus = zip(&neg, right, &zero)?;
     let result = add(&plus, &result)?;
     let result = try_rem(&result, right, enable_ansi_mode)?;
+
+    // The remainder is bounded by the divisor, but the result type only carries
+    // `min(p1 - s1, p2 - s2)` integer digits, so a remainder approaching a
+    // divisor wider than the dividend does not always fit. Spark wraps decimal
+    // arithmetic in `CheckOverflow(nullOnOverflow = !ansiEnabled)`, so an
+    // overflow here is NULL in legacy mode and an error under ANSI.
+    let result = match result_type {
+        Some(result_type) if result.data_type() != &result_type => {
+            let narrow = CastOptions {
+                safe: !enable_ansi_mode,
+                ..Default::default()
+            };
+            cast_with_options(&result, &result_type, &narrow)?
+        }
+        _ => result,
+    };
     Ok(ColumnarValue::Array(result))
 }
 
@@ -182,7 +304,7 @@ impl Default for SparkPmod {
 impl SparkPmod {
     pub fn new() -> Self {
         Self {
-            signature: Signature::numeric(2, Volatility::Immutable),
+            signature: Signature::user_defined(Volatility::Immutable),
         }
     }
 }
@@ -203,9 +325,31 @@ impl ScalarUDFImpl for SparkPmod {
             "pmod expects exactly two arguments"
         );
 
-        // Return the same type as the first argument for simplicity
-        // Arrow's rem function handles type promotion internally
-        Ok(arg_types[0].clone())
+        match (&arg_types[0], &arg_types[1]) {
+            (DataType::Decimal128(p1, s1), DataType::Decimal128(p2, s2)) => {
+                Ok(pmod_decimal_result_type(*p1, *s1, *p2, *s2))
+            }
+            // Arrow's rem function handles type promotion for the rest
+            _ => Ok(arg_types[0].clone()),
+        }
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        if arg_types.len() != 2 {
+            return plan_err!(
+                "Function 'pmod' expects 2 arguments but received {}",
+                arg_types.len()
+            );
+        }
+
+        match (&arg_types[0], &arg_types[1]) {
+            // Spark applies resultDecimalType to the declared argument types, so
+            // these are left alone; spark_pmod widens them for the computation.
+            (DataType::Decimal128(_, _), DataType::Decimal128(_, _)) => {
+                Ok(arg_types.to_vec())
+            }
+            (lhs, rhs) => pmod_numeric_coercion(lhs, rhs),
+        }
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -934,5 +1078,36 @@ mod test {
         } else {
             panic!("Expected array result");
         }
+    }
+
+    /// Spark's `Pmod.resultDecimalType`: scale = max(s1, s2),
+    /// precision = min(p1 - s1, p2 - s2) + scale.
+    #[test]
+    fn test_pmod_decimal_result_type() {
+        // Equal scales: the narrower argument decides the precision.
+        assert_eq!(
+            pmod_decimal_result_type(3, 1, 2, 1),
+            DataType::Decimal128(2, 1)
+        );
+        // The divisor is wider, so the dividend bounds the result.
+        assert_eq!(
+            pmod_decimal_result_type(5, 2, 4, 1),
+            DataType::Decimal128(5, 2)
+        );
+        // Differing scales: the wider scale wins.
+        assert_eq!(
+            pmod_decimal_result_type(6, 3, 4, 1),
+            DataType::Decimal128(6, 3)
+        );
+        // Integral decimals keep a zero scale.
+        assert_eq!(
+            pmod_decimal_result_type(10, 0, 5, 0),
+            DataType::Decimal128(5, 0)
+        );
+        // The result never exceeds the maximum precision arrow can represent.
+        assert_eq!(
+            pmod_decimal_result_type(38, 0, 38, 38),
+            DataType::Decimal128(38, 38)
+        );
     }
 }

--- a/datafusion/spark/src/function/math/modulus.rs
+++ b/datafusion/spark/src/function/math/modulus.rs
@@ -133,9 +133,7 @@ pub fn spark_pmod(
     assert_eq_or_internal_err!(args.len(), 2, "pmod expects exactly two arguments");
     let args = ColumnarValue::values_to_arrays(args)?;
 
-    // A null argument is passed through uncoerced by `Coercible` (#19458), so
-    // it still carries `DataType::Null` here. Every operation below needs a
-    // concrete numeric type, and the answer is null regardless.
+    // Need to handle nulls separately as they are pass through by the signature
     if args.iter().any(|arg| arg.data_type() == &DataType::Null) {
         return Ok(ColumnarValue::Scalar(ScalarValue::try_new_null(
             result_type,

--- a/datafusion/sqllogictest/test_files/spark/math/pmod.slt
+++ b/datafusion/sqllogictest/test_files/spark/math/pmod.slt
@@ -132,6 +132,35 @@ SELECT pmod(NULL::int, NULL::int) as pmod_null_3;
 ----
 NULL
 
+# An untyped NULL matches the decimal signature and is passed through
+# uncoerced (apache/datafusion#19458), so these types are decided explicitly
+# rather than by coercion. `mod` answers Float64 for two untyped nulls and
+# keeps the other side's type when only one is null; pmod matches it.
+query T
+SELECT arrow_typeof(pmod(NULL, NULL));
+----
+Float64
+
+query R
+SELECT pmod(NULL, NULL);
+----
+NULL
+
+query T
+SELECT arrow_typeof(pmod(2.5::decimal(3,1), NULL));
+----
+Decimal128(3, 1)
+
+query R
+SELECT pmod(2.5::decimal(3,1), NULL);
+----
+NULL
+
+# An untyped NULL beside a typed non-decimal argument takes the Numeric path,
+# which cannot coerce the pair. `mod` rejects it the same way.
+statement error DataFusion error: Error during planning: Internal error: Function 'pmod' failed to match any signature
+SELECT pmod(NULL, 3::int);
+
 # PMOD tests with large integers
 query I
 SELECT pmod(100::int, 30::int) as pmod_large_1;

--- a/datafusion/sqllogictest/test_files/spark/math/pmod.slt
+++ b/datafusion/sqllogictest/test_files/spark/math/pmod.slt
@@ -98,6 +98,10 @@ SELECT pmod(10.5::float8, 0.0::float8);
 statement error DataFusion error: Arrow error: Divide by zero error
 SELECT pmod(10.5::float8, -0.0::float8);
 
+# A decimal result that does not fit raises instead of returning NULL
+statement error DataFusion error: Arrow error: Invalid argument error: 9999\.8 is too large to store in a Decimal128 of precision 3
+SELECT pmod(-0.1::decimal(3,1), 9999.9::decimal(5,1));
+
 # A NULL dividend short-circuits to NULL before the divisor is validated
 query I
 SELECT pmod(NULL::int, 0::int) as pmod_null_dividend_ansi;
@@ -304,6 +308,70 @@ query R
 SELECT pmod(-10.0::decimal(3,1), 3.0::decimal(2,1)) as pmod_decimal_4;
 ----
 2
+
+# The decimal result type follows Spark's Pmod.resultDecimalType, which applies
+# the Remainder rule to the declared argument types:
+#   scale     = max(s1, s2)
+#   precision = min(p1 - s1, p2 - s2) + scale
+query T
+SELECT arrow_typeof(pmod(2.5::decimal(3,1), 1.2::decimal(2,1)));
+----
+Decimal128(2, 1)
+
+# The divisor bounds the result, so the narrower argument decides the precision
+query T
+SELECT arrow_typeof(pmod(10.0::decimal(5,2), 3.0::decimal(4,1)));
+----
+Decimal128(5, 2)
+
+# Differing scales: the wider scale wins
+query T
+SELECT arrow_typeof(pmod(1.234::decimal(6,3), 2.1::decimal(4,1)));
+----
+Decimal128(6, 3)
+
+# The dividend does not fit the result type, so it must not be narrowed before
+# the remainder is taken
+query T
+SELECT arrow_typeof(pmod(99.9::decimal(3,1), 2.5::decimal(2,1)));
+----
+Decimal128(2, 1)
+
+query R
+SELECT pmod(99.9::decimal(3,1), 2.5::decimal(2,1));
+----
+2.4
+
+# A remainder is bounded by the divisor, not by the result type, so a divisor
+# wider than the dividend can produce a value the result type cannot hold. Spark
+# wraps decimal arithmetic in CheckOverflow(nullOnOverflow = !ansiEnabled), so
+# this is NULL in legacy mode and an error under ANSI (asserted further down).
+query T
+SELECT arrow_typeof(pmod(-0.1::decimal(3,1), 9999.9::decimal(5,1)));
+----
+Decimal128(3, 1)
+
+query R
+SELECT pmod(-0.1::decimal(3,1), 9999.9::decimal(5,1));
+----
+NULL
+
+# An untyped NULL pair falls back to Float64, as it did under Signature::numeric
+query T
+SELECT arrow_typeof(pmod(NULL, NULL));
+----
+Float64
+
+query R
+SELECT pmod(NULL, NULL);
+----
+NULL
+
+# A null divisor takes the dividend's type
+query T
+SELECT arrow_typeof(pmod(2.5::decimal(3,1), NULL));
+----
+Decimal128(3, 1)
 
 # PMOD tests with different integer types
 query I

--- a/datafusion/sqllogictest/test_files/spark/math/pmod.slt
+++ b/datafusion/sqllogictest/test_files/spark/math/pmod.slt
@@ -132,10 +132,6 @@ SELECT pmod(NULL::int, NULL::int) as pmod_null_3;
 ----
 NULL
 
-# An untyped NULL matches the decimal signature and is passed through
-# uncoerced (apache/datafusion#19458), so these types are decided explicitly
-# rather than by coercion. `mod` answers Float64 for two untyped nulls and
-# keeps the other side's type when only one is null; pmod matches it.
 query T
 SELECT arrow_typeof(pmod(NULL, NULL));
 ----

--- a/datafusion/sqllogictest/test_files/spark/math/pmod.slt
+++ b/datafusion/sqllogictest/test_files/spark/math/pmod.slt
@@ -141,20 +141,10 @@ SELECT arrow_typeof(pmod(NULL, NULL));
 ----
 Float64
 
-query R
-SELECT pmod(NULL, NULL);
-----
-NULL
-
 query T
 SELECT arrow_typeof(pmod(2.5::decimal(3,1), NULL));
 ----
 Decimal128(3, 1)
-
-query R
-SELECT pmod(2.5::decimal(3,1), NULL);
-----
-NULL
 
 # An untyped NULL beside a typed non-decimal argument takes the Numeric path,
 # which cannot coerce the pair. `mod` rejects it the same way.
@@ -374,7 +364,7 @@ SELECT pmod(99.9::decimal(3,1), 2.5::decimal(2,1));
 # A remainder is bounded by the divisor, not by the result type, so a divisor
 # wider than the dividend can produce a value the result type cannot hold. Spark
 # wraps decimal arithmetic in CheckOverflow(nullOnOverflow = !ansiEnabled), so
-# this is NULL in legacy mode and an error under ANSI (asserted further down).
+# this is NULL in legacy mode; the ANSI error is asserted in the ANSI block above.
 query T
 SELECT arrow_typeof(pmod(-0.1::decimal(3,1), 9999.9::decimal(5,1)));
 ----
@@ -384,23 +374,6 @@ query R
 SELECT pmod(-0.1::decimal(3,1), 9999.9::decimal(5,1));
 ----
 NULL
-
-# An untyped NULL pair falls back to Float64, as it did under Signature::numeric
-query T
-SELECT arrow_typeof(pmod(NULL, NULL));
-----
-Float64
-
-query R
-SELECT pmod(NULL, NULL);
-----
-NULL
-
-# A null divisor takes the dividend's type
-query T
-SELECT arrow_typeof(pmod(2.5::decimal(3,1), NULL));
-----
-Decimal128(3, 1)
 
 # PMOD tests with different integer types
 query I


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #23895.

## Rationale for this change

`pmod` reports a wider decimal type than Spark does. Spark derives the result
type of `pmod` with `Pmod.resultDecimalType`, which applies the `Remainder`
rule to the *declared* argument types:

```text
scale     = max(s1, s2)
precision = min(p1 - s1, p2 - s2) + scale
```

For `pmod(decimal(3,1), decimal(2,1))` Spark reports `decimal(2,1)`, but
DataFusion reported `Decimal128(3, 1)`.

The cause is coercion. `SparkPmod` used `Signature::numeric`, which collapses
both arguments to a common decimal before `return_type` runs, so the two
precisions `return_type` saw were already equal and the rule degenerated to the
input precision.

## What changes are included in this PR?

- `SparkPmod` moves to `Signature::user_defined` with a `coerce_types` that
  leaves a decimal/decimal argument pair intact, following the precedent set by
  `try_sum`. Every other argument combination keeps the coercion
  `Signature::numeric` performed — including its null handling, where a null
  argument is skipped and an all-null call falls back to `Float64` — so only the
  decimal pair changes behaviour.
- `return_type` applies Spark's `Pmod.resultDecimalType` rule for decimal
  arguments and is unchanged for everything else.
- Because Spark's result type is *narrower* than the dividend, the operands
  cannot be cast to it before the remainder is taken without overflowing the
  dividend — `pmod(99.9::decimal(3,1), 2.5::decimal(2,1))` returns
  `decimal(2,1)`, which cannot hold `99.9`. `spark_pmod` therefore widens the
  operands to a common computation type, takes the remainder there, and narrows
  the result afterwards.

### Overflow semantics

The remainder is bounded by the divisor, but the result type only carries
`min(p1 - s1, p2 - s2)` integer digits, so the narrowing step can overflow when
the divisor is wider than the dividend:

```sql
-- result type decimal(3,1), true value 9999.8
SELECT pmod(-0.1::decimal(3,1), 9999.9::decimal(5,1));
```

Spark wraps decimal arithmetic in `CheckOverflow(nullOnOverflow = !ansiEnabled)`,
so the narrowing cast returns NULL in legacy mode and raises under ANSI. The
widening cast uses `safe: false` in both modes, since the computation type is
chosen to fit both operands and a silent NULL there would hide a real bug.

### Scope

Deliberately limited to `pmod` over two `Decimal128` arguments, which is what
#23895 reports. Three adjacent gaps are left alone and are happy to be follow-ups
if you would rather see them here:

- **`SparkMod`** has the same bug, since `Remainder.resultDecimalType` is the
  same rule. It is the easier of the two: arrow's `Op::Rem` already computes
  `min(p1-s1, p2-s2) + max(s1, s2)`, so `mod` needs only the `coerce_types`
  pass-through and the matching `return_type`, with no widen/narrow step.
- **Decimal mixed with integer** still diverges: `pmod(2.5::decimal(3,1), 3)`
  reports `Decimal128(21, 1)` where Spark casts INT to `decimal(10,0)` and
  reports `decimal(3,1)`.
- **`Decimal256`, `Decimal64` and `Decimal32`** pairs fall through to the
  previous behaviour. Spark has no equivalent of the wider types.

## Are these changes tested?

Yes.

`datafusion/sqllogictest/test_files/spark/math/pmod.slt` gains:

- four `arrow_typeof` assertions covering equal scales, differing precisions,
  differing scales, and the narrowing case;
- a value test for `pmod(99.9::decimal(3,1), 2.5::decimal(2,1))`, the case that
  would regress if the operands were narrowed before the remainder;
- the overflow case above, asserted as NULL in legacy mode and as an error in
  the ANSI block; and
- null-argument cases pinning the coercion parity described above.

`modulus.rs` gains a unit test for `pmod_decimal_result_type` covering the rule
directly, independent of the planner.

The existing `pmod` and `mod` value tests are unchanged and still pass. Verified
locally: `cargo test -p datafusion-spark --all-features` (279 passed), all 244
`spark/` sqllogictest files, `cargo clippy --all-targets --all-features -D
warnings`, and `cargo fmt --all --check`.

## Are there any user-facing changes?

Yes, and it is the point of the fix: `pmod` over two decimals now reports the
same result type Spark does. Values that fit the Spark result type are
unchanged. Values that do not fit were previously returned at the wider type and
are now NULL (legacy) or an error (ANSI), matching Spark. No public API changes.
