### PR TITLE
fix(catalog): apply a MemTable DELETE or UPDATE when the plan runs

### DIFF
--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -33,7 +33,9 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::error::Result;
 use datafusion_common::tree_node::TreeNodeRecursion;
-use datafusion_common::{Constraints, DFSchema, SchemaExt, not_impl_err, plan_err};
+use datafusion_common::{
+    Constraints, DFSchema, SchemaExt, internal_err, not_impl_err, plan_err,
+};
 use datafusion_datasource::memory::{MemSink, MemorySourceConfig};
 use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::source::DataSourceExec;
@@ -361,71 +363,24 @@ impl MemTable {
         state: &'a dyn Session,
         filters: Vec<Expr>,
     ) -> BoxFuture<'a, Result<Arc<dyn ExecutionPlan>>> {
-        Box::pin(self.delete_from_inner(state, filters))
+        Box::pin(ready(self.plan_delete(state, filters)))
     }
 
-    async fn delete_from_inner(
+    /// Build the plan of a DELETE. The rows change when the plan runs, not here.
+    fn plan_delete(
         &self,
         state: &dyn Session,
         filters: Vec<Expr>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Early exit if table has no partitions
         if self.batches.is_empty() {
-            return Ok(Arc::new(DmlResultExec::new(0)));
+            return Ok(self.dml_exec(vec![], vec![], MemDmlOp::Delete));
         }
 
-        *self.sort_order.lock() = vec![];
-
-        let mut total_deleted: u64 = 0;
         let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
+        let filters = compile_filters(filters, &df_schema, state.execution_props())?;
 
-        for partition_data in &self.batches {
-            let mut partition = partition_data.write().await;
-            let mut new_batches = Vec::with_capacity(partition.len());
-
-            for batch in partition.iter() {
-                if batch.num_rows() == 0 {
-                    continue;
-                }
-
-                // Evaluate filters - None means "match all rows"
-                let filter_mask = evaluate_filters_to_mask(
-                    &filters,
-                    batch,
-                    &df_schema,
-                    state.execution_props(),
-                )?;
-
-                let (delete_count, keep_mask) = match filter_mask {
-                    Some(mask) => {
-                        // Count rows where mask is true (will be deleted)
-                        let count = mask.iter().filter(|v| v == &Some(true)).count();
-                        // Keep rows where predicate is false or NULL (SQL three-valued logic)
-                        let keep: BooleanArray =
-                            mask.iter().map(|v| Some(v != Some(true))).collect();
-                        (count, keep)
-                    }
-                    None => {
-                        // No filters = delete all rows
-                        (
-                            batch.num_rows(),
-                            BooleanArray::from(vec![false; batch.num_rows()]),
-                        )
-                    }
-                };
-
-                total_deleted += delete_count as u64;
-
-                let filtered_batch = filter_record_batch(batch, &keep_mask)?;
-                if filtered_batch.num_rows() > 0 {
-                    new_batches.push(filtered_batch);
-                }
-            }
-
-            *partition = new_batches;
-        }
-
-        Ok(Arc::new(DmlResultExec::new(total_deleted)))
+        Ok(self.dml_exec(self.batches.clone(), filters, MemDmlOp::Delete))
     }
 
     fn update_boxed<'a>(
@@ -434,10 +389,13 @@ impl MemTable {
         assignments: Vec<(String, Expr)>,
         filters: Vec<Expr>,
     ) -> BoxFuture<'a, Result<Arc<dyn ExecutionPlan>>> {
-        Box::pin(self.update_inner(state, assignments, filters))
+        Box::pin(ready(self.plan_update(state, assignments, filters)))
     }
 
