### PR TITLE
fix: support RunEndEncoded arrays in function and window frame type coercion

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -1654,7 +1654,8 @@ mod tests {
         // Timestamp, but a REE-encoded column (e.g. a segment written with
         // REE-dict encoding for that field) should still coerce against
         // them via the wrapped value type.
-        let type_from = run_end_encoded_of(DataType::Timestamp(TimeUnit::Nanosecond, None));
+        let type_from =
+            run_end_encoded_of(DataType::Timestamp(TimeUnit::Nanosecond, None));
         let type_into = DataType::Timestamp(TimeUnit::Nanosecond, None);
         assert_eq!(
             coerced_from(&type_into, &type_from),

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -1158,9 +1158,6 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-        // coerced run-end encoded the same way as dictionary: callers of a
-        // signature built from `Exact`/`OneOf` only know the logical value
-        // type, not that the argument happens to be physically run-encoded.
         (_, RunEndEncoded(_, value_type))
             if coerced_from(type_into, value_type.data_type()).is_some() =>
         {
@@ -1657,6 +1654,17 @@ mod tests {
         let type_from =
             run_end_encoded_of(DataType::Timestamp(TimeUnit::Nanosecond, None));
         let type_into = DataType::Timestamp(TimeUnit::Nanosecond, None);
+        assert_eq!(
+            coerced_from(&type_into, &type_from),
+            Some(type_into.clone())
+        );
+
+        // The reverse direction: a plain type coercing into an REE target
+        // (e.g. a signature that happens to require RunEndEncoded) should
+        // succeed whenever the plain type coerces into the wrapped value
+        // type.
+        let type_into = run_end_encoded_of(DataType::Int64);
+        let type_from = DataType::Int32;
         assert_eq!(
             coerced_from(&type_into, &type_from),
             Some(type_into.clone())

--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -1158,6 +1158,19 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
+        // coerced run-end encoded the same way as dictionary: callers of a
+        // signature built from `Exact`/`OneOf` only know the logical value
+        // type, not that the argument happens to be physically run-encoded.
+        (_, RunEndEncoded(_, value_type))
+            if coerced_from(type_into, value_type.data_type()).is_some() =>
+        {
+            Some(type_into.clone())
+        }
+        (RunEndEncoded(_, value_type), _)
+            if coerced_from(value_type.data_type(), type_from).is_some() =>
+        {
+            Some(type_into.clone())
+        }
         // coerced into type_into
         (Int8, Null | Int8) => Some(type_into.clone()),
         (Int16, Null | Int8 | Int16 | UInt8) => Some(type_into.clone()),
@@ -1611,6 +1624,38 @@ mod tests {
         let type_from =
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::UInt32));
         let type_into = DataType::Int64;
+        assert_eq!(
+            coerced_from(&type_into, &type_from),
+            Some(type_into.clone())
+        );
+    }
+
+    #[test]
+    fn test_coerced_from_run_end_encoded() {
+        let run_end_encoded_of = |value_type: DataType| {
+            DataType::RunEndEncoded(
+                Field::new("run_ends", DataType::Int32, false).into(),
+                Field::new("values", value_type, true).into(),
+            )
+        };
+
+        let type_into = run_end_encoded_of(DataType::UInt32);
+        let type_from = DataType::Int64;
+        assert_eq!(coerced_from(&type_into, &type_from), None);
+
+        let type_from = run_end_encoded_of(DataType::UInt32);
+        let type_into = DataType::Int64;
+        assert_eq!(
+            coerced_from(&type_into, &type_from),
+            Some(type_into.clone())
+        );
+
+        // Signature candidates for functions like `date_bin` are plain
+        // Timestamp, but a REE-encoded column (e.g. a segment written with
+        // REE-dict encoding for that field) should still coerce against
+        // them via the wrapped value type.
+        let type_from = run_end_encoded_of(DataType::Timestamp(TimeUnit::Nanosecond, None));
+        let type_into = DataType::Timestamp(TimeUnit::Nanosecond, None);
         assert_eq!(
             coerced_from(&type_into, &type_from),
             Some(type_into.clone())

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1088,6 +1088,8 @@ fn extract_window_frame_target_type(col_type: &DataType) -> Result<DataType> {
         Ok(DataType::Interval(IntervalUnit::MonthDayNano))
     } else if let DataType::Dictionary(_, value_type) = col_type {
         extract_window_frame_target_type(value_type)
+    } else if let DataType::RunEndEncoded(_, value_type) = col_type {
+        extract_window_frame_target_type(value_type.data_type())
     } else {
         internal_err!("Cannot run range queries on datatype: {col_type}")
     }
@@ -1113,8 +1115,11 @@ fn coerce_window_frame(
                 // `current_value ± offset`, so it is only meaningful for target
                 // types that support arithmetic. Other orderable target types can
                 // still use free range frames, whose bounds require comparison only.
+                // REE arrays are not supported by arrow's numeric kernesl.
+                // Tracked at https://github.com/apache/arrow-rs/issues/10891).
                 let supports_offset_arithmetic =
-                    target_type.is_numeric() || is_interval(&target_type);
+                    !matches!(col_type, DataType::RunEndEncoded(_, _))
+                        && (target_type.is_numeric() || is_interval(&target_type));
                 if !supports_offset_arithmetic && !window_frame.free_range() {
                     return plan_err!(
                         "RANGE with offset PRECEDING/FOLLOWING is not supported for ORDER BY type {target_type}"

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1088,6 +1088,8 @@ fn extract_window_frame_target_type(col_type: &DataType) -> Result<DataType> {
         Ok(DataType::Interval(IntervalUnit::MonthDayNano))
     } else if let DataType::Dictionary(_, value_type) = col_type {
         extract_window_frame_target_type(value_type)
+    } else if let DataType::RunEndEncoded(_, value_type) = col_type {
+        extract_window_frame_target_type(value_type.data_type())
     } else {
         internal_err!("Cannot run range queries on datatype: {col_type}")
     }

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1088,8 +1088,6 @@ fn extract_window_frame_target_type(col_type: &DataType) -> Result<DataType> {
         Ok(DataType::Interval(IntervalUnit::MonthDayNano))
     } else if let DataType::Dictionary(_, value_type) = col_type {
         extract_window_frame_target_type(value_type)
-    } else if let DataType::RunEndEncoded(_, value_type) = col_type {
-        extract_window_frame_target_type(value_type.data_type())
     } else {
         internal_err!("Cannot run range queries on datatype: {col_type}")
     }

--- a/datafusion/sqllogictest/test_files/run_end_encoded.slt
+++ b/datafusion/sqllogictest/test_files/run_end_encoded.slt
@@ -85,3 +85,47 @@ false false
 true true
 true true
 true true
+
+# date_bin's signature is a plain Timestamp, not RunEndEncoded, so this only
+# plans if coerced_from() unwraps the REE value type the same way it does for
+# Dictionary (see test_coerced_from_run_end_encoded)
+statement ok
+CREATE TABLE ree_timestamps AS
+SELECT
+    arrow_cast(
+        arrow_cast(ts, 'Timestamp(Nanosecond, None)'),
+        'RunEndEncoded("run_ends": non-null Int32, "values": Timestamp(Nanosecond, None))'
+    ) AS ts
+FROM (VALUES
+    ('2023-12-04T00:00:00'),
+    ('2023-12-04T00:05:00'),
+    ('2023-12-04T00:35:00')
+) AS t(ts);
+
+query P rowsort
+SELECT date_bin('30 minutes', ts) FROM ree_timestamps;
+----
+2023-12-04T00:00:00
+2023-12-04T00:00:00
+2023-12-04T00:30:00
+
+# RANGE window frame ordered by an REE-encoded column: extract_window_frame_target_type()
+# must unwrap RunEndEncoded the same way it does for Dictionary, or planning
+# fails with "Cannot run range queries on datatype: RunEndEncoded(...)"
+query II
+SELECT
+    temperature,
+    SUM(temperature) OVER (
+        ORDER BY arrow_cast(
+            temperature,
+            'RunEndEncoded("run_ends": non-null Int32, "values": Int64)'
+        )
+        RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS windowed_sum
+FROM sensor_readings
+ORDER BY temperature;
+----
+20 20
+22 42
+23 65
+24 89

--- a/datafusion/sqllogictest/test_files/run_end_encoded.slt
+++ b/datafusion/sqllogictest/test_files/run_end_encoded.slt
@@ -109,10 +109,18 @@ SELECT date_bin('30 minutes', ts) FROM ree_timestamps;
 2023-12-04T00:00:00
 2023-12-04T00:30:00
 
-# RANGE window frame ordered by an REE-encoded column: extract_window_frame_target_type()
-# must unwrap RunEndEncoded the same way it does for Dictionary, or planning
-# fails with "Cannot run range queries on datatype: RunEndEncoded(...)"
-query II
+# RANGE window frames are intentionally NOT supported over an REE-encoded
+# ORDER BY column and must fail at planning time, unlike Dictionary (which
+# extract_window_frame_target_type() in
+# datafusion/optimizer/src/analyzer/type_coercion.rs does unwrap). An offset
+# RANGE bound (`k PRECEDING`/`k FOLLOWING`) is computed by adding/subtracting
+# the offset from the current row's value, and a value pulled from a
+# still-REE-wrapped column isn't something arrow's arithmetic kernels handle
+# -- so rather than let that reach execution (silently or otherwise), REE is
+# rejected up front for RANGE frames of any bound kind. Tracked upstream at
+# https://github.com/apache/arrow-rs/issues/10891 (arithmetic kernel support
+# for RunEndEncoded); once that lands, this can go back to a real query.
+query error Cannot run range queries on datatype: RunEndEncoded
 SELECT
     temperature,
     SUM(temperature) OVER (
@@ -124,8 +132,16 @@ SELECT
     ) AS windowed_sum
 FROM sensor_readings
 ORDER BY temperature;
-----
-20 20
-22 42
-23 65
-24 89
+
+query error Cannot run range queries on datatype: RunEndEncoded
+SELECT
+    temperature,
+    SUM(temperature) OVER (
+        ORDER BY arrow_cast(
+            temperature,
+            'RunEndEncoded("run_ends": non-null Int32, "values": Int64)'
+        )
+        RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING
+    ) AS windowed_sum
+FROM sensor_readings
+ORDER BY temperature;

--- a/datafusion/sqllogictest/test_files/run_end_encoded.slt
+++ b/datafusion/sqllogictest/test_files/run_end_encoded.slt
@@ -109,18 +109,10 @@ SELECT date_bin('30 minutes', ts) FROM ree_timestamps;
 2023-12-04T00:00:00
 2023-12-04T00:30:00
 
-# RANGE window frames are intentionally NOT supported over an REE-encoded
-# ORDER BY column and must fail at planning time, unlike Dictionary (which
-# extract_window_frame_target_type() in
-# datafusion/optimizer/src/analyzer/type_coercion.rs does unwrap). An offset
-# RANGE bound (`k PRECEDING`/`k FOLLOWING`) is computed by adding/subtracting
-# the offset from the current row's value, and a value pulled from a
-# still-REE-wrapped column isn't something arrow's arithmetic kernels handle
-# -- so rather than let that reach execution (silently or otherwise), REE is
-# rejected up front for RANGE frames of any bound kind. Tracked upstream at
-# https://github.com/apache/arrow-rs/issues/10891 (arithmetic kernel support
-# for RunEndEncoded); once that lands, this can go back to a real query.
-query error Cannot run range queries on datatype: RunEndEncoded
+# RANGE window frame ordered by an REE-encoded column: extract_window_frame_target_type()
+# unwraps RunEndEncoded the same way it does for Dictionary, so a frame that
+# doesn't need offset arithmetic.
+query II
 SELECT
     temperature,
     SUM(temperature) OVER (
@@ -132,8 +124,18 @@ SELECT
     ) AS windowed_sum
 FROM sensor_readings
 ORDER BY temperature;
+----
+20 20
+22 42
+23 65
+24 89
 
-query error Cannot run range queries on datatype: RunEndEncoded
+# An offset RANGE bound (`k PRECEDING`/`k FOLLOWING`, unlike CURRENT ROW or
+# UNBOUNDED above) is computed by adding/subtracting the offset from the
+# current row's value, and arrow's numeric kernels don't support arithmetic
+# on a still-RunEndEncoded-wrapped value (tracked at
+# https://github.com/apache/arrow-rs/issues/10891).
+query error RANGE with offset PRECEDING/FOLLOWING is not supported for ORDER BY type
 SELECT
     temperature,
     SUM(temperature) OVER (


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24564.

## Rationale for this change

Adds missing support for coercing REE arrays and extracting range windows from REE arrays.

## What changes are included in this PR?

Added case statements for supporting REE arrays

## Are these changes tested?

Yes a unit test is included.

## Are there any user-facing changes?
No
