### PR TITLE
chore: remove ExecutionProps::start_execution

### DIFF
--- a/datafusion/expr/src/execution_props.rs
+++ b/datafusion/expr/src/execution_props.rs
@@ -87,12 +87,6 @@ impl ExecutionProps {
         self
     }
 
-    #[deprecated(since = "50.0.0", note = "Use mark_start_execution instead")]
-    pub fn start_execution(&mut self) -> &Self {
-        let default_config = Arc::new(ConfigOptions::default());
-        self.mark_start_execution(default_config)
-    }
-
     /// Marks the execution of query started timestamp.
     /// This also instantiates a new alias generator.
     pub fn mark_start_execution(&mut self, config_options: Arc<ConfigOptions>) -> &Self {


### PR DESCRIPTION
## Which issue does this PR close?

Part of #24542.

## Rationale for this change

This API is past DataFusion's [deprecation period](https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines).

## What changes are included in this PR?

Removes `ExecutionProps::start_execution`; use `mark_start_execution` instead.

## Are these changes tested?

NA
## Are there any user-facing changes?

Yes, this is a breaking Rust API change.