### PR TITLE
Fix `cargo audit` by updating `h2` to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Which issue does this PR close?

N/A -- fixes the `security_audit` CI failure on `main`: https://github.com/apache/datafusion/actions/runs/32165471695/job/95803921510

## Rationale for this change

The `security_audit` job on `main` reports [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) (h2 unbounded empty DATA frames) for `h2` 0.4.13. The advisory is fixed in `h2` >= 0.4.16.

## What changes are included in this PR?

Update `h2` from 0.4.13 to 0.4.16 in `Cargo.lock`, following the same fix as apache/arrow-rs#10740.

## Are these changes tested?

`cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195` passes locally with this change.

## Are there any user-facing changes?

No