### PR TITLE
 Add reservation-backed memory accounting to LimitedBatchCoalescer

### DIFF
--- a/datafusion/core/tests/memory_limit/mod.rs
+++ b/datafusion/core/tests/memory_limit/mod.rs
@@ -130,7 +130,7 @@ async fn join_by_key_multiple_partitions() {
         .with_query("select t1.* from t t1 JOIN t t2 ON t1.service = t2.service")
         .with_expected_errors(vec![
             "Resources exhausted: Additional allocation failed",
-            "with top memory consumers (across reservations) as:\n  HashJoinInput",
+            "with top memory consumers (across reservations) as:\n  HashJoinOutput",
         ])
         .with_memory_limit(1_000)
         .with_config(config)
@@ -145,7 +145,7 @@ async fn join_by_key_single_partition() {
         .with_query("select t1.* from t t1 JOIN t t2 ON t1.service = t2.service")
         .with_expected_errors(vec![
             "Resources exhausted: Additional allocation failed",
-            "with top memory consumers (across reservations) as:\n  HashJoinInput",
+            "with top memory consumers (across reservations) as:\n  HashJoinOutput",
         ])
         .with_memory_limit(1_000)
         .with_config(config)
@@ -356,7 +356,7 @@ async fn oom_recursive_cte() {
         SELECT * FROM nodes;",
         )
         .with_expected_errors(vec![
-            "Resources exhausted: Additional allocation failed",
+            "Resources exhausted: Additional allocation failed for FilterExecOutput[0]",
             "with top memory consumers (across reservations) as:\n  RecursiveQuery",
         ])
         .with_memory_limit(2_000)

--- a/datafusion/physical-plan/src/async_func.rs
+++ b/datafusion/physical-plan/src/async_func.rs
@@ -27,6 +27,7 @@ use arrow::array::RecordBatch;
 use arrow_schema::{FieldRef, Fields, Schema, SchemaRef};
 use datafusion_common::Result;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion_execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion_physical_expr::ScalarFunctionExpr;
 use datafusion_physical_expr::async_scalar_function::AsyncFuncExpr;
@@ -234,12 +235,15 @@ impl ExecutionPlan for AsyncFuncExec {
         let schema_captured = self.schema();
         let config_options_ref = Arc::clone(context.session_config().options());
 
+        let reservation = MemoryConsumer::new(format!("AsyncFuncInput[{partition}]"))
+            .register(context.memory_pool());
         let coalesced_input_stream = CoalesceInputStream {
             input_stream,
-            batch_coalescer: LimitedBatchCoalescer::new(
+            batch_coalescer: LimitedBatchCoalescer::new_with_reservation(
                 Arc::clone(&self.input.schema()),
                 config_options_ref.execution.batch_size.get(),
                 None,
+                reservation,
             ),
         };
 
@@ -252,14 +256,22 @@ impl ExecutionPlan for AsyncFuncExec {
             let baseline_metrics_captured = baseline_metrics.clone();
 
             async move {
-                let batch = batch?;
+                let CoalescedInputBatch { batch, reservation } = batch?;
                 // append the result of evaluating the async expressions to the output
                 let mut output_arrays = batch.columns().to_vec();
                 for async_expr in async_exprs_captured.iter() {
                     let output = async_expr
                         .invoke_with_args(&batch, Arc::clone(&config_options))
-                        .await?;
-                    output_arrays.push(output.to_array(batch.num_rows())?);
+                        .await?
+                        .to_array(batch.num_rows())?;
+                    let size = output.get_array_memory_size();
+                    if let Err(error) = reservation.try_grow(size) {
+                        // The array already exists, so keep it accounted while
+                        // the terminal error propagates.
+                        reservation.grow(size);
+                        return Err(error);
+                    }
+                    output_arrays.push(output);
                 }
                 let batch = RecordBatch::try_new(schema_captured, output_arrays)?;
 
@@ -368,13 +380,18 @@ impl AsyncFuncExec {
     }
 }
 
+struct CoalescedInputBatch {
+    batch: RecordBatch,
+    reservation: MemoryReservation,
+}
+
 struct CoalesceInputStream {
     input_stream: Pin<Box<dyn RecordBatchStream + Send>>,
     batch_coalescer: LimitedBatchCoalescer,
 }
 
 impl Stream for CoalesceInputStream {
-    type Item = Result<RecordBatch>;
+    type Item = Result<CoalescedInputBatch>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -383,8 +400,10 @@ impl Stream for CoalesceInputStream {
         let mut completed = false;
 
         loop {
-            if let Some(batch) = self.batch_coalescer.next_completed_batch() {
-                return Poll::Ready(Some(Ok(batch)));
+            if let Some((batch, reservation)) =
+                self.batch_coalescer.next_completed_batch_with_reservation()
+            {
+                return Poll::Ready(Some(Ok(CoalescedInputBatch { batch, reservation })));
             }
 
             if completed {
@@ -397,8 +416,8 @@ impl Stream for CoalesceInputStream {
                         return Poll::Ready(Some(Err(err)));
                     }
                 }
-                Some(err) => {
-                    return Poll::Ready(Some(err));
+                Some(Err(err)) => {
+                    return Poll::Ready(Some(Err(err)));
                 }
                 None => {
                     completed = true;
@@ -508,10 +527,13 @@ mod tests {
     use arrow::array::{RecordBatch, UInt32Array};
     use arrow_schema::{DataType, Field, Schema};
     use datafusion_common::Result;
+    use datafusion_execution::memory_pool::MemoryConsumer;
     use datafusion_execution::{TaskContext, config::SessionConfig};
     use futures::StreamExt;
 
-    use crate::{ExecutionPlan, async_func::AsyncFuncExec, test::TestMemoryExec};
+    use super::{AsyncFuncExec, CoalesceInputStream};
+    use crate::coalesce::LimitedBatchCoalescer;
+    use crate::{ExecutionPlan, test::TestMemoryExec};
 
     #[tokio::test]
     async fn test_async_fn_with_coalescing() -> Result<()> {
@@ -545,6 +567,41 @@ mod tests {
             .expect("expected to get a record batch")?;
         assert_eq!(100, batch.num_rows());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn coalesced_input_stays_reserved_until_async_stage_drops_it() -> Result<()> {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("c0", DataType::UInt32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(UInt32Array::from(vec![1, 2, 3]))],
+        )?;
+        let task_ctx = Arc::new(TaskContext::default());
+        let pool = Arc::clone(task_ctx.memory_pool());
+        let input = TestMemoryExec::try_new_exec(&[vec![batch]], schema, None)?
+            .execute(0, Arc::clone(&task_ctx))?;
+        let reservation = MemoryConsumer::new("AsyncFuncInputTest").register(&pool);
+        let coalescer = LimitedBatchCoalescer::new_with_reservation(
+            input.schema(),
+            8,
+            None,
+            reservation,
+        );
+        let baseline = pool.reserved();
+        let mut stream = CoalesceInputStream {
+            input_stream: input,
+            batch_coalescer: coalescer,
+        };
+
+        let batch = stream.next().await.expect("expected input batch")?;
+        assert_eq!(batch.batch.num_rows(), 3);
+        assert!(pool.reserved() > baseline);
+        drop(batch);
+        assert_eq!(pool.reserved(), baseline);
+        drop(stream);
+        assert_eq!(pool.reserved(), 0);
         Ok(())
     }
 }

--- a/datafusion/physical-plan/src/async_func.rs
+++ b/datafusion/physical-plan/src/async_func.rs
@@ -244,7 +244,7 @@ impl ExecutionPlan for AsyncFuncExec {
                 config_options_ref.execution.batch_size.get(),
                 None,
                 reservation,
-            ),
+            )?,
         };
 
         let stream_with_async_functions = coalesced_input_stream.then(move |batch| {
@@ -588,7 +588,7 @@ mod tests {
             8,
             None,
             reservation,
-        );
+        )?;
         let baseline = pool.reserved();
         let mut stream = CoalesceInputStream {
             input_stream: input,

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -44,6 +44,7 @@ use datafusion_execution::memory_pool::{
 /// [`DataFusionError::ResourcesExhausted`]: datafusion_common::DataFusionError::ResourcesExhausted
 #[derive(Debug)]
 pub struct LimitedBatchCoalescer {
+    /// The arrow structure that builds the output batches
     inner: BatchCoalescer,
     reservation: MemoryReservation,
     target_batch_size: usize,
@@ -96,7 +97,7 @@ impl LimitedBatchCoalescer {
         let reservation = MemoryConsumer::new("LimitedBatchCoalescer(untracked)")
             .register(&untracked_pool);
         Self::new_with_reservation(schema, target_batch_size, fetch, reservation)
-            .expect("private unbounded memory pool cannot reject reservation")
+            .expect("target batch size must be greater than zero")
     }
 
     /// Create a coalescer whose retained input and output batches are charged to
@@ -194,11 +195,7 @@ impl LimitedBatchCoalescer {
             .map(|remaining| remaining.min(batch.num_rows()))
             .unwrap_or_else(|| batch.num_rows());
         if accepted_rows == 0 {
-            return Ok(if limit_reached {
-                PushBatchStatus::LimitReached
-            } else {
-                PushBatchStatus::Continue
-            });
+            return Ok(PushBatchStatus::Continue);
         }
 
         let accepted = if accepted_rows == batch.num_rows() {
@@ -285,11 +282,8 @@ impl LimitedBatchCoalescer {
     pub(crate) fn next_completed_batch_with_reservation(
         &mut self,
     ) -> Option<(RecordBatch, MemoryReservation)> {
-        let source_size = self.inner.size();
         let batch = self.inner.next_completed_batch()?;
-        let charged_bytes = source_size
-            .checked_sub(self.inner.size())
-            .expect("dequeue cannot increase the coalescer size");
+        let charged_bytes = batch.get_array_memory_size();
         let reservation = self.reservation.split(charged_bytes);
         self.reset_if_drained_after_pressure();
         Some((batch, reservation))
@@ -297,10 +291,10 @@ impl LimitedBatchCoalescer {
 
     /// Return the next completed batch and release its reservation.
     pub fn next_completed_batch(&mut self) -> Option<RecordBatch> {
-        let batch = self.inner.next_completed_batch();
+        let batch = self.inner.next_completed_batch()?;
+        self.reservation.shrink(batch.get_array_memory_size());
         self.reset_if_drained_after_pressure();
-        self.reconcile_reservation();
-        batch
+        Some(batch)
     }
 }
 
@@ -405,6 +399,7 @@ mod tests {
 
         let baseline = pool.reserved();
         assert!(baseline > 0, "the empty Arrow coalescer retains capacity");
+        assert_eq!(coalescer.reservation.size(), coalescer.inner.size());
 
         assert_eq!(
             coalescer.push_batch(batch.clone()).unwrap(),
@@ -415,6 +410,7 @@ mod tests {
             buffered_size > baseline,
             "buffered arrays must increase the reservation"
         );
+        assert_eq!(coalescer.reservation.size(), coalescer.inner.size());
 
         coalescer.finish().unwrap();
         let completed_size = pool.reserved();
@@ -422,9 +418,11 @@ mod tests {
             completed_size > baseline,
             "completed output must remain reserved"
         );
+        assert_eq!(coalescer.reservation.size(), coalescer.inner.size());
 
         assert_eq!(coalescer.next_completed_batch().unwrap(), batch);
         assert_eq!(pool.reserved(), baseline);
+        assert_eq!(coalescer.reservation.size(), coalescer.inner.size());
     }
 
     #[test]
@@ -472,6 +470,7 @@ mod tests {
         let (actual, batch_reservation) =
             coalescer.next_completed_batch_with_reservation().unwrap();
         assert_eq!(actual, batch);
+        assert_eq!(batch_reservation.size(), actual.get_array_memory_size());
         assert!(
             batch_reservation.size() > 0,
             "the dequeued batch must remain charged"
@@ -583,6 +582,7 @@ mod tests {
         // While the error propagates, the reservation keeps reflecting the
         // memory actually held, even beyond the pool limit.
         assert!(pool.reserved() > 512);
+        assert_eq!(coalescer.reservation.size(), coalescer.inner.size());
 
         drop(coalescer);
         assert_eq!(pool.reserved(), 0, "drop releases all retained memory");
@@ -610,7 +610,7 @@ mod tests {
             coalescer.push_batch(batch.clone()).unwrap(),
             PushBatchStatus::Continue
         );
-        assert!(pool.reserved() >= baseline + batch.get_array_memory_size());
+        assert_eq!(pool.reserved(), baseline + batch.get_array_memory_size());
 
         assert_eq!(coalescer.next_completed_batch().unwrap(), batch);
         assert_eq!(pool.reserved(), baseline);
@@ -636,11 +636,16 @@ mod tests {
             PushBatchStatus::LimitReached
         );
         assert!(pool.reserved() > baseline, "truncated rows stay charged");
+        assert_eq!(coalescer.reservation.size(), coalescer.inner.size());
+        let reserved_at_limit = pool.reserved();
+
         // Further pushes are ignored once the limit is reached.
         assert_eq!(
             coalescer.push_batch(batch).unwrap(),
             PushBatchStatus::LimitReached
         );
+        assert_eq!(pool.reserved(), reserved_at_limit);
+        assert_eq!(coalescer.reservation.size(), coalescer.inner.size());
         coalescer.finish().unwrap();
 
         let mut rows = 0;
@@ -649,6 +654,7 @@ mod tests {
         }
         assert_eq!(rows, 3, "fetch limit must truncate the accepted rows");
         assert_eq!(pool.reserved(), baseline);
+        assert_eq!(coalescer.reservation.size(), coalescer.inner.size());
     }
 
     /// Test for [`LimitedBatchCoalescer`]

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -15,19 +15,44 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use arrow::array::RecordBatch;
 use arrow::compute::BatchCoalescer;
 use arrow::datatypes::SchemaRef;
 use datafusion_common::{Result, assert_or_internal_err};
+use datafusion_execution::memory_pool::{
+    MemoryConsumer, MemoryPool, MemoryReservation, UnboundedMemoryPool,
+};
 
-/// Concatenate multiple [`RecordBatch`]es and apply a limit
+/// Concatenate multiple [`RecordBatch`]es and apply a limit while accounting
+/// for every retained batch in a [`MemoryReservation`].
 ///
-/// See [`BatchCoalescer`] for more details on how this works.
+/// # Memory accounting
+///
+/// The reservation always mirrors [`BatchCoalescer::size`], which covers both
+/// in-progress buffers and completed batches. Growth caused by
+/// [`Self::push_batch`], [`Self::flush_buffered_batch`], and [`Self::finish`] is
+/// enforced against the pool limit and surfaces as a
+/// [`DataFusionError::ResourcesExhausted`]
+/// error, unless enforcement is disabled via
+/// [`Self::with_unenforced_accounting`]; the small baseline of an empty
+/// coalescer is charged infallibly at construction. Note that completed
+/// batches retained without copying (see
+/// [`BatchCoalescer::with_biggest_coalesce_batch_size`]) are measured with
+/// [`RecordBatch::get_array_memory_size`], which counts the full backing
+/// buffers of shared or sliced arrays and may therefore over-report.
+///
+/// [`DataFusionError::ResourcesExhausted`]: datafusion_common::DataFusionError::ResourcesExhausted
 #[derive(Debug)]
 pub struct LimitedBatchCoalescer {
-    /// The arrow structure that builds the output batches
     inner: BatchCoalescer,
-    /// Total number of rows returned so far
+    reservation: MemoryReservation,
+    /// When false, reservation growth is recorded infallibly instead of
+    /// being checked against the pool limit. See
+    /// [`Self::with_unenforced_accounting`].
+    enforce_limit: bool,
+    /// Total number of rows accepted so far
     total_rows: usize,
     /// Limit: maximum number of rows to fetch, `None` means fetch all rows
     fetch: Option<usize>,
@@ -47,25 +72,128 @@ pub enum PushBatchStatus {
 }
 
 impl LimitedBatchCoalescer {
-    /// Create a new `BatchCoalescer`
+    /// Create a coalescer that does **not** account for the batches it
+    /// retains: they are charged to a private, unbounded pool invisible to
+    /// the query's [`MemoryPool`].
     ///
     /// # Arguments
     /// - `schema` - the schema of the output batches
     /// - `target_batch_size` - the minimum number of rows for each
     ///   output batch (until limit reached)
     /// - `fetch` - the maximum number of rows to fetch, `None` means fetch all rows
+    #[deprecated(
+        since = "55.0.0",
+        note = "use `new_with_reservation` so retained batches are charged to the query's memory pool"
+    )]
     pub fn new(
         schema: SchemaRef,
         target_batch_size: usize,
         fetch: Option<usize>,
     ) -> Self {
-        Self {
-            inner: BatchCoalescer::new(schema, target_batch_size)
-                .with_biggest_coalesce_batch_size(Some(target_batch_size / 2)),
+        let untracked_pool: Arc<dyn MemoryPool> =
+            Arc::new(UnboundedMemoryPool::default());
+        // The reservation's registration keeps the private pool alive.
+        let reservation = MemoryConsumer::new("LimitedBatchCoalescer(untracked)")
+            .register(&untracked_pool);
+        Self::new_with_reservation(schema, target_batch_size, fetch, reservation)
+    }
+
+    /// Create a coalescer whose retained input and output batches are charged to
+    /// `reservation`.
+    pub fn new_with_reservation(
+        schema: SchemaRef,
+        target_batch_size: usize,
+        fetch: Option<usize>,
+        reservation: MemoryReservation,
+    ) -> Self {
+        Self::new_inner(
+            schema,
+            target_batch_size,
+            fetch,
+            reservation,
+            Some(target_batch_size / 2),
+        )
+    }
+
+    /// Create a reservation-backed coalescer that always emits target-sized
+    /// batches, except for the final partial batch.
+    pub fn new_exact_with_reservation(
+        schema: SchemaRef,
+        target_batch_size: usize,
+        fetch: Option<usize>,
+        reservation: MemoryReservation,
+    ) -> Self {
+        Self::new_inner(schema, target_batch_size, fetch, reservation, None)
+    }
+
+    fn new_inner(
+        schema: SchemaRef,
+        target_batch_size: usize,
+        fetch: Option<usize>,
+        reservation: MemoryReservation,
+        biggest_coalesce_batch_size: Option<usize>,
+    ) -> Self {
+        assert!(
+            target_batch_size > 0,
+            "LimitedBatchCoalescer: target batch size must be greater than zero"
+        );
+        let inner = BatchCoalescer::new(schema, target_batch_size)
+            .with_biggest_coalesce_batch_size(biggest_coalesce_batch_size);
+        let coalescer = Self {
+            inner,
+            reservation,
+            enforce_limit: true,
             total_rows: 0,
             fetch,
             finished: false,
+        };
+        coalescer.reconcile_reservation();
+        coalescer
+    }
+
+    /// Disable pool-limit enforcement: reservation growth is recorded
+    /// infallibly instead of returning
+    /// [`ResourcesExhausted`](datafusion_common::DataFusionError::ResourcesExhausted).
+    ///
+    /// Intended for the bounded output buffers of operators that manage
+    /// memory pressure by spilling (e.g. sort-merge join, memory-limited
+    /// nested-loop join, repartitioning): their output buffer cannot spill
+    /// (batches must flow downstream), so failing it would turn queries the
+    /// operator could complete by spilling into errors. The memory is still
+    /// fully accounted, appearing in pool usage and top-consumer reports.
+    pub fn with_unenforced_accounting(mut self) -> Self {
+        self.enforce_limit = false;
+        self
+    }
+
+    /// Sync the reservation to the coalescer's current size without enforcing
+    /// the pool limit.
+    ///
+    /// Used on shrink-only paths (dequeueing completed batches) and for the
+    /// empty-coalescer baseline at construction.
+    fn reconcile_reservation(&self) {
+        self.reservation.resize(self.inner.size());
+    }
+
+    /// Sync the reservation to the coalescer's current size, returning an
+    /// error if growth would exceed the pool limit (unless enforcement is
+    /// disabled, see [`Self::with_unenforced_accounting`]).
+    ///
+    /// On error the reservation is still synced infallibly so it keeps
+    /// reflecting the memory actually held while the error propagates; the
+    /// caller must treat the error as terminal and drop this coalescer to
+    /// release the reservation.
+    fn try_reconcile_reservation(&self) -> Result<()> {
+        if !self.enforce_limit {
+            self.reconcile_reservation();
+            return Ok(());
         }
+        let actual_size = self.inner.size();
+        let result = self.reservation.try_resize(actual_size);
+        if result.is_err() {
+            self.reservation.resize(actual_size);
+        }
+        result
     }
 
     /// Return the schema of the output batches
@@ -75,62 +203,86 @@ impl LimitedBatchCoalescer {
 
     /// Pushes the next [`RecordBatch`] into the coalescer and returns its status.
     ///
-    /// # Arguments
-    /// * `batch` - The [`RecordBatch`] to append.
-    ///
-    /// # Returns
-    /// * [`PushBatchStatus::Continue`] - More batches can still be pushed.
-    /// * [`PushBatchStatus::LimitReached`] - The row limit was reached after processing
-    ///   this batch. The caller should call [`Self::finish`] before retrieving the
-    ///   remaining buffered batches.
-    ///
     /// # Errors
-    /// Returns an error if called after [`Self::finish`] or if the internal push
-    /// operation fails.
+    /// Returns an error if called after [`Self::finish`], if the internal push
+    /// operation fails, or if the memory pool cannot accommodate the newly
+    /// buffered data. Errors are terminal: the caller should stop pushing and
+    /// drop the coalescer to release its reservation.
     pub fn push_batch(&mut self, batch: RecordBatch) -> Result<PushBatchStatus> {
         assert_or_internal_err!(
             !self.finished,
             "LimitedBatchCoalescer: cannot push batch after finish"
         );
 
-        // if we are at the limit, return LimitReached
-        if let Some(fetch) = self.fetch {
-            // limit previously reached
-            if self.total_rows >= fetch {
-                return Ok(PushBatchStatus::LimitReached);
-            }
-
-            // limit now reached
-            if self.total_rows + batch.num_rows() >= fetch {
-                // Limit is reached
-                let remaining_rows = fetch - self.total_rows;
-                debug_assert!(remaining_rows > 0);
-
-                let batch_head = batch.slice(0, remaining_rows);
-                self.total_rows += batch_head.num_rows();
-                self.inner.push_batch(batch_head)?;
-                return Ok(PushBatchStatus::LimitReached);
-            }
+        let remaining = self
+            .fetch
+            .map(|fetch| fetch.saturating_sub(self.total_rows));
+        if remaining == Some(0) {
+            return Ok(PushBatchStatus::LimitReached);
         }
 
-        // Limit not reached, push the entire batch
-        self.total_rows += batch.num_rows();
-        self.inner.push_batch(batch)?;
+        let limit_reached =
+            remaining.is_some_and(|remaining| batch.num_rows() >= remaining);
+        let accepted_rows = remaining
+            .map(|remaining| remaining.min(batch.num_rows()))
+            .unwrap_or_else(|| batch.num_rows());
+        if accepted_rows == 0 {
+            return Ok(if limit_reached {
+                PushBatchStatus::LimitReached
+            } else {
+                PushBatchStatus::Continue
+            });
+        }
 
-        Ok(PushBatchStatus::Continue)
+        let accepted = if accepted_rows == batch.num_rows() {
+            batch
+        } else {
+            batch.slice(0, accepted_rows)
+        };
+        let result = self.inner.push_batch(accepted);
+        let reconciled = self.try_reconcile_reservation();
+        result?;
+        reconciled?;
+        self.total_rows += accepted_rows;
+
+        Ok(if limit_reached {
+            PushBatchStatus::LimitReached
+        } else {
+            PushBatchStatus::Continue
+        })
     }
 
-    /// Return true if there is no data buffered
+    /// Return true if there is no data buffered or completed.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
-    /// Complete the current buffered batch and finish the coalescer
+    /// Return true if a completed batch is ready to be fetched.
+    pub fn has_completed_batch(&self) -> bool {
+        self.inner.has_completed_batch()
+    }
+
+    /// Complete the current buffered batch without preventing future pushes.
     ///
-    /// Any subsequent calls to `push_batch()` will return an Err
+    /// # Errors
+    /// See [`Self::push_batch`]; errors are terminal.
+    pub fn flush_buffered_batch(&mut self) -> Result<()> {
+        assert_or_internal_err!(
+            !self.finished,
+            "LimitedBatchCoalescer: cannot flush after finish"
+        );
+        let result = self.inner.finish_buffered_batch();
+        let reconciled = self.try_reconcile_reservation();
+        result?;
+        reconciled
+    }
+
+    /// Complete the current buffered batch and finish the coalescer.
     pub fn finish(&mut self) -> Result<()> {
-        self.inner.finish_buffered_batch()?;
-        self.finished = true;
+        if !self.finished {
+            self.flush_buffered_batch()?;
+            self.finished = true;
+        }
         Ok(())
     }
 
@@ -138,9 +290,24 @@ impl LimitedBatchCoalescer {
         self.finished
     }
 
-    /// Return the next completed batch, if any
+    /// Return the next completed batch and an owned reservation for its charge.
+    /// Dropping the returned reservation releases the charge.
+    pub fn next_completed_batch_with_reservation(
+        &mut self,
+    ) -> Option<(RecordBatch, MemoryReservation)> {
+        let source_size = self.inner.size();
+        let batch = self.inner.next_completed_batch()?;
+        let charged_bytes = source_size
+            .checked_sub(self.inner.size())
+            .expect("dequeue cannot increase the coalescer size");
+        Some((batch, self.reservation.split(charged_bytes)))
+    }
+
+    /// Return the next completed batch and release its reservation.
     pub fn next_completed_batch(&mut self) -> Option<RecordBatch> {
-        self.inner.next_completed_batch()
+        let batch = self.inner.next_completed_batch();
+        self.reconcile_reservation();
+        batch
     }
 }
 
@@ -153,6 +320,10 @@ mod tests {
     use arrow::array::UInt32Array;
     use arrow::compute::concat_batches;
     use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion_common::DataFusionError;
+    use datafusion_execution::memory_pool::{
+        GreedyMemoryPool, MemoryConsumer, MemoryPool, UnboundedMemoryPool,
+    };
 
     #[test]
     fn test_coalesce() {
@@ -223,6 +394,267 @@ mod tests {
             .with_fetch(Some(7))
             .with_expected_output_sizes(vec![7])
             .run()
+    }
+
+    #[test]
+    fn reservation_tracks_buffered_completed_and_drained_size() {
+        let batch = uint32_batch(0..2);
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            4,
+            None,
+            reservation,
+        );
+
+        let baseline = pool.reserved();
+        assert!(baseline > 0, "the empty Arrow coalescer retains capacity");
+
+        assert_eq!(
+            coalescer.push_batch(batch.clone()).unwrap(),
+            PushBatchStatus::Continue
+        );
+        let buffered_size = pool.reserved();
+        assert!(
+            buffered_size > baseline,
+            "buffered arrays must increase the reservation"
+        );
+
+        coalescer.finish().unwrap();
+        let completed_size = pool.reserved();
+        assert!(
+            completed_size > baseline,
+            "completed output must remain reserved"
+        );
+
+        assert_eq!(coalescer.next_completed_batch().unwrap(), batch);
+        assert_eq!(pool.reserved(), baseline);
+    }
+
+    #[test]
+    fn dropping_coalescer_releases_baseline_and_buffered_reservation() {
+        let batch = uint32_batch(0..2);
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            4,
+            None,
+            reservation,
+        );
+
+        let baseline = pool.reserved();
+        assert!(baseline > 0, "the empty Arrow coalescer retains capacity");
+        coalescer.push_batch(batch).unwrap();
+        assert!(pool.reserved() > baseline);
+
+        drop(coalescer);
+        assert_eq!(pool.reserved(), 0, "drop releases all retained memory");
+    }
+
+    #[test]
+    fn dequeue_transfers_reservation_until_returned_reservation_is_dropped() {
+        let batch = uint32_batch(0..2);
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            4,
+            None,
+            reservation,
+        );
+
+        let baseline = pool.reserved();
+        coalescer.push_batch(batch.clone()).unwrap();
+        coalescer.finish().unwrap();
+        let completed_size = pool.reserved();
+
+        let (actual, batch_reservation) =
+            coalescer.next_completed_batch_with_reservation().unwrap();
+        assert_eq!(actual, batch);
+        assert!(
+            batch_reservation.size() > 0,
+            "the dequeued batch must remain charged"
+        );
+        assert_eq!(batch_reservation.size(), completed_size - baseline);
+        assert_eq!(pool.reserved(), completed_size);
+
+        drop(batch_reservation);
+        assert_eq!(pool.reserved(), baseline);
+        drop(coalescer);
+        assert_eq!(pool.reserved(), 0);
+    }
+
+    #[test]
+    fn exact_coalescer_can_flush_and_continue() {
+        let input = uint32_batch(0..5);
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let mut coalescer = LimitedBatchCoalescer::new_exact_with_reservation(
+            input.schema(),
+            2,
+            None,
+            reservation,
+        );
+
+        coalescer.push_batch(input).unwrap();
+        coalescer.flush_buffered_batch().unwrap();
+        assert!(coalescer.has_completed_batch());
+        let mut sizes = vec![];
+        while let Some(batch) = coalescer.next_completed_batch() {
+            sizes.push(batch.num_rows());
+        }
+        assert_eq!(sizes, vec![2, 2, 1]);
+        assert!(!coalescer.is_finished());
+
+        coalescer.push_batch(uint32_batch(5..6)).unwrap();
+        coalescer.finish().unwrap();
+        assert_eq!(coalescer.next_completed_batch().unwrap().num_rows(), 1);
+        assert!(coalescer.is_finished());
+        assert!(coalescer.push_batch(uint32_batch(6..7)).is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "target batch size must be greater than zero")]
+    fn zero_target_batch_size_is_rejected_at_construction() {
+        let batch = uint32_batch(0..1);
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let _ = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            0,
+            None,
+            reservation,
+        );
+    }
+
+    #[test]
+    #[expect(deprecated)]
+    fn deprecated_new_works_without_a_memory_pool() {
+        let batch = uint32_batch(0..2);
+        let mut coalescer = LimitedBatchCoalescer::new(batch.schema(), 4, None);
+        coalescer.push_batch(batch.clone()).unwrap();
+        coalescer.finish().unwrap();
+        assert_eq!(coalescer.next_completed_batch().unwrap(), batch);
+    }
+
+    #[test]
+    fn push_batch_fails_when_pool_limit_exceeded() {
+        let batch = uint32_batch(0..1024);
+        let pool: Arc<dyn MemoryPool> = Arc::new(GreedyMemoryPool::new(512));
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            8,
+            None,
+            reservation,
+        );
+
+        let err = coalescer.push_batch(batch).unwrap_err();
+        assert!(
+            matches!(err, DataFusionError::ResourcesExhausted(_)),
+            "expected ResourcesExhausted, got {err:?}"
+        );
+        // While the error propagates, the reservation keeps reflecting the
+        // memory actually held, even beyond the pool limit.
+        assert!(pool.reserved() > 512);
+
+        drop(coalescer);
+        assert_eq!(pool.reserved(), 0, "drop releases all retained memory");
+    }
+
+    #[test]
+    fn unenforced_accounting_allows_growth_beyond_pool_limit() {
+        let batch = uint32_batch(0..1024);
+        let pool: Arc<dyn MemoryPool> = Arc::new(GreedyMemoryPool::new(512));
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            8,
+            None,
+            reservation,
+        )
+        .with_unenforced_accounting();
+
+        assert_eq!(
+            coalescer.push_batch(batch).unwrap(),
+            PushBatchStatus::Continue
+        );
+        assert!(pool.reserved() > 512);
+        coalescer.finish().unwrap();
+        while coalescer.next_completed_batch().is_some() {}
+
+        drop(coalescer);
+        assert_eq!(pool.reserved(), 0);
+    }
+
+    #[test]
+    fn bypass_batches_are_accounted_and_released() {
+        // A batch larger than half the target bypasses coalescing (see
+        // `BatchCoalescer::with_biggest_coalesce_batch_size`) and is retained
+        // as-is; it must still be charged to the reservation while queued.
+        let batch = uint32_batch(0..100);
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            8,
+            None,
+            reservation,
+        );
+        let baseline = pool.reserved();
+
+        assert_eq!(
+            coalescer.push_batch(batch.clone()).unwrap(),
+            PushBatchStatus::Continue
+        );
+        assert!(pool.reserved() >= baseline + batch.get_array_memory_size());
+
+        assert_eq!(coalescer.next_completed_batch().unwrap(), batch);
+        assert_eq!(pool.reserved(), baseline);
+    }
+
+    #[test]
+    fn fetch_limit_truncates_and_reservation_drains_to_baseline() {
+        let batch = uint32_batch(0..5);
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            4,
+            Some(3),
+            reservation,
+        );
+        let baseline = pool.reserved();
+
+        assert_eq!(
+            coalescer.push_batch(batch.clone()).unwrap(),
+            PushBatchStatus::LimitReached
+        );
+        assert!(pool.reserved() > baseline, "truncated rows stay charged");
+        // Further pushes are ignored once the limit is reached.
+        assert_eq!(
+            coalescer.push_batch(batch).unwrap(),
+            PushBatchStatus::LimitReached
+        );
+        coalescer.finish().unwrap();
+
+        let mut rows = 0;
+        while let Some(out) = coalescer.next_completed_batch() {
+            rows += out.num_rows();
+        }
+        assert_eq!(rows, 3, "fetch limit must truncate the accepted rows");
+        assert_eq!(pool.reserved(), baseline);
     }
 
     /// Test for [`LimitedBatchCoalescer`]
@@ -297,8 +729,15 @@ mod tests {
             // create a single large input batch for output comparison
             let single_input_batch = concat_batches(&schema, &input_batches).unwrap();
 
-            let mut coalescer =
-                LimitedBatchCoalescer::new(Arc::clone(&schema), target_batch_size, fetch);
+            let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+            let reservation =
+                MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+            let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
+                Arc::clone(&schema),
+                target_batch_size,
+                fetch,
+                reservation,
+            );
 
             let mut output_batches = vec![];
             for batch in input_batches {

--- a/datafusion/physical-plan/src/coalesce/mod.rs
+++ b/datafusion/physical-plan/src/coalesce/mod.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use arrow::compute::BatchCoalescer;
 use arrow::datatypes::SchemaRef;
-use datafusion_common::{Result, assert_or_internal_err};
+use datafusion_common::{DataFusionError, Result, assert_or_internal_err};
 use datafusion_execution::memory_pool::{
     MemoryConsumer, MemoryPool, MemoryReservation, UnboundedMemoryPool,
 };
@@ -31,13 +31,11 @@ use datafusion_execution::memory_pool::{
 /// # Memory accounting
 ///
 /// The reservation always mirrors [`BatchCoalescer::size`], which covers both
-/// in-progress buffers and completed batches. Growth caused by
-/// [`Self::push_batch`], [`Self::flush_buffered_batch`], and [`Self::finish`] is
-/// enforced against the pool limit and surfaces as a
-/// [`DataFusionError::ResourcesExhausted`]
-/// error, unless enforcement is disabled via
-/// [`Self::with_unenforced_accounting`]; the small baseline of an empty
-/// coalescer is charged infallibly at construction. Note that completed
+/// in-progress buffers and completed batches. The baseline allocation is
+/// enforced at construction, and later growth caused by [`Self::push_batch`]
+/// and [`Self::finish`] surfaces as a [`DataFusionError::ResourcesExhausted`]
+/// error. Internal spill-capable callers may instead flush a partial batch on
+/// memory pressure. Note that completed
 /// batches retained without copying (see
 /// [`BatchCoalescer::with_biggest_coalesce_batch_size`]) are measured with
 /// [`RecordBatch::get_array_memory_size`], which counts the full backing
@@ -48,10 +46,12 @@ use datafusion_execution::memory_pool::{
 pub struct LimitedBatchCoalescer {
     inner: BatchCoalescer,
     reservation: MemoryReservation,
-    /// When false, reservation growth is recorded infallibly instead of
-    /// being checked against the pool limit. See
-    /// [`Self::with_unenforced_accounting`].
-    enforce_limit: bool,
+    target_batch_size: usize,
+    /// Complete the partial batch instead of erroring when reservation growth
+    /// is rejected. The caller must immediately drain the completed batches.
+    flush_on_memory_pressure: bool,
+    /// Drop reusable Arrow capacity after pressure-generated batches are drained.
+    reset_after_drain: bool,
     /// Total number of rows accepted so far
     total_rows: usize,
     /// Limit: maximum number of rows to fetch, `None` means fetch all rows
@@ -96,98 +96,65 @@ impl LimitedBatchCoalescer {
         let reservation = MemoryConsumer::new("LimitedBatchCoalescer(untracked)")
             .register(&untracked_pool);
         Self::new_with_reservation(schema, target_batch_size, fetch, reservation)
+            .expect("private unbounded memory pool cannot reject reservation")
     }
 
     /// Create a coalescer whose retained input and output batches are charged to
-    /// `reservation`.
+    /// an empty `reservation`.
+    ///
+    /// # Errors
+    /// Returns an error if `target_batch_size` is zero, `reservation` is not
+    /// empty, or its pool cannot accommodate the coalescer's baseline allocation.
     pub fn new_with_reservation(
         schema: SchemaRef,
         target_batch_size: usize,
         fetch: Option<usize>,
         reservation: MemoryReservation,
-    ) -> Self {
-        Self::new_inner(
-            schema,
-            target_batch_size,
-            fetch,
-            reservation,
-            Some(target_batch_size / 2),
-        )
-    }
-
-    /// Create a reservation-backed coalescer that always emits target-sized
-    /// batches, except for the final partial batch.
-    pub fn new_exact_with_reservation(
-        schema: SchemaRef,
-        target_batch_size: usize,
-        fetch: Option<usize>,
-        reservation: MemoryReservation,
-    ) -> Self {
-        Self::new_inner(schema, target_batch_size, fetch, reservation, None)
-    }
-
-    fn new_inner(
-        schema: SchemaRef,
-        target_batch_size: usize,
-        fetch: Option<usize>,
-        reservation: MemoryReservation,
-        biggest_coalesce_batch_size: Option<usize>,
-    ) -> Self {
-        assert!(
+    ) -> Result<Self> {
+        assert_or_internal_err!(
             target_batch_size > 0,
             "LimitedBatchCoalescer: target batch size must be greater than zero"
         );
+        assert_or_internal_err!(
+            reservation.size() == 0,
+            "LimitedBatchCoalescer: reservation must be empty"
+        );
         let inner = BatchCoalescer::new(schema, target_batch_size)
-            .with_biggest_coalesce_batch_size(biggest_coalesce_batch_size);
-        let coalescer = Self {
+            .with_biggest_coalesce_batch_size(Some(target_batch_size / 2));
+        reservation.try_resize(inner.size())?;
+        Ok(Self {
             inner,
             reservation,
-            enforce_limit: true,
+            target_batch_size,
+            flush_on_memory_pressure: false,
+            reset_after_drain: false,
             total_rows: 0,
             fetch,
             finished: false,
-        };
-        coalescer.reconcile_reservation();
-        coalescer
+        })
     }
 
-    /// Disable pool-limit enforcement: reservation growth is recorded
-    /// infallibly instead of returning
-    /// [`ResourcesExhausted`](datafusion_common::DataFusionError::ResourcesExhausted).
-    ///
-    /// Intended for the bounded output buffers of operators that manage
-    /// memory pressure by spilling (e.g. sort-merge join, memory-limited
-    /// nested-loop join, repartitioning): their output buffer cannot spill
-    /// (batches must flow downstream), so failing it would turn queries the
-    /// operator could complete by spilling into errors. The memory is still
-    /// fully accounted, appearing in pool usage and top-consumer reports.
-    pub fn with_unenforced_accounting(mut self) -> Self {
-        self.enforce_limit = false;
+    /// Flush partial batches when the pool rejects reservation growth. The
+    /// caller must immediately drain and either send or spill completed batches.
+    pub(crate) fn with_flush_on_memory_pressure(mut self) -> Self {
+        self.flush_on_memory_pressure = true;
         self
     }
 
     /// Sync the reservation to the coalescer's current size without enforcing
-    /// the pool limit.
-    ///
-    /// Used on shrink-only paths (dequeueing completed batches) and for the
-    /// empty-coalescer baseline at construction.
+    /// the pool limit. Used after allocation and on shrink-only paths.
     fn reconcile_reservation(&self) {
         self.reservation.resize(self.inner.size());
     }
 
     /// Sync the reservation to the coalescer's current size, returning an
-    /// error if growth would exceed the pool limit (unless enforcement is
-    /// disabled, see [`Self::with_unenforced_accounting`]).
+    /// error if growth would exceed the pool limit.
     ///
     /// On error the reservation is still synced infallibly so it keeps
-    /// reflecting the memory actually held while the error propagates; the
-    /// caller must treat the error as terminal and drop this coalescer to
-    /// release the reservation.
+    /// reflecting the memory actually held while the error propagates. Unless
+    /// configured to flush on pressure, the caller must treat the error as
+    /// terminal and drop this coalescer to release the reservation.
     fn try_reconcile_reservation(&self) -> Result<()> {
-        if !self.enforce_limit {
-            self.reconcile_reservation();
-            return Ok(());
-        }
         let actual_size = self.inner.size();
         let result = self.reservation.try_resize(actual_size);
         if result.is_err() {
@@ -242,7 +209,18 @@ impl LimitedBatchCoalescer {
         let result = self.inner.push_batch(accepted);
         let reconciled = self.try_reconcile_reservation();
         result?;
-        reconciled?;
+        match reconciled {
+            Ok(()) => {}
+            Err(DataFusionError::ResourcesExhausted(_))
+                if self.flush_on_memory_pressure =>
+            {
+                let result = self.inner.finish_buffered_batch();
+                self.reconcile_reservation();
+                result?;
+                self.reset_after_drain = true;
+            }
+            Err(error) => return Err(error),
+        }
         self.total_rows += accepted_rows;
 
         Ok(if limit_reached {
@@ -257,16 +235,11 @@ impl LimitedBatchCoalescer {
         self.inner.is_empty()
     }
 
-    /// Return true if a completed batch is ready to be fetched.
-    pub fn has_completed_batch(&self) -> bool {
-        self.inner.has_completed_batch()
-    }
-
     /// Complete the current buffered batch without preventing future pushes.
     ///
     /// # Errors
     /// See [`Self::push_batch`]; errors are terminal.
-    pub fn flush_buffered_batch(&mut self) -> Result<()> {
+    pub(crate) fn flush_buffered_batch(&mut self) -> Result<()> {
         assert_or_internal_err!(
             !self.finished,
             "LimitedBatchCoalescer: cannot flush after finish"
@@ -274,7 +247,15 @@ impl LimitedBatchCoalescer {
         let result = self.inner.finish_buffered_batch();
         let reconciled = self.try_reconcile_reservation();
         result?;
-        reconciled
+        match reconciled {
+            Err(DataFusionError::ResourcesExhausted(_))
+                if self.flush_on_memory_pressure =>
+            {
+                self.reset_after_drain = true;
+                Ok(())
+            }
+            result => result,
+        }
     }
 
     /// Complete the current buffered batch and finish the coalescer.
@@ -290,9 +271,18 @@ impl LimitedBatchCoalescer {
         self.finished
     }
 
+    fn reset_if_drained_after_pressure(&mut self) {
+        if self.reset_after_drain && self.inner.is_empty() {
+            self.inner = BatchCoalescer::new(self.inner.schema(), self.target_batch_size)
+                .with_biggest_coalesce_batch_size(Some(self.target_batch_size / 2));
+            self.reset_after_drain = false;
+            self.reconcile_reservation();
+        }
+    }
+
     /// Return the next completed batch and an owned reservation for its charge.
     /// Dropping the returned reservation releases the charge.
-    pub fn next_completed_batch_with_reservation(
+    pub(crate) fn next_completed_batch_with_reservation(
         &mut self,
     ) -> Option<(RecordBatch, MemoryReservation)> {
         let source_size = self.inner.size();
@@ -300,12 +290,15 @@ impl LimitedBatchCoalescer {
         let charged_bytes = source_size
             .checked_sub(self.inner.size())
             .expect("dequeue cannot increase the coalescer size");
-        Some((batch, self.reservation.split(charged_bytes)))
+        let reservation = self.reservation.split(charged_bytes);
+        self.reset_if_drained_after_pressure();
+        Some((batch, reservation))
     }
 
     /// Return the next completed batch and release its reservation.
     pub fn next_completed_batch(&mut self) -> Option<RecordBatch> {
         let batch = self.inner.next_completed_batch();
+        self.reset_if_drained_after_pressure();
         self.reconcile_reservation();
         batch
     }
@@ -407,7 +400,8 @@ mod tests {
             4,
             None,
             reservation,
-        );
+        )
+        .unwrap();
 
         let baseline = pool.reserved();
         assert!(baseline > 0, "the empty Arrow coalescer retains capacity");
@@ -444,7 +438,8 @@ mod tests {
             4,
             None,
             reservation,
-        );
+        )
+        .unwrap();
 
         let baseline = pool.reserved();
         assert!(baseline > 0, "the empty Arrow coalescer retains capacity");
@@ -466,7 +461,8 @@ mod tests {
             4,
             None,
             reservation,
-        );
+        )
+        .unwrap();
 
         let baseline = pool.reserved();
         coalescer.push_batch(batch.clone()).unwrap();
@@ -490,48 +486,69 @@ mod tests {
     }
 
     #[test]
-    fn exact_coalescer_can_flush_and_continue() {
-        let input = uint32_batch(0..5);
-        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
-        let reservation =
-            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
-        let mut coalescer = LimitedBatchCoalescer::new_exact_with_reservation(
-            input.schema(),
-            2,
-            None,
-            reservation,
-        );
-
-        coalescer.push_batch(input).unwrap();
-        coalescer.flush_buffered_batch().unwrap();
-        assert!(coalescer.has_completed_batch());
-        let mut sizes = vec![];
-        while let Some(batch) = coalescer.next_completed_batch() {
-            sizes.push(batch.num_rows());
-        }
-        assert_eq!(sizes, vec![2, 2, 1]);
-        assert!(!coalescer.is_finished());
-
-        coalescer.push_batch(uint32_batch(5..6)).unwrap();
-        coalescer.finish().unwrap();
-        assert_eq!(coalescer.next_completed_batch().unwrap().num_rows(), 1);
-        assert!(coalescer.is_finished());
-        assert!(coalescer.push_batch(uint32_batch(6..7)).is_err());
-    }
-
-    #[test]
-    #[should_panic(expected = "target batch size must be greater than zero")]
     fn zero_target_batch_size_is_rejected_at_construction() {
         let batch = uint32_batch(0..1);
         let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
         let reservation =
             MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
-        let _ = LimitedBatchCoalescer::new_with_reservation(
+        let error = LimitedBatchCoalescer::new_with_reservation(
             batch.schema(),
             0,
             None,
             reservation,
-        );
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("target batch size"));
+    }
+
+    #[test]
+    fn nonempty_reservation_is_rejected_at_construction() {
+        let batch = uint32_batch(0..1);
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        reservation.grow(1);
+
+        let error = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            4,
+            None,
+            reservation,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("reservation must be empty"));
+        assert_eq!(pool.reserved(), 0);
+    }
+
+    #[test]
+    fn construction_fails_when_baseline_exceeds_pool_limit() {
+        let batch = uint32_batch(0..1);
+        let unbounded: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerBaseline").register(&unbounded);
+        let coalescer = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            4,
+            None,
+            reservation,
+        )
+        .unwrap();
+        let baseline = unbounded.reserved();
+        drop(coalescer);
+
+        let pool: Arc<dyn MemoryPool> =
+            Arc::new(GreedyMemoryPool::new(baseline.saturating_sub(1)));
+        let reservation =
+            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
+        let error = LimitedBatchCoalescer::new_with_reservation(
+            batch.schema(),
+            4,
+            None,
+            reservation,
+        )
+        .unwrap_err();
+        assert!(matches!(error, DataFusionError::ResourcesExhausted(_)));
+        assert_eq!(pool.reserved(), 0);
     }
 
     #[test]
@@ -555,7 +572,8 @@ mod tests {
             8,
             None,
             reservation,
-        );
+        )
+        .unwrap();
 
         let err = coalescer.push_batch(batch).unwrap_err();
         assert!(
@@ -568,32 +586,6 @@ mod tests {
 
         drop(coalescer);
         assert_eq!(pool.reserved(), 0, "drop releases all retained memory");
-    }
-
-    #[test]
-    fn unenforced_accounting_allows_growth_beyond_pool_limit() {
-        let batch = uint32_batch(0..1024);
-        let pool: Arc<dyn MemoryPool> = Arc::new(GreedyMemoryPool::new(512));
-        let reservation =
-            MemoryConsumer::new("LimitedBatchCoalescerTest").register(&pool);
-        let mut coalescer = LimitedBatchCoalescer::new_with_reservation(
-            batch.schema(),
-            8,
-            None,
-            reservation,
-        )
-        .with_unenforced_accounting();
-
-        assert_eq!(
-            coalescer.push_batch(batch).unwrap(),
-            PushBatchStatus::Continue
-        );
-        assert!(pool.reserved() > 512);
-        coalescer.finish().unwrap();
-        while coalescer.next_completed_batch().is_some() {}
-
-        drop(coalescer);
-        assert_eq!(pool.reserved(), 0);
     }
 
     #[test]
@@ -610,7 +602,8 @@ mod tests {
             8,
             None,
             reservation,
-        );
+        )
+        .unwrap();
         let baseline = pool.reserved();
 
         assert_eq!(
@@ -634,7 +627,8 @@ mod tests {
             4,
             Some(3),
             reservation,
-        );
+        )
+        .unwrap();
         let baseline = pool.reserved();
 
         assert_eq!(
@@ -737,7 +731,8 @@ mod tests {
                 target_batch_size,
                 fetch,
                 reservation,
-            );
+            )
+            .unwrap();
 
             let mut output_batches = vec![];
             for batch in input_batches {

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -36,6 +36,7 @@ use arrow::record_batch::RecordBatch;
 use datafusion_common::Result;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_execution::TaskContext;
+use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_physical_expr::PhysicalExpr;
 
 use crate::coalesce::{LimitedBatchCoalescer, PushBatchStatus};
@@ -225,12 +226,16 @@ impl ExecutionPlan for CoalesceBatchesExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        let reservation =
+            MemoryConsumer::new(format!("CoalesceBatchesOutput[{partition}]"))
+                .register(context.memory_pool());
         Ok(Box::pin(CoalesceBatchesStream {
             input: self.input.execute(partition, context)?,
-            coalescer: LimitedBatchCoalescer::new(
+            coalescer: LimitedBatchCoalescer::new_with_reservation(
                 self.input.schema(),
                 self.target_batch_size,
                 self.fetch,
+                reservation,
             ),
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             completed: false,

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -236,7 +236,7 @@ impl ExecutionPlan for CoalesceBatchesExec {
                 self.target_batch_size,
                 self.fetch,
                 reservation,
-            ),
+            )?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             completed: false,
         }))

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -60,6 +60,7 @@ use datafusion_common::{
     DataFusionError, Result, ScalarValue, internal_err, plan_err, project_schema,
 };
 use datafusion_execution::TaskContext;
+use datafusion_execution::memory_pool::MemoryConsumer;
 use datafusion_expr::Operator;
 use datafusion_physical_expr::equivalence::ProjectionMapping;
 use datafusion_physical_expr::expressions::{
@@ -606,16 +607,19 @@ impl ExecutionPlan for FilterExec {
             context.task_id()
         );
         let metrics = FilterExecMetrics::new(&self.metrics, partition);
+        let reservation = MemoryConsumer::new(format!("FilterExecOutput[{partition}]"))
+            .register(context.memory_pool());
         Ok(Box::pin(FilterExecStream {
             schema: self.schema(),
             predicate: Arc::clone(&self.predicate),
             input: self.input.execute(partition, context)?,
             metrics,
             projection: self.projection.clone(),
-            batch_coalescer: LimitedBatchCoalescer::new(
+            batch_coalescer: LimitedBatchCoalescer::new_with_reservation(
                 self.schema(),
                 self.batch_size,
                 self.fetch,
+                reservation,
             ),
         }))
     }

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -620,7 +620,7 @@ impl ExecutionPlan for FilterExec {
                 self.batch_size,
                 self.fetch,
                 reservation,
-            ),
+            )?,
         }))
     }
 

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -1581,7 +1581,7 @@ impl ExecutionPlan for HashJoinExec {
             self.null_aware,
             self.fetch,
             output_reservation,
-        )))
+        )?))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -5936,7 +5936,8 @@ mod tests {
 
         for join_type in join_types {
             let runtime = RuntimeEnvBuilder::new()
-                .with_memory_limit(100, 1.0)
+                // Enough for the output coalescer baseline, but not the build batch.
+                .with_memory_limit(150, 1.0)
                 .build_arc()?;
             let task_ctx = TaskContext::default().with_runtime(runtime);
             let task_ctx = Arc::new(task_ctx);
@@ -6068,7 +6069,8 @@ mod tests {
 
         for join_type in join_types {
             let runtime = RuntimeEnvBuilder::new()
-                .with_memory_limit(100, 1.0)
+                // Enough for the output coalescer baseline, but not the build batch.
+                .with_memory_limit(150, 1.0)
                 .build_arc()?;
             let session_config = SessionConfig::default().with_batch_size(50);
             let task_ctx = TaskContext::default()

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -1539,7 +1539,7 @@ impl ExecutionPlan for HashJoinExec {
 
         // we have the batches and the hash map with their keys. We can how create a stream
         // over the right that uses this information to issue new batches.
-        let right_stream = self.right.execute(partition, context)?;
+        let right_stream = self.right.execute(partition, Arc::clone(&context))?;
 
         // update column indices to reflect the projection
         let column_indices_after_projection = match self.projection.as_ref() {
@@ -1555,6 +1555,10 @@ impl ExecutionPlan for HashJoinExec {
             .iter()
             .map(|(_, right_expr)| Arc::clone(right_expr))
             .collect::<Vec<_>>();
+
+        let output_reservation =
+            MemoryConsumer::new(format!("HashJoinOutput[{partition}]"))
+                .register(context.memory_pool());
 
         Ok(Box::pin(HashJoinStream::new(
             partition,
@@ -1576,6 +1580,7 @@ impl ExecutionPlan for HashJoinExec {
             self.mode,
             self.null_aware,
             self.fetch,
+            output_reservation,
         )))
     }
 
@@ -5947,10 +5952,12 @@ mod tests {
             let stream = join.execute(0, task_ctx)?;
             let err = common::collect(stream).await.unwrap_err();
 
-            // Asserting that operator-level reservation attempting to overallocate
+            // Asserting that operator-level reservation attempting to overallocate.
+            // The output coalescer's `HashJoinOutput` consumer holds its idle
+            // baseline at failure time, so it ranks above the failing consumer.
             assert_contains!(
                 err.to_string(),
-                "Resources exhausted: Additional allocation failed for HashJoinInput with top memory consumers (across reservations) as:\n  HashJoinInput"
+                "Resources exhausted: Additional allocation failed for HashJoinInput with top memory consumers (across reservations) as:\n  HashJoinOutput"
             );
 
             assert_contains!(
@@ -6084,10 +6091,12 @@ mod tests {
             let stream = join.execute(1, task_ctx)?;
             let err = common::collect(stream).await.unwrap_err();
 
-            // Asserting that stream-level reservation attempting to overallocate
+            // Asserting that stream-level reservation attempting to overallocate.
+            // The output coalescer's `HashJoinOutput` consumer holds its idle
+            // baseline at failure time, so it ranks above the failing consumer.
             assert_contains!(
                 err.to_string(),
-                "Resources exhausted: Additional allocation failed for HashJoinInput[1] with top memory consumers (across reservations) as:\n  HashJoinInput[1]"
+                "Resources exhausted: Additional allocation failed for HashJoinInput[1] with top memory consumers (across reservations) as:\n  HashJoinOutput[1]"
             );
 
             assert_contains!(

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -46,6 +46,7 @@ use crate::{
         need_produce_result_in_final,
     },
 };
+use datafusion_execution::memory_pool::MemoryReservation;
 
 use arrow::array::{Array, ArrayRef, UInt32Array, UInt64Array};
 use arrow::buffer::NullBuffer;
@@ -487,10 +488,15 @@ impl HashJoinStream {
         mode: PartitionMode,
         null_aware: bool,
         fetch: Option<usize>,
+        reservation: MemoryReservation,
     ) -> Self {
         // Create output buffer with coalescing and optional fetch limit.
-        let output_buffer =
-            LimitedBatchCoalescer::new(Arc::clone(&schema), batch_size, fetch);
+        let output_buffer = LimitedBatchCoalescer::new_with_reservation(
+            Arc::clone(&schema),
+            batch_size,
+            fetch,
+            reservation,
+        );
 
         Self {
             partition,

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -489,16 +489,16 @@ impl HashJoinStream {
         null_aware: bool,
         fetch: Option<usize>,
         reservation: MemoryReservation,
-    ) -> Self {
+    ) -> Result<Self> {
         // Create output buffer with coalescing and optional fetch limit.
         let output_buffer = LimitedBatchCoalescer::new_with_reservation(
             Arc::clone(&schema),
             batch_size,
             fetch,
             reservation,
-        );
+        )?;
 
-        Self {
+        Ok(Self {
             partition,
             schema,
             on_right,
@@ -520,7 +520,7 @@ impl HashJoinStream {
             mode,
             output_buffer,
             null_aware,
-        }
+        })
     }
 
     /// Returns the next state after the build side has been fully collected

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -63,7 +63,7 @@ use datafusion_common::{
 use datafusion_common::{Result, not_impl_err};
 use datafusion_common_runtime::SpawnedTask;
 use datafusion_execution::TaskContext;
-use datafusion_execution::memory_pool::MemoryConsumer;
+use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion_expr::ColumnarValue;
 use datafusion_physical_expr::{EquivalenceProperties, PhysicalExpr, RangePartitioning};
 use datafusion_physical_expr_common::physical_expr::PhysicalExprRef;
@@ -209,10 +209,13 @@ impl PartitionSpillWriters {
 }
 
 impl OutputChannel {
-    fn coalesce(&mut self, batch: RecordBatch) -> Result<Vec<RecordBatch>> {
+    fn coalesce(
+        &mut self,
+        batch: RecordBatch,
+    ) -> Result<Vec<(RecordBatch, Option<MemoryReservation>)>> {
         match &self.shared_coalescer {
-            Some(shared) => Ok(shared.push_and_drain(batch)?),
-            None => Ok(vec![batch]),
+            Some(shared) => shared.push_and_drain(batch),
+            None => Ok(vec![(batch, None)]),
         }
     }
 
@@ -221,20 +224,35 @@ impl OutputChannel {
     /// from `self.inner` if the receiver has hung up.
     ///
     /// Used after [`OutputChannel::coalesce`] for performance purposes.
-    async fn send(&mut self, batch: RecordBatch) -> Result<(), SendError<MaybeBatch>> {
+    async fn send(
+        &mut self,
+        batch: RecordBatch,
+        source_reservation: Option<MemoryReservation>,
+    ) -> Result<(), SendError<MaybeBatch>> {
         let size = batch.get_array_memory_size();
 
-        // Decide the payload outside of any await: never hold a MutexGuard
-        // across an await point.
-        let (payload, is_memory_batch) = {
-            match self.reservation.try_grow(size) {
-                Ok(_) => (Ok(RepartitionBatch::Memory(batch)), true),
-                Err(_) => match self.spill_writer.push_batch(&batch) {
-                    Ok(()) => (Ok(RepartitionBatch::Spilled), false),
-                    Err(err) => (Err(err), false),
-                },
+        // Transfer the existing coalescer charge to the channel without
+        // double-counting it. If the channel cannot reserve the batch, restore
+        // the source charge while synchronously writing the spill.
+        let source_size = source_reservation
+            .as_ref()
+            .map(MemoryReservation::free)
+            .unwrap_or_default();
+        let (payload, is_memory_batch) = match self.reservation.try_grow(size) {
+            Ok(_) => (Ok(RepartitionBatch::Memory(batch)), true),
+            Err(_) => {
+                if let Some(reservation) = &source_reservation {
+                    reservation.grow(source_size);
+                }
+                let payload = self
+                    .spill_writer
+                    .push_batch(&batch)
+                    .map(|_| RepartitionBatch::Spilled);
+                drop(batch);
+                (payload, false)
             }
         };
+        drop(source_reservation);
 
         let result = self.sender.send(Some(payload)).await;
         if result.is_err() && is_memory_batch {
@@ -247,10 +265,10 @@ impl OutputChannel {
         let Some(shared) = self.shared_coalescer.take() else {
             return Ok(());
         };
-        for batch in shared.finalize()? {
+        for (batch, reservation) in shared.finalize()? {
             // If this errored, it means that nobody is listening on the other side, which is fine
             // and can happen in certain cases, like when a LIMIT drops the stream that listens.
-            let _ = self.send(batch).await;
+            let _ = self.send(batch, reservation).await;
         }
         Ok(())
     }
@@ -272,33 +290,48 @@ struct SharedCoalescer {
 }
 
 impl SharedCoalescer {
-    fn new(schema: SchemaRef, target_batch_size: usize, num_senders: usize) -> Self {
+    fn new(
+        schema: SchemaRef,
+        target_batch_size: usize,
+        num_senders: usize,
+        reservation: MemoryReservation,
+    ) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(LimitedBatchCoalescer::new(
-                schema,
-                target_batch_size,
-                None,
-            ))),
+            // Unenforced: repartitioning handles memory pressure by spilling
+            // at the channel level (see `OutputChannel::send`); failing this
+            // bounded pre-channel buffer would defeat that.
+            inner: Arc::new(Mutex::new(
+                LimitedBatchCoalescer::new_with_reservation(
+                    schema,
+                    target_batch_size,
+                    None,
+                    reservation,
+                )
+                .with_unenforced_accounting(),
+            )),
             active_senders: Arc::new(AtomicUsize::new(num_senders)),
         }
     }
 
     /// Push `batch` into the coalescer and drain any newly completed
     /// batches. The mutex is held only briefly.
-    fn push_and_drain(&self, batch: RecordBatch) -> Result<Vec<RecordBatch>> {
+    fn push_and_drain(
+        &self,
+        batch: RecordBatch,
+    ) -> Result<Vec<(RecordBatch, Option<MemoryReservation>)>> {
         let mut acc = Vec::new();
         let mut c = self.inner.lock();
         c.push_batch(batch)?;
-        while let Some(b) = c.next_completed_batch() {
-            acc.push(b);
+        while let Some((batch, reservation)) = c.next_completed_batch_with_reservation() {
+            acc.push((batch, Some(reservation)));
         }
         Ok(acc)
     }
 
     /// Decrement the active-senders counter. If this caller was the last
     /// sender, finalize the coalescer and return its residual batches; if
-    /// other senders are still active, return `Ok(None)`.
-    fn finalize(&self) -> Result<Vec<RecordBatch>> {
+    /// other senders are still active, return an empty `Vec`.
+    fn finalize(&self) -> Result<Vec<(RecordBatch, Option<MemoryReservation>)>> {
         let was_last = self.active_senders.fetch_sub(1, AtomicOrdering::AcqRel) == 1;
         if !was_last {
             return Ok(vec![]);
@@ -306,8 +339,8 @@ impl SharedCoalescer {
         let mut acc = Vec::new();
         let mut c = self.inner.lock();
         c.finish()?;
-        while let Some(b) = c.next_completed_batch() {
-            acc.push(b);
+        while let Some((batch, reservation)) = c.next_completed_batch_with_reservation() {
+            acc.push((batch, Some(reservation)));
         }
         Ok(acc)
     }
@@ -538,10 +571,14 @@ impl RepartitionExecState {
             // handles batching, and for unbounded inputs, where a residual
             // batch could otherwise be withheld indefinitely.
             let shared_coalescer = coalesce_batches.then(|| {
+                let reservation =
+                    MemoryConsumer::new(format!("{name}[Coalesce {partition}]"))
+                        .register(context.memory_pool());
                 SharedCoalescer::new(
                     input.schema(),
                     context.session_config().batch_size(),
                     num_input_partitions,
+                    reservation,
                 )
             });
 
@@ -2150,8 +2187,8 @@ impl RepartitionExec {
                 let timer = metrics.send_time[partition].timer();
                 // if there is still a receiver, send to it
                 if let Some(output_channel) = output_channels.get_mut(&partition) {
-                    for batch in output_channel.coalesce(batch)? {
-                        if output_channel.send(batch).await.is_err() {
+                    for (batch, reservation) in output_channel.coalesce(batch)? {
+                        if output_channel.send(batch, reservation).await.is_err() {
                             // If the other end has hung up, it was an early shutdown (e.g. LIMIT)
                             // so ignore this channel from now on.
                             output_channels.remove(&partition);
@@ -2487,6 +2524,10 @@ mod tests {
     use datafusion_common::test_util::batches_to_sort_string;
     use datafusion_common_runtime::JoinSet;
     use datafusion_execution::config::SessionConfig;
+    use datafusion_execution::disk_manager::DiskManagerBuilder;
+    use datafusion_execution::memory_pool::{
+        GreedyMemoryPool, MemoryPool, UnboundedMemoryPool,
+    };
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_physical_expr::{PhysicalSortExpr, RangePartitioning, SplitPoint};
     use insta::assert_snapshot;
@@ -2550,6 +2591,79 @@ mod tests {
         assert_eq!(rewritten.sort_options(), sort_options);
         assert_eq!(rewritten.split_points(), split_points);
 
+        Ok(())
+    }
+
+    #[test]
+    fn shared_coalescer_reserves_final_batch_until_released() -> Result<()> {
+        let batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(UInt32Array::from(vec![1])) as ArrayRef,
+        )])?;
+        let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation = MemoryConsumer::new("RepartitionCoalescerTest").register(&pool);
+        let coalescer = SharedCoalescer::new(batch.schema(), 4, 2, reservation);
+        let other_sender = coalescer.clone();
+
+        assert!(coalescer.push_and_drain(batch)?.is_empty());
+        assert!(coalescer.finalize()?.is_empty());
+
+        let output = other_sender.finalize()?;
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].0.num_rows(), 1);
+        assert!(output[0].1.as_ref().unwrap().size() > 0);
+
+        drop(output);
+        drop(other_sender);
+        drop(coalescer);
+        assert_eq!(pool.reserved(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn spilled_coalescer_batch_releases_source_reservation() -> Result<()> {
+        let batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(UInt32Array::from(vec![1, 2, 3])) as ArrayRef,
+        )])?;
+        let size = batch.get_array_memory_size();
+        let pool: Arc<dyn MemoryPool> = Arc::new(GreedyMemoryPool::new(size));
+        let blocker = MemoryConsumer::new("RepartitionBlocker").register(&pool);
+        blocker.try_grow(size)?;
+        let source = MemoryConsumer::new("RepartitionSource").register(&pool);
+        source.grow(size);
+        let destination =
+            Arc::new(MemoryConsumer::new("RepartitionDestination").register(&pool));
+
+        let runtime = RuntimeEnvBuilder::new()
+            .with_disk_manager_builder(DiskManagerBuilder::default())
+            .build_arc()?;
+        let spill_manager = Arc::new(SpillManager::new(
+            runtime,
+            SpillMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
+            batch.schema(),
+        ));
+        let (spill_writer, mut spill_reader) =
+            spill_pool::spsc_channel(usize::MAX, spill_manager);
+        let (mut senders, mut receivers) = channels::<MaybeBatch>(1);
+        let mut output = OutputChannel {
+            sender: senders.pop().unwrap(),
+            reservation: Arc::clone(&destination),
+            spill_writer,
+            shared_coalescer: None,
+        };
+
+        output.send(batch.clone(), Some(source)).await.unwrap();
+        assert_eq!(destination.size(), 0);
+        assert_eq!(pool.reserved(), size);
+        assert!(matches!(
+            receivers[0].recv().await,
+            Some(Some(Ok(RepartitionBatch::Spilled)))
+        ));
+        assert_eq!(spill_reader.next().await.transpose()?, Some(batch));
+
+        drop(blocker);
+        assert_eq!(pool.reserved(), 0);
         Ok(())
     }
 

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -2657,6 +2657,15 @@ mod tests {
 
         drop(output);
         assert_eq!(pool.reserved(), baseline);
+
+        // Draining a pressure-generated batch resets the Arrow coalescer, which
+        // must remain usable for later input.
+        let output = coalescer.push_and_drain(batch.clone())?;
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].0, batch);
+        drop(output);
+        assert_eq!(pool.reserved(), baseline);
+
         drop(coalescer);
         assert_eq!(pool.reserved(), 0);
         Ok(())

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -238,6 +238,9 @@ impl OutputChannel {
             .as_ref()
             .map(MemoryReservation::free)
             .unwrap_or_default();
+
+        // Decide the payload outside of any await: never hold a MutexGuard
+        // across an await point.
         let (payload, is_memory_batch) = match self.reservation.try_grow(size) {
             Ok(_) => (Ok(RepartitionBatch::Memory(batch)), true),
             Err(_) => {
@@ -295,22 +298,21 @@ impl SharedCoalescer {
         target_batch_size: usize,
         num_senders: usize,
         reservation: MemoryReservation,
-    ) -> Self {
-        Self {
-            // Unenforced: repartitioning handles memory pressure by spilling
-            // at the channel level (see `OutputChannel::send`); failing this
-            // bounded pre-channel buffer would defeat that.
+    ) -> Result<Self> {
+        Ok(Self {
+            // Flush partial batches on memory pressure so `OutputChannel::send`
+            // can route them through the existing spill fallback.
             inner: Arc::new(Mutex::new(
                 LimitedBatchCoalescer::new_with_reservation(
                     schema,
                     target_batch_size,
                     None,
                     reservation,
-                )
-                .with_unenforced_accounting(),
+                )?
+                .with_flush_on_memory_pressure(),
             )),
             active_senders: Arc::new(AtomicUsize::new(num_senders)),
-        }
+        })
     }
 
     /// Push `batch` into the coalescer and drain any newly completed
@@ -570,17 +572,25 @@ impl RepartitionExecState {
             // Skip in preserve-order mode, where `StreamingMergeBuilder`
             // handles batching, and for unbounded inputs, where a residual
             // batch could otherwise be withheld indefinitely.
-            let shared_coalescer = coalesce_batches.then(|| {
+            let shared_coalescer = if coalesce_batches {
                 let reservation =
                     MemoryConsumer::new(format!("{name}[Coalesce {partition}]"))
                         .register(context.memory_pool());
-                SharedCoalescer::new(
+                match SharedCoalescer::new(
                     input.schema(),
                     context.session_config().batch_size(),
                     num_input_partitions,
                     reservation,
-                )
-            });
+                ) {
+                    Ok(coalescer) => Some(coalescer),
+                    // Sending smaller batches is preferable to failing a
+                    // spill-capable repartition at fixed-buffer construction.
+                    Err(DataFusionError::ResourcesExhausted(_)) => None,
+                    Err(error) => return Err(error),
+                }
+            } else {
+                None
+            };
 
             channels.insert(
                 partition,
@@ -2602,7 +2612,7 @@ mod tests {
         )])?;
         let pool: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
         let reservation = MemoryConsumer::new("RepartitionCoalescerTest").register(&pool);
-        let coalescer = SharedCoalescer::new(batch.schema(), 4, 2, reservation);
+        let coalescer = SharedCoalescer::new(batch.schema(), 4, 2, reservation)?;
         let other_sender = coalescer.clone();
 
         assert!(coalescer.push_and_drain(batch)?.is_empty());
@@ -2615,6 +2625,38 @@ mod tests {
 
         drop(output);
         drop(other_sender);
+        drop(coalescer);
+        assert_eq!(pool.reserved(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn shared_coalescer_flushes_partial_batch_on_memory_pressure() -> Result<()> {
+        let value = "x".repeat(1024);
+        let batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(StringArray::from(vec![value.as_str()])) as ArrayRef,
+        )])?;
+
+        let unbounded: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let reservation =
+            MemoryConsumer::new("RepartitionCoalescerBaseline").register(&unbounded);
+        let baseline_coalescer = SharedCoalescer::new(batch.schema(), 4, 1, reservation)?;
+        let baseline = unbounded.reserved();
+        drop(baseline_coalescer);
+
+        let limit = baseline + 1;
+        let pool: Arc<dyn MemoryPool> = Arc::new(GreedyMemoryPool::new(limit));
+        let reservation = MemoryConsumer::new("RepartitionCoalescerTest").register(&pool);
+        let coalescer = SharedCoalescer::new(batch.schema(), 4, 1, reservation)?;
+
+        let output = coalescer.push_and_drain(batch.clone())?;
+        assert_eq!(output.len(), 1, "memory pressure must flush partial data");
+        assert_eq!(output[0].0, batch);
+        assert!(pool.reserved() > limit);
+
+        drop(output);
+        assert_eq!(pool.reserved(), baseline);
         drop(coalescer);
         assert_eq!(pool.reserved(), 0);
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

 - Part of #23385.

##  Rationale for this change

LimitedBatchCoalescer retains in-progress Arrow buffers and completed batches waiting to be polled, but this memory was not charged to DataFusion's memory pool.

FilterExec, CoalesceBatchesExec, HashJoinExec, AsyncFuncExec, and RepartitionExec could underreport retained memory suicne they use LimitedBatchCoalescer. 

After https://github.com/apache/arrow-rs/pull/10331, which added BatchCoalescer::size() by @rluvaton we can account for this memory.

##  What changes are included in this PR?
Adds reservation-backed memory accounting to LimitedBatchCoalescer and its existing callers. Repartition can flush partial batches through its normal send/spill path under pressure. The old untracked constructor remains available but is deprecated.

 Arrow reports coalescer size after mutation, so already-allocated memory remains charged while an error propagates. Shared or sliced arrays may be conservatively charged for their full backing buffers.

 Remaining operators that use Arrow's BatchCoalescer directly will be handled as follow-up work for #23385.

##  Are these changes tested?
Yes mostly unit tests in LimitedBatchCoalescer

##  Are there any user-facing changes?
`LimitedBatchCoalescer:;new` method is deprecated and `new_with_reservation` method is added. Additionally, there can be errors due to memory limitations such as `ResourcesExhausted`. 