### PR TITLE
fix: drain completed sort-merge join output before awaiting input

### DIFF
--- a/datafusion/physical-plan/src/joins/sort_merge_join/bitwise_stream.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/bitwise_stream.rs
@@ -821,6 +821,7 @@ impl BitwiseSortMergeJoinStream {
     async fn process_filtered_match_loop(
         &mut self,
         spill: Option<Arc<dyn SpillFile>>,
+        emitter: &mut TryEmitter<RecordBatch, DataFusionError>,
     ) -> Result<()> {
         loop {
             self.process_key_match_with_filter(spill.as_ref()).await?;
@@ -836,6 +837,7 @@ impl BitwiseSortMergeJoinStream {
                 slice_keys(&self.outer_key_arrays, outer_batch.num_rows() - 1);
 
             self.emit_outer_batch()?;
+            self.emit_completed_batches(emitter).await;
 
             if !self.next_outer_batch().await? {
                 break;
@@ -856,7 +858,10 @@ impl BitwiseSortMergeJoinStream {
 
     /// Mark the outer key group as matched. If the outer key group continues
     /// into subsequent outer batches, keep marking there too.
-    async fn process_unfiltered_match_loop(&mut self) -> Result<()> {
+    async fn process_unfiltered_match_loop(
+        &mut self,
+        emitter: &mut TryEmitter<RecordBatch, DataFusionError>,
+    ) -> Result<()> {
         loop {
             self.mark_outer_key_group_matched()?;
 
@@ -871,6 +876,7 @@ impl BitwiseSortMergeJoinStream {
                 slice_keys(&self.outer_key_arrays, outer_batch.num_rows() - 1);
 
             self.emit_outer_batch()?;
+            self.emit_completed_batches(emitter).await;
 
             if !self.next_outer_batch().await? {
                 return Ok(());
@@ -888,18 +894,21 @@ impl BitwiseSortMergeJoinStream {
 
     /// Keys at both cursors are equal: determine which outer rows in the key
     /// group have a match. Both key groups may span batch boundaries.
-    async fn process_key_match(&mut self) -> Result<()> {
+    async fn process_key_match(
+        &mut self,
+        emitter: &mut TryEmitter<RecordBatch, DataFusionError>,
+    ) -> Result<()> {
         if self.filter.is_some() {
             // Buffer the inner key group so each inner row can be evaluated
             // against the outer key group, OR-ing filter results into the
             // matched bitset.
             let spill = self.buffer_inner_key_group().await?;
-            self.process_filtered_match_loop(spill).await
+            self.process_filtered_match_loop(spill, emitter).await
         } else {
             // Without a filter, key equality alone means every outer row in
             // the group matches; the inner rows themselves are not needed.
             self.advance_inner_past_key_group().await?;
-            self.process_unfiltered_match_loop().await
+            self.process_unfiltered_match_loop(emitter).await
         }
     }
 
@@ -1037,10 +1046,16 @@ impl BitwiseSortMergeJoinStream {
     /// current outer batch and all remaining ones with their current matched
     /// bits (semi drops unmatched rows, anti emits them, mark emits them
     /// with mark=false).
-    async fn drain_outer(&mut self) -> Result<()> {
-        self.emit_outer_batch()?;
-        while self.next_outer_batch().await? {
+    async fn drain_outer(
+        &mut self,
+        emitter: &mut TryEmitter<RecordBatch, DataFusionError>,
+    ) -> Result<()> {
+        loop {
             self.emit_outer_batch()?;
+            self.emit_completed_batches(emitter).await;
+            if !self.next_outer_batch().await? {
+                break;
+            }
         }
         Ok(())
     }
@@ -1070,7 +1085,7 @@ impl BitwiseSortMergeJoinStream {
         // helpers are only entered at batch boundaries.
         while self.has_current_outer_row() || self.advance_outer_row(emitter).await? {
             if !(self.has_current_inner_row() || self.advance_inner_row().await?) {
-                self.drain_outer().await?;
+                self.drain_outer(emitter).await?;
                 break;
             }
 
@@ -1086,7 +1101,7 @@ impl BitwiseSortMergeJoinStream {
                 }
                 Ordering::Equal => {
                     if !self.try_process_key_match()? {
-                        self.process_key_match().await?;
+                        self.process_key_match(emitter).await?;
                     }
                 }
             }

--- a/datafusion/physical-plan/src/joins/sort_merge_join/tests.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/tests.rs
@@ -4229,6 +4229,109 @@ async fn collect_stream(stream: SendableRecordBatchStream) -> Result<Vec<RecordB
     common::collect(stream).await
 }
 
+#[rstest::rstest]
+#[case::empty_inner(true, false)]
+#[case::matching_key(false, false)]
+#[case::matching_key_with_filter(false, true)]
+#[tokio::test]
+async fn bitwise_emits_completed_batches_before_pending_outer(
+    #[values(LeftMark, RightMark)] join_type: JoinType,
+    #[case] empty_inner: bool,
+    #[case] with_filter: bool,
+) -> Result<()> {
+    let outer_batches = vec![
+        build_table_i32(
+            ("id", &vec![0, 1]),
+            ("key", &vec![1, 1]),
+            ("value", &vec![10, 20]),
+        ),
+        build_table_i32(
+            ("id", &vec![2, 3]),
+            ("key", &vec![1, 1]),
+            ("value", &vec![10, 20]),
+        ),
+    ];
+    let inner_batch = if empty_inner {
+        RecordBatch::new_empty(outer_batches[0].schema())
+    } else {
+        build_table_i32(("id", &vec![0]), ("key", &vec![1]), ("value", &vec![10]))
+    };
+    let outer = Box::pin(PendingStream::new(outer_batches.clone(), vec![false, true]));
+    let inner = Box::pin(PendingStream::new(vec![inner_batch], vec![false]));
+    let filter = with_filter.then(|| {
+        JoinFilter::new(
+            Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("left_value", 0)),
+                Operator::Eq,
+                Arc::new(Column::new("right_value", 1)),
+            )),
+            vec![
+                ColumnIndex {
+                    index: 2,
+                    side: JoinSide::Left,
+                },
+                ColumnIndex {
+                    index: 2,
+                    side: JoinSide::Right,
+                },
+            ],
+            Arc::new(Schema::new(vec![
+                Field::new("left_value", DataType::Int32, false),
+                Field::new("right_value", DataType::Int32, false),
+            ])),
+        )
+    });
+    let mut fields = outer.schema().fields().to_vec();
+    fields.push(Arc::new(Field::new("mark", DataType::Boolean, false)));
+    let schema = Arc::new(Schema::new(fields));
+    let metrics = ExecutionPlanMetricsSet::new();
+    let (reservation, spill_manager, runtime_env) =
+        test_stream_resources(inner.schema(), &metrics);
+    let mut stream = BitwiseSortMergeJoinStream::try_new(
+        Arc::clone(&schema),
+        vec![SortOptions::default()],
+        NullEquality::NullEqualsNothing,
+        outer,
+        inner,
+        vec![Arc::new(Column::new("key", 1))],
+        vec![Arc::new(Column::new("key", 1))],
+        filter,
+        join_type,
+        2,
+        0,
+        &metrics,
+        reservation,
+        spill_manager,
+        runtime_env,
+    )?;
+
+    // The first outer batch already fills an output batch. Do not wait for the next
+    // outer batch, even when draining unmatched rows or continuing the same key group.
+    let first = match futures::poll!(stream.next()) {
+        Poll::Ready(Some(batch)) => batch?,
+        other => panic!("Completed output must precede pending outer input: {other:?}"),
+    };
+    let mut output = vec![first];
+    output.extend(collect_stream(stream).await?);
+
+    let expected = outer_batches
+        .iter()
+        .map(|batch| {
+            let mut columns = batch.columns().to_vec();
+            columns.push(Arc::new(BooleanArray::from(vec![
+                !empty_inner,
+                !empty_inner && !with_filter,
+            ])));
+            RecordBatch::try_new(Arc::clone(&schema), columns)
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert_eq!(
+        arrow::compute::concat_batches(&schema, &output)?,
+        arrow::compute::concat_batches(&schema, &expected)?,
+    );
+    Ok(())
+}
+
 // ==================== join_time metric tests ====================
 //
 // These verify that `join_time` measures only the join's own work: waiting


### PR DESCRIPTION
## Which issue does this PR close?

No issue is automatically closed. This PR includes a standalone regression for completed sort-merge join output being withheld behind pending input.

## Rationale for this change

The bitwise sort-merge join can finish an output batch and then wait for more outer input without yielding that completed batch. This occurs when the inner input is exhausted or a matching key continues across outer batches, with or without a filter. A stalled input can therefore withhold ready results, and long partitions can accumulate completed output in the coalescer.

## What changes are included in this PR?

- Pass the existing emitter through the matching-key helpers and exhausted-inner drainage.
- Drain completed coalescer batches immediately after emitting each outer batch, before awaiting more input.
- Preserve partial-batch coalescing, final flushing, existing spill handling, and the timing helper.
- Add six regressions covering `LeftMark` and `RightMark` for empty inner input, matching keys, and filtered matching keys. Each requires a ready batch before the next outer input becomes pending, then checks all rows and marker values after resumption.

This does not add an operator or change memory-reservation accounting. The broader coalescer accounting work in #24427 and the separate materializing-stream work in #24573 are outside this change.

## Are these changes tested?

Validated against public main `4fcaa01c`:

- All six new regressions fail on unchanged production code with `Completed output must precede pending outer input: Pending`; all six pass with the fix.
- All 1,790 default physical-plan unit tests pass.
- The extended workspace command passes: 10,796 Rust tests, eight existing ignored tests, and all 505 SQL logic files. This includes 118 extended fuzz tests.
- `cargo fmt --all`, `cargo fmt --all -- --check`, and the mandatory full-workspace `cargo clippy --all-targets --all-features -- -D warnings` pass.

```sh
cargo test --locked --profile ci -p datafusion-physical-plan \
  bitwise_emits_completed_batches_before_pending_outer
cargo test --locked --profile ci -p datafusion-physical-plan --lib
RUST_BACKTRACE=1 cargo test --locked --profile ci \
  --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-cli \
  --workspace --lib --tests --bins \
  --features avro,json,backtrace,extended_tests,recursive_protection,parquet_encryption \
  -- --test-threads=8
```

The extended run used a process-local file-descriptor limit of 65,536. With the environment's default limit of 1,024, the existing `sort_fuzz::test_sort_10k_mem` failed with OS error 24; the same failure and successful higher-limit control were reproduced on a clean main checkout.

Existing semi/anti benchmarks were compared using distinct verified main/patched executables, with 100 samples, three seconds of warmup, and five seconds requested measurement:

| Benchmark | Main | Patch | Criterion reported change |
| --- | --- | --- | --- |
| `left_semi_1to10/100000` | 982.64 us | 914.97 us | -6.08% |
| `left_anti_partial/100000` | 2.0535 ms | 2.1284 ms | +3.65% |

**The anti benchmark is slower in this paired run.** This is one microbenchmark comparison on a shared machine, not a claim of universal throughput improvement or no regression. The new pending-input tests are the direct correctness/streaming regression; no RSS/OOM measurement is claimed.

## Are there any user-facing changes?

Completed batches can be consumed before later outer input is ready. Row contents and marker semantics are unchanged; partial batches still coalesce as before. There is no public API, configuration, or dependency change.
