### PR TITLE
feat: stream aggregates when group keys are partition-disjoint

### DIFF
--- a/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
+++ b/datafusion/core/tests/fuzz_cases/aggregate_fuzz.rs
@@ -420,6 +420,202 @@ async fn run_aggregate_test(input1: Vec<RecordBatch>, group_by_columns: Vec<&str
     }
 }
 
+/// Like `streaming_aggregate_test`, but uses partition-disjoint keys instead of
+/// global sort order to enable incremental aggregation.
+#[tokio::test(flavor = "multi_thread")]
+async fn partition_disjoint_streaming_aggregate_test() {
+    let test_cases = [vec!["a"], vec!["b"], vec!["c"]];
+    let n = 10;
+    let distincts = vec![10, 20];
+    for distinct in distincts {
+        let mut join_set = JoinSet::new();
+        for i in 0..n {
+            let test_idx = i % test_cases.len();
+            let group_by_columns = test_cases[test_idx].clone();
+            join_set.spawn(run_partition_disjoint_aggregate_test(
+                make_staggered_batches::<true>(1000, distinct, i as u64),
+                group_by_columns,
+            ));
+        }
+        while let Some(join_handle) = join_set.join_next().await {
+            join_handle.unwrap();
+        }
+    }
+}
+
+fn partition_batches_by_modulo(
+    batches: &[RecordBatch],
+    key_name: &str,
+    n_partitions: usize,
+) -> Vec<Vec<RecordBatch>> {
+    let schema = batches[0].schema();
+    let concat = concat_batches(&schema, batches).unwrap();
+    let key_col = concat.column_by_name(key_name).unwrap();
+    let key_values = key_col.as_primitive::<Int64Type>();
+
+    let mut parts: Vec<Vec<ArrayRef>> = (0..n_partitions)
+        .map(|_| {
+            (0..concat.num_columns())
+                .map(|col_idx| {
+                    arrow::array::new_empty_array(
+                        concat.schema().field(col_idx).data_type(),
+                    )
+                })
+                .collect()
+        })
+        .collect();
+    let mut counts = vec![0usize; n_partitions];
+
+    for (col_idx, column) in concat.columns().iter().enumerate() {
+        for row_idx in 0..concat.num_rows() {
+            let partition_idx =
+                (key_values.value(row_idx).rem_euclid(n_partitions as i64)) as usize;
+            parts[partition_idx][col_idx] = arrow::compute::concat(&[
+                parts[partition_idx][col_idx].as_ref(),
+                column.slice(row_idx, 1).as_ref(),
+            ])
+            .unwrap();
+            if col_idx == 0 {
+                counts[partition_idx] += 1;
+            }
+        }
+    }
+
+    parts
+        .into_iter()
+        .zip(counts)
+        .filter(|(_, count)| *count > 0)
+        .map(|(columns, _)| {
+            vec![RecordBatch::try_new(Arc::clone(&schema), columns).unwrap()]
+        })
+        .collect()
+}
+
+async fn run_partition_disjoint_aggregate_test(
+    input1: Vec<RecordBatch>,
+    group_by_columns: Vec<&str>,
+) {
+    let schema = input1[0].schema();
+    let session_config = SessionConfig::new()
+        .with_batch_size(50)
+        .set_bool("datafusion.execution.enable_migration_aggregate", true);
+    let ctx = SessionContext::new_with_config(session_config);
+
+    let concat_input_record = concat_batches(&schema, &input1).unwrap();
+
+    let usual_source = MemorySourceConfig::try_new_exec(
+        &[vec![concat_input_record]],
+        schema.clone(),
+        None,
+    )
+    .unwrap();
+
+    let partition_key = group_by_columns[0];
+    let partition_batches = partition_batches_by_modulo(&input1, partition_key, 4);
+    assert!(partition_batches.len() > 1);
+    let disjoint_exprs = group_by_columns
+        .iter()
+        .map(|col_name| col(col_name, &schema).unwrap())
+        .collect::<Vec<_>>();
+    let running_source = DataSourceExec::from_data_source(
+        MemorySourceConfig::try_new(&partition_batches, schema.clone(), None)
+            .unwrap()
+            .try_with_partition_disjoint_keys(disjoint_exprs)
+            .unwrap(),
+    );
+
+    let aggregate_expr = vec![
+        AggregateExprBuilder::new(sum_udaf(), vec![col("d", &schema).unwrap()])
+            .schema(Arc::clone(&schema))
+            .alias("sum1")
+            .build()
+            .map(Arc::new)
+            .unwrap(),
+    ];
+    let expr = group_by_columns
+        .iter()
+        .map(|elem| (col(elem, &schema).unwrap(), (*elem).to_string()))
+        .collect::<Vec<_>>();
+    let group_by = PhysicalGroupBy::new_single(expr);
+
+    let aggregate_exec_running = Arc::new(
+        AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by.clone(),
+            aggregate_expr.clone(),
+            vec![None],
+            running_source,
+            schema.clone(),
+        )
+        .unwrap(),
+    );
+    assert_eq!(
+        aggregate_exec_running.input_order_mode(),
+        &InputOrderMode::Linear
+    );
+    assert!(aggregate_exec_running.group_keys_partition_disjoint());
+
+    let aggregate_exec_usual = Arc::new(
+        AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by.clone(),
+            aggregate_expr.clone(),
+            vec![None],
+            usual_source,
+            schema.clone(),
+        )
+        .unwrap(),
+    );
+
+    let task_ctx = ctx.task_ctx();
+    let collected_usual = collect(aggregate_exec_usual.clone(), task_ctx.clone())
+        .await
+        .unwrap();
+
+    let collected_running = collect(aggregate_exec_running.clone(), task_ctx.clone())
+        .await
+        .unwrap();
+    assert!(collected_running.len() > 2);
+    assert!(collected_running.len() > collected_usual.len());
+
+    let usual_formatted = pretty_format_batches(&collected_usual).unwrap().to_string();
+    let running_formatted = pretty_format_batches(&collected_running)
+        .unwrap()
+        .to_string();
+
+    let mut usual_formatted_sorted: Vec<&str> = usual_formatted.trim().lines().collect();
+    usual_formatted_sorted.sort_unstable();
+
+    let mut running_formatted_sorted: Vec<&str> =
+        running_formatted.trim().lines().collect();
+    running_formatted_sorted.sort_unstable();
+    for (i, (usual_line, running_line)) in usual_formatted_sorted
+        .iter()
+        .zip(&running_formatted_sorted)
+        .enumerate()
+    {
+        assert_eq!(
+            (i, usual_line),
+            (i, running_line),
+            "Inconsistent result\n\n\
+             Aggregate_expr: {aggregate_expr:?}\n\
+             group_by: {group_by:?}\n\
+             Left Plan:\n{}\n\
+             Right Plan:\n{}\n\
+             schema:\n{schema}\n\
+             Left Output:\n{}\n\
+             Right Output:\n{}\n\
+             input:\n{}\n\
+             ",
+            displayable(aggregate_exec_usual.as_ref()).indent(false),
+            displayable(aggregate_exec_running.as_ref()).indent(false),
+            usual_formatted,
+            running_formatted,
+            pretty_format_batches(&input1).unwrap(),
+        );
+    }
+}
+
 /// Return randomly sized record batches with:
 /// three sorted int64 columns 'a', 'b', 'c' ranged from 0..'n_distinct' as columns
 /// one random int64 column 'd' as other columns

