### PR TITLE
fix: use to_bits() comparison for float types in eq_array (#24431)

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4574,13 +4574,28 @@ impl ScalarValue {
                 eq_array_primitive!(array, index, as_boolean_array, val)?
             }
             ScalarValue::Float16(val) => {
-                eq_array_primitive!(array, index, as_float16_array, val)?
+                let array = as_float16_array(array)?;
+                let is_valid = array.is_valid(index);
+                Ok(match val {
+                    Some(v) => is_valid && array.value(index).to_bits() == v.to_bits(),
+                    None => !is_valid,
+                })
             }
             ScalarValue::Float32(val) => {
-                eq_array_primitive!(array, index, as_float32_array, val)?
+                let array = as_float32_array(array)?;
+                let is_valid = array.is_valid(index);
+                Ok(match val {
+                    Some(v) => is_valid && array.value(index).to_bits() == v.to_bits(),
+                    None => !is_valid,
+                })
             }
             ScalarValue::Float64(val) => {
-                eq_array_primitive!(array, index, as_float64_array, val)?
+                let array = as_float64_array(array)?;
+                let is_valid = array.is_valid(index);
+                Ok(match val {
+                    Some(v) => is_valid && array.value(index).to_bits() == v.to_bits(),
+                    None => !is_valid,
+                })
             }
             ScalarValue::Int8(val) => {
                 eq_array_primitive!(array, index, as_int8_array, val)?


### PR DESCRIPTION
### Problem

`ScalarValue::eq_array` is documented as an optimized equivalent of extracting an array element with `ScalarValue::try_from_array` and comparing the resulting scalars. However, for floating-point values `eq_array` uses IEEE equality (via the generic `eq_array_primitive!` macro) while `ScalarValue::PartialEq` compares bit representations, producing inconsistent results:

- Identical NaN bit patterns compare equal as `ScalarValue`s but unequal through `eq_array`.
- `+0.0` and `-0.0` compare unequal as `ScalarValue`s but equal through `eq_array`.

### Fix

Replace the Float16, Float32, and Float64 branches of `eq_array` with custom `to_bits()` comparison, matching the semantics of `ScalarValue::PartialEq` for floats.

Closes #24431