### PR TITLE
chore: benchmarks compare.py documentation fixes

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -294,7 +294,7 @@ $ mkdir -p /tmp/output_branch
 $ git checkout my_branch
 $ cargo run --release --bin tpch -- benchmark datafusion --iterations 5 --path ./data --format parquet -o /tmp/output_branch/tpch.json
 # compare the results:
-./compare.py /tmp/output_main/tpch.json  /tmp/output_branch/tpch.json
+uv run ./compare.py /tmp/output_main/tpch.json  /tmp/output_branch/tpch.json
 ```
 
 This will produce output like:

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -258,7 +258,7 @@ def main() -> None:
         "--noise-threshold",
         type=float,
         default=0.05,
-        help="The threshold for statistically insignificant results (+/- %5).",
+        help="The threshold for statistically insignificant results (+/- 5%%).",
     )
     compare_parser.add_argument(
         "--detailed",

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -30,7 +30,7 @@ try:
     from rich.console import Console
     from rich.table import Table
 except ImportError:
-    print("Couldn't import modules -- run `./bench.sh venv` first")
+    print("Couldn't import modules -- run with uv (`uv run compare.py`)")
     raise
 
 


### PR DESCRIPTION
## Which issue does this PR close?

No issue, this is a minor change and not user-facing.

## Rationale for this change

Help developers run benchmarks without getting distracted by errors and trying commands that no longer work.

## What changes are included in this PR?

Updates documentation for `compare.py` to account for the switch to uv (#20414) and fixes a crash when getting the help output (running with `--help`).

## Are these changes tested?

Yes, I've run the script.

## Are there any user-facing changes?

No.