### PR TITLE
chore: remove ExprSimplifier::simplify_with_cycle_count

### DIFF
--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -182,23 +182,6 @@ impl ExprSimplifier {
     /// representing the number of simplification cycles performed, which can be useful for testing
     /// optimizations.
     ///
-    /// See [Self::simplify] for details and usage examples.
-    #[deprecated(
-        since = "48.0.0",
-        note = "Use `simplify_with_cycle_count_transformed` instead"
-    )]
-    #[expect(unused_mut)]
-    pub fn simplify_with_cycle_count(&self, mut expr: Expr) -> Result<(Expr, u32)> {
-        let (transformed, cycle_count) =
-            self.simplify_with_cycle_count_transformed(expr)?;
-        Ok((transformed.data, cycle_count))
-    }
-
-    /// Like [Self::simplify], simplifies this [`Expr`] as much as possible, evaluating
-    /// constants and applying algebraic simplifications. Additionally returns a `u32`
-    /// representing the number of simplification cycles performed, which can be useful for testing
-    /// optimizations.
-    ///
     /// # Returns
     ///
     /// A tuple containing:


### PR DESCRIPTION
## Which issue does this PR close?

Part of #24542.

## Rationale for this change

This API is past DataFusion's [deprecation period](https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines).

## What changes are included in this PR?

Removes `ExprSimplifier::simplify_with_cycle_count`; use `simplify_with_cycle_count_transformed` instead.

## Are these changes tested?

NA
## Are there any user-facing changes?

Yes, this is a breaking Rust API change. 