### PR TITLE
fix: array_sort doesnt respect array inputs for sort order/nulls first

### DIFF
--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -162,10 +162,6 @@ fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         return Ok(Arc::clone(&args[0]));
     }
 
-    if args[1..].iter().any(|array| array.is_null(0)) {
-        return Ok(new_null_array(args[0].data_type(), args[0].len()));
-    }
-
     let sort_order = if args.len() > 1 {
         Some(as_string_array(&args[1])?)
     } else {
@@ -272,6 +268,9 @@ where
         let end = window[1].as_usize() - values_start;
         let slice = &mut values[start..end];
         let descending = if let Some(sort_order) = sort_order {
+            if sort_order.is_null(row_index) {
+                continue;
+            }
             order_desc(sort_order.value(row_index))?
         } else {
             false
@@ -313,6 +312,7 @@ where
     let values_start = offsets[0].as_usize();
     let values_end = offsets[row_count].as_usize();
     let total_values = values_end - values_start;
+    let mut list_validity = BooleanBufferBuilder::new(row_count);
 
     let mut out_values: Vec<T::Native> = vec![T::Native::default(); total_values];
     let mut validity = BooleanBufferBuilder::new(total_values);
@@ -332,6 +332,7 @@ where
 
         if list_array.is_null(row_index) || row_len == 0 {
             validity.append_n(row_len, false);
+            list_validity.append(false);
             continue;
         }
 
@@ -339,6 +340,11 @@ where
         let valid_count = row_len - null_count;
 
         let nulls_first = if let Some(null_order) = null_order {
+            if null_order.is_null(row_index) {
+                list_validity.append(false);
+                validity.append_n(row_len, false);
+                continue;
+            }
             order_nulls_first(null_order.value(row_index))?
         } else {
             true
@@ -358,6 +364,11 @@ where
         let valid_slice = &mut out_values
             [out_start + valid_offset..out_start + valid_offset + valid_count];
         let descending = if let Some(sort_order) = sort_order {
+            if sort_order.is_null(row_index) {
+                validity.append_n(row_len, false);
+                list_validity.append(false);
+                continue;
+            }
             order_desc(sort_order.value(row_index))?
         } else {
             false
@@ -376,6 +387,8 @@ where
             validity.append_n(valid_count, true);
             validity.append_n(null_count, false);
         }
+
+        list_validity.append(true);
     }
 
     let new_offsets = rebase_offsets(offsets);
@@ -390,7 +403,7 @@ where
         field,
         new_offsets,
         sorted_values,
-        list_array.nulls().cloned(),
+        Some(NullBuffer::from(list_validity.finish())),
     )?))
 }
 
@@ -468,12 +481,20 @@ fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
         }
 
         let descending = if let Some(sort_order) = sort_order {
+            if sort_order.is_null(row_index) {
+                new_offsets.push(new_offsets[row_index]);
+                continue;
+            }
             order_desc(sort_order.value(row_index))?
         } else {
             false
         };
 
         let nulls_first = if let Some(null_order) = null_order {
+            if null_order.is_null(row_index) {
+                new_offsets.push(new_offsets[row_index]);
+                continue;
+            }
             order_nulls_first(null_order.value(row_index))?
         } else {
             true

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -18,11 +18,11 @@
 //! [`ScalarUDFImpl`] definitions for array_sort function.
 
 use crate::utils::make_scalar_function;
-use arrow::array::BooleanBufferBuilder;
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, GenericListArray, OffsetSizeTrait,
     PrimitiveArray, UInt32Array, UInt64Array, new_empty_array, new_null_array,
 };
+use arrow::array::{BooleanBufferBuilder, StringArray};
 use arrow::buffer::{NullBuffer, OffsetBuffer};
 use arrow::datatypes::{ArrowNativeTypeOp, DataType, FieldRef};
 use arrow::row::{RowConverter, SortField};
@@ -166,6 +166,12 @@ fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         return Ok(new_null_array(args[0].data_type(), args[0].len()));
     }
 