-    async fn update_inner(
+    /// Build the plan of an UPDATE. The rows change when the plan runs, not
+    /// here. Every check of the statement stays here, so that an `EXPLAIN`
+    /// still reports an invalid statement.
+    fn plan_update(
         &self,
         state: &dyn Session,
         assignments: Vec<(String, Expr)>,
@@ -445,7 +403,7 @@ impl MemTable {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Early exit if table has no partitions
         if self.batches.is_empty() {
-            return Ok(Arc::new(DmlResultExec::new(0)));
+            return Ok(self.dml_exec(vec![], vec![], MemDmlOp::Update(HashMap::new())));
         }
 
         // Validate column names upfront with clear error messages
@@ -469,118 +427,208 @@ impl MemTable {
 
         // Create physical expressions for assignments upfront (outside batch loop)
         let physical_assignments: HashMap<String, Arc<dyn PhysicalExpr>> = assignments
-            .iter()
+            .into_iter()
             .map(|(name, expr)| {
                 let physical_expr = create_physical_expr(
-                    expr,
+                    &expr,
                     &df_schema,
                     state.execution_props(),
                     &PhysicalPlanningContext::default(),
                 )?;
-                Ok((name.clone(), physical_expr))
+                Ok((name, physical_expr))
             })
             .collect::<Result<_>>()?;
 
-        *self.sort_order.lock() = vec![];
+        let filters = compile_filters(filters, &df_schema, state.execution_props())?;
 
-        let mut total_updated: u64 = 0;
+        Ok(self.dml_exec(
+            self.batches.clone(),
+            filters,
+            MemDmlOp::Update(physical_assignments),
+        ))
+    }
 
-        for partition_data in &self.batches {
-            let mut partition = partition_data.write().await;
-            let mut new_batches = Vec::with_capacity(partition.len());
+    /// Build the plan node that applies `op` to `partitions`.
+    fn dml_exec(
+        &self,
+        partitions: Vec<PartitionData>,
+        filters: Vec<Arc<dyn PhysicalExpr>>,
+        op: MemDmlOp,
+    ) -> Arc<dyn ExecutionPlan> {
+        Arc::new(MemDmlExec::new(MemDmlState {
+            partitions,
+            table_schema: Arc::clone(&self.schema),
+            sort_order: Arc::clone(&self.sort_order),
+            filters,
+            op,
+        }))
+    }
+}
 
-            for batch in partition.iter() {
-                if batch.num_rows() == 0 {
-                    continue;
-                }
+/// Compile the `WHERE` clause of a DELETE or an UPDATE into physical
+/// expressions. An empty result means "match all rows".
+fn compile_filters(
+    filters: Vec<Expr>,
+    df_schema: &DFSchema,
+    execution_props: &datafusion_expr::execution_props::ExecutionProps,
+) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
+    filters
+        .into_iter()
+        .map(|filter_expr| {
+            create_physical_expr(
+                &filter_expr,
+                df_schema,
+                execution_props,
+                &PhysicalPlanningContext::default(),
+            )
+        })
+        .collect()
+}
 
-                // Evaluate filters - None means "match all rows"
-                let filter_mask = evaluate_filters_to_mask(
-                    &filters,
-                    batch,
-                    &df_schema,
-                    state.execution_props(),
-                )?;
+/// Delete the rows of `state` that its filters match, and return the number of
+/// rows deleted.
+async fn apply_delete(state: &MemDmlState) -> Result<u64> {
+    let mut total_deleted: u64 = 0;
 
-                let (update_count, update_mask) = match filter_mask {
-                    Some(mask) => {
-                        // Count rows where mask is true (will be updated)
-                        let count = mask.iter().filter(|v| v == &Some(true)).count();
-                        // Normalize mask: only true (not NULL) triggers update
-                        let normalized: BooleanArray =
-                            mask.iter().map(|v| Some(v == Some(true))).collect();
-                        (count, normalized)
-                    }
-                    None => {
-                        // No filters = update all rows
-                        (
-                            batch.num_rows(),
-                            BooleanArray::from(vec![true; batch.num_rows()]),
-                        )
-                    }
-                };
+    for partition_data in &state.partitions {
+        let mut partition = partition_data.write().await;
+        let mut new_batches = Vec::with_capacity(partition.len());
 
-                total_updated += update_count as u64;
-
-                if update_count == 0 {
-                    new_batches.push(batch.clone());
-                    continue;
-                }
-
-                let mut new_columns: Vec<ArrayRef> =
-                    Vec::with_capacity(batch.num_columns());
-
-                for field in self.schema.fields() {
-                    let column_name = field.name();
-                    let original_column =
-                        batch.column_by_name(column_name).ok_or_else(|| {
-                            datafusion_common::DataFusionError::Internal(format!(
-                                "Column '{column_name}' not found in batch"
-                            ))
-                        })?;
-
-                    let new_column = if let Some(physical_expr) =
-                        physical_assignments.get(column_name.as_str())
-                    {
-                        // Use evaluate_selection to only evaluate on matching rows.
-                        // This avoids errors (e.g., divide-by-zero) on rows that won't
-                        // be updated. The result is scattered back with nulls for
-                        // non-matching rows, which zip() will replace with originals.
-                        let new_values =
-                            physical_expr.evaluate_selection(batch, &update_mask)?;
-                        let new_array = new_values.into_array(batch.num_rows())?;
-
-                        // Convert to &dyn Array which implements Datum
-                        let new_arr: &dyn Array = new_array.as_ref();
-                        let orig_arr: &dyn Array = original_column.as_ref();
-                        zip(&update_mask, &new_arr, &orig_arr)?
-                    } else {
-                        Arc::clone(original_column)
-                    };
-
-                    new_columns.push(new_column);
-                }
-
-                let updated_batch =
-                    ArrowRecordBatch::try_new(Arc::clone(&self.schema), new_columns)?;
-                new_batches.push(updated_batch);
+        for batch in partition.iter() {
+            if batch.num_rows() == 0 {
+                continue;
             }
 
-            *partition = new_batches;
+            // Evaluate filters - None means "match all rows"
+            let filter_mask = evaluate_filters_to_mask(&state.filters, batch)?;
+
+            let (delete_count, keep_mask) = match filter_mask {
+                Some(mask) => {
+                    // Count rows where mask is true (will be deleted)
+                    let count = mask.iter().filter(|v| v == &Some(true)).count();
+                    // Keep rows where predicate is false or NULL (SQL three-valued logic)
+                    let keep: BooleanArray =
+                        mask.iter().map(|v| Some(v != Some(true))).collect();
+                    (count, keep)
+                }
+                None => {
+                    // No filters = delete all rows
+                    (
+                        batch.num_rows(),
+                        BooleanArray::from(vec![false; batch.num_rows()]),
+                    )
+                }
+            };
+
+            total_deleted += delete_count as u64;
+
+            let filtered_batch = filter_record_batch(batch, &keep_mask)?;
+            if filtered_batch.num_rows() > 0 {
+                new_batches.push(filtered_batch);
+            }
         }
 
-        Ok(Arc::new(DmlResultExec::new(total_updated)))
+        *partition = new_batches;
     }
+
+    Ok(total_deleted)
+}
+
+/// Assign a new value to each row of `state` that its filters match, and return
+/// the number of rows updated.
+async fn apply_update(
+    state: &MemDmlState,
+    physical_assignments: &HashMap<String, Arc<dyn PhysicalExpr>>,
+) -> Result<u64> {
+    let mut total_updated: u64 = 0;
+
+    for partition_data in &state.partitions {
+        let mut partition = partition_data.write().await;
+        let mut new_batches = Vec::with_capacity(partition.len());
+
+        for batch in partition.iter() {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+
+            // Evaluate filters - None means "match all rows"
+            let filter_mask = evaluate_filters_to_mask(&state.filters, batch)?;
+
+            let (update_count, update_mask) = match filter_mask {
+                Some(mask) => {
+                    // Count rows where mask is true (will be updated)
+                    let count = mask.iter().filter(|v| v == &Some(true)).count();
+                    // Normalize mask: only true (not NULL) triggers update
+                    let normalized: BooleanArray =
+                        mask.iter().map(|v| Some(v == Some(true))).collect();
+                    (count, normalized)
+                }
+                None => {
+                    // No filters = update all rows
+                    (
+                        batch.num_rows(),
+                        BooleanArray::from(vec![true; batch.num_rows()]),
+                    )
+                }
+            };
+
+            total_updated += update_count as u64;
+
+            if update_count == 0 {
+                new_batches.push(batch.clone());
+                continue;
+            }
+
+            let mut new_columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
+
+            for field in state.table_schema.fields() {
+                let column_name = field.name();
+                let original_column =
+                    batch.column_by_name(column_name).ok_or_else(|| {
+                        datafusion_common::DataFusionError::Internal(format!(
+                            "Column '{column_name}' not found in batch"
+                        ))
+                    })?;
+
+                let new_column = if let Some(physical_expr) =
+                    physical_assignments.get(column_name.as_str())
+                {
+                    // Use evaluate_selection to only evaluate on matching rows.
+                    // This avoids errors (e.g., divide-by-zero) on rows that won't
+                    // be updated. The result is scattered back with nulls for
+                    // non-matching rows, which zip() will replace with originals.
+                    let new_values =
+                        physical_expr.evaluate_selection(batch, &update_mask)?;
+                    let new_array = new_values.into_array(batch.num_rows())?;
+
+                    // Convert to &dyn Array which implements Datum
+                    let new_arr: &dyn Array = new_array.as_ref();
+                    let orig_arr: &dyn Array = original_column.as_ref();
+                    zip(&update_mask, &new_arr, &orig_arr)?
+                } else {
+                    Arc::clone(original_column)
+                };
+
+                new_columns.push(new_column);
+            }
+
+            let updated_batch =
+                ArrowRecordBatch::try_new(Arc::clone(&state.table_schema), new_columns)?;
+            new_batches.push(updated_batch);
+        }
+
+        *partition = new_batches;
+    }
+
+    Ok(total_updated)
 }
 
 /// Evaluate filter expressions against a batch and return a combined boolean mask.
 /// Returns None if filters is empty (meaning "match all rows").
 /// The returned mask has true for rows that match the filter predicates.
 fn evaluate_filters_to_mask(
-    filters: &[Expr],
+    filters: &[Arc<dyn PhysicalExpr>],
     batch: &RecordBatch,
-    df_schema: &DFSchema,
-    execution_props: &datafusion_expr::execution_props::ExecutionProps,
 ) -> Result<Option<BooleanArray>> {
     if filters.is_empty() {
         return Ok(None);
@@ -588,14 +636,7 @@ fn evaluate_filters_to_mask(
 
     let mut combined_mask: Option<BooleanArray> = None;
 
-    for filter_expr in filters {
-        let physical_expr = create_physical_expr(
-            filter_expr,
-            df_schema,
-            execution_props,
-            &PhysicalPlanningContext::default(),
-        )?;
-
+    for physical_expr in filters {
         let result = physical_expr.evaluate(batch)?;
         let array = result.into_array(batch.num_rows())?;
         let bool_array = array
@@ -617,16 +658,54 @@ fn evaluate_filters_to_mask(
     Ok(combined_mask)
 }
 
-/// Returns a single row with the count of affected rows.
+/// The operation that a [`MemDmlExec`] applies to the rows of a [`MemTable`].
 #[derive(Debug)]
-struct DmlResultExec {
-    rows_affected: u64,
+enum MemDmlOp {
+    /// Delete each row that the filters match.
+    Delete,
+    /// Assign a new value to each row that the filters match. The map holds one
+    /// expression per assigned column, keyed by column name.
+    Update(HashMap<String, Arc<dyn PhysicalExpr>>),
+}
+
+impl MemDmlOp {
+    fn as_str(&self) -> &'static str {
+        match self {
+            MemDmlOp::Delete => "Delete",
+            MemDmlOp::Update(_) => "Update",
+        }
+    }
+}
+
+/// Everything that a [`MemDmlExec`] needs in order to apply its operation.
+/// Each field is a clone of a field of the [`MemTable`], so the plan changes the
+/// rows of the table itself.
+#[derive(Debug)]
+struct MemDmlState {
+    partitions: Vec<PartitionData>,
+    table_schema: SchemaRef,
+    sort_order: Arc<Mutex<Vec<Vec<SortExpr>>>>,
+    /// The `WHERE` clause of the statement, compiled while the plan was built.
+    /// An empty list means "match all rows".
+    filters: Vec<Arc<dyn PhysicalExpr>>,
+    op: MemDmlOp,
+}
+
+/// Applies a DELETE or an UPDATE to a [`MemTable`], and returns a single row
+/// with the count of affected rows.
+///
+/// The rows change in [`ExecutionPlan::execute`], not while the plan is built,
+/// so an `EXPLAIN` of the statement leaves the table alone. Each run of the plan
+/// applies the operation once more, as [`DataSinkExec`] does for an INSERT.
+#[derive(Debug)]
+struct MemDmlExec {
+    state: Arc<MemDmlState>,
     schema: SchemaRef,
     properties: Arc<PlanProperties>,
 }
 
-impl DmlResultExec {
-    fn new(rows_affected: u64) -> Self {
+impl MemDmlExec {
+    fn new(state: MemDmlState) -> Self {
         let schema = Arc::new(Schema::new(vec![Field::new(
             "count",
             DataType::UInt64,
@@ -641,14 +720,14 @@ impl DmlResultExec {
         );
 
         Self {
-            rows_affected,
+            state: Arc::new(state),
             schema,
             properties: Arc::new(properties),
         }
     }
 }
 
-impl DisplayAs for DmlResultExec {
+impl DisplayAs for MemDmlExec {
     fn fmt_as(
         &self,
         t: DisplayFormatType,
@@ -658,15 +737,15 @@ impl DisplayAs for DmlResultExec {
             DisplayFormatType::Default
             | DisplayFormatType::Verbose
             | DisplayFormatType::TreeRender => {
-                write!(f, "DmlResultExec: rows_affected={}", self.rows_affected)
+                write!(f, "MemDmlExec: op={}", self.state.op.as_str())
             }
         }
     }
 }
 
-impl ExecutionPlan for DmlResultExec {
+impl ExecutionPlan for MemDmlExec {
     fn name(&self) -> &str {
-        "DmlResultExec"
+        "MemDmlExec"
     }
 
     fn schema(&self) -> SchemaRef {
@@ -701,18 +780,38 @@ impl ExecutionPlan for DmlResultExec {
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         _context: Arc<datafusion_execution::TaskContext>,
     ) -> Result<datafusion_execution::SendableRecordBatchStream> {
-        // Create a single batch with the count
-        let count_array = UInt64Array::from(vec![self.rows_affected]);
-        let batch = ArrowRecordBatch::try_new(
-            Arc::clone(&self.schema),
-            vec![Arc::new(count_array) as ArrayRef],
-        )?;
+        if partition != 0 {
+            return internal_err!(
+                "MemDmlExec has one partition, but partition {partition} was requested"
+            );
+        }
 
-        // Create a stream that yields just this one batch
-        let stream = futures::stream::iter(vec![Ok(batch)]);
+        let state = Arc::clone(&self.state);
+        let schema = Arc::clone(&self.schema);
+
+        // Apply the operation, then emit the count as the single output row.
+        let stream = futures::stream::once(async move {
+            // The rows change, so any declared sort order no longer holds. The
+            // guard drops at the end of this statement, before the first await.
+            *state.sort_order.lock() = vec![];
+
+            let rows_affected = match &state.op {
+                MemDmlOp::Delete => apply_delete(&state).await?,
+                MemDmlOp::Update(assignments) => {
+                    apply_update(&state, assignments).await?
+                }
+            };
+
+            let count_array = UInt64Array::from(vec![rows_affected]);
+            Ok(ArrowRecordBatch::try_new(
+                schema,
+                vec![Arc::new(count_array) as ArrayRef],
+            )?)
+        });
+
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             Arc::clone(&self.schema),
             stream,

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -485,144 +485,6 @@ fn compile_filters(
         .collect()
 }
 
-/// Delete the rows of `state` that its filters match, and return the number of
-/// rows deleted.
-async fn apply_delete(state: &MemDmlState) -> Result<u64> {
-    let mut total_deleted: u64 = 0;
-
-    for partition_data in &state.partitions {
-        let mut partition = partition_data.write().await;
-        let mut new_batches = Vec::with_capacity(partition.len());
-
-        for batch in partition.iter() {
-            if batch.num_rows() == 0 {
-                continue;
-            }
-
-            // Evaluate filters - None means "match all rows"
-            let filter_mask = evaluate_filters_to_mask(&state.filters, batch)?;
-
-            let (delete_count, keep_mask) = match filter_mask {
-                Some(mask) => {
-                    // Count rows where mask is true (will be deleted)
-                    let count = mask.iter().filter(|v| v == &Some(true)).count();
-                    // Keep rows where predicate is false or NULL (SQL three-valued logic)
-                    let keep: BooleanArray =
-                        mask.iter().map(|v| Some(v != Some(true))).collect();
-                    (count, keep)
-                }
-                None => {
-                    // No filters = delete all rows
-                    (
-                        batch.num_rows(),
-                        BooleanArray::from(vec![false; batch.num_rows()]),
-                    )
-                }
-            };
-
-            total_deleted += delete_count as u64;
-
-            let filtered_batch = filter_record_batch(batch, &keep_mask)?;
-            if filtered_batch.num_rows() > 0 {
-                new_batches.push(filtered_batch);
-            }
-        }
-
-        *partition = new_batches;
-    }
-
-    Ok(total_deleted)
-}
-
-/// Assign a new value to each row of `state` that its filters match, and return
-/// the number of rows updated.
-async fn apply_update(
-    state: &MemDmlState,
-    physical_assignments: &HashMap<String, Arc<dyn PhysicalExpr>>,
-) -> Result<u64> {
-    let mut total_updated: u64 = 0;
-
-    for partition_data in &state.partitions {
-        let mut partition = partition_data.write().await;
-        let mut new_batches = Vec::with_capacity(partition.len());
-
-        for batch in partition.iter() {
-            if batch.num_rows() == 0 {
-                continue;
-            }
-
-            // Evaluate filters - None means "match all rows"
-            let filter_mask = evaluate_filters_to_mask(&state.filters, batch)?;
-
-            let (update_count, update_mask) = match filter_mask {
-                Some(mask) => {
-                    // Count rows where mask is true (will be updated)
-                    let count = mask.iter().filter(|v| v == &Some(true)).count();
-                    // Normalize mask: only true (not NULL) triggers update
-                    let normalized: BooleanArray =
-                        mask.iter().map(|v| Some(v == Some(true))).collect();
-                    (count, normalized)
-                }
-                None => {
-                    // No filters = update all rows
-                    (
-                        batch.num_rows(),
-                        BooleanArray::from(vec![true; batch.num_rows()]),
-                    )
-                }
-            };
-
-            total_updated += update_count as u64;
-
-            if update_count == 0 {
-                new_batches.push(batch.clone());
-                continue;
-            }
-
-            let mut new_columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
-
-            for field in state.table_schema.fields() {
-                let column_name = field.name();
-                let original_column =
-                    batch.column_by_name(column_name).ok_or_else(|| {
-                        datafusion_common::DataFusionError::Internal(format!(
-                            "Column '{column_name}' not found in batch"
-                        ))
-                    })?;
-
-                let new_column = if let Some(physical_expr) =
-                    physical_assignments.get(column_name.as_str())
-                {
-                    // Use evaluate_selection to only evaluate on matching rows.
-                    // This avoids errors (e.g., divide-by-zero) on rows that won't
-                    // be updated. The result is scattered back with nulls for
-                    // non-matching rows, which zip() will replace with originals.
-                    let new_values =
-                        physical_expr.evaluate_selection(batch, &update_mask)?;
-                    let new_array = new_values.into_array(batch.num_rows())?;
-
-                    // Convert to &dyn Array which implements Datum
-                    let new_arr: &dyn Array = new_array.as_ref();
-                    let orig_arr: &dyn Array = original_column.as_ref();
-                    zip(&update_mask, &new_arr, &orig_arr)?
-                } else {
-                    Arc::clone(original_column)
-                };
-
-                new_columns.push(new_column);
-            }
-
-            let updated_batch =
-                ArrowRecordBatch::try_new(Arc::clone(&state.table_schema), new_columns)?;
-            new_batches.push(updated_batch);
-        }
-
-        *partition = new_batches;
-    }
-
-    Ok(total_updated)
-}
-
 /// Evaluate filter expressions against a batch and return a combined boolean mask.
 /// Returns None if filters is empty (meaning "match all rows").
 /// The returned mask has true for rows that match the filter predicates.
@@ -689,6 +551,149 @@ struct MemDmlState {
     /// An empty list means "match all rows".
     filters: Vec<Arc<dyn PhysicalExpr>>,
     op: MemDmlOp,
+}
+
+impl MemDmlState {
+    /// Delete the rows that the filters match, and return the number of rows
+    /// deleted.
+    async fn apply_delete(&self) -> Result<u64> {
+        let mut total_deleted: u64 = 0;
+
+        for partition_data in &self.partitions {
+            let mut partition = partition_data.write().await;
+            let mut new_batches = Vec::with_capacity(partition.len());
+
+            for batch in partition.iter() {
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+
+                // Evaluate filters - None means "match all rows"
+                let filter_mask = evaluate_filters_to_mask(&self.filters, batch)?;
+
+                let (delete_count, keep_mask) = match filter_mask {
+                    Some(mask) => {
+                        // Count rows where mask is true (will be deleted)
+                        let count = mask.iter().filter(|v| v == &Some(true)).count();
+                        // Keep rows where predicate is false or NULL (SQL three-valued logic)
+                        let keep: BooleanArray =
+                            mask.iter().map(|v| Some(v != Some(true))).collect();
+                        (count, keep)
+                    }
+                    None => {
+                        // No filters = delete all rows
+                        (
+                            batch.num_rows(),
+                            BooleanArray::from(vec![false; batch.num_rows()]),
+                        )
+                    }
+                };
+
+                total_deleted += delete_count as u64;
+
+                let filtered_batch = filter_record_batch(batch, &keep_mask)?;
+                if filtered_batch.num_rows() > 0 {
+                    new_batches.push(filtered_batch);
+                }
+            }
+
+            *partition = new_batches;
+        }
+
+        Ok(total_deleted)
+    }
+
+    /// Assign a new value to each row that the filters match, and return the
+    /// number of rows updated.
+    async fn apply_update(
+        &self,
+        physical_assignments: &HashMap<String, Arc<dyn PhysicalExpr>>,
+    ) -> Result<u64> {
+        let mut total_updated: u64 = 0;
+
+        for partition_data in &self.partitions {
+            let mut partition = partition_data.write().await;
+            let mut new_batches = Vec::with_capacity(partition.len());
+
+            for batch in partition.iter() {
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+
+                // Evaluate filters - None means "match all rows"
+                let filter_mask = evaluate_filters_to_mask(&self.filters, batch)?;
+
+                let (update_count, update_mask) = match filter_mask {
+                    Some(mask) => {
+                        // Count rows where mask is true (will be updated)
+                        let count = mask.iter().filter(|v| v == &Some(true)).count();
+                        // Normalize mask: only true (not NULL) triggers update
+                        let normalized: BooleanArray =
+                            mask.iter().map(|v| Some(v == Some(true))).collect();
+                        (count, normalized)
+                    }
+                    None => {
+                        // No filters = update all rows
+                        (
+                            batch.num_rows(),
+                            BooleanArray::from(vec![true; batch.num_rows()]),
+                        )
+                    }
+                };
+
+                total_updated += update_count as u64;
+
+                if update_count == 0 {
+                    new_batches.push(batch.clone());
+                    continue;
+                }
+
+                let mut new_columns: Vec<ArrayRef> =
+                    Vec::with_capacity(batch.num_columns());
+
+                for field in self.table_schema.fields() {
+                    let column_name = field.name();
+                    let original_column =
+                        batch.column_by_name(column_name).ok_or_else(|| {
+                            datafusion_common::DataFusionError::Internal(format!(
+                                "Column '{column_name}' not found in batch"
+                            ))
+                        })?;
+
+                    let new_column = if let Some(physical_expr) =
+                        physical_assignments.get(column_name.as_str())
+                    {
+                        // Use evaluate_selection to only evaluate on matching rows.
+                        // This avoids errors (e.g., divide-by-zero) on rows that won't
+                        // be updated. The result is scattered back with nulls for
+                        // non-matching rows, which zip() will replace with originals.
+                        let new_values =
+                            physical_expr.evaluate_selection(batch, &update_mask)?;
+                        let new_array = new_values.into_array(batch.num_rows())?;
+
+                        // Convert to &dyn Array which implements Datum
+                        let new_arr: &dyn Array = new_array.as_ref();
+                        let orig_arr: &dyn Array = original_column.as_ref();
+                        zip(&update_mask, &new_arr, &orig_arr)?
+                    } else {
+                        Arc::clone(original_column)
+                    };
+
+                    new_columns.push(new_column);
+                }
+
+                let updated_batch = ArrowRecordBatch::try_new(
+                    Arc::clone(&self.table_schema),
+                    new_columns,
+                )?;
+                new_batches.push(updated_batch);
+            }
+
+            *partition = new_batches;
+        }
+
+        Ok(total_updated)
+    }
 }
 
 /// Applies a DELETE or an UPDATE to a [`MemTable`], and returns a single row
@@ -799,10 +804,8 @@ impl ExecutionPlan for MemDmlExec {
             *state.sort_order.lock() = vec![];
 
             let rows_affected = match &state.op {
-                MemDmlOp::Delete => apply_delete(&state).await?,
-                MemDmlOp::Update(assignments) => {
-                    apply_update(&state, assignments).await?
-                }
+                MemDmlOp::Delete => state.apply_delete().await?,
+                MemDmlOp::Update(assignments) => state.apply_update(assignments).await?,
             };
 
             let count_array = UInt64Array::from(vec![rows_affected]);

--- a/datafusion/core/src/datasource/memory_test.rs
+++ b/datafusion/core/src/datasource/memory_test.rs
@@ -20,17 +20,19 @@ mod tests {
 
     use crate::datasource::MemTable;
     use crate::datasource::{DefaultTableSource, provider_as_source};
-    use crate::physical_plan::collect;
+    use crate::physical_plan::{ExecutionPlan, collect};
     use crate::prelude::SessionContext;
     use arrow::array::{AsArray, Int32Array};
-    use arrow::datatypes::{DataType, Field, Schema, UInt64Type};
+    use arrow::datatypes::{DataType, Field, Int32Type, Schema, UInt64Type};
     use arrow::error::ArrowError;
     use arrow::record_batch::RecordBatch;
     use arrow_schema::SchemaRef;
     use datafusion_catalog::TableProvider;
-    use datafusion_common::{Constraint, Constraints, DataFusionError, Result};
-    use datafusion_expr::LogicalPlanBuilder;
+    use datafusion_common::{
+        Constraint, Constraints, DataFusionError, Result, ScalarValue, assert_contains,
+    };
     use datafusion_expr::dml::InsertOp;
+    use datafusion_expr::{Expr, LogicalPlanBuilder, col, lit};
     use futures::StreamExt;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -499,6 +501,342 @@ mod tests {
             "Error during planning: No partitions provided, expected at least one partition",
             experiment_result.strip_backtrace()
         );
+        Ok(())
+    }
+
+    /// A schema of one non-nullable Int32 column called "a".
+    fn one_column_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    /// A batch of the rows 1, 2 and 3 in the column "a".
+    fn one_column_batch(schema: &SchemaRef) -> Result<RecordBatch> {
+        Ok(RecordBatch::try_new(
+            Arc::clone(schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?)
+    }
+
+    /// A `MemTable` that holds no partition. `MemTable::try_new` rejects an
+    /// empty partition list, so a caller reaches this state through the public
+    /// `batches` field.
+    fn zero_partition_table(schema: SchemaRef) -> Result<MemTable> {
+        let mut table = MemTable::try_new(schema, vec![vec![]])?;
+        table.batches.clear();
+        Ok(table)
+    }
+
+    /// Run a DELETE or an UPDATE plan and return the count that it emits.
+    async fn run_dml(
+        plan: Arc<dyn ExecutionPlan>,
+        session_ctx: &SessionContext,
+    ) -> Result<u64> {
+        Ok(extract_count(collect(plan, session_ctx.task_ctx()).await?))
+    }
+
+    /// Read one partition of a `MemTable` as a plain vector of batches.
+    async fn read_partition(table: &MemTable, partition: usize) -> Vec<RecordBatch> {
+        table.batches[partition].read().await.clone()
+    }
+
+    /// The values of the first column of `batch`, which must hold no null.
+    fn column_values(batch: &RecordBatch) -> Vec<i32> {
+        batch
+            .column(0)
+            .as_primitive::<Int32Type>()
+            .iter()
+            .map(|value| value.expect("expected non null"))
+            .collect()
+    }
+
+    // A DELETE on a table without a partition affects no row
+    #[tokio::test]
+    async fn test_delete_from_zero_partition() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = zero_partition_table(one_column_schema())?;
+
+        let plan = table.delete_from(&state, vec![col("a").gt(lit(1))]).await?;
+        assert_eq!(run_dml(plan, &session_ctx).await?, 0);
+        Ok(())
+    }
+
+    // An UPDATE on a table without a partition affects no row
+    #[tokio::test]
+    async fn test_update_zero_partition() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = zero_partition_table(one_column_schema())?;
+
+        let plan = table
+            .update(&state, vec![("a".to_string(), lit(7))], vec![])
+            .await?;
+        assert_eq!(run_dml(plan, &session_ctx).await?, 0);
+        Ok(())
+    }
+
+    // A DELETE skips a batch of no row and drops it from the partition
+    #[tokio::test]
+    async fn test_delete_from_empty_batch() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![
+                RecordBatch::new_empty(Arc::clone(&schema)),
+                one_column_batch(&schema)?,
+            ]],
+        )?;
+
+        let plan = table.delete_from(&state, vec![col("a").gt(lit(1))]).await?;
+        assert_eq!(run_dml(plan, &session_ctx).await?, 2);
+
+        // The empty batch is gone and the row 1 remains
+        let partition = read_partition(&table, 0).await;
+        assert_eq!(partition.len(), 1);
+        assert_eq!(column_values(&partition[0]), vec![1]);
+        Ok(())
+    }
+
+    // An UPDATE skips a batch of no row and drops it from the partition
+    #[tokio::test]
+    async fn test_update_empty_batch() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![
+                RecordBatch::new_empty(Arc::clone(&schema)),
+                one_column_batch(&schema)?,
+            ]],
+        )?;
+
+        let plan = table
+            .update(
+                &state,
+                vec![("a".to_string(), lit(7))],
+                vec![col("a").gt(lit(1))],
+            )
+            .await?;
+        assert_eq!(run_dml(plan, &session_ctx).await?, 2);
+
+        // The empty batch is gone and the rows 2 and 3 now hold 7
+        let partition = read_partition(&table, 0).await;
+        assert_eq!(partition.len(), 1);
+        assert_eq!(column_values(&partition[0]), vec![1, 7, 7]);
+        Ok(())
+    }
+
+    // The DML plan has one partition and rejects a request for another
+    #[tokio::test]
+    async fn test_dml_exec_rejects_other_partition() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![one_column_batch(&schema)?]],
+        )?;
+
+        let plan = table.delete_from(&state, vec![]).await?;
+        let Err(err) = plan.execute(1, session_ctx.task_ctx()) else {
+            panic!("expected an error for partition 1");
+        };
+        assert_contains!(
+            err.strip_backtrace(),
+            "MemDmlExec has one partition, but partition 1 was requested"
+        );
+
+        // The failed request leaves the rows alone
+        assert_eq!(read_partition(&table, 0).await[0].num_rows(), 3);
+        Ok(())
+    }
+
+    // A DELETE whose `WHERE` clause names an unknown column fails while the
+    // plan is built, before any row changes
+    #[tokio::test]
+    async fn test_delete_from_unknown_filter_column() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![one_column_batch(&schema)?]],
+        )?;
+
+        let err = table
+            .delete_from(&state, vec![col("nonexistent").eq(lit(1))])
+            .await
+            .unwrap_err();
+        assert_contains!(err.strip_backtrace(), "nonexistent");
+        Ok(())
+    }
+
+    // An UPDATE whose `WHERE` clause names an unknown column fails while the
+    // plan is built, before any row changes
+    #[tokio::test]
+    async fn test_update_unknown_filter_column() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![one_column_batch(&schema)?]],
+        )?;
+
+        let err = table
+            .update(
+                &state,
+                vec![("a".to_string(), lit(7))],
+                vec![col("nonexistent").eq(lit(1))],
+            )
+            .await
+            .unwrap_err();
+        assert_contains!(err.strip_backtrace(), "nonexistent");
+        Ok(())
+    }
+
+    // A DELETE whose `WHERE` clause is not a predicate fails when the plan runs
+    #[tokio::test]
+    async fn test_delete_from_non_boolean_filter() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![one_column_batch(&schema)?]],
+        )?;
+
+        let plan = table.delete_from(&state, vec![lit(1)]).await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "Filter did not evaluate to boolean");
+
+        // The failed run leaves the rows alone
+        assert_eq!(read_partition(&table, 0).await[0].num_rows(), 3);
+        Ok(())
+    }
+
+    // An UPDATE whose `WHERE` clause is not a predicate fails when the plan runs
+    #[tokio::test]
+    async fn test_update_non_boolean_filter() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![one_column_batch(&schema)?]],
+        )?;
+
+        let plan = table
+            .update(&state, vec![("a".to_string(), lit(7))], vec![lit(1)])
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "Filter did not evaluate to boolean");
+        Ok(())
+    }
+
+    // An UPDATE reports the column that a batch of the table does not hold
+    #[tokio::test]
+    async fn test_update_column_missing_from_batch() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, true),
+        ]));
+        let table = MemTable::try_new(
+            Arc::clone(&table_schema),
+            vec![vec![RecordBatch::try_new(
+                table_schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2, 3])),
+                    Arc::new(Int32Array::from(vec![4, 5, 6])),
+                ],
+            )?]],
+        )?;
+        // `try_new` rejects a batch that misses a column of the table, so the
+        // test writes one straight into the partition. The UPDATE reports the
+        // missing column instead of a panic.
+        let batch = one_column_batch(&one_column_schema())?;
+        *table.batches[0].write().await = vec![batch];
+
+        let plan = table
+            .update(&state, vec![("a".to_string(), lit(7))], vec![])
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "Column 'b' not found in batch");
+        Ok(())
+    }
+
+    // An UPDATE reports the failure of an assignment expression
+    #[tokio::test]
+    async fn test_update_assignment_evaluation_error() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![one_column_batch(&schema)?]],
+        )?;
+
+        let plan = table
+            .update(
+                &state,
+                vec![("a".to_string(), col("a") / lit(0))],
+                vec![col("a").gt(lit(1))],
+            )
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "Divide by zero");
+        Ok(())
+    }
+
+    // An UPDATE reports an assignment of a value of the wrong type
+    #[tokio::test]
+    async fn test_update_assignment_type_mismatch() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![one_column_batch(&schema)?]],
+        )?;
+
+        let assignment: (String, Expr) = ("a".to_string(), lit("seven"));
+        let plan = table
+            .update(&state, vec![assignment], vec![col("a").gt(lit(1))])
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(
+            err.strip_backtrace(),
+            "arguments need to have the same data type"
+        );
+        Ok(())
+    }
+
+    // An UPDATE rejects a null value for a column that the table declares NOT NULL
+    #[tokio::test]
+    async fn test_update_null_into_non_nullable_column() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![one_column_batch(&schema)?]],
+        )?;
+
+        let null = lit(ScalarValue::Int32(None));
+        let plan = table
+            .update(
+                &state,
+                vec![("a".to_string(), null)],
+                vec![col("a").gt(lit(1))],
+            )
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "non-nullable but contains null");
         Ok(())
     }
 }

