### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install HawkEye
         uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780  # v2.86.1
         with:
-          tool: hawkeye@6.2.0
+          tool: hawkeye
       - name: Run license header check
         run: ci/scripts/license_header.sh
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install HawkEye
         uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780  # v2.86.1
         with:
-          tool: hawkeye
+          tool: hawkeye@7.0.0
       - name: Run license header check
         run: ci/scripts/license_header.sh
 

--- a/benchmarks/compile_profile.py
+++ b/benchmarks/compile_profile.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/benchmarks/lineprotocol.py
+++ b/benchmarks/lineprotocol.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 """ 
 Converts a given json to LineProtocol format that can be 
 visualised by grafana/other systems that support LineProtocol. 

--- a/ci/scripts/license_header.sh
+++ b/ci/scripts/license_header.sh
@@ -63,15 +63,7 @@ fi
 
 if [[ "$MODE" == "write" ]]; then
   echo "[${SCRIPT_NAME}] \`hawkeye format --config ${HAWKEYE_CONFIG}\`"
-  if ! hawkeye format --config "${HAWKEYE_CONFIG}"; then
-    status=$?
-    # hawkeye returns exit code 1 when it applies fixes; treat that as success.
-    if [[ $status -eq 1 ]]; then
-      echo "[${SCRIPT_NAME}] hawkeye format applied fixes (exit 1 treated as success)"
-    else
-      exit $status
-    fi
-  fi
+  hawkeye format --config "${HAWKEYE_CONFIG}"
 else
   echo "[${SCRIPT_NAME}] \`hawkeye check --config ${HAWKEYE_CONFIG}\`"
   hawkeye check --config "${HAWKEYE_CONFIG}"

--- a/docs/scripts/update_committer_list.py
+++ b/docs/scripts/update_committer_list.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 
 """
 Utility for updating the committer list in the governance documentation

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -15,8 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-headerPath = "Apache-2.0-ASF.txt"
+[header]
+builtin = "Apache-2.0-ASF"
 
+[files]
 includes = [
     "*.rs",
     "*.py",
@@ -25,7 +27,7 @@ includes = [
 
 excludes = [
     # generated code
-    "datafusion/proto/src/generated/",
-    "datafusion/proto-common/src/generated/",
-    "datafusion/proto-models/src/generated/",
+    "datafusion/proto/src/generated/**",
+    "datafusion/proto-common/src/generated/**",
+    "datafusion/proto-models/src/generated/**",
 ]

--- a/test-utils/src/string_gen.rs
+++ b/test-utils/src/string_gen.rs
@@ -1,4 +1,3 @@
-use crate::array_gen::StringArrayGenerator;
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -16,6 +15,7 @@ use crate::array_gen::StringArrayGenerator;
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::array_gen::StringArrayGenerator;
 use crate::stagger_batch;
 use arrow::record_batch::RecordBatch;
 use rand::rngs::StdRng;


### PR DESCRIPTION
## Which issue does this PR close?

N/A — this is a maintenance migration for the license-header tooling.

## Rationale for this change

HawkEye v7 uses a new configuration schema and removes the v6 formatter exit-code behavior. The existing integration would stop working once v7 is installed.

## What changes are included in this PR?

- migrate the HawkEye configuration to v7
- ~~install the latest HawkEye release without pinning the tool version~~
- update the license-header helper for v7 formatter semantics
- normalize the small set of existing headers that v7 recognizes but rewrites canonically

## Are these changes tested?

Yes. The repository license-header script passes with HawkEye v7 (1713 files, 0 changes, 0 conflicts, 0 unsupported). Changed YAML, TOML, Bash, and Python files also passed syntax or formatter checks as applicable.

## Are there any user-facing changes?

No.