### PR TITLE
feat: tests for nan and nulls in percentile and median UDAF

### DIFF
--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -827,6 +827,15 @@ SELECT approx_median(col_f64_nan) FROM median_table
 ----
 NaN
 
+query R
+SELECT percentile_cont(col_f64_nan, 0.5) FROM median_table
+----
+NaN
+
+query R
+SELECT approx_percentile_cont(col_f64_nan, 0.5) FROM median_table
+----
+NaN
 
 # median_i8_overflow_negative
 query R


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #3039.

## Rationale for this change

I recently refined null support for `median` / `percentile_cont` and their approximate counterparts `approx_median, `appprox_percentile_cont`

With the following tests for `NaN` for percentiles, the behaviour of all four functions for `NaN` and nulls is defined and covered by tests in `aggregate.slt`

## What changes are included in this PR?

Missing tests for `NaN` for two functions

## Are these changes tested?

Verified with DuckDB and PostgreSQL

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