--- a/datafusion/sqllogictest/test_files/delete.slt
+++ b/datafusion/sqllogictest/test_files/delete.slt
@@ -36,7 +36,7 @@ logical_plan
 02)--TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDmlExec: op=Delete
 
 
 # Filtered by existing columns
@@ -49,7 +49,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDmlExec: op=Delete
 
 
 # Filtered by existing columns, using qualified and unqualified names
@@ -62,7 +62,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDmlExec: op=Delete
 
 
 # Filtered by a mix of columns and literal predicates
@@ -75,7 +75,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDmlExec: op=Delete
 
 
 # Deleting by columns that do not exist returns an error
@@ -126,7 +126,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDmlExec: op=Delete
 
 
 query TT
@@ -139,7 +139,7 @@ logical_plan
 04)------TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDmlExec: op=Delete
 
 # Config reset
 statement ok

--- a/datafusion/sqllogictest/test_files/dml_delete.slt
+++ b/datafusion/sqllogictest/test_files/dml_delete.slt
@@ -200,3 +200,53 @@ SELECT * FROM test_delete_in;
 
 statement ok
 DROP TABLE test_delete_in;
+
+# Test that EXPLAIN DELETE does not change the rows
+# The rows change when the plan runs, and EXPLAIN prints the plan without
+# running it.
+statement ok
+CREATE TABLE test_explain_delete AS VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+query TT
+EXPLAIN DELETE FROM test_explain_delete WHERE column1 > 1;
+----
+logical_plan
+01)Dml: op=[Delete] table=[test_explain_delete]
+02)--Filter: test_explain_delete.column1 > Int64(1)
+03)----TableScan: test_explain_delete projection=[column1, column2]
+physical_plan
+01)CooperativeExec
+02)--MemDmlExec: op=Delete
+
+query TT
+EXPLAIN DELETE FROM test_explain_delete;
+----
+logical_plan
+01)Dml: op=[Delete] table=[test_explain_delete]
+02)--TableScan: test_explain_delete projection=[column1, column2]
+physical_plan
+01)CooperativeExec
+02)--MemDmlExec: op=Delete
+
+query IT rowsort
+SELECT * FROM test_explain_delete;
+----
+1 a
+2 b
+3 c
+
+# EXPLAIN ANALYZE runs the plan, so the rows do go
+query TT
+EXPLAIN ANALYZE DELETE FROM test_explain_delete WHERE column1 > 1;
+----
+Plan with Metrics
+01)CooperativeExec, metrics=[]
+02)--MemDmlExec: op=Delete, metrics=[]
+
+query IT rowsort
+SELECT * FROM test_explain_delete;
+----
+1 a
+
+statement ok
+DROP TABLE test_explain_delete;

