### PR TITLE
docs: Document expectations of PartialReduce aggregate mode

### DIFF
--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -358,6 +358,17 @@ pub enum AggregateMode {
     /// This reduces shuffling traffic in a distributed setting. See
     /// <https://github.com/datafusion-contrib/datafusion-distributed/issues/360>
     /// for details.
+    ///
+    /// # Best-Effort Reduction
+    ///
+    /// `PartialReduce` is meant as an optimization: it reduces the volume of
+    /// intermediate state (for example, before sending it over the network),
+    /// and thus its output may not be fully reduced. In particular, an
+    /// implementation may emit partially merged state, or pass its input
+    /// through unchanged (for example, under memory pressure), so the same
+    /// group key may appear in multiple output batches. Consumers must merge
+    /// the output of a `PartialReduce` aggregation exactly as they would
+    /// merge the output of a `Partial` aggregation.
     PartialReduce,
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Related to #22710 and #24486
- Follow on to #20019

## Rationale for this change

When `AggregateMode::PartialReduce` was added in #20019 from @njsmith, I believe the intention was that it is purely a best-effort optimization: it reduces the volume of intermediate aggregate state (for example, before sending it over the network in a distributed plan), but it is not required to be fully reduced, and consumers must merge it regardless.

However, this contract was never explicitly written down, which came up while I was reviewing #24486 from @2010YOUY01 

## What changes are included in this PR?

Documentation only (no code changes): add a "Best-Effort Reduction" section to
the `AggregateMode::PartialReduce` variant docs stating the output contract.

## Are these changes tested?

Covered by CI docs checks (`cargo doc` passes with `-D warnings`).

## Are there any user-facing changes?

Documentation only.
