### PR TITLE
docs: Fix rendering of `get_record_batch_memory_size` buffer diagram

### DIFF
--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -131,19 +131,21 @@ pub fn estimate_memory_size<T>(num_elements: usize, fixed_size: usize) -> Result
 /// For a `RecordBatch` with two columns: `col1` and `col2`, two columns are pointing
 /// to a sub-region of the same buffer.
 ///
+/// ```text
 /// {xxxxxxxxxxxxxxxxxxx} <--- buffer
 ///       ^    ^  ^    ^
 ///       |    |  |    |
 /// col1->{    }  |    |
 /// col2--------->{    }
+/// ```
 ///
 /// In the above case, `get_record_batch_memory_size` will return the size of
 /// the buffer, instead of the sum of `col1` and `col2`'s actual memory size.
 ///
-/// Note: Current `RecordBatch`.get_array_memory_size()` will double count the
-/// buffer memory size if multiple arrays within the batch are sharing the same
-/// `Buffer`. This method provides temporary fix until the issue is resolved:
-/// <https://github.com/apache/arrow-rs/issues/6439>
+/// Note: The current [`RecordBatch::get_array_memory_size`] will double count
+/// the buffer memory size if multiple arrays within the batch are sharing the
+/// same `Buffer`. This method provides a temporary fix until the issue is
+/// resolved: <https://github.com/apache/arrow-rs/issues/6439>
 pub fn get_record_batch_memory_size(batch: &RecordBatch) -> usize {
     RecordBatchMemoryCounter::new().count_batch(batch)
 }


### PR DESCRIPTION
## Which issue does this PR close?

- N/A (minor doc fix). Follow on to #24592, which I noticed while reviewing that PR.

## Rationale for this change

The docs for [`get_record_batch_memory_size`](https://docs.rs/datafusion/latest/datafusion/common/utils/memory/fn.get_record_batch_memory_size.html) render poorly on docs.rs:
1. The ASCII-art buffer diagram is not in a code block, so rustdoc collapses it into a single unreadable line
2. A stray backtick in ```Current `RecordBatch`.get_array_memory_size()` will ...``` causes the rest of the paragraph to render as inline code

The diagram currently renders as this single line:

```
{xxxxxxxxxxxxxxxxxxx} <— buffer ^ ^ ^ ^ | | | | col1->{ } | | col2———>{ }
```

<img width="1541" height="871" alt="Screenshot 2026-08-24 at 3 29 49 PM" src="https://github.com/user-attachments/assets/efd24f7e-f6d9-4ac6-aaee-9c2849851c2d" />


## What changes are included in this PR?

- Wrap the diagram in a `text` code fence so it renders as drawn
- Replace the mis-quoted method reference with an intra-doc link to `RecordBatch::get_array_memory_size`

## Are these changes tested?

Yes: `RUSTDOCFLAGS="-D warnings" cargo doc -p datafusion-common --no-deps` passes (this also verifies the new intra-doc link resolves).

## Are there any user-facing changes?

Documentation only.
