### PR TITLE
chore: remove ScalarValue::raw_data

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -4032,17 +4032,6 @@ impl ScalarValue {
         }
     }
 
-    #[deprecated(
-        since = "46.0.0",
-        note = "This function is obsolete. Use `to_array` instead"
-    )]
-    pub fn raw_data(&self) -> Result<ArrayRef> {
-        match self {
-            ScalarValue::List(arr) => Ok(arr.to_owned()),
-            _ => _internal_err!("ScalarValue is not a list"),
-        }
-    }
-
     /// Converts a value in `array` at `index` into a ScalarValue
     pub fn try_from_array(array: &dyn Array, index: usize) -> Result<Self> {
         // handle NULL value


### PR DESCRIPTION
## Which issue does this PR close?

Part of #24542.

## Rationale for this change

This API is past DataFusion's [deprecation period](https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines).

## What changes are included in this PR?

Removes `ScalarValue::raw_data`; use `ScalarValue::to_array` instead.

## Are these changes tested?

NA
## Are there any user-facing changes?

Yes, this is a breaking Rust API change.