### PR TITLE
test: check sql_example tables line up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ dependencies = [
  "tempfile",
  "test-utils",
  "tokio",
+ "unicode-width 0.2.2",
  "url",
  "uuid",
  "zstd",

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -190,6 +190,7 @@ serde_json = { workspace = true }
 sysinfo = "0.39.3"
 test-utils = { path = "../../test-utils" }
 tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot", "fs"] }
+unicode-width = "0.2"
 
 [package.metadata.cargo-machete]
 ignored = ["datafusion-doc", "datafusion-macros", "dashmap"]

--- a/datafusion/core/tests/core_integration.rs
+++ b/datafusion/core/tests/core_integration.rs
@@ -63,6 +63,9 @@ mod tracing;
 /// Run all tests that are found in the `extension_types` directory
 mod extension_types;
 
+/// Run all tests that are found in the `function_docs` directory
+mod function_docs;
+
 /// Helper functions for tests.
 mod helper;
 

--- a/datafusion/core/tests/function_docs/mod.rs
+++ b/datafusion/core/tests/function_docs/mod.rs
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Checks the ASCII tables inside `sql_example` docs. They are copied verbatim onto
+//! the generated pages, so a table that does not line up here does not line up there.
+
+use datafusion::execution::SessionStateDefaults;
+use datafusion::logical_expr::Documentation;
+use unicode_width::UnicodeWidthStr;
+
+fn is_border(line: &str) -> bool {
+    line.len() > 2
+        && line.starts_with('+')
+        && line.ends_with('+')
+        && line.bytes().all(|b| matches!(b, b'-' | b'+'))
+}
+
+/// Markdown's header rule, `| --- | :---: |`, which `arrow` never emits.
+fn is_separator(line: &str) -> bool {
+    line.trim_matches('|').split('|').all(|cell| {
+        let cell = cell.trim();
+        cell.len() >= 3 && cell.bytes().all(|b| matches!(b, b'-' | b':' | b' '))
+    })
+}
+
+fn fault(line: &str) -> Option<&'static str> {
+    if line.starts_with('+') {
+        (!is_border(line)).then_some("not a border")
+    } else if is_separator(line) {
+        Some("markdown separator row")
+    } else if !(line.starts_with("| ") && line.ends_with(" |")) {
+        Some("cell is not padded as `| value |`")
+    } else {
+        None
+    }
+}
+
+fn misaligned_tables(name: &str, example: &str) -> Vec<String> {
+    let lines: Vec<&str> = example.lines().map(str::trim_end).collect();
+    let mut reports = vec![];
+    let mut i = 0;
+    while i < lines.len() {
+        if !is_border(lines[i].trim_start()) {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < lines.len() && lines[i].trim_start().starts_with(['+', '|']) {
+            i += 1;
+        }
+        let table = &lines[start..i];
+        let faults: Vec<Option<&str>> =
+            table.iter().map(|l| fault(l.trim_start())).collect();
+        let widths: Vec<usize> = table.iter().map(|l| l.width()).collect();
+        if faults.iter().all(Option::is_none) && widths.iter().all(|w| *w == widths[0]) {
+            continue;
+        }
+        let mut report = format!("{name}, table at line {} of the example:", start + 1);
+        for ((line, width), fault) in table.iter().zip(&widths).zip(&faults) {
+            report.push_str(&format!("\n  {width:>4}  {line}"));
+            if let Some(fault) = fault {
+                report.push_str(&format!("    <- {fault}"));
+            }
+        }
+        reports.push(report);
+    }
+    reports
+}
+
+#[test]
+fn sql_examples_are_well_formed_tables() {
+    let mut reports = vec![];
+    let mut check = |name: &str, doc: Option<&Documentation>| {
+        if let Some(example) = doc.and_then(|d| d.sql_example.as_deref()) {
+            reports.extend(misaligned_tables(name, example));
+        }
+    };
+
+    for f in SessionStateDefaults::default_scalar_functions() {
+        check(f.name(), f.documentation());
+    }
+    for f in SessionStateDefaults::default_higher_order_functions() {
+        check(f.name(), f.documentation());
+    }
+    for f in SessionStateDefaults::default_aggregate_functions() {
+        check(f.name(), f.documentation());
+    }
+    for f in SessionStateDefaults::default_window_functions() {
+        check(f.name(), f.documentation());
+    }
+
+    assert!(
+        reports.is_empty(),
+        "{} `sql_example` table(s) are not what `arrow` prints. Every line of a table \
+         has the same display width and every cell is padded as `| value |`.\n\n{}",
+        reports.len(),
+        reports.join("\n\n")
+    );
+}
+
+#[test]
+fn wide_characters_are_measured_by_display_width() {
+    let example = r#"+-------------------+
+| ascii(Utf8("🚀")) |
++-------------------+"#;
+    assert!(misaligned_tables("ascii", example).is_empty());
+}
+
+#[test]
+fn short_row_is_reported() {
+    let example = "+-------+\n| 1   |\n+-------+";
+    assert_eq!(misaligned_tables("f", example).len(), 1);
+}
+
+#[test]
+fn unpadded_cell_is_reported() {
+    let example = "+------+\n| value|\n+------+";
+    assert_eq!(misaligned_tables("f", example).len(), 1);
+}
+
+#[test]
+fn markdown_separator_row_is_reported() {
+    let example = "+-----+\n| --- |\n+-----+";
+    assert_eq!(misaligned_tables("f", example).len(), 1);
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #24209, box 1.

## Rationale for this change

The SQL example tables live inside `sql_example` literals and nothing measures them. `print_functions_docs` copies each one onto the page verbatim, so a table that doesn't line up in the source doesn't line up on the website. `config-docs-check` only proves the page matches the literal, not that either is well formed. Before #24596 there were 32 of these across 24 files.

## What changes are included in this PR?

A test that walks the same four registries `print_functions_docs` builds the pages from, finds the ASCII tables in each `sql_example`, and checks every line of a table is the same display width and every cell is padded as `| value |`. It also rejects a markdown separator row inside an arrow table, since `regr`'s four were all the correct width and a width check alone misses them.

A failure names the function and prints the table with its widths:

```
first_value, table at line 3 of the example:
    49  +-----------------------------------------------+
    49  | first_value(column_name ORDER BY other_column)|    <- cell is not padded as `| value |`
    49  +-----------------------------------------------+
```

It sits in `datafusion/core/tests/` rather than `ci/scripts/` so it rides `cargo test (amd64)`, already a required check, and can read `Documentation::sql_example` directly instead of scraping the source. Width comes from `unicode-width`, the same crate `comfy-table` measures with, at the version already in `Cargo.lock`.

Two limits. A table ends when a line stops starting with `+` or `|`, so two tables printed back to back with nothing between them would read as one. Nothing in the tree does that. And the separator rule wants every cell to be three or more of `-`, `:` and space, so a value that is literally `---` would read as a rule.

## Are these changes tested?

It passes on main, so the evidence is the ablation. Reverting the sweep for `arrow_field`, the example the issue links:

```
arrow_field, table at line 3 of the example:
    63  +-------------------------------------------------------------+
    63  | arrow_field(Int64(1))                                       |
    63  +-------------------------------------------------------------+
    64  | {name: lit, data_type: Int64, nullable: false, metadata: {}} |
    63  +-------------------------------------------------------------+
```

Against the tree before #24596 it reports all 32. Four unit cases pin the rules one at a time: a wide-character table that must pass, a short row, an unpadded cell, and a separator row.

## Are there any user-facing changes?

No.
