### PR TITLE
chore: replace MaybeNullBuilder with trait over arrow NullBuilder

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use crate::aggregates::group_values::multi_group_by::Nulls;
 use crate::aggregates::group_values::multi_group_by::{GroupColumn, nulls_equal_to};
-use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
+use crate::aggregates::group_values::null_builder::NullBufferBuilderExt;
 use arrow::array::{
     Array as _, ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder, NullBufferBuilder,
 };

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use crate::aggregates::group_values::multi_group_by::Nulls;
 use crate::aggregates::group_values::multi_group_by::{GroupColumn, nulls_equal_to};
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{Array as _, ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder};
+use arrow::array::{Array as _, ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder, NullBufferBuilder};
 use datafusion_common::Result;
 
 /// An implementation of [`GroupColumn`] for booleans
@@ -33,7 +33,7 @@ use datafusion_common::Result;
 #[derive(Debug)]
 pub struct BooleanGroupValueBuilder<const NULLABLE: bool> {
     buffer: BooleanBufferBuilder,
-    nulls: MaybeNullBufferBuilder,
+    nulls: NullBufferBuilder,
 }
 
 impl<const NULLABLE: bool> BooleanGroupValueBuilder<NULLABLE> {
@@ -41,7 +41,7 @@ impl<const NULLABLE: bool> BooleanGroupValueBuilder<NULLABLE> {
     pub fn new() -> Self {
         Self {
             buffer: BooleanBufferBuilder::new(0),
-            nulls: MaybeNullBufferBuilder::new(),
+            nulls: NullBufferBuilder::empty(),
         }
     }
 }
@@ -62,10 +62,10 @@ impl<const NULLABLE: bool> GroupColumn for BooleanGroupValueBuilder<NULLABLE> {
     fn append_val(&mut self, array: &ArrayRef, row: usize) -> Result<()> {
         if NULLABLE {
             if array.is_null(row) {
-                self.nulls.append(true);
+                self.nulls.append_null();
                 self.buffer.append(bool::default());
             } else {
-                self.nulls.append(false);
+                self.nulls.append_non_null();
                 self.buffer.append(array.as_boolean().value(row));
             }
         } else {
@@ -125,24 +125,24 @@ impl<const NULLABLE: bool> GroupColumn for BooleanGroupValueBuilder<NULLABLE> {
             (true, Nulls::Some) => {
                 for &row in rows {
                     if array.is_null(row) {
-                        self.nulls.append(true);
+                        self.nulls.append_null();
                         self.buffer.append(bool::default());
                     } else {
-                        self.nulls.append(false);
+                        self.nulls.append_non_null();
                         self.buffer.append(arr.value(row));
                     }
                 }
             }
 
             (true, Nulls::None) => {
-                self.nulls.append_n(rows.len(), false);
+                self.nulls.append_n_non_nulls(rows.len());
                 for &row in rows {
                     self.buffer.append(arr.value(row));
                 }
             }
 
             (true, Nulls::All) => {
-                self.nulls.append_n(rows.len(), true);
+                self.nulls.append_n_nulls(rows.len());
                 self.buffer.append_n(rows.len(), bool::default());
             }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 use crate::aggregates::group_values::multi_group_by::Nulls;
 use crate::aggregates::group_values::multi_group_by::{GroupColumn, nulls_equal_to};
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{Array as _, ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder, NullBufferBuilder};
+use arrow::array::{
+    Array as _, ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder, NullBufferBuilder,
+};
 use datafusion_common::Result;
 
 /// An implementation of [`GroupColumn`] for booleans

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
@@ -19,10 +19,7 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{
-    Array, ArrayRef, AsArray, BooleanBufferBuilder, BufferBuilder, GenericBinaryArray,
-    GenericByteArray, GenericStringArray, OffsetSizeTrait, types::GenericStringType,
-};
+use arrow::array::{types::GenericStringType, Array, ArrayRef, AsArray, BooleanBufferBuilder, BufferBuilder, GenericBinaryArray, GenericByteArray, GenericStringArray, NullBufferBuilder, OffsetSizeTrait};
 use arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{ByteArrayType, DataType, GenericBinaryType};
 use datafusion_common::utils::proxy::VecAllocExt;
@@ -52,7 +49,7 @@ where
     /// are stored as a zero length string.
     offsets: Vec<O>,
     /// Nulls
-    nulls: MaybeNullBufferBuilder,
+    nulls: NullBufferBuilder,
     /// The maximum size of the buffer for `0`
     max_buffer_size: usize,
 }
@@ -66,7 +63,7 @@ where
             output_type,
             buffer: BufferBuilder::new(INITIAL_BUFFER_CAPACITY),
             offsets: vec![O::default()],
-            nulls: MaybeNullBufferBuilder::new(),
+            nulls: NullBufferBuilder::empty(),
             max_buffer_size: if O::IS_LARGE {
                 i64::MAX as usize
             } else {
@@ -89,12 +86,12 @@ where
     {
         let arr = array.as_bytes::<B>();
         if arr.is_null(row) {
-            self.nulls.append(true);
+            self.nulls.append_null();
             // nulls need a zero length in the offset buffer
             let offset = self.buffer.len();
             self.offsets.push(O::usize_as(offset));
         } else {
-            self.nulls.append(false);
+            self.nulls.append_non_null();
             self.do_append_val_inner(arr, row)?;
         }
 
@@ -152,14 +149,14 @@ where
             }
 
             Nulls::None => {
-                self.nulls.append_n(rows.len(), false);
+                self.nulls.append_n_non_nulls(rows.len());
                 for &row in rows {
                     self.do_append_val_inner(arr, row)?;
                 }
             }
 
             Nulls::All => {
-                self.nulls.append_n(rows.len(), true);
+                self.nulls.append_n_nulls(rows.len());
 
                 let new_len = self.offsets.len() + rows.len();
                 let offset = self.buffer.len();

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
@@ -19,7 +19,11 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{types::GenericStringType, Array, ArrayRef, AsArray, BooleanBufferBuilder, BufferBuilder, GenericBinaryArray, GenericByteArray, GenericStringArray, NullBufferBuilder, OffsetSizeTrait};
+use arrow::array::{
+    Array, ArrayRef, AsArray, BooleanBufferBuilder, BufferBuilder, GenericBinaryArray,
+    GenericByteArray, GenericStringArray, NullBufferBuilder, OffsetSizeTrait,
+    types::GenericStringType,
+};
 use arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{ByteArrayType, DataType, GenericBinaryType};
 use datafusion_common::utils::proxy::VecAllocExt;

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
@@ -18,7 +18,7 @@
 use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
-use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
+use crate::aggregates::group_values::null_builder::NullBufferBuilderExt;
 use arrow::array::{
     Array, ArrayRef, AsArray, BooleanBufferBuilder, BufferBuilder, GenericBinaryArray,
     GenericByteArray, GenericStringArray, NullBufferBuilder, OffsetSizeTrait,

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -19,9 +19,7 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{
-    Array, ArrayRef, AsArray, BooleanBufferBuilder, ByteView, GenericByteViewArray,
-};
+use arrow::array::{Array, ArrayRef, AsArray, BooleanBufferBuilder, ByteView, GenericByteViewArray, NullBufferBuilder};
 use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::ByteViewType;
 use datafusion_common::Result;
@@ -69,7 +67,7 @@ pub struct ByteViewGroupValueBuilder<B: ByteViewType> {
     max_block_size: usize,
 
     /// Nulls
-    nulls: MaybeNullBufferBuilder,
+    nulls: NullBufferBuilder,
 
     /// phantom data so the type requires `<B>`
     _phantom: PhantomData<B>,
@@ -88,7 +86,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             in_progress: Vec::new(),
             completed: Vec::new(),
             max_block_size: BYTE_VIEW_MAX_BLOCK_SIZE,
-            nulls: MaybeNullBufferBuilder::new(),
+            nulls: NullBufferBuilder::empty(),
             _phantom: PhantomData {},
         }
     }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -18,7 +18,7 @@
 use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
-use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
+use crate::aggregates::group_values::null_builder::NullBufferBuilderExt;
 use arrow::array::{
     Array, ArrayRef, AsArray, BooleanBufferBuilder, ByteView, GenericByteViewArray,
     NullBufferBuilder,

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -19,7 +19,10 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{Array, ArrayRef, AsArray, BooleanBufferBuilder, ByteView, GenericByteViewArray, NullBufferBuilder};
+use arrow::array::{
+    Array, ArrayRef, AsArray, BooleanBufferBuilder, ByteView, GenericByteViewArray,
+    NullBufferBuilder,
+};
 use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::ByteViewType;
 use datafusion_common::Result;

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -108,13 +108,13 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
 
         // Null row case, set and return
         if arr.is_null(row) {
-            self.nulls.append(true);
+            self.nulls.append_null();
             self.views.push(0);
             return;
         }
 
         // Not null row case
-        self.nulls.append(false);
+        self.nulls.append_non_null();
         self.do_append_val_inner(arr, row);
     }
 
@@ -166,7 +166,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             }
 
             Nulls::None => {
-                self.nulls.append_n(rows.len(), false);
+                self.nulls.append_n_non_nulls(rows.len());
                 if arr.data_buffers().is_empty() {
                     // Fast path: all strings are inline (≤12 bytes).
                     // The input array's u128 views are already in the correct format;
@@ -189,7 +189,7 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
             }
 
             Nulls::All => {
-                self.nulls.append_n(rows.len(), true);
+                self.nulls.append_n_nulls(rows.len());
                 let new_len = self.views.len() + rows.len();
                 self.views.resize(new_len, 0);
             }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/fixed_size_binary.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/fixed_size_binary.rs
@@ -19,7 +19,10 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{Array, ArrayRef, AsArray, BooleanBufferBuilder, FixedSizeBinaryArray, NullBufferBuilder};
+use arrow::array::{
+    Array, ArrayRef, AsArray, BooleanBufferBuilder, FixedSizeBinaryArray,
+    NullBufferBuilder,
+};
 use arrow::buffer::{Buffer, NullBuffer};
 use datafusion_common::utils::proxy::VecAllocExt;
 use datafusion_common::utils::split_vec_min_alloc;

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/fixed_size_binary.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/fixed_size_binary.rs
@@ -18,7 +18,7 @@
 use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
-use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
+use crate::aggregates::group_values::null_builder::NullBufferBuilderExt;
 use arrow::array::{
     Array, ArrayRef, AsArray, BooleanBufferBuilder, FixedSizeBinaryArray,
     NullBufferBuilder,

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/fixed_size_binary.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/fixed_size_binary.rs
@@ -19,9 +19,7 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{
-    Array, ArrayRef, AsArray, BooleanBufferBuilder, FixedSizeBinaryArray,
-};
+use arrow::array::{Array, ArrayRef, AsArray, BooleanBufferBuilder, FixedSizeBinaryArray, NullBufferBuilder};
 use arrow::buffer::{Buffer, NullBuffer};
 use datafusion_common::utils::proxy::VecAllocExt;
 use datafusion_common::utils::split_vec_min_alloc;
@@ -50,7 +48,7 @@ pub struct FixedSizeBinaryGroupValueBuilder {
     /// `byte_width` may be `0`
     len: usize,
     /// Null state (null rows still occupy `byte_width` bytes in `buffer`)
-    nulls: MaybeNullBufferBuilder,
+    nulls: NullBufferBuilder,
 }
 
 impl FixedSizeBinaryGroupValueBuilder {
@@ -65,18 +63,18 @@ impl FixedSizeBinaryGroupValueBuilder {
             byte_width: byte_width as usize,
             buffer: Vec::new(),
             len: 0,
-            nulls: MaybeNullBufferBuilder::new(),
+            nulls: NullBufferBuilder::empty(),
         }
     }
 
     fn do_append_val_inner(&mut self, array: &FixedSizeBinaryArray, row: usize) {
         if array.is_null(row) {
-            self.nulls.append(true);
+            self.nulls.append_null();
             // Null rows still occupy `byte_width` (zeroed) bytes in the
             // buffer so the value offset stays a function of the row index
             self.buffer.resize(self.buffer.len() + self.byte_width, 0);
         } else {
-            self.nulls.append(false);
+            self.nulls.append_non_null();
             self.buffer.extend_from_slice(array.value(row));
         }
         self.len += 1;
@@ -187,7 +185,7 @@ impl GroupColumn for FixedSizeBinaryGroupValueBuilder {
             }
 
             Nulls::None => {
-                self.nulls.append_n(rows.len(), false);
+                self.nulls.append_n_non_nulls(rows.len());
                 for &row in rows {
                     self.buffer.extend_from_slice(arr.value(row));
                 }
@@ -195,7 +193,7 @@ impl GroupColumn for FixedSizeBinaryGroupValueBuilder {
             }
 
             Nulls::All => {
-                self.nulls.append_n(rows.len(), true);
+                self.nulls.append_n_nulls(rows.len());
                 self.buffer
                     .resize(self.buffer.len() + rows.len() * self.byte_width, 0);
                 self.len += rows.len();

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -19,7 +19,7 @@ use crate::aggregates::group_values::HashValue;
 use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
-use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
+use crate::aggregates::group_values::null_builder::NullBufferBuilderExt;
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, BooleanBufferBuilder, PrimitiveArray,
     cast::AsArray,

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -20,11 +20,11 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::{ArrowNativeTypeOp, NullBufferBuilder};
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, BooleanBufferBuilder, PrimitiveArray,
     cast::AsArray,
 };
+use arrow::array::{ArrowNativeTypeOp, NullBufferBuilder};
 use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::DataType;
 use arrow::util::bit_util::apply_bitwise_binary_op;

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -20,7 +20,7 @@ use crate::aggregates::group_values::multi_group_by::{
     GroupColumn, Nulls, nulls_equal_to,
 };
 use crate::aggregates::group_values::null_builder::MaybeNullBufferBuilder;
-use arrow::array::ArrowNativeTypeOp;
+use arrow::array::{ArrowNativeTypeOp, NullBufferBuilder};
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, BooleanBufferBuilder, PrimitiveArray,
     cast::AsArray,
@@ -46,7 +46,7 @@ use std::sync::Arc;
 pub struct PrimitiveGroupValueBuilder<T: ArrowPrimitiveType, const NULLABLE: bool> {
     data_type: DataType,
     group_values: Vec<T::Native>,
-    nulls: MaybeNullBufferBuilder,
+    nulls: NullBufferBuilder,
 }
 
 impl<T, const NULLABLE: bool> PrimitiveGroupValueBuilder<T, NULLABLE>
@@ -59,7 +59,7 @@ where
         Self {
             data_type,
             group_values: vec![],
-            nulls: MaybeNullBufferBuilder::new(),
+            nulls: NullBufferBuilder::empty(),
         }
     }
 
@@ -170,10 +170,10 @@ where
         // Perf: skip null check if input can't have nulls
         if NULLABLE {
             if array.is_null(row) {
-                self.nulls.append(true);
+                self.nulls.append_null();
                 self.group_values.push(T::default_value());
             } else {
-                self.nulls.append(false);
+                self.nulls.append_non_null();
                 self.group_values
                     .push(array.as_primitive::<T>().value(row).canonicalize());
             }
@@ -221,24 +221,24 @@ where
             (true, Nulls::Some) => {
                 for &row in rows {
                     if array.is_null(row) {
-                        self.nulls.append(true);
+                        self.nulls.append_null();
                         self.group_values.push(T::default_value());
                     } else {
-                        self.nulls.append(false);
+                        self.nulls.append_non_null();
                         self.group_values.push(arr.value(row).canonicalize());
                     }
                 }
             }
 
             (true, Nulls::None) => {
-                self.nulls.append_n(rows.len(), false);
+                self.nulls.append_n_non_nulls(rows.len());
                 for &row in rows {
                     self.group_values.push(arr.value(row).canonicalize());
                 }
             }
 
             (true, Nulls::All) => {
-                self.nulls.append_n(rows.len(), true);
+                self.nulls.append_n_nulls(rows.len());
                 self.group_values
                     .extend(iter::repeat_n(T::default_value(), rows.len()));
             }

--- a/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
@@ -19,7 +19,7 @@ use arrow::array::NullBufferBuilder;
 use arrow::buffer::NullBuffer;
 
 /// Helper methods for NullBufferBuilder that are used in Group By columns
-pub(crate) trait MaybeNullBufferBuilder {
+pub(crate) trait NullBufferBuilderExt {
     fn empty() -> Self;
 
     /// Return true if the row at index `row` is null
@@ -36,7 +36,7 @@ pub(crate) trait MaybeNullBufferBuilder {
     fn might_have_nulls(&self) -> bool;
 }
 
-impl MaybeNullBufferBuilder for NullBufferBuilder {
+impl NullBufferBuilderExt for NullBufferBuilder {
     fn empty() -> Self {
         Self::new(0)
     }
@@ -61,10 +61,6 @@ impl MaybeNullBufferBuilder for NullBufferBuilder {
         new_builder.finish()
     }
 
-    /// Returns true if this builder might have any nulls
-    ///
-    /// This is guaranteed to be true if there are nulls
-    /// but may be true even if there are no nulls
     fn might_have_nulls(&self) -> bool {
         self.as_slice().is_some()
     }

--- a/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
@@ -18,19 +18,12 @@
 use arrow::array::NullBufferBuilder;
 use arrow::buffer::NullBuffer;
 
-
-/// Builder for an (optional) null mask
-///
-/// Optimized for avoid creating the bitmask when all values are non-null
+/// Helper methods for NullBufferBuilder that are used in Group By columns
 pub(crate) trait MaybeNullBufferBuilder {
-
     fn empty() -> Self;
 
     /// Return true if the row at index `row` is null
     fn is_null(&self, row: usize) -> bool;
-
-    fn append_n(&mut self, n: usize, is_valid: bool);
-
 
     /// Returns a NullBuffer representing the first `n` rows accumulated so far
     /// shifting any remaining down by `n`
@@ -52,14 +45,6 @@ impl MaybeNullBufferBuilder for NullBufferBuilder {
         !self.is_valid(row)
     }
 
-    fn append_n(&mut self, n: usize, is_valid: bool) {
-        if is_valid {
-            self.append_n_non_nulls(n);
-        } else {
-            self.append_n_nulls(n);
-        }
-    }
-
     fn take_n(&mut self, n: usize) -> Option<NullBuffer> {
         // Copy over the values at  n..len-1 values to the start of a
         // new builder and leave it in self
@@ -69,7 +54,7 @@ impl MaybeNullBufferBuilder for NullBufferBuilder {
         for i in n..self.len() {
             new_builder.append(self.is_valid(i));
         }
-        std::mem::swap(&mut new_builder, &mut self);
+        std::mem::swap(&mut new_builder, self);
 
         // take only first n values from the original builder
         new_builder.truncate(n);

--- a/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
@@ -18,72 +18,58 @@
 use arrow::array::NullBufferBuilder;
 use arrow::buffer::NullBuffer;
 
+
 /// Builder for an (optional) null mask
 ///
 /// Optimized for avoid creating the bitmask when all values are non-null
-#[derive(Debug)]
-pub(crate) struct MaybeNullBufferBuilder {
-    /// Note this is an Arrow *VALIDITY* buffer (so it is false for nulls, true
-    /// for non-nulls)
-    nulls: NullBufferBuilder,
-}
+pub(crate) trait MaybeNullBufferBuilder {
 
-impl MaybeNullBufferBuilder {
-    /// Create a new builder
-    pub fn new() -> Self {
-        Self {
-            nulls: NullBufferBuilder::new(0),
-        }
-    }
+    fn empty() -> Self;
 
     /// Return true if the row at index `row` is null
-    pub fn is_null(&self, row: usize) -> bool {
-        match self.nulls.as_slice() {
-            // validity mask means a unset bit is NULL
-            Some(_) => !self.nulls.is_valid(row),
-            None => false,
-        }
-    }
+    fn is_null(&self, row: usize) -> bool;
 
-    /// Set the nullness of the next row to `is_null`
-    ///
-    /// If `value` is true, the row is null.
-    /// If `value` is false, the row is non null
-    pub fn append(&mut self, is_null: bool) {
-        self.nulls.append(!is_null)
-    }
+    fn append_n(&mut self, n: usize, is_valid: bool);
 
-    pub fn append_n(&mut self, n: usize, is_null: bool) {
-        if is_null {
-            self.nulls.append_n_nulls(n);
-        } else {
-            self.nulls.append_n_non_nulls(n);
-        }
-    }
-
-    /// return the number of heap allocated bytes used by this structure to store boolean values
-    pub fn allocated_size(&self) -> usize {
-        // NullBufferBuilder builder::allocated_size returns capacity in bits
-        self.nulls.allocated_size() / 8
-    }
-
-    /// Return a NullBuffer representing the accumulated nulls so far
-    pub fn build(mut self) -> Option<NullBuffer> {
-        self.nulls.finish()
-    }
 
     /// Returns a NullBuffer representing the first `n` rows accumulated so far
     /// shifting any remaining down by `n`
-    pub fn take_n(&mut self, n: usize) -> Option<NullBuffer> {
+    fn take_n(&mut self, n: usize) -> Option<NullBuffer>;
+
+    /// Returns true if this builder might have any nulls
+    ///
+    /// This is guaranteed to be true if there are nulls
+    /// but may be true even if there are no nulls
+    fn might_have_nulls(&self) -> bool;
+}
+
+impl MaybeNullBufferBuilder for NullBufferBuilder {
+    fn empty() -> Self {
+        Self::new(0)
+    }
+
+    fn is_null(&self, row: usize) -> bool {
+        !self.is_valid(row)
+    }
+
+    fn append_n(&mut self, n: usize, is_valid: bool) {
+        if is_valid {
+            self.append_n_non_nulls(n);
+        } else {
+            self.append_n_nulls(n);
+        }
+    }
+
+    fn take_n(&mut self, n: usize) -> Option<NullBuffer> {
         // Copy over the values at  n..len-1 values to the start of a
         // new builder and leave it in self
         //
         // TODO: it would be great to use something like `set_bits` from arrow here.
-        let mut new_builder = NullBufferBuilder::new(self.nulls.len());
-        for i in n..self.nulls.len() {
-            new_builder.append(self.nulls.is_valid(i));
+        let mut new_builder = NullBufferBuilder::new(self.len());
+        for i in n..self.len() {
+            new_builder.append(self.is_valid(i));
         }
-        std::mem::swap(&mut new_builder, &mut self.nulls);
+        std::mem::swap(&mut new_builder, &mut self);
 
         // take only first n values from the original builder
         new_builder.truncate(n);
@@ -94,7 +80,7 @@ impl MaybeNullBufferBuilder {
     ///
     /// This is guaranteed to be true if there are nulls
     /// but may be true even if there are no nulls
-    pub(crate) fn might_have_nulls(&self) -> bool {
-        self.nulls.as_slice().is_some()
+    fn might_have_nulls(&self) -> bool {
+        self.as_slice().is_some()
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?
None

## Rationale for this change

No need to have a separate struct, this open for bugs like:
- https://github.com/apache/datafusion/pull/24605

this can just be a trait over the arrow NullBufferBuilder

## What changes are included in this PR?

replace MaybeNullBuilder with trait and update usages

## Are these changes tested?
existing tests

## Are there any user-facing changes?
no, the struct was `pub(crate)` and stayed like that