### PR TITLE
fix: don't allow zero-argument first_value/last_value/nth_value window functions

### DIFF
--- a/datafusion/functions-window/src/nth_value.rs
+++ b/datafusion/functions-window/src/nth_value.rs
@@ -98,11 +98,7 @@ impl NthValue {
     pub fn new(kind: NthValueKind) -> Self {
         Self {
             signature: Signature::one_of(
-                vec![
-                    TypeSignature::Nullary,
-                    TypeSignature::Any(1),
-                    TypeSignature::Any(2),
-                ],
+                vec![TypeSignature::Any(1), TypeSignature::Any(2)],
                 Volatility::Immutable,
             ),
             kind,
@@ -272,6 +268,10 @@ impl WindowUDFImpl for NthValue {
         &self,
         partition_evaluator_args: PartitionEvaluatorArgs,
     ) -> Result<Box<dyn PartitionEvaluator>> {
+        if partition_evaluator_args.input_exprs().is_empty() {
+            return exec_err!("{} requires at least one argument", self.kind.name());
+        }
+
         let state = NthValueState {
             finalized_result: None,
             kind: self.kind,
@@ -690,5 +690,23 @@ mod tests {
         assert!(err.to_string().starts_with(
             "Execution error: The second argument of nth_value must not be i64::MIN"
         ));
+    }
+
+    #[test]
+    fn zero_arguments_returns_error() {
+        let err = NthValue::first()
+            .partition_evaluator(PartitionEvaluatorArgs::new(
+                &[],
+                &[Field::new("f", DataType::Int32, true).into()],
+                false,
+                false,
+            ))
+            .unwrap_err();
+
+        assert!(
+            err.to_string().starts_with(
+                "Execution error: first_value requires at least one argument"
+            )
+        );
     }
 }

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -7014,3 +7014,12 @@ ORDER BY x
 false 3
 true 2
 true 2
+
+statement error DataFusion error: Error during planning: 'first_value' does not support zero arguments
+SELECT first_value() OVER () FROM (VALUES (1), (2), (3)) t(x)
+
+statement error DataFusion error: Error during planning: 'last_value' does not support zero arguments
+SELECT last_value() OVER () FROM (VALUES (1), (2), (3)) t(x)
+
+statement error DataFusion error: Error during planning: 'nth_value' does not support zero arguments
+SELECT nth_value() OVER () FROM (VALUES (1), (2), (3)) t(x)


### PR DESCRIPTION
Which issue does this PR close?

- None

Rationale for this change

select first_value() over () from ... panics the whole process instead of returning a query error (index out of bounds in nth_value.rs). last_value()/nth_value() do the same. In an embedding application this takes down the whole process, not just the one query. An exemplary query is `select first_value() over () from (values (1), (2), (3)) as t(x);`.

Before the UDWF conversion in #13201, these functions had exact arity (1 arg for first/last, 2 for nth) and a zero-argument call was rejected during planning. The conversion added TypeSignature::Nullary to the signature, letting first_value() pass type checking and reach the evaluator, which unconditionally indexes values[0].

What changes are included in this PR?

- Remove Nullary from the signature in nth_value.rs, restoring the pre-#13201 arity (matches lead/lag, which never had it). DataFusion's generic argument-count check now rejects first_value() during planning.
- Validate argument count in partition_evaluator() too, matching the early-validation call in create_udwf_window_expr (physical-plan/src/windows/mod.rs).

Are these changes tested?

Manually verified first_value()/last_value()/nth_value() (with/without ORDER BY) now fail cleanly at planning instead of panicking, and existing unit + window.slt tests still pass.

Are there any user-facing changes?

Zero-argument calls now error instead of panicking. No valid query is affected.