### PR TITLE
fix: use total_cmp for grouped float MIN/MAX accumulators (#24432)

### DIFF
--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -132,6 +132,25 @@ macro_rules! primitive_max_accumulator {
     }};
 }
 
+/// Creates a [`PrimitiveGroupsAccumulator`] for computing `MAX`
+/// over floating-point values (Float16, Float32, Float64).
+///
+/// Uses `total_cmp` instead of `partial_cmp` to handle NaNs and signed zeros
+/// deterministically, matching the non-grouped accumulator semantics.
+macro_rules! primitive_float_max_accumulator {
+    ($DATA_TYPE:ident, $NATIVE:ident, $PRIMTYPE:ident) => {{
+        Ok(Box::new(
+            PrimitiveGroupsAccumulator::<$PRIMTYPE, _>::new($DATA_TYPE, |cur, new| {
+                if new.total_cmp(cur) == Ordering::Greater {
+                    *cur = new
+                }
+            })
+            // Initialize each accumulator to the minimum of the total ordering
+            .with_starting_value($NATIVE::NEG_INFINITY),
+        ))
+    }};
+}
+
 /// Creates a [`PrimitiveGroupsAccumulator`] for computing `MIN`
 /// the specified [`ArrowPrimitiveType`].
 ///
@@ -151,6 +170,25 @@ macro_rules! primitive_min_accumulator {
             })
             // Initialize each accumulator to $NATIVE::MAX
             .with_starting_value($NATIVE::MAX),
+        ))
+    }};
+}
+
+/// Creates a [`PrimitiveGroupsAccumulator`] for computing `MIN`
+/// over floating-point values (Float16, Float32, Float64).
+///
+/// Uses `total_cmp` instead of `partial_cmp` to handle NaNs and signed zeros
+/// deterministically, matching the non-grouped accumulator semantics.
+macro_rules! primitive_float_min_accumulator {
+    ($DATA_TYPE:ident, $NATIVE:ident, $PRIMTYPE:ident) => {{
+        Ok(Box::new(
+            PrimitiveGroupsAccumulator::<$PRIMTYPE, _>::new(&$DATA_TYPE, |cur, new| {
+                if new.total_cmp(cur) == Ordering::Less {
+                    *cur = new
+                }
+            })
+            // Initialize each accumulator to the maximum of the total ordering
+            .with_starting_value($NATIVE::INFINITY),
         ))
     }};
 }
@@ -272,13 +310,13 @@ impl AggregateUDFImpl for Max {
             UInt32 => primitive_max_accumulator!(data_type, u32, UInt32Type),
             UInt64 => primitive_max_accumulator!(data_type, u64, UInt64Type),
             Float16 => {
-                primitive_max_accumulator!(data_type, f16, Float16Type)
+                primitive_float_max_accumulator!(data_type, f16, Float16Type)
             }
             Float32 => {
-                primitive_max_accumulator!(data_type, f32, Float32Type)
+                primitive_float_max_accumulator!(data_type, f32, Float32Type)
             }
             Float64 => {
-                primitive_max_accumulator!(data_type, f64, Float64Type)
+                primitive_float_max_accumulator!(data_type, f64, Float64Type)
             }
             Date32 => primitive_max_accumulator!(data_type, i32, Date32Type),
             Date64 => primitive_max_accumulator!(data_type, i64, Date64Type),
@@ -566,13 +604,13 @@ impl AggregateUDFImpl for Min {
             UInt32 => primitive_min_accumulator!(data_type, u32, UInt32Type),
             UInt64 => primitive_min_accumulator!(data_type, u64, UInt64Type),
             Float16 => {
-                primitive_min_accumulator!(data_type, f16, Float16Type)
+                primitive_float_min_accumulator!(data_type, f16, Float16Type)
             }
             Float32 => {
-                primitive_min_accumulator!(data_type, f32, Float32Type)
+                primitive_float_min_accumulator!(data_type, f32, Float32Type)
             }
             Float64 => {
-                primitive_min_accumulator!(data_type, f64, Float64Type)
+                primitive_float_min_accumulator!(data_type, f64, Float64Type)
             }
             Date32 => primitive_min_accumulator!(data_type, i32, Date32Type),
             Date64 => primitive_min_accumulator!(data_type, i64, Date64Type),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #24432.

## What changes are included in this PR?

This PR fixes the grouped floating-point MIN and MAX accumulators to use
`total_cmp` instead of `partial_cmp` for Float16, Float32, and Float64.

**Problem:** `partial_cmp` returns `None` for NaN comparisons, causing the
grouped update closure to unconditionally overwrite the current value. This
makes results order-dependent: `MAX([NaN, 1.0])` = `1.0` but `MAX([1.0, NaN])`
= `NaN`.

**Fix:**

1. New `primitive_float_max_accumulator` and `primitive_float_min_accumulator`
   macros that use `total_cmp` (IEEE 754 total ordering) instead of `partial_cmp`.

2. Initial values changed from `$NATIVE::MIN` / `$NATIVE::MAX` (finite
   constants) to `$NATIVE::NEG_INFINITY` / `$NATIVE::INFINITY` (the true
   extrema of the total ordering), so infinities and NaNs are handled correctly.

## Are these changes tested?

Existing tests cover the non-grouped behavior. The grouped accumulators
now match the same total-ordering semantics.

## Are there any user-facing changes?

Grouped `MIN`/`MAX` on Float16, Float32, and Float64 columns will now
return deterministic results regardless of input order, batching, or
partitioning.

**Before:** `MAX([NaN, 1.0])` = `1.0` (order-dependent)
**After:** `MAX([NaN, 1.0])` = `NaN` (deterministic)