### PR TITLE
chore: remove DynEq and DynHash re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -34,6 +34,7 @@ use datafusion_common::{
     Result, ScalarValue, assert_eq_or_internal_err, exec_err, not_impl_err,
 };
 use datafusion_expr_common::columnar_value::ColumnarValue;
+use datafusion_expr_common::dyn_eq::{DynEq, DynHash};
 use datafusion_expr_common::interval_arithmetic::Interval;
 use datafusion_expr_common::placement::ExpressionPlacement;
 use datafusion_expr_common::sort_properties::ExprProperties;
@@ -795,12 +796,6 @@ pub mod proto_decode {
     }
 }
 
-#[deprecated(
-    since = "50.0.0",
-    note = "Use `datafusion_expr_common::dyn_eq` instead"
-)]
-pub use datafusion_expr_common::dyn_eq::{DynEq, DynHash};
-
 impl dyn PhysicalExpr {
     /// Returns `true` if the expression is of type `T`.
     ///
@@ -907,7 +902,7 @@ where
 /// # use arrow::datatypes::{DataType, Field, FieldRef, Schema};
 /// # use datafusion_common::Result;
 /// # use datafusion_expr_common::columnar_value::ColumnarValue;
-/// # use datafusion_physical_expr_common::physical_expr::{fmt_sql, DynEq, PhysicalExpr};
+/// # use datafusion_physical_expr_common::physical_expr::{fmt_sql, PhysicalExpr};
 /// # #[derive(Debug, PartialEq, Eq, Hash)]
 /// # struct MyExpr {}
 /// # impl PhysicalExpr for MyExpr {

--- a/datafusion/physical-expr/src/expressions/dynamic_filters/mod.rs
+++ b/datafusion/physical-expr/src/expressions/dynamic_filters/mod.rs
@@ -30,7 +30,7 @@ use datafusion_common::{
 };
 
 use datafusion_expr::ColumnarValue;
-use datafusion_physical_expr_common::physical_expr::DynHash;
+use datafusion_expr_common::dyn_eq::DynHash;
 
 mod tracker;
 pub use tracker::{DynamicFilterTracker, DynamicFilterTracking};

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -70,6 +70,7 @@ datafusion-common = { workspace = true }
 datafusion-common-runtime = { workspace = true, default-features = true }
 datafusion-execution = { workspace = true }
 datafusion-expr = { workspace = true }
+datafusion-expr-common = { workspace = true }
 datafusion-functions = { workspace = true }
 datafusion-functions-aggregate-common = { workspace = true }
 datafusion-functions-window-common = { workspace = true }

--- a/datafusion/physical-plan/src/joins/hash_join/partitioned_hash_eval.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/partitioned_hash_eval.rs
@@ -30,9 +30,8 @@ use datafusion_common::hash_utils::{create_hashes, with_hashes};
 #[cfg(feature = "proto")]
 use datafusion_common::internal_err;
 use datafusion_expr::ColumnarValue;
-use datafusion_physical_expr_common::physical_expr::{
-    DynHash, PhysicalExpr, PhysicalExprRef,
-};
+use datafusion_expr_common::dyn_eq::DynHash;
+use datafusion_physical_expr_common::physical_expr::{PhysicalExpr, PhysicalExprRef};
 
 use crate::joins::Map;
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #24542.

## Rationale for this change

These re-exports are past DataFusion's [deprecation period](https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines).

## What changes are included in this PR?

Removes the `DynEq` and `DynHash` re-exports and updates internal users to import them from `datafusion_expr_common::dyn_eq`.

## Are these changes tested?

NA
## Are there any user-facing changes?

Yes, this is a breaking Rust API change.