+    let sort_order = if args.len() > 1 {
+        Some(as_string_array(&args[1])?)
+    } else {
+        None
+    };
+
     let sort_options = if args.len() >= 2 {
         let order = as_string_array(&args[1])?.value(0);
         let descending = order_desc(order)?;
@@ -190,11 +196,11 @@ fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         }
         DataType::List(field) => {
             let array = as_list_array(&args[0])?;
-            array_sort_generic(array, Arc::clone(field), sort_options)
+            array_sort_generic(array, Arc::clone(field), sort_order, sort_options)
         }
         DataType::LargeList(field) => {
             let array = as_large_list_array(&args[0])?;
-            array_sort_generic(array, Arc::clone(field), sort_options)
+            array_sort_generic(array, Arc::clone(field), sort_order, sort_options)
         }
         // Signature should prevent this arm ever occurring
         _ => exec_err!("array_sort expects list for first argument"),
@@ -204,14 +210,15 @@ fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 fn array_sort_generic<OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
+    sort_order: Option<&StringArray>,
     sort_options: Option<SortOptions>,
 ) -> Result<ArrayRef> {
     let values = list_array.values();
 
     if values.data_type().is_primitive() {
-        array_sort_primitive(list_array, field, sort_options)
+        array_sort_primitive(list_array, field, sort_order, sort_options)
     } else {
-        array_sort_non_primitive(list_array, field, sort_options)
+        array_sort_non_primitive(list_array, field, sort_order, sort_options)
     }
 }
 
@@ -220,11 +227,12 @@ fn array_sort_generic<OffsetSize: OffsetSizeTrait>(
 fn array_sort_primitive<OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
+    sort_order: Option<&StringArray>,
     sort_options: Option<SortOptions>,
 ) -> Result<ArrayRef> {
     let values = list_array.values().as_ref();
     downcast_primitive_array! {
-        values => sort_primitive_list(values, list_array, field, sort_options),
+        values => sort_primitive_list(values, list_array, field, sort_order, sort_options),
         _ => exec_err!("array_sort: unsupported primitive type")
     }
 }
@@ -233,15 +241,16 @@ fn sort_primitive_list<T: ArrowPrimitiveType, OffsetSize: OffsetSizeTrait>(
     prim_values: &PrimitiveArray<T>,
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
+    sort_order: Option<&StringArray>,
     sort_options: Option<SortOptions>,
 ) -> Result<ArrayRef>
 where
     T::Native: ArrowNativeTypeOp,
 {
     if prim_values.null_count() > 0 {
-        sort_list_with_nulls(prim_values, list_array, field, sort_options)
+        sort_list_with_nulls(prim_values, list_array, field, sort_order, sort_options)
     } else {
-        sort_list_no_nulls(prim_values, list_array, field, sort_options)
+        sort_list_no_nulls(prim_values, list_array, field, sort_order)
     }
 }
 
@@ -251,7 +260,7 @@ fn sort_list_no_nulls<T: ArrowPrimitiveType, OffsetSize: OffsetSizeTrait>(
     prim_values: &PrimitiveArray<T>,
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
-    sort_options: Option<SortOptions>,
+    sort_order: Option<&StringArray>,
 ) -> Result<ArrayRef>
 where
     T::Native: ArrowNativeTypeOp,
@@ -260,8 +269,6 @@ where
     let offsets = list_array.offsets();
     let values_start = offsets[0].as_usize();
     let values_end = offsets[row_count].as_usize();
-
-    let descending = sort_options.is_some_and(|o| o.descending);
 
     // Copy all values into a mutable buffer
     let mut values: Vec<T::Native> =
@@ -274,6 +281,11 @@ where
         let start = window[0].as_usize() - values_start;
         let end = window[1].as_usize() - values_start;
         let slice = &mut values[start..end];
