### PR TITLE
fix: count SortExec TopK output_batches after emit split

### DIFF
--- a/datafusion/core/tests/physical_optimizer/mod.rs
+++ b/datafusion/core/tests/physical_optimizer/mod.rs
@@ -36,6 +36,7 @@ mod projection_pushdown;
 mod pushdown_sort;
 mod replace_with_order_preserving_variants;
 mod sanity_checker;
+mod sort_exec_topk_metrics;
 #[expect(clippy::needless_pass_by_value)]
 mod test_utils;
 mod window_optimize;

--- a/datafusion/core/tests/physical_optimizer/sort_exec_topk_metrics.rs
+++ b/datafusion/core/tests/physical_optimizer/sort_exec_topk_metrics.rs
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Metrics coverage for SortExec in TopK mode.
+
+use std::sync::Arc;
+
+use datafusion::common::Result;
+use datafusion::physical_plan::metrics::MetricValue;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::{ExecutionPlan, collect};
+use datafusion::prelude::*;
+
+/// The `output_batches` metric of a TopK sort should equal the number of
+/// batches the operator emits to its consumer.
+///
+/// Regression test for <https://github.com/apache/datafusion/issues/24468>.
+#[tokio::test]
+async fn topk_output_batches_metric_matches_emitted_batches() -> Result<()> {
+    // A top-25 over 100 unsorted rows, at batch_size 10, so the TopK result
+    // must be emitted as multiple batches.
+    let config = SessionConfig::new()
+        .with_batch_size(10)
+        .with_target_partitions(1);
+    let ctx = SessionContext::new_with_config(config);
+    ctx.sql("CREATE TABLE t AS SELECT value FROM range(0, 100)")
+        .await?
+        .collect()
+        .await?;
+    let df = ctx
+        .sql("SELECT value FROM t ORDER BY value DESC LIMIT 25")
+        .await?;
+    let plan = df.create_physical_plan().await?;
+
+    let batches = collect(Arc::clone(&plan), ctx.task_ctx()).await?;
+    let emitted_sizes: Vec<usize> = batches.iter().map(|b| b.num_rows()).collect();
+
+    let sort = find_sort(&plan).expect("plan should contain SortExec");
+    let metrics = sort.metrics().expect("SortExec should have metrics");
+    let output_batches = metrics
+        .sum(|m| matches!(m.value(), MetricValue::OutputBatches(_)))
+        .expect("output_batches metric should be present")
+        .as_usize();
+
+    // The 25 result rows arrive as three batches of at most batch_size rows
+    assert_eq!(emitted_sizes, vec![10, 10, 5]);
+    // ... so the metric should report three output batches
+    assert_eq!(
+        output_batches,
+        emitted_sizes.len(),
+        "output_batches metric disagrees with the number of emitted batches"
+    );
+    Ok(())
+}
+
+fn find_sort(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
+    if plan.downcast_ref::<SortExec>().is_some() {
+        return Some(Arc::clone(plan));
+    }
+    plan.children().into_iter().find_map(find_sort)
+}

--- a/datafusion/physical-plan/src/topk/mod.rs
+++ b/datafusion/physical-plan/src/topk/mod.rs
@@ -807,17 +807,20 @@ impl TopK {
         // local emitter marks the dynamic filter complete.
         filter.read().mark_topk_emitted();
 
-        // break into record batches as needed
+        // Record output metrics on each batch actually sent to the consumer
+        // after splitting to `batch_size`. Recording the pre-split heap
+        // batch once would leave `output_batches` stuck at 1.
         let mut batches = vec![];
         if let Some(mut batch) = heap.emit()? {
-            (&batch).record_output(&metrics.baseline);
-
             loop {
                 if batch.num_rows() <= batch_size {
+                    (&batch).record_output(&metrics.baseline);
                     batches.push(Ok(batch));
                     break;
                 } else {
-                    batches.push(Ok(batch.slice(0, batch_size)));
+                    let next = batch.slice(0, batch_size);
+                    (&next).record_output(&metrics.baseline);
+                    batches.push(Ok(next));
                     let remaining_length = batch.num_rows() - batch_size;
                     batch = batch.slice(batch_size, remaining_length);
                 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24468

## Rationale for this change

When `SortExec` runs in TopK mode (`ORDER BY ... LIMIT k` on unsorted input) and the k result rows span more than one output batch, `output_batches` reported `1` regardless of how many batches the operator actually emitted.

For example, a top-25 query at `batch_size = 10` emits `[10, 10, 5]` but reported `output_batches=1`.

This is the SortExec TopK counterpart of #24470 / #24495 (`PartitionedTopKExec` metrics). That sibling work is out of scope here.

## What changes are included in this PR?

`TopK::emit` now records baseline output metrics (`output_rows`, `output_batches`, `output_bytes`) on each batch sent to the consumer after splitting to `batch_size`, instead of once on the pre-split heap batch.

## Are these changes tested?

Added the issue's reproduction as `topk_output_batches_metric_matches_emitted_batches`: it asserts `output_batches` equals the number of batches actually emitted (`[10, 10, 5]` → 3).

Also ran:
- `cargo test -p datafusion-physical-plan --lib topk` (82 passed)
- `cargo test -p datafusion --test core_integration topk_output_batches_metric_matches_emitted_batches` (passed)
- `cargo fmt --all`
- `cargo clippy -p datafusion-physical-plan --all-targets --all-features -- -D warnings`
- `cargo clippy -p datafusion --test core_integration -- -D warnings`

## Are there any user-facing changes?

`EXPLAIN ANALYZE` now reports the correct `output_batches` for SortExec in TopK mode when the result spans multiple batches.
