### PR TITLE
ci: Check datafusion-spark feature combinations to catch publish errors

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -66,6 +66,7 @@ github:
           - "cargo check datafusion-proto features"
           - "cargo check datafusion features"
           - "cargo check datafusion-functions features"
+          - "cargo check datafusion-spark features"
           - "cargo test (amd64)"
           - "cargo test datafusion-cli (amd64)"
           - "cargo examples (amd64)"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -287,6 +287,35 @@ jobs:
       - name: Check datafusion-functions (unicode_expressions)
         run: cargo check --profile ci --no-default-features -p datafusion-functions --features=unicode_expressions
 
+  # Check datafusion-spark crate features
+  #
+  # Ensure via `cargo check` that the crate can be built with a
+  # subset of the features packages enabled. In particular, check
+  # the crate builds without the optional `core` feature (which is
+  # what `cargo publish` verifies).
+  # See https://github.com/apache/datafusion/issues/24474
+  linux-cargo-check-datafusion-spark:
+    name: cargo check datafusion-spark features
+    needs: linux-build-lib
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Check datafusion-spark (default features)
+        run: cargo check --profile ci --all-targets -p datafusion-spark
+      #
+      # Note: Only check libraries (not --all-targets) to cover end user APIs
+      #
+      - name: Check datafusion-spark (no-default-features)
+        run: cargo check --profile ci --no-default-features -p datafusion-spark
+      - name: Check datafusion-spark (core)
+        run: cargo check --profile ci --no-default-features -p datafusion-spark --features=core
+
   # Library and integration tests
   linux-test:
     name: cargo test (amd64)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -290,9 +290,7 @@ jobs:
   # Check datafusion-spark crate features
   #
   # Ensure via `cargo check` that the crate can be built with a
-  # subset of the features packages enabled. In particular, check
-  # the crate builds without the optional `core` feature (which is
-  # what `cargo publish` verifies).
+  # subset of the features packages enabled.
   # See https://github.com/apache/datafusion/issues/24474
   linux-cargo-check-datafusion-spark:
     name: cargo check datafusion-spark features


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24474

## Rationale for this change

Publishing `datafusion-spark` 55.0.0 failed with

```
error[E0433]: cannot find module or crate `datafusion` in this scope
  --> src/function/string/quote.rs:20:5
```

because the library referenced the optional `datafusion` dependency (only enabled by the `core` feature) from code that is not gated on that feature.

CI did not catch this  workspace-wide builds always compile `datafusion-spark` with the optional `datafusion` dependency present due to feature unification. 

The underlying import error was already fixed on `main` in #24351, so this PR adds the missing CI coverage to prevent the problem from reoccurring.

## What changes are included in this PR?

Add a `cargo check datafusion-spark features` CI job, following the pattern of the existing per-crate feature check jobs (e.g. `datafusion-functions`), that checks the crate standalone.

Also add the new job to the required status checks in `.asf.yaml`, like the other per-crate feature check jobs.

## Are these changes tested?

Yes, by CI itself (the new job runs on this PR). 

## Are there any user-facing changes?
No, CI only.
