### PR TITLE
bench: add window aggregate filter benchmarks

### DIFF
--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -151,3 +151,7 @@ required-features = ["test_utils"]
 [[bench]]
 harness = false
 name = "bounded_window"
+
+[[bench]]
+harness = false
+name = "window_filter"

--- a/datafusion/physical-plan/benches/window_filter.rs
+++ b/datafusion/physical-plan/benches/window_filter.rs
@@ -192,6 +192,7 @@ fn benchmark_window_case(
     filter_percents: &[usize],
 ) {
     let mut group = c.benchmark_group(format!("window_aggregate_filter/{name}"));
+    group.sample_size(10);
 
     for &filter_percent in filter_percents {
         for &argument_kind in argument_kinds {
@@ -225,12 +226,8 @@ fn window_filter_benchmark(c: &mut Criterion) {
         &runtime,
         "bounded_cumulative",
         &cumulative_frame(),
-        &[
-            ArgumentKind::Column,
-            ArgumentKind::Divide,
-            ArgumentKind::Power,
-        ],
-        &[10, 30, 50],
+        &[ArgumentKind::Column, ArgumentKind::Power],
+        &[30],
     );
     benchmark_window_case(
         c,
@@ -245,8 +242,12 @@ fn window_filter_benchmark(c: &mut Criterion) {
         &runtime,
         "window_whole_partition",
         &whole_partition_frame(),
-        &[ArgumentKind::Column, ArgumentKind::Power],
-        &[30],
+        &[
+            ArgumentKind::Column,
+            ArgumentKind::Divide,
+            ArgumentKind::Power,
+        ],
+        &[10, 30, 50],
     );
 }
 

--- a/datafusion/physical-plan/benches/window_filter.rs
+++ b/datafusion/physical-plan/benches/window_filter.rs
@@ -43,9 +43,13 @@ use datafusion_physical_plan::windows::{
     BoundedWindowAggExec, WindowAggExec, create_window_expr,
 };
 use datafusion_physical_plan::{ExecutionPlan, InputOrderMode, collect};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
 
 const BATCH_SIZE: usize = 8192;
 const NUM_BATCHES: usize = 4;
+const NUM_ROWS: usize = BATCH_SIZE * NUM_BATCHES;
 
 #[derive(Clone, Copy)]
 enum ArgumentKind {
@@ -72,22 +76,23 @@ fn schema() -> SchemaRef {
     ]))
 }
 
+fn make_filter_mask(filter_percent: usize) -> Vec<bool> {
+    let selected_rows = NUM_ROWS * filter_percent / 100;
+    let mut mask = vec![false; NUM_ROWS];
+    mask[..selected_rows].fill(true);
+    mask.shuffle(&mut StdRng::seed_from_u64(42));
+    mask
+}
+
 fn make_batches(filter_percent: Option<usize>) -> Vec<RecordBatch> {
+    let include = make_filter_mask(filter_percent.unwrap_or(100));
     (0..NUM_BATCHES)
         .map(|batch_index| {
             let start = batch_index * BATCH_SIZE;
             let end = start + BATCH_SIZE;
             let id = UInt64Array::from_iter_values((start..end).map(|i| i as u64));
             let value = Float64Array::from_iter_values((start..end).map(|i| i as f64));
-            let include = BooleanArray::from(
-                (start..end)
-                    .map(|i| {
-                        filter_percent
-                            .map(|percent| (i * percent) % 100 < percent)
-                            .unwrap_or(true)
-                    })
-                    .collect::<Vec<_>>(),
-            );
+            let include = BooleanArray::from(include[start..end].to_vec());
 
             RecordBatch::try_new(
                 schema(),
@@ -202,19 +207,18 @@ fn benchmark_window_case(
     let mut group = c.benchmark_group(format!("window_aggregate_filter/{name}"));
     group.sample_size(sample_size);
 
-    let plan = make_window_plan(None, ArgumentKind::Column, window_frame.clone());
-    let task_ctx = Arc::new(TaskContext::default());
-    group.bench_function(
-        BenchmarkId::new(ArgumentKind::Column.name(), "no_filter"),
-        |b| {
+    for &argument_kind in argument_kinds {
+        let plan = make_window_plan(None, argument_kind, window_frame.clone());
+        let task_ctx = Arc::new(TaskContext::default());
+        group.bench_function(BenchmarkId::new(argument_kind.name(), "no_filter"), |b| {
             b.iter(|| {
                 let batches = runtime
                     .block_on(collect(Arc::clone(&plan), Arc::clone(&task_ctx)))
                     .unwrap();
                 black_box(batches);
             })
-        },
-    );
+        });
+    }
 
     for &filter_percent in filter_percents {
         for &argument_kind in argument_kinds {

--- a/datafusion/physical-plan/benches/window_filter.rs
+++ b/datafusion/physical-plan/benches/window_filter.rs
@@ -50,6 +50,7 @@ use rand::seq::SliceRandom;
 const BATCH_SIZE: usize = 8192;
 const NUM_BATCHES: usize = 4;
 const NUM_ROWS: usize = BATCH_SIZE * NUM_BATCHES;
+const FILTER_CASES: &[Option<usize>] = &[None, Some(10), Some(30), Some(50)];
 
 #[derive(Clone, Copy)]
 enum ArgumentKind {
@@ -201,38 +202,22 @@ fn benchmark_window_case(
     name: &str,
     window_frame: &WindowFrame,
     argument_kinds: &[ArgumentKind],
-    filter_percents: &[usize],
     sample_size: usize,
 ) {
     let mut group = c.benchmark_group(format!("window_aggregate_filter/{name}"));
     group.sample_size(sample_size);
 
     for &argument_kind in argument_kinds {
-        let plan = make_window_plan(None, argument_kind, window_frame.clone());
-        let task_ctx = Arc::new(TaskContext::default());
-        group.bench_function(BenchmarkId::new(argument_kind.name(), "no_filter"), |b| {
-            b.iter(|| {
-                let batches = runtime
-                    .block_on(collect(Arc::clone(&plan), Arc::clone(&task_ctx)))
-                    .unwrap();
-                black_box(batches);
-            })
-        });
-    }
-
-    for &filter_percent in filter_percents {
-        for &argument_kind in argument_kinds {
-            let plan = make_window_plan(
-                Some(filter_percent),
-                argument_kind,
-                window_frame.clone(),
-            );
+        for &filter_percent in FILTER_CASES {
+            let case_name = match filter_percent {
+                None => "no_filter".to_string(),
+                Some(percent) => format!("{percent}_percent"),
+            };
+            let plan =
+                make_window_plan(filter_percent, argument_kind, window_frame.clone());
             let task_ctx = Arc::new(TaskContext::default());
             group.bench_function(
-                BenchmarkId::new(
-                    argument_kind.name(),
-                    format!("{filter_percent}_percent"),
-                ),
+                BenchmarkId::new(argument_kind.name(), case_name),
                 |b| {
                     b.iter(|| {
                         let batches = runtime
@@ -260,7 +245,6 @@ fn window_filter_benchmark(c: &mut Criterion) {
             ArgumentKind::Divide,
             ArgumentKind::Power,
         ],
-        &[10, 30, 50],
         10,
     );
     benchmark_window_case(
@@ -273,7 +257,6 @@ fn window_filter_benchmark(c: &mut Criterion) {
             ArgumentKind::Divide,
             ArgumentKind::Power,
         ],
-        &[10, 30, 50],
         10,
     );
     benchmark_window_case(
@@ -286,7 +269,6 @@ fn window_filter_benchmark(c: &mut Criterion) {
             ArgumentKind::Divide,
             ArgumentKind::Power,
         ],
-        &[10, 30, 50],
         100,
     );
 }

--- a/datafusion/physical-plan/benches/window_filter.rs
+++ b/datafusion/physical-plan/benches/window_filter.rs
@@ -190,9 +190,10 @@ fn benchmark_window_case(
     window_frame: &WindowFrame,
     argument_kinds: &[ArgumentKind],
     filter_percents: &[usize],
+    sample_size: usize,
 ) {
     let mut group = c.benchmark_group(format!("window_aggregate_filter/{name}"));
-    group.sample_size(10);
+    group.sample_size(sample_size);
 
     for &filter_percent in filter_percents {
         for &argument_kind in argument_kinds {
@@ -226,8 +227,13 @@ fn window_filter_benchmark(c: &mut Criterion) {
         &runtime,
         "bounded_cumulative",
         &cumulative_frame(),
-        &[ArgumentKind::Column, ArgumentKind::Power],
-        &[30],
+        &[
+            ArgumentKind::Column,
+            ArgumentKind::Divide,
+            ArgumentKind::Power,
+        ],
+        &[10, 30, 50],
+        10,
     );
     benchmark_window_case(
         c,
@@ -236,6 +242,7 @@ fn window_filter_benchmark(c: &mut Criterion) {
         &sliding_frame(),
         &[ArgumentKind::Column, ArgumentKind::Power],
         &[30],
+        10,
     );
     benchmark_window_case(
         c,
@@ -248,6 +255,7 @@ fn window_filter_benchmark(c: &mut Criterion) {
             ArgumentKind::Power,
         ],
         &[10, 30, 50],
+        100,
     );
 }
 

--- a/datafusion/physical-plan/benches/window_filter.rs
+++ b/datafusion/physical-plan/benches/window_filter.rs
@@ -1,0 +1,254 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Microbenchmark for window aggregates with `FILTER`. The benchmark uses
+//! pre-ordered input to exclude sorting and query planning, but executes the
+//! physical window plan so both stateful and whole-partition evaluation paths
+//! are represented.
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arrow::array::{BooleanArray, Float64Array, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion_common::{ScalarValue, config::ConfigOptions};
+use datafusion_execution::TaskContext;
+use datafusion_expr::{
+    Operator, WindowFrame, WindowFrameBound, WindowFrameUnits, WindowFunctionDefinition,
+};
+use datafusion_functions::math::power;
+use datafusion_functions_aggregate::sum::sum_udaf;
+use datafusion_physical_expr::expressions::{BinaryExpr, col, lit};
+use datafusion_physical_expr::{
+    LexOrdering, PhysicalExpr, PhysicalSortExpr, ScalarFunctionExpr,
+};
+use datafusion_physical_plan::test::TestMemoryExec;
+use datafusion_physical_plan::windows::{
+    BoundedWindowAggExec, WindowAggExec, create_window_expr,
+};
+use datafusion_physical_plan::{ExecutionPlan, InputOrderMode, collect};
+
+const BATCH_SIZE: usize = 8192;
+const NUM_BATCHES: usize = 4;
+
+#[derive(Clone, Copy)]
+enum ArgumentKind {
+    Column,
+    Divide,
+    Power,
+}
+
+impl ArgumentKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Column => "column",
+            Self::Divide => "divide",
+            Self::Power => "power_udf",
+        }
+    }
+}
+
+fn schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::UInt64, false),
+        Field::new("value", DataType::Float64, false),
+        Field::new("include", DataType::Boolean, false),
+    ]))
+}
+
+fn make_batches(filter_percent: usize) -> Vec<RecordBatch> {
+    (0..NUM_BATCHES)
+        .map(|batch_index| {
+            let start = batch_index * BATCH_SIZE;
+            let end = start + BATCH_SIZE;
+            let id = UInt64Array::from_iter_values((start..end).map(|i| i as u64));
+            let value = Float64Array::from_iter_values((start..end).map(|i| i as f64));
+            let include = BooleanArray::from(
+                (start..end)
+                    .map(|i| (i * filter_percent) % 100 < filter_percent)
+                    .collect::<Vec<_>>(),
+            );
+
+            RecordBatch::try_new(
+                schema(),
+                vec![Arc::new(id), Arc::new(value), Arc::new(include)],
+            )
+            .unwrap()
+        })
+        .collect()
+}
+
+fn window_argument(kind: ArgumentKind, schema: &Schema) -> Arc<dyn PhysicalExpr> {
+    let column = col("value", schema).unwrap();
+    match kind {
+        ArgumentKind::Column => column,
+        ArgumentKind::Divide => {
+            Arc::new(BinaryExpr::new(column, Operator::Divide, lit(10.0_f64)))
+        }
+        ArgumentKind::Power => Arc::new(
+            ScalarFunctionExpr::try_new(
+                power(),
+                vec![column, lit(1.5_f64)],
+                schema,
+                Arc::new(ConfigOptions::default()),
+            )
+            .unwrap(),
+        ),
+    }
+}
+
+fn cumulative_frame() -> WindowFrame {
+    WindowFrame::new_bounds(
+        WindowFrameUnits::Rows,
+        WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+        WindowFrameBound::CurrentRow,
+    )
+}
+
+fn sliding_frame() -> WindowFrame {
+    WindowFrame::new_bounds(
+        WindowFrameUnits::Rows,
+        WindowFrameBound::Preceding(ScalarValue::UInt64(Some(10))),
+        WindowFrameBound::CurrentRow,
+    )
+}
+
+fn whole_partition_frame() -> WindowFrame {
+    WindowFrame::new_bounds(
+        WindowFrameUnits::Rows,
+        WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+        WindowFrameBound::Following(ScalarValue::UInt64(None)),
+    )
+}
+
+fn make_window_plan(
+    filter_percent: usize,
+    argument_kind: ArgumentKind,
+    window_frame: WindowFrame,
+) -> Arc<dyn ExecutionPlan> {
+    let schema = schema();
+    let order_by = vec![PhysicalSortExpr {
+        expr: col("id", &schema).unwrap(),
+        options: Default::default(),
+    }];
+    let window_expr = create_window_expr(
+        &WindowFunctionDefinition::AggregateUDF(sum_udaf()),
+        format!("sum({}) FILTER (WHERE include)", argument_kind.name()),
+        &[window_argument(argument_kind, &schema)],
+        &[],
+        &order_by,
+        Arc::new(window_frame),
+        Arc::clone(&schema),
+        false,
+        false,
+        Some(col("include", &schema).unwrap()),
+    )
+    .unwrap();
+
+    let source = TestMemoryExec::try_new(&[make_batches(filter_percent)], schema, None)
+        .unwrap()
+        .try_with_sort_information(LexOrdering::new(order_by).into_iter().collect())
+        .unwrap();
+    let input: Arc<dyn ExecutionPlan> =
+        Arc::new(TestMemoryExec::update_cache(&Arc::new(source)));
+
+    if window_expr.uses_bounded_memory() {
+        Arc::new(
+            BoundedWindowAggExec::try_new(
+                vec![window_expr],
+                input,
+                InputOrderMode::Sorted,
+                false,
+            )
+            .unwrap(),
+        )
+    } else {
+        Arc::new(WindowAggExec::try_new(vec![window_expr], input, false).unwrap())
+    }
+}
+
+fn benchmark_window_case(
+    c: &mut Criterion,
+    runtime: &tokio::runtime::Runtime,
+    name: &str,
+    window_frame: &WindowFrame,
+    argument_kinds: &[ArgumentKind],
+    filter_percents: &[usize],
+) {
+    let mut group = c.benchmark_group(format!("window_aggregate_filter/{name}"));
+
+    for &filter_percent in filter_percents {
+        for &argument_kind in argument_kinds {
+            let plan =
+                make_window_plan(filter_percent, argument_kind, window_frame.clone());
+            let task_ctx = Arc::new(TaskContext::default());
+            group.bench_function(
+                BenchmarkId::new(
+                    argument_kind.name(),
+                    format!("{filter_percent}_percent"),
+                ),
+                |b| {
+                    b.iter(|| {
+                        let batches = runtime
+                            .block_on(collect(Arc::clone(&plan), Arc::clone(&task_ctx)))
+                            .unwrap();
+                        black_box(batches);
+                    })
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn window_filter_benchmark(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    benchmark_window_case(
+        c,
+        &runtime,
+        "bounded_cumulative",
+        &cumulative_frame(),
+        &[
+            ArgumentKind::Column,
+            ArgumentKind::Divide,
+            ArgumentKind::Power,
+        ],
+        &[10, 30, 50],
+    );
+    benchmark_window_case(
+        c,
+        &runtime,
+        "bounded_sliding_10_rows",
+        &sliding_frame(),
+        &[ArgumentKind::Column, ArgumentKind::Power],
+        &[30],
+    );
+    benchmark_window_case(
+        c,
+        &runtime,
+        "window_whole_partition",
+        &whole_partition_frame(),
+        &[ArgumentKind::Column, ArgumentKind::Power],
+        &[30],
+    );
+}
+
+criterion_group!(benches, window_filter_benchmark);
+criterion_main!(benches);

--- a/datafusion/physical-plan/benches/window_filter.rs
+++ b/datafusion/physical-plan/benches/window_filter.rs
@@ -72,7 +72,7 @@ fn schema() -> SchemaRef {
     ]))
 }
 
-fn make_batches(filter_percent: usize) -> Vec<RecordBatch> {
+fn make_batches(filter_percent: Option<usize>) -> Vec<RecordBatch> {
     (0..NUM_BATCHES)
         .map(|batch_index| {
             let start = batch_index * BATCH_SIZE;
@@ -81,7 +81,11 @@ fn make_batches(filter_percent: usize) -> Vec<RecordBatch> {
             let value = Float64Array::from_iter_values((start..end).map(|i| i as f64));
             let include = BooleanArray::from(
                 (start..end)
-                    .map(|i| (i * filter_percent) % 100 < filter_percent)
+                    .map(|i| {
+                        filter_percent
+                            .map(|percent| (i * percent) % 100 < percent)
+                            .unwrap_or(true)
+                    })
                     .collect::<Vec<_>>(),
             );
 
@@ -138,7 +142,7 @@ fn whole_partition_frame() -> WindowFrame {
 }
 
 fn make_window_plan(
-    filter_percent: usize,
+    filter_percent: Option<usize>,
     argument_kind: ArgumentKind,
     window_frame: WindowFrame,
 ) -> Arc<dyn ExecutionPlan> {
@@ -149,7 +153,10 @@ fn make_window_plan(
     }];
     let window_expr = create_window_expr(
         &WindowFunctionDefinition::AggregateUDF(sum_udaf()),
-        format!("sum({}) FILTER (WHERE include)", argument_kind.name()),
+        match filter_percent {
+            Some(_) => format!("sum({}) FILTER (WHERE include)", argument_kind.name()),
+            None => format!("sum({})", argument_kind.name()),
+        },
         &[window_argument(argument_kind, &schema)],
         &[],
         &order_by,
@@ -157,7 +164,7 @@ fn make_window_plan(
         Arc::clone(&schema),
         false,
         false,
-        Some(col("include", &schema).unwrap()),
+        filter_percent.map(|_| col("include", &schema).unwrap()),
     )
     .unwrap();
 
@@ -195,10 +202,27 @@ fn benchmark_window_case(
     let mut group = c.benchmark_group(format!("window_aggregate_filter/{name}"));
     group.sample_size(sample_size);
 
+    let plan = make_window_plan(None, ArgumentKind::Column, window_frame.clone());
+    let task_ctx = Arc::new(TaskContext::default());
+    group.bench_function(
+        BenchmarkId::new(ArgumentKind::Column.name(), "no_filter"),
+        |b| {
+            b.iter(|| {
+                let batches = runtime
+                    .block_on(collect(Arc::clone(&plan), Arc::clone(&task_ctx)))
+                    .unwrap();
+                black_box(batches);
+            })
+        },
+    );
+
     for &filter_percent in filter_percents {
         for &argument_kind in argument_kinds {
-            let plan =
-                make_window_plan(filter_percent, argument_kind, window_frame.clone());
+            let plan = make_window_plan(
+                Some(filter_percent),
+                argument_kind,
+                window_frame.clone(),
+            );
             let task_ctx = Arc::new(TaskContext::default());
             group.bench_function(
                 BenchmarkId::new(
@@ -240,8 +264,12 @@ fn window_filter_benchmark(c: &mut Criterion) {
         &runtime,
         "bounded_sliding_10_rows",
         &sliding_frame(),
-        &[ArgumentKind::Column, ArgumentKind::Power],
-        &[30],
+        &[
+            ArgumentKind::Column,
+            ArgumentKind::Divide,
+            ArgumentKind::Power,
+        ],
+        &[10, 30, 50],
         10,
     );
     benchmark_window_case(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Refs #24508.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

Add benchmark coverage for evaluating the performance impact of the window aggregate filter argument evaluation changes in #24508.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a Criterion benchmark for window aggregates with `FILTER` over pre-ordered input.

It covers:

- Cumulative and sliding frames through `BoundedWindowAggExec`.
- Whole-partition frames through `WindowAggExec`.
- Column, division, and `power` arguments.
- Different representative `FILTER` selectivities.

This PR only adds benchmark coverage and does not change behavior.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

No.