--- a/datafusion/datasource/src/memory.rs
+++ b/datafusion/datasource/src/memory.rs
@@ -33,7 +33,9 @@ use datafusion_common::{
     Result, ScalarValue, assert_or_internal_err, plan_err, project_schema,
 };
 use datafusion_execution::TaskContext;
+use datafusion_physical_expr::equivalence::ProjectionMapping;
 use datafusion_physical_expr::equivalence::project_orderings;
+use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_expr::projection::ProjectionExprs;
 use datafusion_physical_expr::utils::collect_columns;
 use datafusion_physical_expr::{EquivalenceProperties, LexOrdering};
@@ -68,6 +70,8 @@ pub struct MemorySourceConfig {
     projection: Option<Vec<usize>>,
     /// Sort information: one or more equivalent orderings
     sort_information: Vec<LexOrdering>,
+    /// Expressions known to be disjoint across output partitions
+    partition_disjoint_exprs: Vec<Arc<dyn PhysicalExpr>>,
     /// if partition sizes should be displayed
     show_sizes: bool,
     /// The maximum number of records to read from this plan. If `None`,
@@ -182,10 +186,12 @@ impl DataSource for MemorySourceConfig {
     }
 
     fn eq_properties(&self) -> EquivalenceProperties {
-        EquivalenceProperties::new_with_orderings(
+        let mut eq_properties = EquivalenceProperties::new_with_orderings(
             Arc::clone(&self.projected_schema),
             self.sort_information.clone(),
-        )
+        );
+        eq_properties.set_partition_disjoint_exprs(self.partition_disjoint_exprs.clone());
+        eq_properties
     }
 
     fn scheduling_type(&self) -> SchedulingType {
@@ -333,6 +339,7 @@ impl MemorySourceConfig {
             projected_schema,
             projection,
             sort_information: vec![],
+            partition_disjoint_exprs: vec![],
             show_sizes: true,
             fetch: None,
         })
@@ -435,6 +442,7 @@ impl MemorySourceConfig {
             projected_schema: Arc::clone(&schema),
             projection: None,
             sort_information: vec![],
+            partition_disjoint_exprs: vec![],
             show_sizes: true,
             fetch: None,
         };
@@ -522,6 +530,55 @@ impl MemorySourceConfig {
 
         self.sort_information = sort_information;
         Ok(self)
+    }
+
+    /// Attach expressions known to be disjoint across output partitions.
+    ///
+    /// Each output partition is assumed to contain a non-overlapping subset of
+    /// values for the given expressions. If there is an internal projection,
+    /// the expressions are projected to match the output schema.
+    pub fn try_with_partition_disjoint_keys(
+        mut self,
+        mut partition_disjoint_exprs: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Self> {
+        let fields = self.schema.fields();
+        let ambiguous_column = partition_disjoint_exprs
+            .iter()
+            .flat_map(collect_columns)
+            .find(|col| {
+                fields
+                    .get(col.index())
+                    .map(|field| field.name() != col.name())
+                    .unwrap_or(true)
+            });
+        assert_or_internal_err!(
+            ambiguous_column.is_none(),
+            "Column {:?} is not found in the original schema of the MemorySourceConfig",
+            ambiguous_column.as_ref().unwrap()
+        );
+
+        if let Some(projection) = &self.projection {
+            let base_schema = self.original_schema();
+            let proj_exprs = projection.iter().map(|idx| {
+                let name = base_schema.field(*idx).name();
+                (Arc::new(Column::new(name, *idx)) as _, name.to_string())
+            });
+            let projection_mapping =
+                ProjectionMapping::try_new(proj_exprs, &base_schema)?;
+            let mut base_eqp = EquivalenceProperties::new(Arc::clone(&base_schema));
+            base_eqp.set_partition_disjoint_exprs(partition_disjoint_exprs);
+            let proj_eqp =
+                base_eqp.project(&projection_mapping, Arc::clone(&self.projected_schema));
+            partition_disjoint_exprs = proj_eqp.partition_disjoint_exprs().to_vec();
+        }
+
+        self.partition_disjoint_exprs = partition_disjoint_exprs;
+        Ok(self)
+    }
+
+    /// Ref to partition-disjoint expressions
+    pub fn partition_disjoint_exprs(&self) -> &[Arc<dyn PhysicalExpr>] {
+        &self.partition_disjoint_exprs
     }
 
     /// Arc clone of ref to original schema

--- a/datafusion/physical-expr/src/equivalence/properties/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/properties/mod.rs
@@ -36,7 +36,7 @@ use crate::equivalence::{
 use crate::expressions::{Column, Literal, with_new_schema};
 use crate::{
     ConstExpr, LexOrdering, LexRequirement, PhysicalExpr, PhysicalSortExpr,
-    PhysicalSortRequirement,
+    PhysicalSortRequirement, physical_exprs_contains,
 };
 
 use arrow::datatypes::SchemaRef;
@@ -144,6 +144,10 @@ pub struct EquivalenceProperties {
     oeq_cache: OrderingEquivalenceCache,
     /// Table constraints that factor in equivalence calculations.
     constraints: Constraints,
+    /// Expressions whose values are known to be disjoint across output
+    /// partitions. Each output partition contains a non-overlapping subset of
+    /// values for these expressions.
+    partition_disjoint_exprs: Vec<Arc<dyn PhysicalExpr>>,
     /// Schema associated with this object.
     schema: SchemaRef,
 }
@@ -229,6 +233,7 @@ impl EquivalenceProperties {
             oeq_class: OrderingEquivalenceClass::default(),
             oeq_cache: OrderingEquivalenceCache::default(),
             constraints: Constraints::default(),
+            partition_disjoint_exprs: vec![],
             schema,
         }
     }
@@ -262,6 +267,7 @@ impl EquivalenceProperties {
             oeq_class,
             eq_group,
             constraints: Constraints::default(),
+            partition_disjoint_exprs: vec![],
             schema,
         }
     }
@@ -319,6 +325,34 @@ impl EquivalenceProperties {
     pub fn clear_orderings(&mut self) {
         self.oeq_class.clear();
         self.oeq_cache.clear();
+    }
+
+    /// Clears expressions known to be disjoint across output partitions.
+    /// Call this method when merging or repartitioning destroys that guarantee.
+    pub fn clear_partition_disjoint_exprs(&mut self) {
+        self.partition_disjoint_exprs.clear();
+    }
+
+    /// Sets expressions known to be disjoint across output partitions.
+    pub fn set_partition_disjoint_exprs(
+        &mut self,
+        exprs: impl IntoIterator<Item = Arc<dyn PhysicalExpr>>,
+    ) {
+        self.partition_disjoint_exprs = exprs.into_iter().collect();
+    }
+
+    /// Returns expressions known to be disjoint across output partitions.
+    pub fn partition_disjoint_exprs(&self) -> &[Arc<dyn PhysicalExpr>] {
+        &self.partition_disjoint_exprs
+    }
+
+    /// Returns whether `exprs` are covered by the partition-disjoint property.
+    pub fn partition_disjoint_satisfies(&self, exprs: &[Arc<dyn PhysicalExpr>]) -> bool {
+        !self.partition_disjoint_exprs.is_empty()
+            && !exprs.is_empty()
+            && exprs
+                .iter()
+                .all(|expr| physical_exprs_contains(&self.partition_disjoint_exprs, expr))
     }
 
     /// Removes constant expressions that may change across partitions.
@@ -1175,10 +1209,16 @@ impl EquivalenceProperties {
             .iter()
             .cloned()
             .map(|o| eq_group.normalize_sort_exprs(o));
+        let partition_disjoint_exprs = self
+            .partition_disjoint_exprs
+            .iter()
+            .filter_map(|expr| self.project_expr(expr, mapping))
+            .collect();
         Self {
             oeq_cache: OrderingEquivalenceCache::new(normal_orderings),
             oeq_class: OrderingEquivalenceClass::new(orderings),
             constraints: self.projected_constraints(mapping).unwrap_or_default(),
+            partition_disjoint_exprs,
             schema: output_schema,
             eq_group,
         }
@@ -1361,6 +1401,12 @@ impl EquivalenceProperties {
         self.oeq_class = self.oeq_class.with_new_schema(&schema)?;
         self.oeq_cache.normal_cls = self.oeq_cache.normal_cls.with_new_schema(&schema)?;
 
+        self.partition_disjoint_exprs = self
+            .partition_disjoint_exprs
+            .into_iter()
+            .map(|expr| with_new_schema(expr, &schema))
+            .collect::<Result<_>>()?;
+
         // Update the schema:
         self.schema = schema;
 
@@ -1384,15 +1430,32 @@ impl Display for EquivalenceProperties {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let empty_eq_group = self.eq_group.is_empty();
         let empty_oeq_class = self.oeq_class.is_empty();
-        if empty_oeq_class && empty_eq_group {
+        let empty_partition_disjoint = self.partition_disjoint_exprs.is_empty();
+        if empty_oeq_class && empty_eq_group && empty_partition_disjoint {
             write!(f, "No properties")?;
         } else if !empty_oeq_class {
             write!(f, "order: {}", self.oeq_class)?;
             if !empty_eq_group {
                 write!(f, ", eq: {}", self.eq_group)?;
             }
-        } else {
+            if !empty_partition_disjoint {
+                write!(
+                    f,
+                    ", partition_disjoint: {:?}",
+                    self.partition_disjoint_exprs
+                )?;
+            }
+        } else if !empty_eq_group {
             write!(f, "eq: {}", self.eq_group)?;
+            if !empty_partition_disjoint {
+                write!(
+                    f,
+                    ", partition_disjoint: {:?}",
+                    self.partition_disjoint_exprs
+                )?;
+            }
+        } else {
+            write!(f, "partition_disjoint: {:?}", self.partition_disjoint_exprs)?;
         }
         Ok(())
     }

--- a/datafusion/physical-optimizer/src/ensure_requirements/enforce_distribution.rs
+++ b/datafusion/physical-optimizer/src/ensure_requirements/enforce_distribution.rs
@@ -778,6 +778,34 @@ fn preserving_order_enables_streaming(
     Ok(without_ordered.pipeline_behavior() == EmissionType::Final)
 }
 
+/// Checks whether preserving a child's partition-disjoint group keys enables
+/// the parent to run in streaming mode.
+fn preserving_partition_disjoint_enables_streaming(
+    parent: &Arc<dyn ExecutionPlan>,
+    child: &Arc<dyn ExecutionPlan>,
+) -> Result<bool> {
+    if parent.children().len() != 1 {
+        return Ok(false);
+    }
+    if child
+        .equivalence_properties()
+        .partition_disjoint_exprs()
+        .is_empty()
+    {
+        return Ok(false);
+    }
+    let with_disjoint =
+        replace_children_if_necessary(Arc::clone(parent), vec![Arc::clone(child)])?;
+    if with_disjoint.pipeline_behavior() == EmissionType::Final {
+        return Ok(false);
+    }
+    let coalesced_child: Arc<dyn ExecutionPlan> =
+        Arc::new(CoalescePartitionsExec::new(Arc::clone(child)));
+    let without_disjoint =
+        replace_children_if_necessary(Arc::clone(parent), vec![coalesced_child])?;
+    Ok(without_disjoint.pipeline_behavior() == EmissionType::Final)
+}
+
 /// # Returns
 ///
 /// Updated node with an execution plan, where the desired single distribution
@@ -1425,6 +1453,10 @@ pub fn ensure_distribution(
              }| {
                 let streaming_benefit = if context.data {
                     preserving_order_enables_streaming(&plan, &context.plan)?
+                        || preserving_partition_disjoint_enables_streaming(
+                            &plan,
+                            &context.plan,
+                        )?
                 } else {
                     false
                 };

--- a/datafusion/physical-plan/src/aggregates/aggregate_hash_table/common_ordered.rs
+++ b/datafusion/physical-plan/src/aggregates/aggregate_hash_table/common_ordered.rs
@@ -183,6 +183,7 @@ impl<AggrMode> OrderedAggregateTable<AggrMode> {
         state_schema: SchemaRef,
         batch_size: usize,
         input_order_mode: &InputOrderMode,
+        group_keys_partition_disjoint: bool,
         aggregate_mode: &AggregateMode,
         filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
         metrics: OrderedAggregateTableMetrics,
@@ -192,7 +193,8 @@ impl<AggrMode> OrderedAggregateTable<AggrMode> {
             "OrderedAggregateTable requires config batch_size >= 1"
         );
 
-        let group_ordering = GroupOrdering::try_new(input_order_mode)?;
+        let group_ordering =
+            GroupOrdering::try_new(input_order_mode, group_keys_partition_disjoint)?;
         let group_schema = agg.group_by.group_schema(input_schema)?;
         let group_values = new_group_values(group_schema, &group_ordering)?;
         let aggregate_arguments = aggregate_expressions(

--- a/datafusion/physical-plan/src/aggregates/aggregate_hash_table/ordered_final_table.rs
+++ b/datafusion/physical-plan/src/aggregates/aggregate_hash_table/ordered_final_table.rs
@@ -57,6 +57,7 @@ impl OrderedAggregateTable<FinalMarker> {
             Arc::clone(input_schema),
             batch_size,
             input_order_mode,
+            agg.group_keys_partition_disjoint(),
             &AggregateMode::Final,
             vec![None; agg.aggr_expr.len()],
             metrics,

--- a/datafusion/physical-plan/src/aggregates/aggregate_hash_table/ordered_partial_table.rs
+++ b/datafusion/physical-plan/src/aggregates/aggregate_hash_table/ordered_partial_table.rs
@@ -68,6 +68,7 @@ impl OrderedAggregateTable<PartialMarker> {
             state_schema,
             batch_size,
             &agg.input_order_mode,
+            agg.group_keys_partition_disjoint(),
             &AggregateMode::Partial,
             agg.filter_expr.iter().cloned().collect(),
             metrics,

--- a/datafusion/physical-plan/src/aggregates/aggregate_hash_table/ordered_single_table.rs
+++ b/datafusion/physical-plan/src/aggregates/aggregate_hash_table/ordered_single_table.rs
@@ -60,6 +60,7 @@ impl OrderedAggregateTable<SingleMarker> {
             state_schema,
             batch_size,
             &agg.input_order_mode,
+            agg.group_keys_partition_disjoint(),
             &agg.mode,
             agg.filter_expr.iter().cloned().collect(),
             metrics,

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -203,7 +203,10 @@ pub fn new_group_values(
     }
 
     if multi_group_by::supported_schema(schema.as_ref()) {
-        if matches!(group_ordering, GroupOrdering::None) {
+        if matches!(
+            group_ordering,
+            GroupOrdering::None | GroupOrdering::PartitionDisjoint(_)
+        ) {
             Ok(Box::new(GroupValuesColumn::<false>::try_new(schema)?))
         } else {
             Ok(Box::new(GroupValuesColumn::<true>::try_new(schema)?))

--- a/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs
@@ -501,16 +501,22 @@ impl GroupedHashAggregateStream {
             .collect::<Vec<_>>()
             .join(", ");
         let name = format!("GroupedHashAggregateStream[{partition}] ({agg_fn_names})");
-        let group_ordering = GroupOrdering::try_new(&agg.input_order_mode)?;
+        let group_ordering = GroupOrdering::try_new(
+            &agg.input_order_mode,
+            agg.group_keys_partition_disjoint(),
+        )?;
         let oom_mode = match (agg.mode, &group_ordering) {
             // In partial aggregation mode, always prefer to emit incomplete results early.
             (AggregateMode::Partial, _) => OutOfMemoryMode::EmitEarly,
             // For non-partial aggregation modes, emitting incomplete results is not an option.
             // Instead, use disk spilling to store sorted, incomplete results, and merge them
             // afterwards.
-            (_, GroupOrdering::None | GroupOrdering::Partial(_))
-                if context.runtime_env().disk_manager.tmp_files_enabled() =>
-            {
+            (
+                _,
+                GroupOrdering::None
+                | GroupOrdering::Partial(_)
+                | GroupOrdering::PartitionDisjoint(_),
+            ) if context.runtime_env().disk_manager.tmp_files_enabled() => {
                 OutOfMemoryMode::Spill
             }
             // For `GroupOrdering::Full`, the incoming stream is already sorted. This ensures the
@@ -559,7 +565,10 @@ impl GroupedHashAggregateStream {
         //   since Final mode expects unique group values as its input
         // - there is only one GROUP BY expressions set
         let skip_aggregation_probe = if agg.mode == AggregateMode::Partial
-            && matches!(group_ordering, GroupOrdering::None)
+            && matches!(
+                group_ordering,
+                GroupOrdering::None | GroupOrdering::PartitionDisjoint(_)
+            )
             && agg_group_by.is_single()
         {
             let options = &context.session_config().options().execution;

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -866,6 +866,9 @@ pub struct AggregateExec {
     required_input_ordering: Option<OrderingRequirements>,
     /// Describes how the input is ordered relative to the group by columns
     input_order_mode: InputOrderMode,
+    /// Whether group keys are disjoint across input partitions without being
+    /// ordered within each partition.
+    group_keys_partition_disjoint: bool,
     cache: Arc<PlanProperties>,
     /// During initialization, if the plan supports dynamic filtering (see [`AggrDynFilter`]),
     /// it is set to `Some(..)` regardless of whether it can be pushed down to a child node.
@@ -890,6 +893,7 @@ impl AggregateExec {
             required_input_ordering: self.required_input_ordering.clone(),
             metrics: ExecutionPlanMetricsSet::new(),
             input_order_mode: self.input_order_mode.clone(),
+            group_keys_partition_disjoint: self.group_keys_partition_disjoint,
             cache: Arc::clone(&self.cache),
             mode: self.mode,
             group_by: Arc::clone(&self.group_by),
@@ -910,6 +914,7 @@ impl AggregateExec {
             required_input_ordering: self.required_input_ordering.clone(),
             metrics: ExecutionPlanMetricsSet::new(),
             input_order_mode: self.input_order_mode.clone(),
+            group_keys_partition_disjoint: self.group_keys_partition_disjoint,
             cache: Arc::clone(&self.cache),
             mode: self.mode,
             group_by: Arc::clone(&self.group_by),
@@ -1026,6 +1031,9 @@ impl AggregateExec {
             InputOrderMode::Linear
         };
 
+        let group_keys_partition_disjoint = input_order_mode == InputOrderMode::Linear
+            && input_eq_properties.partition_disjoint_satisfies(&groupby_exprs);
+
         // construct a map from the input expression to the output expression of the Aggregation group by
         let group_expr_mapping =
             ProjectionMapping::try_new(group_by.expr.clone(), &input.schema())?;
@@ -1037,6 +1045,7 @@ impl AggregateExec {
             group_by.is_true_no_grouping(),
             &mode,
             &input_order_mode,
+            group_keys_partition_disjoint,
             aggr_expr.as_ref(),
         )?;
 
@@ -1052,6 +1061,7 @@ impl AggregateExec {
             required_input_ordering,
             limit_options: None,
             input_order_mode,
+            group_keys_partition_disjoint,
             cache: Arc::new(cache),
             dynamic_filter: None,
         };
@@ -1366,6 +1376,10 @@ impl AggregateExec {
     }
 
     /// This function creates the cache object that stores the plan properties such as schema, equivalence properties, ordering, partitioning, etc.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "aggregate property computation needs input, schema, grouping and mode context"
+    )]
     pub fn compute_properties(
         input: &Arc<dyn ExecutionPlan>,
         schema: SchemaRef,
@@ -1373,6 +1387,7 @@ impl AggregateExec {
         is_true_no_grouping: bool,
         mode: &AggregateMode,
         input_order_mode: &InputOrderMode,
+        group_keys_partition_disjoint: bool,
         aggr_exprs: &[Arc<AggregateFunctionExpr>],
     ) -> Result<PlanProperties> {
         // Construct equivalence properties:
@@ -1424,10 +1439,12 @@ impl AggregateExec {
         };
 
         // TODO: Emission type and boundedness information can be enhanced here
-        let emission_type = if *input_order_mode == InputOrderMode::Linear {
-            EmissionType::Final
-        } else {
-            input.pipeline_behavior()
+        let emission_type = match input_order_mode {
+            InputOrderMode::Linear if !group_keys_partition_disjoint => {
+                EmissionType::Final
+            }
+            InputOrderMode::Linear => EmissionType::Incremental,
+            _ => input.pipeline_behavior(),
         };
 
         Ok(PlanProperties::new(
@@ -1440,6 +1457,12 @@ impl AggregateExec {
 
     pub fn input_order_mode(&self) -> &InputOrderMode {
         &self.input_order_mode
+    }
+
+    /// Whether group keys are disjoint across input partitions without being
+    /// ordered within each partition.
+    pub fn group_keys_partition_disjoint(&self) -> bool {
+        self.group_keys_partition_disjoint
     }
 
     /// Estimates output statistics for this aggregate node.
@@ -2298,6 +2321,8 @@ impl ExecutionPlan for AggregateExec {
             required_input_ordering: _,
             // Derived at construction from the input ordering and `group_by`.
             input_order_mode: _,
+            // Derived at construction from the input partition-disjoint property.
+            group_keys_partition_disjoint: _,
             // Derived at construction by `Self::compute_properties`.
             cache: _,
             dynamic_filter,
@@ -3172,6 +3197,7 @@ mod tests {
     use crate::common::collect;
     use crate::empty::EmptyExec;
     use crate::execution_plan::Boundedness;
+    use crate::execution_plan::EmissionType;
     use crate::expressions::col;
     use crate::filter::FilterExecBuilder;
     use crate::metrics::MetricValue;
@@ -4540,6 +4566,95 @@ mod tests {
         let finite_memory_task_ctx = new_finite_memory_migrated_hash_ctx(2, 1024 * 1024)?;
         let stream = aggregate.execute_typed(0, &finite_memory_task_ctx)?;
         assert!(matches!(stream, StreamType::OrderedPartialAggregate(_)));
+
+        Ok(())
+    }
+
+    /// Ensures unsorted multi-partition input with partition-disjoint group keys
+    /// uses incremental partial hash aggregation.
+    #[tokio::test]
+    async fn partition_disjoint_partial_aggregate_planning() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("value", DataType::Int64, false),
+        ]));
+
+        let partition_0 = vec![RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![2, 1, 1])),
+                Arc::new(Int64Array::from(vec![10, 20, 30])),
+            ],
+        )?];
+        let partition_1 = vec![RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![4, 3])),
+                Arc::new(Int64Array::from(vec![40, 50])),
+            ],
+        )?];
+
+        let group_by =
+            PhysicalGroupBy::new_single(vec![(col("key", &schema)?, "key".to_string())]);
+        let aggr_expr = vec![Arc::new(
+            AggregateExprBuilder::new(sum_udaf(), vec![col("value", &schema)?])
+                .schema(Arc::clone(&schema))
+                .alias("SUM(value)")
+                .build()?,
+        )];
+
+        let test_input = TestMemoryExec::try_new(
+            &[partition_0, partition_1],
+            Arc::clone(&schema),
+            None,
+        )?
+        .try_with_partition_disjoint_keys(vec![col("key", &schema)?])?;
+        let partition_data: Vec<Vec<RecordBatch>> = test_input.partitions().to_vec();
+        let input: Arc<dyn ExecutionPlan> =
+            Arc::new(TestMemoryExec::update_cache(&Arc::new(test_input)));
+
+        let aggregate = AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by.clone(),
+            aggr_expr.clone(),
+            vec![None],
+            Arc::clone(&input),
+            Arc::clone(&schema),
+        )?;
+        assert_eq!(aggregate.input_order_mode(), &InputOrderMode::Linear);
+        assert!(aggregate.group_keys_partition_disjoint());
+        assert_eq!(aggregate.cache().emission_type, EmissionType::Incremental);
+
+        let task_ctx = new_migrated_hash_ctx(2);
+        let stream = aggregate.execute_typed(0, &task_ctx)?;
+        assert!(matches!(stream, StreamType::PartialHash(_)));
+
+        let stream: SendableRecordBatchStream = stream.into();
+        let output = collect(stream).await?;
+        assert_snapshot!(batches_to_sort_string(&output), @r"
++-----+-----------------+
+| key | SUM(value)[sum] |
++-----+-----------------+
+| 1   | 50              |
+| 2   | 10              |
++-----+-----------------+
+");
+
+        let blocking_input =
+            TestMemoryExec::try_new_exec(&partition_data, Arc::clone(&schema), None)?;
+        let blocking_aggregate = AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by,
+            aggr_expr,
+            vec![None],
+            blocking_input,
+            schema,
+        )?;
+        assert!(!blocking_aggregate.group_keys_partition_disjoint());
+        assert_eq!(
+            blocking_aggregate.cache().emission_type,
+            EmissionType::Final
+        );
 
         Ok(())
     }

--- a/datafusion/physical-plan/src/aggregates/order/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/order/mod.rs
@@ -23,10 +23,12 @@ use datafusion_expr::EmitTo;
 
 mod full;
 mod partial;
+mod partition_disjoint;
 
 use crate::InputOrderMode;
 pub use full::GroupOrderingFull;
 pub use partial::GroupOrderingPartial;
+pub use partition_disjoint::GroupOrderingPartitionDisjoint;
 
 /// Ordering information for each group in the hash table
 #[derive(Debug)]
@@ -37,12 +39,21 @@ pub enum GroupOrdering {
     Partial(GroupOrderingPartial),
     /// Groups are entirely contiguous,
     Full(GroupOrderingFull),
+    /// Group keys are disjoint across output partitions, but not ordered within
+    /// each partition.
+    PartitionDisjoint(GroupOrderingPartitionDisjoint),
 }
 
 impl GroupOrdering {
     /// Create a `GroupOrdering` for the specified ordering
-    pub fn try_new(mode: &InputOrderMode) -> Result<Self> {
+    pub fn try_new(
+        mode: &InputOrderMode,
+        group_keys_partition_disjoint: bool,
+    ) -> Result<Self> {
         match mode {
+            InputOrderMode::Linear if group_keys_partition_disjoint => Ok(
+                GroupOrdering::PartitionDisjoint(GroupOrderingPartitionDisjoint::new()),
+            ),
             InputOrderMode::Linear => Ok(GroupOrdering::None),
             InputOrderMode::PartiallySorted(order_indices) => {
                 GroupOrderingPartial::try_new(order_indices.clone())
@@ -59,6 +70,9 @@ impl GroupOrdering {
             GroupOrdering::None => None,
             GroupOrdering::Partial(partial) => partial.emit_to(),
             GroupOrdering::Full(full) => full.emit_to(),
+            GroupOrdering::PartitionDisjoint(partition_disjoint) => {
+                partition_disjoint.emit_to()
+            }
         }
     }
 
@@ -81,6 +95,7 @@ impl GroupOrdering {
                     EmitTo::All => EmitTo::First(n),
                 })
             }
+            GroupOrdering::PartitionDisjoint(_) => Some(EmitTo::First(n)),
         }
     }
 
@@ -90,6 +105,9 @@ impl GroupOrdering {
             GroupOrdering::None => {}
             GroupOrdering::Partial(partial) => partial.input_done(),
             GroupOrdering::Full(full) => full.input_done(),
+            GroupOrdering::PartitionDisjoint(partition_disjoint) => {
+                partition_disjoint.input_done()
+            }
         }
     }
 
@@ -104,6 +122,9 @@ impl GroupOrdering {
             GroupOrdering::None => {}
             GroupOrdering::Partial(partial) => partial.reset(),
             GroupOrdering::Full(full) => full.reset(),
+            GroupOrdering::PartitionDisjoint(partition_disjoint) => {
+                partition_disjoint.reset()
+            }
         }
     }
 
@@ -114,6 +135,9 @@ impl GroupOrdering {
             GroupOrdering::None => {}
             GroupOrdering::Partial(partial) => partial.remove_groups(n),
             GroupOrdering::Full(full) => full.remove_groups(n),
+            GroupOrdering::PartitionDisjoint(partition_disjoint) => {
+                partition_disjoint.remove_groups(n)
+            }
         }
     }
 
@@ -143,6 +167,9 @@ impl GroupOrdering {
             GroupOrdering::Full(full) => {
                 full.new_groups(total_num_groups);
             }
+            GroupOrdering::PartitionDisjoint(partition_disjoint) => {
+                partition_disjoint.new_groups(total_num_groups);
+            }
         };
         Ok(())
     }
@@ -154,6 +181,9 @@ impl GroupOrdering {
                 GroupOrdering::None => 0,
                 GroupOrdering::Partial(partial) => partial.size(),
                 GroupOrdering::Full(full) => full.size(),
+                GroupOrdering::PartitionDisjoint(partition_disjoint) => {
+                    partition_disjoint.size()
+                }
             }
     }
 }

--- a/datafusion/physical-plan/src/aggregates/order/partition_disjoint.rs
+++ b/datafusion/physical-plan/src/aggregates/order/partition_disjoint.rs
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion_expr::EmitTo;
+use std::mem::size_of;
+
+/// Tracks grouping state when group keys are disjoint across output partitions,
+/// but rows within each partition are not ordered by the group keys.
+///
+/// Groups can only be emitted once the partition input is complete, because
+/// intra-partition row order does not reveal completed groups early.
+#[derive(Debug)]
+pub struct GroupOrderingPartitionDisjoint {
+    state: State,
+}
+
+#[derive(Debug)]
+enum State {
+    InProgress,
+    Complete,
+}
+
+impl GroupOrderingPartitionDisjoint {
+    pub fn new() -> Self {
+        Self {
+            state: State::InProgress,
+        }
+    }
+
+    pub fn emit_to(&self) -> Option<EmitTo> {
+        match &self.state {
+            State::InProgress => None,
+            State::Complete => Some(EmitTo::All),
+        }
+    }
+
+    pub fn remove_groups(&mut self, _n: usize) {
+        // No tracked group indexes to shift; emission bookkeeping lives in
+        // `GroupValues` / accumulators only.
+    }
+
+    pub fn input_done(&mut self) {
+        self.state = State::Complete;
+    }
+
+    pub fn reset(&mut self) {
+        self.state = State::InProgress;
+    }
+
+    pub fn new_groups(&mut self, _total_num_groups: usize) {}
+
+    pub(crate) fn size(&self) -> usize {
+        size_of::<Self>()
+    }
+}
+
+impl Default for GroupOrderingPartitionDisjoint {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/datafusion/physical-plan/src/coalesce_partitions.rs
+++ b/datafusion/physical-plan/src/coalesce_partitions.rs
@@ -97,6 +97,7 @@ impl CoalescePartitionsExec {
         let mut eq_properties = input.equivalence_properties().clone();
         eq_properties.clear_orderings();
         eq_properties.clear_per_partition_constants();
+        eq_properties.clear_partition_disjoint_exprs();
         PlanProperties::new(
             eq_properties,                        // Equivalence Properties
             Partitioning::UnknownPartitioning(1), // Output Partitioning

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -2053,6 +2053,7 @@ impl RepartitionExec {
         // If the ordering is lost, reset the ordering equivalence class:
         if !Self::maintains_input_order_helper(input, preserve_order)[0] {
             eq_properties.clear_orderings();
+            eq_properties.clear_partition_disjoint_exprs();
         }
         // When there are more than one input partitions, they will be fused at the output.
         // Therefore, remove per partition constants.

--- a/datafusion/physical-plan/src/test.rs
+++ b/datafusion/physical-plan/src/test.rs
@@ -73,6 +73,8 @@ pub struct TestMemoryExec {
     projection: Option<Vec<usize>>,
     /// Sort information: one or more equivalent orderings
     sort_information: Vec<LexOrdering>,
+    /// Expressions known to be disjoint across output partitions
+    partition_disjoint_exprs: Vec<Arc<dyn PhysicalExpr>>,
     /// if partition sizes should be displayed
     show_sizes: bool,
     /// The maximum number of records to read from this plan. If `None`,
@@ -233,10 +235,12 @@ impl TestMemoryExec {
     }
 
     fn eq_properties(&self) -> EquivalenceProperties {
-        EquivalenceProperties::new_with_orderings(
+        let mut eq_properties = EquivalenceProperties::new_with_orderings(
             Arc::clone(&self.projected_schema),
             self.sort_information.clone(),
-        )
+        );
+        eq_properties.set_partition_disjoint_exprs(self.partition_disjoint_exprs.clone());
+        eq_properties
     }
 
     fn statistics_inner(&self) -> Result<Statistics> {
@@ -268,6 +272,7 @@ impl TestMemoryExec {
             projected_schema,
             projection,
             sort_information: vec![],
+            partition_disjoint_exprs: vec![],
             show_sizes: true,
             fetch: None,
         })
@@ -361,6 +366,52 @@ impl TestMemoryExec {
         self.sort_information = sort_information;
         self.cache = Arc::new(self.compute_properties());
         Ok(self)
+    }
+
+    /// Attach expressions known to be disjoint across output partitions.
+    pub fn try_with_partition_disjoint_keys(
+        mut self,
+        mut partition_disjoint_exprs: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Self> {
+        let fields = self.schema.fields();
+        let ambiguous_column = partition_disjoint_exprs
+            .iter()
+            .flat_map(collect_columns)
+            .find(|col| {
+                fields
+                    .get(col.index())
+                    .map(|field| field.name() != col.name())
+                    .unwrap_or(true)
+            });
+        assert_or_internal_err!(
+            ambiguous_column.is_none(),
+            "Column {:?} is not found in the original schema of the TestMemoryExec",
+            ambiguous_column.as_ref().unwrap()
+        );
+
+        if let Some(projection) = &self.projection {
+            let base_schema = self.original_schema();
+            let proj_exprs = projection.iter().map(|idx| {
+                let name = base_schema.field(*idx).name();
+                (Arc::new(Column::new(name, *idx)) as _, name.to_string())
+            });
+            let projection_mapping =
+                ProjectionMapping::try_new(proj_exprs, &base_schema)?;
+            let mut base_eqp = EquivalenceProperties::new(Arc::clone(&base_schema));
+            base_eqp.set_partition_disjoint_exprs(partition_disjoint_exprs);
+            let proj_eqp =
+                base_eqp.project(&projection_mapping, Arc::clone(&self.projected_schema));
+            partition_disjoint_exprs = proj_eqp.partition_disjoint_exprs().to_vec();
+        }
+
+        self.partition_disjoint_exprs = partition_disjoint_exprs;
+        self.cache = Arc::new(self.compute_properties());
+        Ok(self)
+    }
+
+    /// Ref to partition-disjoint expressions
+    pub fn partition_disjoint_exprs(&self) -> &[Arc<dyn PhysicalExpr>] {
+        &self.partition_disjoint_exprs
     }
 
     /// Arc clone of ref to original schema


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24438.

## Rationale for this change

When data is range-partitioned on group-by keys, merging many data partitions into fewer DataFusion partitions (to keep `target_partitions` near the CPU count) can lose the global `(key, time)` sort order. `AggregateExec` then falls back to blocking hash aggregation even though group-by keys still do not overlap across the merged partitions.

This PR lets callers declare that guarantee so aggregation can stream without requiring a global sort.

## What changes are included in this PR?

- Add a `partition_disjoint_exprs` property on `EquivalenceProperties`, with setter/clear/satisfies helpers.
- Let `MemoryExec` / `TestMemoryExec` attach the property via `try_with_partition_disjoint_keys`.
- When `InputOrderMode` is `Linear` but group-by keys are partition-disjoint, `AggregateExec` uses incremental emission and a `GroupOrdering::PartitionDisjoint` path that emits completed groups when each partition finishes.
- Clear the property on `CoalescePartitionsExec` and `RepartitionExec`, where the disjointness guarantee is lost.
- Treat the property like ordering when deciding whether preserving distribution enables streaming.

## Are these changes tested?

- Unit test `partition_disjoint_partial_aggregate_planning` checks that the property enables streaming planning, and that the same unsorted input without the property stays blocking.
- Fuzz test `partition_disjoint_streaming_aggregate_test` compares partition-disjoint incremental aggregation against a concatenated baseline.

## Are there any user-facing changes?

Yes: public APIs on `EquivalenceProperties` and `MemoryExec` / `TestMemoryExec` to declare partition-disjoint group keys. No SQL syntax changes. Downstream engines that merge range-partitioned files can set this property so `AggregateExec` streams.


Made with [Cursor](https://cursor.com)