### PR TITLE
docs: document negative n behavior for `nth_value`

### DIFF
--- a/datafusion/functions-aggregate/src/nth_value.rs
+++ b/datafusion/functions-aggregate/src/nth_value.rs
@@ -85,7 +85,9 @@ pub fn nth_value(
     ),
     argument(
         name = "n",
-        description = "The position (nth) of the value to retrieve, based on the ordering."
+        description = "The position of the value to retrieve. Positive values count from the first \
+            value, starting at 1; negative values count backward from the last value, where -1 \
+            returns the last value."
     )
 )]
 /// Expression for a `NTH_VALUE(..., ... ORDER BY ...)` aggregation. In a multi

--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -217,7 +217,9 @@ static NTH_VALUE_DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
     )
     .with_argument(
         "n",
-        "Integer. Specifies the row number (starting from 1) in the window frame.",
+        "Integer position in the window frame. Positive values count from the first \
+        row, starting at 1; negative values count backward from the last row, where -1 \
+        returns the last row.",
     )
     .with_sql_example(
         r#"

--- a/docs/source/user-guide/sql/aggregate_functions.md
+++ b/docs/source/user-guide/sql/aggregate_functions.md
@@ -705,7 +705,7 @@ nth_value(expression, n ORDER BY expression)
 #### Arguments
 
 - **expression**: The column or expression to retrieve the nth value from.
-- **n**: The position (nth) of the value to retrieve, based on the ordering.
+- **n**: The position of the value to retrieve. Positive values count from the first value, starting at 1; negative values count backward from the last value, where -1 returns the last value.
 
 #### Example
 

--- a/docs/source/user-guide/sql/window_functions.md
+++ b/docs/source/user-guide/sql/window_functions.md
@@ -498,7 +498,7 @@ nth_value(expression, n)
 #### Arguments
 
 - **expression**: The column from which to retrieve the nth value.
-- **n**: Integer. Specifies the row number (starting from 1) in the window frame.
+- **n**: Integer position in the window frame. Positive values count from the first row, starting at 1; negative values count backward from the last row, where -1 returns the last row.
 
 #### Example
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Follow-up to #24453.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

`nth_value` supports negative `n`, but the user documentation only describes positive, one-based positions. This behavior was discussed while reviewing #24453, where a documentation follow-up was proposed.

Negative `n` is a DataFusion extension that counts backward from the end of the ordered group or window frame. It provides the behavior of SQL-standard `from last`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Document positive and negative `n` for the aggregate `nth_value`.
- Document positive and negative `n` for the window `nth_value`.
- Update the generated aggregate and window function documentation.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. Documentation formatting was checked.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

Documentation only;