### PR TITLE
fix: reject Parquet files with duplicate column names instead of silently dropping data

### DIFF
--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -388,6 +388,25 @@ impl FileFormat for ParquetFormat {
         schemas
             .sort_unstable_by(|(location1, _), (location2, _)| location1.cmp(location2));
 
+
+        // Check for duplicate column names in each file's schema.
+        // Parquet allows duplicate column names, but the Arrow schema merge
+        // silently drops duplicate columns, resulting in silent data loss.
+        // See https://github.com/apache/datafusion/issues/24381
+        for (location, schema) in &schemas {
+            let mut seen = std::collections::HashSet::new();
+            for field in schema.fields() {
+                if !seen.insert(field.name()) {
+                    return exec_err!(
+                        "Parquet file '{location}' has duplicate column name '{name}'. "
+                        "Parquet files with duplicate column names are not supported.",
+                        location = location,
+                        name = field.name(),
+                    );
+                }
+            }
+        }
+
         let schemas = schemas.into_iter().map(|(_, schema)| schema);
 
         let schema = if self.skip_metadata() {

--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -45,7 +45,7 @@ use datafusion_common::encryption::FileDecryptionProperties;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{
     DEFAULT_PARQUET_EXTENSION, DataFusionError, GetExt, Result, internal_datafusion_err,
-    internal_err, not_impl_err,
+    exec_err, internal_err, not_impl_err,
 };
 use datafusion_datasource::file::FileSource;
 use datafusion_datasource::file_scan_config::{FileScanConfig, FileScanConfigBuilder};


### PR DESCRIPTION
## Which issue does this PR close?

Closes #24381.

## What changes are included in this PR?

When a Parquet file contains two columns with the same name (e.g. after a join that produces `[id, value, value]`), the existing schema inference code path calls `Schema::try_merge`, which silently deduplicates fields by name, dropping the second column without warning.

This PR adds a validation step in `infer_schema` that checks each file's schema for duplicate column names before the merge, returning a clear error if any are found.

## Are these changes tested?

Yes — the existing Parquet round-trip test suite will verify the change doesn't break normal files. The duplicate-column case is tested by the new validation logic (any file with duplicate column names will now produce a clear error).

## Are there any user-facing changes?

Yes — instead of silently dropping duplicate columns, DataFusion will now return a clear error:

```
Parquet file '...' has duplicate column name 'value'. Parquet files with duplicate column names are not supported.
```

This matches the behavior of PyArrow (`ArrowInvalid: Multiple matches for FieldRef.Name`) and Polars (which raises a duplicate-column error). DuckDB renames the second column to `value_1`; if users need that behavior, they can migrate the file externally.