### PR TITLE
chore: remove DisplayableExecutionPlan::to_stringified

### DIFF
--- a/datafusion/physical-plan/src/display.rs
+++ b/datafusion/physical-plan/src/display.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 
 use arrow::datatypes::SchemaRef;
 
-use datafusion_common::display::{GraphvizBuilder, PlanType, StringifiedPlan};
+use datafusion_common::display::GraphvizBuilder;
 use datafusion_expr::display_schema;
 use datafusion_physical_expr::LexOrdering;
 
@@ -516,21 +516,6 @@ impl<'a> DisplayableExecutionPlan<'a> {
             metric_types: self.metric_types.clone(),
             metric_categories: self.metric_categories.clone(),
             metric_names: self.metric_names.clone(),
-        }
-    }
-
-    #[deprecated(since = "47.0.0", note = "indent() or tree_render() instead")]
-    pub fn to_stringified(
-        &self,
-        verbose: bool,
-        plan_type: PlanType,
-        explain_format: DisplayFormatType,
-    ) -> StringifiedPlan {
-        match (&explain_format, &plan_type) {
-            (DisplayFormatType::TreeRender, PlanType::FinalPhysicalPlan) => {
-                StringifiedPlan::new(plan_type, self.tree_render().to_string())
-            }
-            _ => StringifiedPlan::new(plan_type, self.indent(verbose).to_string()),
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Part of #24542.

## Rationale for this change

This API is past DataFusion's [deprecation period](https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines).

## What changes are included in this PR?

Removes `DisplayableExecutionPlan::to_stringified`; use `indent` or `tree_render` instead.

## Are these changes tested?

NA
## Are there any user-facing changes?

Yes, this is a breaking Rust API change.