--- a/datafusion/sqllogictest/test_files/dml_update.slt
+++ b/datafusion/sqllogictest/test_files/dml_update.slt
@@ -284,3 +284,53 @@ SELECT * FROM test_update_div;
 
 statement ok
 DROP TABLE test_update_div;
+
+# Test that EXPLAIN UPDATE does not change the rows
+# The rows change when the plan runs, and EXPLAIN prints the plan without
+# running it.
+statement ok
+CREATE TABLE test_explain_update(id INT, name VARCHAR);
+
+statement ok
+INSERT INTO test_explain_update VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+query TT
+EXPLAIN UPDATE test_explain_update SET name = 'z' WHERE id > 1;
+----
+logical_plan
+01)Dml: op=[Update] table=[test_explain_update]
+02)--Projection: test_explain_update.id AS id, Utf8View("z") AS name
+03)----Filter: test_explain_update.id > Int32(1)
+04)------TableScan: test_explain_update projection=[id]
+physical_plan
+01)CooperativeExec
+02)--MemDmlExec: op=Update
+
+query IT rowsort
+SELECT * FROM test_explain_update;
+----
+1 a
+2 b
+3 c
+
+# EXPLAIN still reports a statement that cannot be planned
+statement error No field named nonexistent
+EXPLAIN UPDATE test_explain_update SET nonexistent = 'z';
+
+# EXPLAIN ANALYZE runs the plan, so the rows do change
+query TT
+EXPLAIN ANALYZE UPDATE test_explain_update SET name = 'z' WHERE id > 1;
+----
+Plan with Metrics
+01)CooperativeExec, metrics=[]
+02)--MemDmlExec: op=Update, metrics=[]
+
+query IT rowsort
+SELECT * FROM test_explain_update;
+----
+1 a
+2 z
+3 z
+
+statement ok
+DROP TABLE test_explain_update;

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -35,7 +35,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDmlExec: op=Update
 
 query TT
 explain update t1 set a=c+1, b=a, c=c+1.0, d=b;
