### PR TITLE
chore: remove NowFunc::new

### DIFF
--- a/datafusion/functions/src/datetime/now.rs
+++ b/datafusion/functions/src/datetime/now.rs
@@ -69,16 +69,6 @@ impl Default for NowFunc {
 }
 
 impl NowFunc {
-    #[deprecated(since = "50.2.0", note = "use `new_with_config` instead")]
-    /// Deprecated constructor retained for backwards compatibility.
-    ///
-    /// Prefer [`NowFunc::new_with_config`] which allows specifying the
-    /// timezone via [`ConfigOptions`]. This helper now mirrors the
-    /// canonical default offset (None) provided by `ConfigOptions::default()`.
-    pub fn new() -> Self {
-        Self::new_with_config(&ConfigOptions::default())
-    }
-
     pub fn new_with_config(config: &ConfigOptions) -> Self {
         Self {
             signature: Signature::nullary(Volatility::Stable),
@@ -152,46 +142,5 @@ impl ScalarUDFImpl for NowFunc {
 
     fn documentation(&self) -> Option<&Documentation> {
         self.doc()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[expect(deprecated)]
-    #[test]
-    fn now_func_default_matches_config() {
-        let default_config = ConfigOptions::default();
-
-        let legacy_now = NowFunc::new();
-        let configured_now = NowFunc::new_with_config(&default_config);
-
-        let empty_fields: [FieldRef; 0] = [];
-        let empty_scalars: [Option<&ScalarValue>; 0] = [];
-
-        let legacy_field = legacy_now
-            .return_field_from_args(ReturnFieldArgs {
-                arg_fields: &empty_fields,
-                scalar_arguments: &empty_scalars,
-            })
-            .expect("legacy now() return field");
-
-        let configured_field = configured_now
-            .return_field_from_args(ReturnFieldArgs {
-                arg_fields: &empty_fields,
-                scalar_arguments: &empty_scalars,
-            })
-            .expect("configured now() return field");
-
-        assert_eq!(legacy_field.as_ref(), configured_field.as_ref());
-
-        let legacy_scalar =
-            ScalarValue::TimestampNanosecond(None, legacy_now.timezone.clone());
-        let configured_scalar =
-            ScalarValue::TimestampNanosecond(None, configured_now.timezone.clone());
-
-        assert_eq!(legacy_scalar, configured_scalar);
-        assert_eq!(None, legacy_now.timezone.as_deref());
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Part of #24542.

## Rationale for this change

This API is past DataFusion's [deprecation period](https://datafusion.apache.org/contributor-guide/api-health.html#deprecation-guidelines).

## What changes are included in this PR?

Removes `NowFunc::new`; use `NowFunc::new_with_config` instead.

## Are these changes tested?

NA
## Are there any user-facing changes?

Yes, this is a breaking Rust API change. 