+        let descending = if let Some(sort_order) = sort_order {
+            order_desc(sort_order.value(row_index))?
+        } else {
+            false
+        };
         if descending {
             slice.sort_unstable_by(|a, b| b.compare(*a));
         } else {
@@ -300,6 +312,7 @@ fn sort_list_with_nulls<T: ArrowPrimitiveType, OffsetSize: OffsetSizeTrait>(
     prim_values: &PrimitiveArray<T>,
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
+    sort_order: Option<&StringArray>,
     sort_options: Option<SortOptions>,
 ) -> Result<ArrayRef>
 where
@@ -311,7 +324,6 @@ where
     let values_end = offsets[row_count].as_usize();
     let total_values = values_end - values_start;
 
-    let descending = sort_options.is_some_and(|o| o.descending);
     let nulls_first = sort_options.is_none_or(|o| o.nulls_first);
 
     let mut out_values: Vec<T::Native> = vec![T::Native::default(); total_values];
@@ -351,6 +363,11 @@ where
 
         let valid_slice = &mut out_values
             [out_start + valid_offset..out_start + valid_offset + valid_count];
+        let descending = if let Some(sort_order) = sort_order {
+            order_desc(sort_order.value(row_index))?
+        } else {
+            false
+        };
         if descending {
             valid_slice.sort_unstable_by(|a, b| b.compare(*a));
         } else {
@@ -390,6 +407,7 @@ where
 fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
+    _sort_order: Option<&StringArray>,
     sort_options: Option<SortOptions>,
 ) -> Result<ArrayRef> {
     let row_count = list_array.len();

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -172,18 +172,8 @@ fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         None
     };
 
-    let sort_options = if args.len() >= 2 {
-        let order = as_string_array(&args[1])?.value(0);
-        let descending = order_desc(order)?;
-        let nulls_first = if args.len() >= 3 {
-            order_nulls_first(as_string_array(&args[2])?.value(0))?
-        } else {
-            true
-        };
-        Some(SortOptions {
-            descending,
-            nulls_first,
-        })
+    let null_order = if args.len() > 2 {
+        Some(as_string_array(&args[2])?)
     } else {
         None
     };
@@ -196,11 +186,11 @@ fn array_sort_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         }
         DataType::List(field) => {
             let array = as_list_array(&args[0])?;
-            array_sort_generic(array, Arc::clone(field), sort_order, sort_options)
+            array_sort_generic(array, Arc::clone(field), sort_order, null_order)
         }
         DataType::LargeList(field) => {
             let array = as_large_list_array(&args[0])?;
-            array_sort_generic(array, Arc::clone(field), sort_order, sort_options)
+            array_sort_generic(array, Arc::clone(field), sort_order, null_order)
         }
         // Signature should prevent this arm ever occurring
         _ => exec_err!("array_sort expects list for first argument"),
@@ -211,14 +201,14 @@ fn array_sort_generic<OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
     sort_order: Option<&StringArray>,
-    sort_options: Option<SortOptions>,
+    null_order: Option<&StringArray>,
 ) -> Result<ArrayRef> {
     let values = list_array.values();
 
     if values.data_type().is_primitive() {
-        array_sort_primitive(list_array, field, sort_order, sort_options)
+        array_sort_primitive(list_array, field, sort_order, null_order)
     } else {
-        array_sort_non_primitive(list_array, field, sort_order, sort_options)
+        array_sort_non_primitive(list_array, field, sort_order, null_order)
     }
 }
 
@@ -228,11 +218,11 @@ fn array_sort_primitive<OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
     sort_order: Option<&StringArray>,
-    sort_options: Option<SortOptions>,
+    null_order: Option<&StringArray>,
 ) -> Result<ArrayRef> {
     let values = list_array.values().as_ref();
     downcast_primitive_array! {
-        values => sort_primitive_list(values, list_array, field, sort_order, sort_options),
+        values => sort_primitive_list(values, list_array, field, sort_order, null_order),
         _ => exec_err!("array_sort: unsupported primitive type")
     }
 }
@@ -242,13 +232,13 @@ fn sort_primitive_list<T: ArrowPrimitiveType, OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
     sort_order: Option<&StringArray>,
-    sort_options: Option<SortOptions>,
+    null_order: Option<&StringArray>,
 ) -> Result<ArrayRef>
 where
     T::Native: ArrowNativeTypeOp,
 {
     if prim_values.null_count() > 0 {
-        sort_list_with_nulls(prim_values, list_array, field, sort_order, sort_options)
+        sort_list_with_nulls(prim_values, list_array, field, sort_order, null_order)
     } else {
         sort_list_no_nulls(prim_values, list_array, field, sort_order)
     }
@@ -313,7 +303,7 @@ fn sort_list_with_nulls<T: ArrowPrimitiveType, OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
     sort_order: Option<&StringArray>,
-    sort_options: Option<SortOptions>,
+    null_order: Option<&StringArray>,
 ) -> Result<ArrayRef>
 where
     T::Native: ArrowNativeTypeOp,
