### PR TITLE
fix: preserve per-node UNION vs UNION ALL when unparsing

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -85,6 +85,29 @@ impl QueryBuilder {
     pub fn is_distinct_union(&self) -> bool {
         self.distinct_union
     }
+    /// Consume the distinct-UNION flag for the current `UNION` node.
+    ///
+    /// `Distinct(Union)` sets this on the enclosing query so that *this*
+    /// union unparses as `UNION` rather than `UNION ALL`. Taking the flag
+    /// keeps it from leaking to sibling or parent unions that share a
+    /// `QueryBuilder`.
+    pub fn take_distinct_union(&mut self) -> bool {
+        std::mem::replace(&mut self.distinct_union, false)
+    }
+    /// Whether this query carries clauses that bind to one operand of a
+    /// set operation (`ORDER BY`, `LIMIT`, `WITH`, ...). Those operands
+    /// must be parenthesized so the clauses do not apply to the whole
+    /// `UNION`.
+    pub fn has_operand_scoped_clauses(&self) -> bool {
+        self.with.is_some()
+            || self.order_by_kind.is_some()
+            || self.limit.is_some()
+            || self.offset.is_some()
+            || self.fetch.is_some()
+            || self.for_clause.is_some()
+            || !self.limit_by.is_empty()
+            || !self.locks.is_empty()
+    }
     pub fn build(&self) -> Result<ast::Query, BuilderError> {
         let order_by = self
             .order_by_kind

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1591,25 +1591,47 @@ impl Unparser<'_> {
                     );
                 }
 
+                // Bind the set quantifier to this UNION node before walking
+                // inputs. A sticky query-level flag is insufficient: a nested
+                // Distinct(Union) would set it while the outer UNION ALL is
+                // still being built, and every later UNION would unparse as
+                // distinct.
+                let set_quantifier =
+                    if query.as_mut().is_some_and(|q| q.take_distinct_union()) {
+                        // None unparses as `UNION` rather than `UNION ALL`.
+                        ast::SetQuantifier::None
+                    } else {
+                        ast::SetQuantifier::All
+                    };
+
+                // Each operand gets its own QueryBuilder so a nested
+                // Distinct(Union) cannot leak `distinct_union` (or ORDER BY /
+                // LIMIT) into this node. sqlparser does not parenthesize
+                // nested SetOperations, so any non-SELECT or clause-bearing
+                // branch is wrapped as a parenthesized subquery.
                 let input_exprs: Vec<SetExpr> = union
                     .inputs
                     .iter()
-                    .map(|input| self.select_to_sql_expr(input, query))
+                    .map(|input| {
+                        let mut branch_query = Some(QueryBuilder::default());
+                        let body = self.select_to_sql_expr(input, &mut branch_query)?;
+                        match branch_query {
+                            Some(mut branch_query)
+                                if !matches!(body, SetExpr::Select(_))
+                                    || branch_query.has_operand_scoped_clauses() =>
+                            {
+                                let query = branch_query.body(Box::new(body)).build()?;
+                                Ok(SetExpr::Query(Box::new(query)))
+                            }
+                            _ => Ok(body),
+                        }
+                    })
                     .collect::<Result<Vec<_>>>()?;
 
                 assert_or_internal_err!(
                     input_exprs.len() >= 2,
                     "UNION operator requires at least 2 inputs"
                 );
-
-                let set_quantifier =
-                    if query.as_ref().is_some_and(|q| q.is_distinct_union()) {
-                        // Setting the SetQuantifier to None will unparse as a `UNION`
-                        // rather than a `UNION ALL`.
-                        ast::SetQuantifier::None
-                    } else {
-                        ast::SetQuantifier::All
-                    };
 
                 // Build the union expression tree bottom-up by reversing the order
                 // note that we are also swapping left and right inputs because of the rev

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -170,6 +170,7 @@ fn roundtrip_statement() -> Result<()> {
             SELECT j2_string as string FROM j2
             ORDER BY string DESC
             LIMIT 10"#,
+            r#"SELECT j1_string FROM j1 UNION ALL (SELECT j2_string FROM j2 UNION SELECT j1_string FROM j1)"#,
             r#"SELECT col1, id FROM (
                 SELECT j1_string AS col1, j1_id AS id FROM j1
                 UNION ALL
@@ -436,6 +437,20 @@ fn roundtrip_statement_with_dialect_8() -> Result<(), DataFusionError> {
         parser_dialect: GenericDialect {},
         unparser_dialect: UnparserDefaultDialect {},
         expected: @"SELECT j1.j1_id FROM j1 UNION ALL SELECT tb.j2_id AS j1_id FROM j2 AS tb ORDER BY j1_id ASC NULLS LAST LIMIT 10",
+    );
+    Ok(())
+}
+
+#[test]
+fn roundtrip_statement_union_all_with_nested_distinct_union()
+-> Result<(), DataFusionError> {
+    // Mixed set quantifiers must stay per UNION node. A query-global
+    // distinct_union flag previously rewrote this to a flat distinct UNION.
+    roundtrip_statement_with_dialect_helper!(
+        sql: "SELECT j1_string FROM j1 UNION ALL (SELECT j2_string FROM j2 UNION SELECT j1_string FROM j1)",
+        parser_dialect: GenericDialect {},
+        unparser_dialect: UnparserDefaultDialect {},
+        expected: @"SELECT j1.j1_string FROM j1 UNION ALL (SELECT j2.j2_string FROM j2 UNION SELECT j1.j1_string FROM j1)",
     );
     Ok(())
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24446

## Rationale for this change

Unparsing mixed `UNION` / `UNION ALL` trees was incorrect. `a UNION ALL (b UNION a)` was emitted as a flat, all-distinct `a UNION b UNION a`. `QueryBuilder::distinct_union` was a single query-level boolean: walking the inner `Distinct(Union)` set that flag, and every later UNION in the same statement then unparsed as distinct. Set quantifiers are a per-node property, so a sticky statement-wide flag cannot represent mixed ALL vs DISTINCT.

## What changes are included in this PR?

- Consume `distinct_union` on the UNION node that it belongs to (`take_distinct_union`), so the flag cannot leak to a parent or sibling union.
- Unparse each UNION operand in its own `QueryBuilder`. Nested distinct unions (and operand-scoped `ORDER BY` / `LIMIT`) stay isolated from the enclosing set operation.
- Wrap non-SELECT or clause-bearing operands as parenthesized subqueries. sqlparser does not parenthesize nested `SetOperation`s, so this is required to keep `ALL` vs distinct precedence.

## Are these changes tested?

Yes. The issue reproduction is in `datafusion/sql/tests/cases/plan_to_sql.rs` as both a plan round-trip and a snapshot of the unparsed SQL. The snapshot asserts the outer `UNION ALL` and the parenthesized inner `UNION`. Without this change the snapshot fails because the unparser emits a flat distinct UNION.

## Are there any user-facing changes?

Unparsed SQL for mixed `UNION` / `UNION ALL` now preserves each node's set quantifier and the parentheses needed for that meaning. This is a bug fix for `plan_to_sql`; there is no public API break.