### PR TITLE
docs: Remove stale "temporary fix" note from `get_record_batch_memory_size`

### DIFF
--- a/datafusion/common/src/utils/memory.rs
+++ b/datafusion/common/src/utils/memory.rs
@@ -142,10 +142,9 @@ pub fn estimate_memory_size<T>(num_elements: usize, fixed_size: usize) -> Result
 /// In the above case, `get_record_batch_memory_size` will return the size of
 /// the buffer, instead of the sum of `col1` and `col2`'s actual memory size.
 ///
-/// Note: The current [`RecordBatch::get_array_memory_size`] will double count
-/// the buffer memory size if multiple arrays within the batch are sharing the
-/// same `Buffer`. This method provides a temporary fix until the issue is
-/// resolved: <https://github.com/apache/arrow-rs/issues/6439>
+/// Note: [`RecordBatch::get_array_memory_size`] double counts the buffer
+/// memory size if multiple arrays within the batch are sharing the same
+/// `Buffer`, while this function counts each `Buffer` exactly once.
 pub fn get_record_batch_memory_size(batch: &RecordBatch) -> usize {
     RecordBatchMemoryCounter::new().count_batch(batch)
 }


### PR DESCRIPTION
## Which issue does this PR close?

- N/A (minor doc fix). 
- Follow on to #24637

## Rationale for this change

Address @nuno-faria 's comment addressing https://github.com/apache/datafusion/pull/24637#discussion_r3856817631

This issue is complete, so we can remove the reference
- https://github.com/apache/arrow-rs/issues/6439 


## What changes are included in this PR?

- Remove stale doc

## Are these changes tested?

CI

## Are there any user-facing changes?

Documentation only.
