### PR TITLE
chore: fix malformed example tables in aggregate function docs

### DIFF
--- a/datafusion/functions-aggregate/src/approx_percentile_cont_with_weight.rs
+++ b/datafusion/functions-aggregate/src/approx_percentile_cont_with_weight.rs
@@ -90,11 +90,11 @@ An alternative syntax is also supported:
 
 ```sql
 > SELECT approx_percentile_cont_with_weight(column_name, weight_column, 0.90) FROM table_name;
-+--------------------------------------------------+
++----------------------------------------------------------------------+
 | approx_percentile_cont_with_weight(column_name, weight_column, 0.90) |
-+--------------------------------------------------+
-| 78.5                                             |
-+--------------------------------------------------+
++----------------------------------------------------------------------+
+| 78.5                                                                 |
++----------------------------------------------------------------------+
 ```"#,
     standard_argument(name = "expression", prefix = "The"),
     argument(

--- a/datafusion/functions-aggregate/src/array_agg.rs
+++ b/datafusion/functions-aggregate/src/array_agg.rs
@@ -77,7 +77,7 @@ This aggregation function can only mix DISTINCT and ORDER BY if the ordering exp
 +-----------------------------------------------+
 > SELECT array_agg(DISTINCT column_name ORDER BY column_name) FROM table_name;
 +--------------------------------------------------------+
-| array_agg(DISTINCT column_name ORDER BY column_name)  |
+| array_agg(DISTINCT column_name ORDER BY column_name)   |
 +--------------------------------------------------------+
 | [element1, element2, element3]                         |
 +--------------------------------------------------------+

--- a/datafusion/functions-aggregate/src/average.rs
+++ b/datafusion/functions-aggregate/src/average.rs
@@ -83,9 +83,9 @@ pub fn avg_distinct(expr: Expr) -> Expr {
     sql_example = r#"```sql
 > SELECT avg(column_name) FROM table_name;
 +---------------------------+
-| avg(column_name)           |
+| avg(column_name)          |
 +---------------------------+
-| 42.75                      |
+| 42.75                     |
 +---------------------------+
 ```"#,
     standard_argument(name = "expression",)

--- a/datafusion/functions-aggregate/src/bool_and_or.rs
+++ b/datafusion/functions-aggregate/src/bool_and_or.rs
@@ -97,9 +97,9 @@ make_udaf_expr_and_func!(
     sql_example = r#"```sql
 > SELECT bool_and(column_name) FROM table_name;
 +----------------------------+
-| bool_and(column_name)       |
+| bool_and(column_name)      |
 +----------------------------+
-| true                        |
+| true                       |
 +----------------------------+
 ```"#,
     standard_argument(name = "expression", prefix = "The")
@@ -226,9 +226,9 @@ impl Accumulator for BoolAndAccumulator {
     sql_example = r#"```sql
 > SELECT bool_and(column_name) FROM table_name;
 +----------------------------+
-| bool_and(column_name)       |
+| bool_and(column_name)      |
 +----------------------------+
-| true                        |
+| true                       |
 +----------------------------+
 ```"#,
     standard_argument(name = "expression", prefix = "The")

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -139,7 +139,7 @@ pub fn count_all_window() -> Expr {
     sql_example = r#"```sql
 > SELECT count(column_name) FROM table_name;
 +-----------------------+
-| count(column_name)     |
+| count(column_name)    |
 +-----------------------+
 | 100                   |
 +-----------------------+

--- a/datafusion/functions-aggregate/src/grouping.rs
+++ b/datafusion/functions-aggregate/src/grouping.rs
@@ -44,13 +44,13 @@ make_udaf_expr_and_func!(
 > SELECT column_name, GROUPING(column_name) AS group_column
   FROM table_name
   GROUP BY GROUPING SETS ((column_name), ());
-+-------------+-------------+
++-------------+--------------+
 | column_name | group_column |
-+-------------+-------------+
-| value1      | 0           |
-| value2      | 0           |
-| NULL        | 1           |
-+-------------+-------------+
++-------------+--------------+
+| value1      | 0            |
+| value2      | 0            |
+| NULL        | 1            |
++-------------+--------------+
 ```"#,
     argument(
         name = "expression",

--- a/datafusion/functions-aggregate/src/median.rs
+++ b/datafusion/functions-aggregate/src/median.rs
@@ -73,7 +73,7 @@ make_udaf_expr_and_func!(
     sql_example = r#"```sql
 > SELECT median(column_name) FROM table_name;
 +----------------------+
-| median(column_name)   |
+| median(column_name)  |
 +----------------------+
 | 45.5                 |
 +----------------------+

--- a/datafusion/functions-aggregate/src/min_max.rs
+++ b/datafusion/functions-aggregate/src/min_max.rs
@@ -84,7 +84,7 @@ fn get_min_max_result_type(input_types: &[DataType]) -> Result<Vec<DataType>> {
     sql_example = r#"```sql
 > SELECT max(column_name) FROM table_name;
 +----------------------+
-| max(column_name)      |
+| max(column_name)     |
 +----------------------+
 | 150                  |
 +----------------------+
@@ -456,7 +456,7 @@ impl Accumulator for SlidingMaxAccumulator {
     sql_example = r#"```sql
 > SELECT min(column_name) FROM table_name;
 +----------------------+
-| min(column_name)      |
+| min(column_name)     |
 +----------------------+
 | 12                   |
 +----------------------+

--- a/datafusion/functions-aggregate/src/percentile_cont.rs
+++ b/datafusion/functions-aggregate/src/percentile_cont.rs
@@ -99,11 +99,11 @@ pub fn percentile_cont(order_by: Sort, percentile: Expr) -> Expr {
     syntax_example = "percentile_cont(percentile) WITHIN GROUP (ORDER BY expression)",
     sql_example = r#"```sql
 > SELECT percentile_cont(0.75) WITHIN GROUP (ORDER BY column_name) FROM table_name;
-+----------------------------------------------------------+
++-----------------------------------------------------------+
 | percentile_cont(0.75) WITHIN GROUP (ORDER BY column_name) |
-+----------------------------------------------------------+
-| 45.5                                                     |
-+----------------------------------------------------------+
++-----------------------------------------------------------+
+| 45.5                                                      |
++-----------------------------------------------------------+
 ```
 
 An alternate syntax is also supported:

--- a/datafusion/functions-aggregate/src/regr.rs
+++ b/datafusion/functions-aggregate/src/regr.rs
@@ -170,7 +170,7 @@ create table weekly_performance(week int, productivity_score int) as values (1,6
 select * from weekly_performance;
 +------+---------------------+
 | week | productivity_score  |
-| ---- | ------------------- |
++------+---------------------+
 | 1    | 60                  |
 | 2    | 65                  |
 | 3    | 70                  |
@@ -179,12 +179,11 @@ select * from weekly_performance;
 +------+---------------------+
 
 SELECT regr_intercept(productivity_score, week) AS intercept FROM weekly_performance;
-+----------+
-|intercept|
-|intercept |
-+----------+
-|  55      |
-+----------+
++-----------+
+| intercept |
++-----------+
+| 55        |
++-----------+
 ```
 "#
                 )
@@ -206,7 +205,7 @@ create table daily_metrics(day int, user_signups int) as values (1,100), (2,120)
 select * from daily_metrics;
 +-----+---------------+
 | day | user_signups  |
-| --- | ------------- |
++-----+---------------+
 | 1   | 100           |
 | 2   | 120           |
 | 3   | NULL          |
@@ -250,11 +249,11 @@ select * from weekly_performance;
 +-----+--------------+
 
 SELECT regr_r2(user_signups, day) AS r_squared FROM weekly_performance;
-+---------+
-|r_squared|
-+---------+
-| 1.0     |
-+---------+
++-----------+
+| r_squared |
++-----------+
+| 1.0       |
++-----------+
 ```
 "#
                 )
@@ -276,7 +275,7 @@ create table daily_sales(day int, total_sales int) as values (1,100), (2,150), (
 select * from daily_sales;
 +-----+-------------+
 | day | total_sales |
-| --- | ----------- |
++-----+-------------+
 | 1   | 100         |
 | 2   | 150         |
 | 3   | 200         |
@@ -311,7 +310,7 @@ create table daily_temperature(day int, temperature int) as values (1,30), (2,32
 select * from daily_temperature;
 +-----+-------------+
 | day | temperature |
-| --- | ----------- |
++-----+-------------+
 | 1   | 30          |
 | 2   | 32          |
 | 3   | NULL        |

--- a/datafusion/functions-aggregate/src/stddev.rs
+++ b/datafusion/functions-aggregate/src/stddev.rs
@@ -53,7 +53,7 @@ make_udaf_expr_and_func!(
     sql_example = r#"```sql
 > SELECT stddev(column_name) FROM table_name;
 +----------------------+
-| stddev(column_name)   |
+| stddev(column_name)  |
 +----------------------+
 | 12.34                |
 +----------------------+
@@ -157,7 +157,7 @@ make_udaf_expr_and_func!(
     sql_example = r#"```sql
 > SELECT stddev_pop(column_name) FROM table_name;
 +--------------------------+
-| stddev_pop(column_name)   |
+| stddev_pop(column_name)  |
 +--------------------------+
 | 10.56                    |
 +--------------------------+

--- a/datafusion/functions-aggregate/src/string_agg.rs
+++ b/datafusion/functions-aggregate/src/string_agg.rs
@@ -74,7 +74,7 @@ This aggregation function can only mix DISTINCT and ORDER BY if the ordering exp
 +--------------------------+
 | names_list               |
 +--------------------------+
-| Charlie, Bob, Alice |
+| Charlie, Bob, Alice      |
 +--------------------------+
 ```"#,
     argument(

--- a/datafusion/functions-aggregate/src/sum.rs
+++ b/datafusion/functions-aggregate/src/sum.rs
@@ -153,7 +153,7 @@ macro_rules! downcast_sum {
     sql_example = r#"```sql
 > SELECT sum(column_name) FROM table_name;
 +-----------------------+
-| sum(column_name)       |
+| sum(column_name)      |
 +-----------------------+
 | 12345                 |
 +-----------------------+

--- a/docs/source/user-guide/sql/aggregate_functions.md
+++ b/docs/source/user-guide/sql/aggregate_functions.md
@@ -153,7 +153,7 @@ array_agg(expression [ORDER BY expression])
 +-----------------------------------------------+
 > SELECT array_agg(DISTINCT column_name ORDER BY column_name) FROM table_name;
 +--------------------------------------------------------+
-| array_agg(DISTINCT column_name ORDER BY column_name)  |
+| array_agg(DISTINCT column_name ORDER BY column_name)   |
 +--------------------------------------------------------+
 | [element1, element2, element3]                         |
 +--------------------------------------------------------+
@@ -176,9 +176,9 @@ avg(expression)
 ```sql
 > SELECT avg(column_name) FROM table_name;
 +---------------------------+
-| avg(column_name)           |
+| avg(column_name)          |
 +---------------------------+
-| 42.75                      |
+| 42.75                     |
 +---------------------------+
 ```
 
@@ -239,9 +239,9 @@ bool_and(expression)
 ```sql
 > SELECT bool_and(column_name) FROM table_name;
 +----------------------------+
-| bool_and(column_name)       |
+| bool_and(column_name)      |
 +----------------------------+
-| true                        |
+| true                       |
 +----------------------------+
 ```
 
@@ -262,9 +262,9 @@ bool_and(expression)
 ```sql
 > SELECT bool_and(column_name) FROM table_name;
 +----------------------------+
-| bool_and(column_name)       |
+| bool_and(column_name)      |
 +----------------------------+
-| true                        |
+| true                       |
 +----------------------------+
 ```
 
@@ -285,7 +285,7 @@ count(expression)
 ```sql
 > SELECT count(column_name) FROM table_name;
 +-----------------------+
-| count(column_name)     |
+| count(column_name)    |
 +-----------------------+
 | 100                   |
 +-----------------------+
@@ -339,13 +339,13 @@ grouping(expression)
 > SELECT column_name, GROUPING(column_name) AS group_column
   FROM table_name
   GROUP BY GROUPING SETS ((column_name), ());
-+-------------+-------------+
++-------------+--------------+
 | column_name | group_column |
-+-------------+-------------+
-| value1      | 0           |
-| value2      | 0           |
-| NULL        | 1           |
-+-------------+-------------+
++-------------+--------------+
+| value1      | 0            |
+| value2      | 0            |
+| NULL        | 1            |
++-------------+--------------+
 ```
 
 ### `last_value`
@@ -388,7 +388,7 @@ max(expression)
 ```sql
 > SELECT max(column_name) FROM table_name;
 +----------------------+
-| max(column_name)      |
+| max(column_name)     |
 +----------------------+
 | 150                  |
 +----------------------+
@@ -415,7 +415,7 @@ median(expression)
 ```sql
 > SELECT median(column_name) FROM table_name;
 +----------------------+
-| median(column_name)   |
+| median(column_name)  |
 +----------------------+
 | 45.5                 |
 +----------------------+
@@ -438,7 +438,7 @@ min(expression)
 ```sql
 > SELECT min(column_name) FROM table_name;
 +----------------------+
-| min(column_name)      |
+| min(column_name)     |
 +----------------------+
 | 12                   |
 +----------------------+
@@ -461,11 +461,11 @@ percentile_cont(percentile) WITHIN GROUP (ORDER BY expression)
 
 ```sql
 > SELECT percentile_cont(0.75) WITHIN GROUP (ORDER BY column_name) FROM table_name;
-+----------------------------------------------------------+
++-----------------------------------------------------------+
 | percentile_cont(0.75) WITHIN GROUP (ORDER BY column_name) |
-+----------------------------------------------------------+
-| 45.5                                                     |
-+----------------------------------------------------------+
++-----------------------------------------------------------+
+| 45.5                                                      |
++-----------------------------------------------------------+
 ```
 
 An alternate syntax is also supported:
@@ -522,7 +522,7 @@ string_agg([DISTINCT] expression, delimiter [ORDER BY expression])
 +--------------------------+
 | names_list               |
 +--------------------------+
-| Charlie, Bob, Alice |
+| Charlie, Bob, Alice      |
 +--------------------------+
 ```
 
@@ -543,7 +543,7 @@ sum(expression)
 ```sql
 > SELECT sum(column_name) FROM table_name;
 +-----------------------+
-| sum(column_name)       |
+| sum(column_name)      |
 +-----------------------+
 | 12345                 |
 +-----------------------+
@@ -743,7 +743,7 @@ create table daily_sales(day int, total_sales int) as values (1,100), (2,150), (
 select * from daily_sales;
 +-----+-------------+
 | day | total_sales |
-| --- | ----------- |
++-----+-------------+
 | 1   | 100         |
 | 2   | 150         |
 | 3   | 200         |
@@ -779,7 +779,7 @@ create table daily_temperature(day int, temperature int) as values (1,30), (2,32
 select * from daily_temperature;
 +-----+-------------+
 | day | temperature |
-| --- | ----------- |
++-----+-------------+
 | 1   | 30          |
 | 2   | 32          |
 | 3   | NULL        |
@@ -816,7 +816,7 @@ create table daily_metrics(day int, user_signups int) as values (1,100), (2,120)
 select * from daily_metrics;
 +-----+---------------+
 | day | user_signups  |
-| --- | ------------- |
++-----+---------------+
 | 1   | 100           |
 | 2   | 120           |
 | 3   | NULL          |
@@ -852,7 +852,7 @@ create table weekly_performance(week int, productivity_score int) as values (1,6
 select * from weekly_performance;
 +------+---------------------+
 | week | productivity_score  |
-| ---- | ------------------- |
++------+---------------------+
 | 1    | 60                  |
 | 2    | 65                  |
 | 3    | 70                  |
@@ -861,12 +861,11 @@ select * from weekly_performance;
 +------+---------------------+
 
 SELECT regr_intercept(productivity_score, week) AS intercept FROM weekly_performance;
-+----------+
-|intercept|
-|intercept |
-+----------+
-|  55      |
-+----------+
++-----------+
+| intercept |
++-----------+
+| 55        |
++-----------+
 ```
 
 ### `regr_r2`
@@ -898,11 +897,11 @@ select * from weekly_performance;
 +-----+--------------+
 
 SELECT regr_r2(user_signups, day) AS r_squared FROM weekly_performance;
-+---------+
-|r_squared|
-+---------+
-| 1.0     |
-+---------+
++-----------+
+| r_squared |
++-----------+
+| 1.0       |
++-----------+
 ```
 
 ### `regr_slope`
@@ -1062,7 +1061,7 @@ stddev(expression)
 ```sql
 > SELECT stddev(column_name) FROM table_name;
 +----------------------+
-| stddev(column_name)   |
+| stddev(column_name)  |
 +----------------------+
 | 12.34                |
 +----------------------+
@@ -1089,7 +1088,7 @@ stddev_pop(expression)
 ```sql
 > SELECT stddev_pop(column_name) FROM table_name;
 +--------------------------+
-| stddev_pop(column_name)   |
+| stddev_pop(column_name)  |
 +--------------------------+
 | 10.56                    |
 +--------------------------+
@@ -1237,9 +1236,9 @@ An alternative syntax is also supported:
 
 ```sql
 > SELECT approx_percentile_cont_with_weight(column_name, weight_column, 0.90) FROM table_name;
-+--------------------------------------------------+
++----------------------------------------------------------------------+
 | approx_percentile_cont_with_weight(column_name, weight_column, 0.90) |
-+--------------------------------------------------+
-| 78.5                                             |
-+--------------------------------------------------+
++----------------------------------------------------------------------+
+| 78.5                                                                 |
++----------------------------------------------------------------------+
 ```


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #24209.

## Rationale for this change

16 of the 53 SQL example tables on the aggregate functions page don't line up:

```
+--------------------------+
| names_list               |
+--------------------------+
| Charlie, Bob, Alice |
+--------------------------+
```

The tables are hand-written inside `sql_example` literals and nothing measures them. `config-docs-check` only asserts the generated page matches the literals.

## What changes are included in this PR?

Pads the 16 blocks across 13 `functions-aggregate` sources, fixes four markdown separator rows and a duplicated header row in the `regr` examples, and commits the regenerated `aggregate_functions.md`. No cell content changed.

Follow-ups, not here: `bool_or`'s example calls `bool_and`, the same sweep for `scalar_functions.md`, and the lint the issue's first box asks for.

## Are these changes tested?

No test, nothing in the repo reads a `sql_example` body. fmt, clippy and the docs checks pass; the other generated pages regenerate byte-identical.

## Are there any user-facing changes?

The rendered docs page only.