@@ -323,8 +313,6 @@ where
     let values_start = offsets[0].as_usize();
     let values_end = offsets[row_count].as_usize();
     let total_values = values_end - values_start;
-
-    let nulls_first = sort_options.is_none_or(|o| o.nulls_first);
 
     let mut out_values: Vec<T::Native> = vec![T::Native::default(); total_values];
     let mut validity = BooleanBufferBuilder::new(total_values);
@@ -349,6 +337,12 @@ where
 
         let null_count = src_nulls.slice(start, row_len).null_count();
         let valid_count = row_len - null_count;
+
+        let nulls_first = if let Some(null_order) = null_order {
+            order_nulls_first(null_order.value(row_index))?
+        } else {
+            true
+        };
 
         // Compact valid values directly into the target region of the output
         // buffer: after nulls (if nulls_first) or at the start (if nulls_last).
@@ -408,7 +402,7 @@ fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
     sort_order: Option<&StringArray>,
-    sort_options: Option<SortOptions>,
+    null_order: Option<&StringArray>,
 ) -> Result<ArrayRef> {
     let row_count = list_array.len();
     let values = list_array.values();
@@ -416,27 +410,47 @@ fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
     let values_start = offsets[0].as_usize();
     let total_values = offsets[row_count].as_usize() - values_start;
 
-    let nulls_first = sort_options.unwrap_or_default().nulls_first;
-
-    let desc_converter = RowConverter::new(vec![SortField::new_with_options(
+    let desc_first_converter = RowConverter::new(vec![SortField::new_with_options(
         values.data_type().clone(),
         SortOptions {
             descending: true,
-            nulls_first,
+            nulls_first: true,
         },
     )])?;
 
-    let asc_converter = RowConverter::new(vec![SortField::new_with_options(
+    let desc_last_converter = RowConverter::new(vec![SortField::new_with_options(
+        values.data_type().clone(),
+        SortOptions {
+            descending: true,
+            nulls_first: false,
+        },
+    )])?;
+
+    let asc_first_converter = RowConverter::new(vec![SortField::new_with_options(
         values.data_type().clone(),
         SortOptions {
             descending: false,
-            nulls_first,
+            nulls_first: true,
+        },
+    )])?;
+
+    let asc_last_converter = RowConverter::new(vec![SortField::new_with_options(
+        values.data_type().clone(),
+        SortOptions {
+            descending: false,
+            nulls_first: false,
         },
     )])?;
 
     let values_sliced = values.slice(values_start, total_values);
-    let desc_rows = desc_converter.convert_columns(&[Arc::clone(&values_sliced)])?;
-    let asc_rows = asc_converter.convert_columns(&[Arc::clone(&values_sliced)])?;
+    let desc_first_rows =
+        desc_first_converter.convert_columns(&[Arc::clone(&values_sliced)])?;
+    let desc_last_rows =
+        desc_last_converter.convert_columns(&[Arc::clone(&values_sliced)])?;
+    let asc_first_rows =
+        asc_first_converter.convert_columns(&[Arc::clone(&values_sliced)])?;
+    let asc_last_rows =
+        asc_last_converter.convert_columns(&[Arc::clone(&values_sliced)])?;
 
     let mut indices: Vec<OffsetSize> = Vec::with_capacity(total_values);
     let mut new_offsets = Vec::with_capacity(row_count + 1);
@@ -459,6 +473,12 @@ fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
             false
         };
 
+        let nulls_first = if let Some(null_order) = null_order {
+            order_nulls_first(null_order.value(row_index))?
+        } else {
+            true
+        };
+
         let len = (end - start).as_usize();
         let local_start = start.as_usize() - values_start;
 
@@ -469,11 +489,25 @@ fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
             sort_scratch.extend(local_start..local_start + len);
 
             if descending {
-                sort_scratch
-                    .sort_unstable_by(|&a, &b| desc_rows.row(a).cmp(&desc_rows.row(b)));
+                if nulls_first {
+                    sort_scratch.sort_unstable_by(|&a, &b| {
+                        desc_first_rows.row(a).cmp(&desc_first_rows.row(b))
+                    });
+                } else {
+                    sort_scratch.sort_unstable_by(|&a, &b| {
+                        desc_last_rows.row(a).cmp(&desc_last_rows.row(b))
+                    });
+                }
             } else {
-                sort_scratch
-                    .sort_unstable_by(|&a, &b| asc_rows.row(a).cmp(&asc_rows.row(b)));
+                if nulls_first {
+                    sort_scratch.sort_unstable_by(|&a, &b| {
+                        asc_first_rows.row(a).cmp(&asc_first_rows.row(b))
+                    });
+                } else {
+                    sort_scratch.sort_unstable_by(|&a, &b| {
+                        asc_last_rows.row(a).cmp(&asc_last_rows.row(b))
+                    });
+                }
             }
 
             indices.extend(sort_scratch.iter().map(|&i| OffsetSize::usize_as(i)));

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -407,7 +407,7 @@ where
 fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
     list_array: &GenericListArray<OffsetSize>,
     field: FieldRef,
-    _sort_order: Option<&StringArray>,
+    sort_order: Option<&StringArray>,
     sort_options: Option<SortOptions>,
 ) -> Result<ArrayRef> {
     let row_count = list_array.len();
@@ -416,12 +416,27 @@ fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
     let values_start = offsets[0].as_usize();
     let total_values = offsets[row_count].as_usize() - values_start;
 
-    let converter = RowConverter::new(vec![SortField::new_with_options(
+    let nulls_first = sort_options.unwrap_or_default().nulls_first;
+
+    let desc_converter = RowConverter::new(vec![SortField::new_with_options(
         values.data_type().clone(),
-        sort_options.unwrap_or_default(),
+        SortOptions {
+            descending: true,
+            nulls_first,
+        },
     )])?;
+
+    let asc_converter = RowConverter::new(vec![SortField::new_with_options(
+        values.data_type().clone(),
+        SortOptions {
+            descending: false,
+            nulls_first,
+        },
+    )])?;
+
     let values_sliced = values.slice(values_start, total_values);
-    let rows = converter.convert_columns(&[Arc::clone(&values_sliced)])?;
+    let desc_rows = desc_converter.convert_columns(&[Arc::clone(&values_sliced)])?;
+    let asc_rows = asc_converter.convert_columns(&[Arc::clone(&values_sliced)])?;
 
     let mut indices: Vec<OffsetSize> = Vec::with_capacity(total_values);
     let mut new_offsets = Vec::with_capacity(row_count + 1);
@@ -438,6 +453,12 @@ fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
             continue;
         }
 
+        let descending = if let Some(sort_order) = sort_order {
+            order_desc(sort_order.value(row_index))?
+        } else {
+            false
+        };
+
         let len = (end - start).as_usize();
         let local_start = start.as_usize() - values_start;
 
@@ -446,7 +467,15 @@ fn array_sort_non_primitive<OffsetSize: OffsetSizeTrait>(
         } else {
             sort_scratch.clear();
             sort_scratch.extend(local_start..local_start + len);
-            sort_scratch.sort_unstable_by(|&a, &b| rows.row(a).cmp(&rows.row(b)));
+
+            if descending {
+                sort_scratch
+                    .sort_unstable_by(|&a, &b| desc_rows.row(a).cmp(&desc_rows.row(b)));
+            } else {
+                sort_scratch
+                    .sort_unstable_by(|&a, &b| asc_rows.row(a).cmp(&asc_rows.row(b)));
+            }
+
             indices.extend(sort_scratch.iter().map(|&i| OffsetSize::usize_as(i)));
         }
 

--- a/datafusion/functions-nested/src/sort.rs
+++ b/datafusion/functions-nested/src/sort.rs
@@ -20,7 +20,7 @@
 use crate::utils::make_scalar_function;
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, GenericListArray, OffsetSizeTrait,
-    PrimitiveArray, UInt32Array, UInt64Array, new_empty_array, new_null_array,
+    PrimitiveArray, UInt32Array, UInt64Array, new_empty_array,
 };
 use arrow::array::{BooleanBufferBuilder, StringArray};
 use arrow::buffer::{NullBuffer, OffsetBuffer};

--- a/datafusion/sqllogictest/test_files/array/array_sort.slt
+++ b/datafusion/sqllogictest/test_files/array/array_sort.slt
@@ -264,6 +264,8 @@ select array_sort(arrow_cast([1, 3, null, 5, NULL, -5], 'LargeListView(Int64)'))
 ----
 [NULL, NULL, -5, 1, 3, 5]
 
+# Ensure that sort options (asc/desc, null placement) can vary per-row.
+
 query ?
 select array_sort(arr, order)
 from values
@@ -291,10 +293,32 @@ select array_sort(arr, order)
 from values
   (make_array('b', 'a'), 'asc'),
   (make_array('y', 'z', 'x'), 'desc'),
-  (make_array('m', 'n', 'l'), 'desc') as t(arr, order);
+  (make_array('m', 'n', NULL), 'desc') as t(arr, order);
 ----
 [a, b]
 [z, y, x]
-[n, m, l]
+[NULL, n, m]
+
+query ?
+select array_sort(arr, order, null_order)
+from values
+  (make_array(5, 2, NULL, 3, NULL), 'asc', 'NULLS FIRST'),
+  (make_array(NULL, 5, NULL, 3, null), 'desc', 'NULLS LAST'),
+  (make_array(10, NULL, null, 20, 30, NULL), 'desc', 'NULLS LAST') as t(arr, order, null_order);
+----
+[NULL, NULL, 2, 3, 5]
+[5, 3, NULL, NULL, NULL]
+[30, 20, 10, NULL, NULL, NULL]
+
+query ?
+select array_sort(arr, order, null_order)
+from values
+  (make_array('a', 'c', NULL, 'b', NULL), 'asc', 'NULLS FIRST'),
+  (make_array(NULL, 'x', NULL, 'y', null), 'desc', 'NULLS LAST'),
+  (make_array('j', NULL, null, 'l', 'k', NULL), 'desc', 'NULLS LAST') as t(arr, order, null_order);
+----
+[NULL, NULL, a, b, c]
+[y, x, NULL, NULL, NULL]
+[l, k, j, NULL, NULL, NULL]
 
 include ./cleanup.slt.part

--- a/datafusion/sqllogictest/test_files/array/array_sort.slt
+++ b/datafusion/sqllogictest/test_files/array/array_sort.slt
@@ -272,7 +272,18 @@ from values
   (make_array(10, 20, 30), 'desc') as t(arr, order);
 ----
 [2, 3, 5]
+[5, 3, 2]
+[30, 20, 10]
+
+query ?
+select array_sort(arr, order)
+from values
+  (make_array(5, 2, 3), 'asc'),
+  (make_array(5, NULL, 3), 'desc'),
+  (make_array(10, 20, 30), 'desc') as t(arr, order);
+----
 [2, 3, 5]
-[10, 20, 30]
+[NULL, 5, 3]
+[30, 20, 10]
 
 include ./cleanup.slt.part

--- a/datafusion/sqllogictest/test_files/array/array_sort.slt
+++ b/datafusion/sqllogictest/test_files/array/array_sort.slt
@@ -286,4 +286,15 @@ from values
 [NULL, 5, 3]
 [30, 20, 10]
 
+query ?
+select array_sort(arr, order)
+from values
+  (make_array('b', 'a'), 'asc'),
+  (make_array('y', 'z', 'x'), 'desc'),
+  (make_array('m', 'n', 'l'), 'desc') as t(arr, order);
+----
+[a, b]
+[z, y, x]
+[n, m, l]
+
 include ./cleanup.slt.part

--- a/datafusion/sqllogictest/test_files/array/array_sort.slt
+++ b/datafusion/sqllogictest/test_files/array/array_sort.slt
@@ -264,5 +264,15 @@ select array_sort(arrow_cast([1, 3, null, 5, NULL, -5], 'LargeListView(Int64)'))
 ----
 [NULL, NULL, -5, 1, 3, 5]
 
+query ?
+select array_sort(arr, order)
+from values
+  (make_array(5, 2, 3), 'asc'),
+  (make_array(5, 2, 3), 'desc'),
+  (make_array(10, 20, 30), 'desc') as t(arr, order);
+----
+[2, 3, 5]
+[2, 3, 5]
+[10, 20, 30]
 
 include ./cleanup.slt.part


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes https://github.com/apache/datafusion/issues/24132

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
