### PR TITLE
Fix sum by name in custom metrics

### DIFF
--- a/datafusion/physical-expr-common/src/metrics/mod.rs
+++ b/datafusion/physical-expr-common/src/metrics/mod.rs
@@ -314,7 +314,7 @@ impl MetricsSet {
             MetricValue::EndTimestamp(_) => false,
             MetricValue::PruningMetrics { name, .. } => name == metric_name,
             MetricValue::Ratio { name, .. } => name == metric_name,
-            MetricValue::Custom { .. } => false,
+            MetricValue::Custom { name, .. } => name == metric_name,
         })
     }
 
@@ -656,6 +656,8 @@ impl Display for LabelValue {
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use chrono::{TimeZone, Utc};
@@ -771,6 +773,60 @@ mod tests {
         };
 
         assert_eq!(metrics.sum(|_| true), Some(expected_sum));
+    }
+
+    #[test]
+    fn test_sum_by_name_custom_metric() {
+        #[derive(Debug)]
+        struct CustomCount(AtomicUsize);
+
+        impl Display for CustomCount {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0.load(Ordering::Relaxed))
+            }
+        }
+
+        impl CustomMetricValue for CustomCount {
+            fn new_empty(&self) -> Arc<dyn CustomMetricValue> {
+                Arc::new(Self(AtomicUsize::new(0)))
+            }
+
+            fn aggregate(&self, other: Arc<dyn CustomMetricValue + 'static>) {
+                let other = other.as_any().downcast_ref::<Self>().unwrap();
+                self.0
+                    .fetch_add(other.0.load(Ordering::Relaxed), Ordering::Relaxed);
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            fn as_usize(&self) -> usize {
+                self.0.load(Ordering::Relaxed)
+            }
+
+            fn is_eq(&self, other: &Arc<dyn CustomMetricValue>) -> bool {
+                other.as_any().downcast_ref::<Self>().is_some_and(|other| {
+                    self.0.load(Ordering::Relaxed) == other.0.load(Ordering::Relaxed)
+                })
+            }
+        }
+
+        let metrics = ExecutionPlanMetricsSet::new();
+        for (name, value) in [("custom_count", 1), ("custom_count", 2), ("other", 4)] {
+            MetricBuilder::new(&metrics).build(MetricValue::Custom {
+                name: name.into(),
+                value: Arc::new(CustomCount(AtomicUsize::new(value))),
+            });
+        }
+
+        assert_eq!(
+            metrics
+                .clone_inner()
+                .sum_by_name("custom_count")
+                .map(|metric| metric.as_usize()),
+            Some(3)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

Something small I spotted. `MetricValue::sum_by_name` seems to be ignoring custom metrics, while these metrics also have a valid name.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The fix and one unit test.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

People can now call `sum_by_name` in custom metrics