### PR TITLE
chore: add missing `since` versions to `#[deprecated]` attributes

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2560,7 +2560,7 @@ type AggregateExprWithOptionalArgs = (
 );
 
 /// Create an aggregate expression with a name from a logical expression
-#[deprecated(note = "use LoweredAggregateBuilder")]
+#[deprecated(since = "54.0.0", note = "use LoweredAggregateBuilder")]
 pub fn create_aggregate_expr_with_name_and_maybe_filter(
     e: &Expr,
     name: Option<String>,
@@ -2587,7 +2587,7 @@ pub fn create_aggregate_expr_with_name_and_maybe_filter(
 }
 
 /// Create an aggregate expression from a logical expression or an alias
-#[deprecated(note = "use LoweredAggregateBuilder")]
+#[deprecated(since = "54.0.0", note = "use LoweredAggregateBuilder")]
 pub fn create_aggregate_expr_and_maybe_filter(
     e: &Expr,
     logical_input_schema: &DFSchema,

--- a/datafusion/functions/src/string/overlay.rs
+++ b/datafusion/functions/src/string/overlay.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 #[deprecated(
+    since = "47.0.0",
     note = "overlay has been moved to core. Update imports to use core::overlay."
 )]
 pub use crate::core::overlay::*;

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -1343,7 +1343,7 @@ fn rewrite_projection(
 /// Creates a new LogicalPlan::Filter node.
 ///
 /// Deprecated: use [`Filter::try_new`] directly.
-#[deprecated]
+#[deprecated(since = "55.0.0", note = "Use `Filter::try_new` instead")]
 pub fn make_filter(predicate: Expr, input: Arc<LogicalPlan>) -> Result<LogicalPlan> {
     Filter::try_new(predicate, input).map(LogicalPlan::Filter)
 }

--- a/datafusion/physical-plan/src/spill/spill_pool.rs
+++ b/datafusion/physical-plan/src/spill/spill_pool.rs
@@ -476,7 +476,7 @@ pub fn spsc_channel(
 }
 
 /// Alias for [`mpsc_channel`].
-#[deprecated(note = "Use mpsc_channel instead")]
+#[deprecated(since = "55.0.0", note = "Use mpsc_channel instead")]
 pub fn channel(
     max_file_size_bytes: usize,
     spill_manager: Arc<SpillManager>,


### PR DESCRIPTION
## Which issue does this PR close?

- Cleanup from looking for deprecated APIs

## Rationale for this change

The [API health policy deprecation guidelines] say:

> Mark the API as deprecated using `#[deprecated]` and specify the exact DataFusion version in which it was deprecated

Five `#[deprecated]` attributes on `main` have no `since`, so there is no way to tell when they can be removed

[API health policy deprecation guidelines]: https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines

## What changes are included in this PR?

Adds `since` to each of the five. The version is the release that first contained the commit which added the attribute, determined with `git tag --contains`:

## Are these changes tested?

CI
## Are there any user-facing changes?

No 

