### PR TITLE
docs: add runnable examples for `input_file_name()` and `file_row_index()`

### DIFF
--- a/datafusion/functions/src/core/file_row_index.rs
+++ b/datafusion/functions/src/core/file_row_index.rs
@@ -45,7 +45,16 @@ evaluation returns an error.
 "#,
     syntax_example = "file_row_index()",
     sql_example = r#"```sql
-SELECT file_row_index() FROM t;
+> COPY (SELECT * from values (100), (200), (300)) to '/tmp/foo.parquet';
+
+> select *, input_file_name(), file_row_index() from '/tmp/foo.parquet';
++---------+-------------------+------------------+
+| column1 | input_file_name() | file_row_index() |
++---------+-------------------+------------------+
+| 100     | tmp/foo.parquet   | 0                |
+| 200     | tmp/foo.parquet   | 1                |
+| 300     | tmp/foo.parquet   | 2                |
++---------+-------------------+------------------+
 ```"#
 )]
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/datafusion/functions/src/core/input_file_name.rs
+++ b/datafusion/functions/src/core/input_file_name.rs
@@ -38,7 +38,16 @@ evaluated outside a file scan, or was not pushed down into one), direct evaluati
 "#,
     syntax_example = "input_file_name()",
     sql_example = r#"```sql
-SELECT input_file_name() FROM t;
+> COPY (SELECT * from values (100), (200), (300)) to '/tmp/foo.parquet';
+
+> select *, input_file_name(), file_row_index() from '/tmp/foo.parquet';
++---------+-------------------+------------------+
+| column1 | input_file_name() | file_row_index() |
++---------+-------------------+------------------+
+| 100     | tmp/foo.parquet   | 0                |
+| 200     | tmp/foo.parquet   | 1                |
+| 300     | tmp/foo.parquet   | 2                |
++---------+-------------------+------------------+
 ```"#
 )]
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -5960,7 +5960,16 @@ file_row_index()
 #### Example
 
 ```sql
-SELECT file_row_index() FROM t;
+> COPY (SELECT * from values (100), (200), (300)) to '/tmp/foo.parquet';
+
+> select *, input_file_name(), file_row_index() from '/tmp/foo.parquet';
++---------+-------------------+------------------+
+| column1 | input_file_name() | file_row_index() |
++---------+-------------------+------------------+
+| 100     | tmp/foo.parquet   | 0                |
+| 200     | tmp/foo.parquet   | 1                |
+| 300     | tmp/foo.parquet   | 2                |
++---------+-------------------+------------------+
 ```
 
 ### `get_field`
@@ -6032,7 +6041,16 @@ input_file_name()
 #### Example
 
 ```sql
-SELECT input_file_name() FROM t;
+> COPY (SELECT * from values (100), (200), (300)) to '/tmp/foo.parquet';
+
+> select *, input_file_name(), file_row_index() from '/tmp/foo.parquet';
++---------+-------------------+------------------+
+| column1 | input_file_name() | file_row_index() |
++---------+-------------------+------------------+
+| 100     | tmp/foo.parquet   | 0                |
+| 200     | tmp/foo.parquet   | 1                |
+| 300     | tmp/foo.parquet   | 2                |
++---------+-------------------+------------------+
 ```
 
 ### `try_cast_to_type`


### PR DESCRIPTION
## Which issue does this PR close?

- N/A -- documentation only.


## Rationale for this change

While writing a blog post
- https://github.com/apache/datafusion-site/pull/203

Which mentiones  `file_row_index()` and `input_file_name()` -- I added a simple example for the post and I think it would help to have docs in the main site too. 


## What changes are included in this PR?

Replaces the `sql_example` with

```sql
> COPY (SELECT * from values (100), (200), (300)) to '/tmp/foo.parquet';

> select *, input_file_name(), file_row_index() from '/tmp/foo.parquet';
+---------+-------------------+------------------+
| column1 | input_file_name() | file_row_index() |
+---------+-------------------+------------------+
| 100     | tmp/foo.parquet   | 0                |
| 200     | tmp/foo.parquet   | 1                |
| 300     | tmp/foo.parquet   | 2                |
+---------+-------------------+------------------+
```

The same example is used for both functions, since showing them together is likely common and I think makes it clear what they do

## Are these changes tested?
By CI

## Are there any user-facing changes?

Yes, but documentation only -- the rendered examples for `input_file_name()`
and `file_row_index()` in the SQL function reference. No API or behavior
changes.