@@ -46,7 +46,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDmlExec: op=Update
 
 statement ok
 create table t2(a int, b varchar, c double, d int);


### PR DESCRIPTION

## Which issue does this PR close?

- closes https://github.com/apache/datafusion/issues/24656

## Rationale for this change


## What changes are included in this PR?

`EXPLAIN DELETE` and `EXPLAIN UPDATE` changed the rows of a `MemTable`. `handle_explain()` builds the physical plan in order to print it, the physical planner calls the provider hook while it builds the plan, and `MemTable` did the whole row change inside the hook. The returned `DmlResultExec` was a constant node that only reported the count the hook had computed, so the plan text also carried the count.

Replace `DmlResultExec` with `MemDmlExec`. The hook now compiles the `WHERE` clause and the assignments, then returns a plan that holds the partitions and the declared sort order of the table. `execute()` applies the operation, clears the sort order, and emits the count. This is the pattern that the provider guide already recommends, and `MemTable` is the reference implementation.

Every check of the statement stays in the hook, so an `EXPLAIN` still reports an invalid statement. A plan that runs twice applies the operation twice, as `DataSinkExec` does for an INSERT.

The `DmlResultExec: rows_affected=0` lines of `delete.slt` and `update.slt` become `MemDmlExec: op=Delete` and `MemDmlExec: op=Update`. The count is unknown while the plan is built, so it no longer appears in the plan text.

## Are these changes tested?

Only with the tests here, which are based on the assumptions made in the issue.

## Are there any user-facing changes?

