### PR TITLE
introduce new dictionary benchmarks

### DIFF
--- a/datafusion/physical-plan/benches/dictionary_group_values.rs
+++ b/datafusion/physical-plan/benches/dictionary_group_values.rs
@@ -221,9 +221,8 @@ fn bench_take_n(c: &mut Criterion) {
     let mut cards = CARDS_RELATIVE.to_vec();
     cards.push(size);
     for cardinality in cards {
-        let batch_a = make_dict(size, cardinality, null_density, SEED);
-        let batch_b = make_dict(size, cardinality, null_density, SEED.wrapping_add(1));
-        group.throughput(Throughput::Elements((size * 2 * N_BATCHES) as u64));
+        let batch = make_dict(size, cardinality, null_density, SEED);
+        group.throughput(Throughput::Elements((size * N_BATCHES) as u64));
         group.bench_function(bench_id("take_n", size, cardinality, null_density), |b| {
             b.iter_batched_ref(
                 || {
@@ -234,13 +233,11 @@ fn bench_take_n(c: &mut Criterion) {
                 },
                 |(gv, groups)| {
                     for _ in 0..N_BATCHES {
-                        gv.intern(std::slice::from_ref(&batch_a), groups).unwrap();
+                        gv.intern(std::slice::from_ref(&batch), groups).unwrap();
                         black_box(&*groups);
-                        gv.intern(std::slice::from_ref(&batch_b), groups).unwrap();
-                        black_box(&*groups);
-                        black_box(gv.emit(EmitTo::First(1)).unwrap());
+                        black_box(gv.emit(EmitTo::First(size / 2)).unwrap());
                     }
-                    black_box(gv.emit(EmitTo::All).unwrap());
+                    black_box(gv.emit(EmitTo::First(gv.len())).unwrap());
                 },
                 BatchSize::SmallInput,
             );

--- a/datafusion/physical-plan/benches/dictionary_group_values.rs
+++ b/datafusion/physical-plan/benches/dictionary_group_values.rs
@@ -29,7 +29,7 @@ use criterion::{
 };
 use datafusion_expr::EmitTo;
 use datafusion_physical_plan::aggregates::group_values::new_group_values;
-use datafusion_physical_plan::aggregates::order::GroupOrdering;
+use datafusion_physical_plan::aggregates::order::{GroupOrdering, GroupOrderingFull};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
@@ -172,5 +172,88 @@ fn bench_repeated_intern_emit(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_intern_emit, bench_repeated_intern_emit);
+// GroupOrdering::Full -> GroupValuesColumn::<true>: scalar append_val/equal_to path.
+fn bench_scalar_append_equal(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dict_scalar_append_equal");
+    let schema = dict_schema();
+    let null_density = 0.1;
+    let size = SIZES[1];
+
+    let mut cards = CARDS_RELATIVE.to_vec();
+    cards.push(size);
+    for cardinality in cards {
+        let array = make_dict(size, cardinality, null_density, SEED);
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_function(
+            bench_id("scalar_append_equal", size, cardinality, null_density),
+            |b| {
+                b.iter_batched_ref(
+                    || {
+                        (
+                            new_group_values(
+                                schema.clone(),
+                                &GroupOrdering::Full(GroupOrderingFull::new()),
+                            )
+                            .unwrap(),
+                            Vec::<usize>::with_capacity(size),
+                        )
+                    },
+                    |(gv, groups)| {
+                        gv.intern(std::slice::from_ref(&array), groups).unwrap();
+                        black_box(&*groups);
+                        black_box(gv.emit(EmitTo::All).unwrap());
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+// EmitTo::First exercises the take-n path; two interns + partial emit per iteration.
+fn bench_take_n(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dict_take_n");
+    let schema = dict_schema();
+    let null_density = 0.10;
+    let size = SIZES[1];
+
+    let mut cards = CARDS_RELATIVE.to_vec();
+    cards.push(size);
+    for cardinality in cards {
+        let batch_a = make_dict(size, cardinality, null_density, SEED);
+        let batch_b = make_dict(size, cardinality, null_density, SEED.wrapping_add(1));
+        group.throughput(Throughput::Elements((size * 2 * N_BATCHES) as u64));
+        group.bench_function(bench_id("take_n", size, cardinality, null_density), |b| {
+            b.iter_batched_ref(
+                || {
+                    (
+                        new_group_values(schema.clone(), &GroupOrdering::None).unwrap(),
+                        Vec::<usize>::with_capacity(size),
+                    )
+                },
+                |(gv, groups)| {
+                    for _ in 0..N_BATCHES {
+                        gv.intern(std::slice::from_ref(&batch_a), groups).unwrap();
+                        black_box(&*groups);
+                        gv.intern(std::slice::from_ref(&batch_b), groups).unwrap();
+                        black_box(&*groups);
+                        black_box(gv.emit(EmitTo::First(1)).unwrap());
+                    }
+                    black_box(gv.emit(EmitTo::All).unwrap());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_intern_emit,
+    bench_repeated_intern_emit,
+    bench_scalar_append_equal,
+    bench_take_n
+);
 criterion_main!(benches);

--- a/datafusion/physical-plan/benches/dictionary_group_values.rs
+++ b/datafusion/physical-plan/benches/dictionary_group_values.rs
@@ -235,7 +235,8 @@ fn bench_take_n(c: &mut Criterion) {
                     for _ in 0..N_BATCHES {
                         gv.intern(std::slice::from_ref(&batch), groups).unwrap();
                         black_box(&*groups);
-                        black_box(gv.emit(EmitTo::First(size / 2)).unwrap());
+                        let emit_n = (size / 2).min(gv.len());
+                        black_box(gv.emit(EmitTo::First(emit_n)).unwrap());
                     }
                     black_box(gv.emit(EmitTo::First(gv.len())).unwrap());
                 },

--- a/datafusion/physical-plan/benches/dictionary_group_values.rs
+++ b/datafusion/physical-plan/benches/dictionary_group_values.rs
@@ -211,7 +211,7 @@ fn bench_scalar_append_equal(c: &mut Criterion) {
     group.finish();
 }
 
-// EmitTo::First exercises the take-n path; two interns + partial emit per iteration.
+//EmitTo::First exercises repeated
 fn bench_take_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("dict_take_n");
     let schema = dict_schema();
@@ -235,7 +235,7 @@ fn bench_take_n(c: &mut Criterion) {
                     for _ in 0..N_BATCHES {
                         gv.intern(std::slice::from_ref(&batch), groups).unwrap();
                         black_box(&*groups);
-                        let emit_n = (size / 2).min(gv.len());
+                        let emit_n = (gv.len() / 2).min(gv.len());
                         black_box(gv.emit(EmitTo::First(emit_n)).unwrap());
                     }
                     black_box(gv.emit(EmitTo::First(gv.len())).unwrap());


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- works towards  #23921  & #24089.

## Rationale for this change

The existing benchmarks only cover the vectorized (GroupOrdering::None) intern/emit path. This adds coverage for the scalar append_val/equal_to path and the rolling EmitTo::First (take-n) emit path.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?

Two new benchmarks in benches/dictionary_group_values.rs:
- bench_scalar_append_equal — uses GroupOrdering::Full to exercise the scalar GroupValuesColumn::<true> code path
- bench_take_n — uses EmitTo::First(size/2) in a loop over N_BATCHES iterations to exercise the partial/rolling emit path

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
n/a
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
