### PR TITLE
docs: list DataFusion Bloom extension

### DIFF
--- a/docs/source/library-user-guide/extensions.md
+++ b/docs/source/library-user-guide/extensions.md
@@ -40,12 +40,14 @@ we'll gladly set up a new repository for your extension.
 | ---------------------------- | ----------------- | --------------------------------------------------------------------------------- |
 | [DataFusion Table Providers] | [`TableProvider`] | Support for `PostgreSQL`, `MySQL`, `SQLite`, `DuckDB`, and `Flight SQL`           |
 | [DataFusion Federation]      | Framework         | Allows DataFusion to execute (part of) a query plan by a remote execution engine. |
+| [DataFusion Bloom]           | Execution layer   | Runs adaptive predicate transfer before DataFusion's native joins                 |
 | [DataFusion ORC]             | [`TableProvider`] | [Apache ORC] file format                                                          |
 | [DataFusion JSON Functions]  | Functions         | Scalar functions for querying JSON strings                                        |
 
 [`tableprovider`]: https://docs.rs/datafusion/latest/datafusion/catalog/trait.TableProvider.html
 [datafusion table providers]: https://github.com/datafusion-contrib/datafusion-table-providers
 [datafusion federation]: https://github.com/datafusion-contrib/datafusion-federation
+[datafusion bloom]: https://github.com/YimingQiao/datafusion-bloom
 [datafusion orc]: https://github.com/datafusion-contrib/datafusion-orc
 [apache orc]: https://orc.apache.org/
 [datafusion json functions]: https://github.com/datafusion-contrib/datafusion-functions-json


### PR DESCRIPTION
## Which issue does this PR close?

- N/A — this is a documentation-only community extension listing.

## Rationale for this change

The Extensions List invites community-maintained DataFusion extensions to add themselves. DataFusion Bloom provides an adaptive predicate-transfer execution layer before DataFusion's native joins and is available as a published Rust crate.

## What changes are included in this PR?

Adds DataFusion Bloom to the Extensions List as an execution layer and links its repository.

## Are these changes tested?

Yes. The documentation Prettier check, Cargo formatting check, and full all-target/all-feature Clippy check pass.

## Are there any user-facing changes?

Yes. Users can discover the community-maintained DataFusion Bloom extension from the library user guide.