### PR TITLE
fix: preserve nested projection expressions

### DIFF
--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -522,30 +522,6 @@ fn optimize_subqueries(
 /// - `Ok(None)`: Signals that merge is not beneficial (and has not taken place).
 /// - `Err(error)`: An error occurred during the function call.
 fn merge_consecutive_projections(proj: Projection) -> Result<Transformed<Projection>> {
-    // Collapse the whole chain in one pass; otherwise an N-deep chain needs
-    // N outer optimizer passes to fully fold.
-    let mut current = proj;
-    let mut transformed_any = false;
-    loop {
-        let Transformed {
-            data, transformed, ..
-        } = merge_consecutive_projections_one_level(current)?;
-        current = data;
-        if !transformed {
-            break;
-        }
-        transformed_any = true;
-    }
-    Ok(if transformed_any {
-        Transformed::yes(current)
-    } else {
-        Transformed::no(current)
-    })
-}
-
-fn merge_consecutive_projections_one_level(
-    proj: Projection,
-) -> Result<Transformed<Projection>> {
     let Projection {
         expr,
         input,

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -522,6 +522,30 @@ fn optimize_subqueries(
 /// - `Ok(None)`: Signals that merge is not beneficial (and has not taken place).
 /// - `Err(error)`: An error occurred during the function call.
 fn merge_consecutive_projections(proj: Projection) -> Result<Transformed<Projection>> {
+    // Collapse the whole chain in one pass; otherwise an N-deep chain needs
+    // N outer optimizer passes to fully fold.
+    let mut current = proj;
+    let mut transformed_any = false;
+    loop {
+        let Transformed {
+            data, transformed, ..
+        } = merge_consecutive_projections_one_level(current)?;
+        current = data;
+        if !transformed {
+            break;
+        }
+        transformed_any = true;
+    }
+    Ok(if transformed_any {
+        Transformed::yes(current)
+    } else {
+        Transformed::no(current)
+    })
+}
+
+fn merge_consecutive_projections_one_level(
+    proj: Projection,
+) -> Result<Transformed<Projection>> {
     let Projection {
         expr,
         input,
@@ -531,17 +555,6 @@ fn merge_consecutive_projections(proj: Projection) -> Result<Transformed<Project
     let LogicalPlan::Projection(prev_projection) = input.as_ref() else {
         return Projection::try_new_with_schema(expr, input, schema).map(Transformed::no);
     };
-
-    // A fast path: if the previous projection is same as the current projection
-    // we can directly remove the current projection and return child projection.
-    if prev_projection.expr == expr {
-        return Projection::try_new_with_schema(
-            expr,
-            Arc::clone(&prev_projection.input),
-            schema,
-        )
-        .map(Transformed::yes);
-    }
 
     // Count usages (referrals) of each projection expression in its input fields:
     let mut column_referral_map = HashMap::<&Column, usize>::new();
@@ -1184,6 +1197,69 @@ mod tests {
           TableScan: test projection=[a]
         "
         )
+    }
+
+    #[test]
+    fn merge_structurally_equal_non_idempotent_projections() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("i", DataType::Int32, false)]);
+        let projection = || col("i").add(lit(1)).alias("i");
+        let plan = table_scan(TableReference::none(), &schema, None)?
+            .project(vec![projection()])?
+            .project(vec![projection()])?
+            .build()?;
+
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: ?table?.i + Int32(1) + Int32(1) AS i
+          TableScan: ?table? projection=[i]
+        "
+        )
+    }
+
+    #[test]
+    fn merge_deep_projection_chain_in_one_pass() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("i", DataType::Int32, false)]);
+        let mut plan = table_scan(TableReference::none(), &schema, None)?
+            .project(vec![col("i").add(lit(1)).alias("i")])?
+            .build()?;
+        for _ in 1..12 {
+            plan = LogicalPlanBuilder::from(plan)
+                .project(vec![col("i").add(lit(1)).alias("i")])?
+                .build()?;
+        }
+
+        let optimizer = Optimizer::with_rules(vec![Arc::new(OptimizeProjections::new())]);
+        let optimized = optimizer.optimize(
+            plan,
+            &OptimizerContext::new().with_max_passes(1),
+            observe,
+        )?;
+        let plan_string = format!("{optimized}");
+        assert_eq!(12, plan_string.matches("Int32(1)").count());
+        assert_eq!(1, plan_string.matches("Projection:").count());
+        Ok(())
+    }
+
+    #[test]
+    fn merge_columns_and_metadata_alias() -> Result<()> {
+        let metadata =
+            datafusion_common::metadata::FieldMetadata::from(HashMap::from([(
+                "key".to_string(),
+                "value".to_string(),
+            )]));
+        let plan = LogicalPlanBuilder::from(test_table_scan()?)
+            .project(vec![col("a")])?
+            .project(vec![col("a").alias_with_metadata("a", Some(metadata))])?
+            .build()?;
+
+        let optimized = optimize(plan)?;
+        assert_eq!(
+            "value",
+            optimized.schema().field(0).metadata().get("key").unwrap()
+        );
+        assert_eq!(1, format!("{optimized}").matches("Projection:").count());
+        Ok(())
     }
 
     #[test]

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -792,10 +792,9 @@ fn extension_node_does_not_block_projection_pruning() -> Result<()> {
     OpaqueRequirementsExtension
       Sort: t.a ASC NULLS FIRST, t.ts ASC NULLS FIRST
         Projection: t.a, CAST(t.ts AS Timestamp(ms, "UTC")) AS ts
-          Projection: t.a, t.ts
-            Filter: __common_expr_3 > TimestampMillisecond(1000, Some("UTC")) AND __common_expr_3 < TimestampMillisecond(2000, Some("UTC"))
-              Projection: CAST(t.ts AS Timestamp(ms, "UTC")) AS __common_expr_3, t.a, t.ts
-                TableScan: t projection=[a, ts], partial_filters=[CAST(t.ts AS Timestamp(ms, "UTC")) > TimestampMillisecond(1000, Some("UTC")), CAST(t.ts AS Timestamp(ms, "UTC")) < TimestampMillisecond(2000, Some("UTC"))]
+          Filter: __common_expr_3 > TimestampMillisecond(1000, Some("UTC")) AND __common_expr_3 < TimestampMillisecond(2000, Some("UTC"))
+            Projection: CAST(t.ts AS Timestamp(ms, "UTC")) AS __common_expr_3, t.a, t.ts
+              TableScan: t projection=[a, ts], partial_filters=[CAST(t.ts AS Timestamp(ms, "UTC")) > TimestampMillisecond(1000, Some("UTC")), CAST(t.ts AS Timestamp(ms, "UTC")) < TimestampMillisecond(2000, Some("UTC"))]
     "#,
     );
 

--- a/datafusion/optimizer/tests/optimizer_integration.rs
+++ b/datafusion/optimizer/tests/optimizer_integration.rs
@@ -792,9 +792,10 @@ fn extension_node_does_not_block_projection_pruning() -> Result<()> {
     OpaqueRequirementsExtension
       Sort: t.a ASC NULLS FIRST, t.ts ASC NULLS FIRST
         Projection: t.a, CAST(t.ts AS Timestamp(ms, "UTC")) AS ts
-          Filter: __common_expr_3 > TimestampMillisecond(1000, Some("UTC")) AND __common_expr_3 < TimestampMillisecond(2000, Some("UTC"))
-            Projection: CAST(t.ts AS Timestamp(ms, "UTC")) AS __common_expr_3, t.a, t.ts
-              TableScan: t projection=[a, ts], partial_filters=[CAST(t.ts AS Timestamp(ms, "UTC")) > TimestampMillisecond(1000, Some("UTC")), CAST(t.ts AS Timestamp(ms, "UTC")) < TimestampMillisecond(2000, Some("UTC"))]
+          Projection: t.a, t.ts
+            Filter: __common_expr_3 > TimestampMillisecond(1000, Some("UTC")) AND __common_expr_3 < TimestampMillisecond(2000, Some("UTC"))
+              Projection: CAST(t.ts AS Timestamp(ms, "UTC")) AS __common_expr_3, t.a, t.ts
+                TableScan: t projection=[a, ts], partial_filters=[CAST(t.ts AS Timestamp(ms, "UTC")) > TimestampMillisecond(1000, Some("UTC")), CAST(t.ts AS Timestamp(ms, "UTC")) < TimestampMillisecond(2000, Some("UTC"))]
     "#,
     );
 

--- a/datafusion/sqllogictest/test_files/projection.slt
+++ b/datafusion/sqllogictest/test_files/projection.slt
@@ -235,17 +235,52 @@ FROM (
         SELECT i + 1 AS i
         FROM (
             SELECT i + 1 AS i
-            FROM nested_projection
+            FROM (
+                SELECT i + 1 AS i
+                FROM (
+                    SELECT i + 1 AS i
+                    FROM (
+                        SELECT i + 1 AS i
+                        FROM nested_projection
+                    )
+                )
+            )
         )
     )
 )
 ----
-6
-7
-8
+10
+11
+9
 
 statement ok
 RESET datafusion.optimizer.max_passes;
+
+query I rowsort
+SELECT i
+FROM (
+    SELECT i + 1 AS i
+    FROM (
+        SELECT i + 1 AS i
+        FROM (
+            SELECT i + 1 AS i
+            FROM (
+                SELECT i + 1 AS i
+                FROM (
+                    SELECT i + 1 AS i
+                    FROM (
+                        SELECT i + 1 AS i
+                        FROM nested_projection
+                    )
+                )
+            )
+        )
+    )
+)
+----
+10
+11
+9
 
 statement ok
 DROP TABLE nested_projection;

--- a/datafusion/sqllogictest/test_files/projection.slt
+++ b/datafusion/sqllogictest/test_files/projection.slt
@@ -217,7 +217,7 @@ SELECT column1 as a from (values (1), (2)) f where f.column1 = 2;
 ----
 2
 
-# Regression: one optimizer pass must preserve anonymous nested projections.
+# Regression: preserve deep anonymous nested projections with one and default passes.
 statement ok
 CREATE TABLE nested_projection(i INT);
 

--- a/datafusion/sqllogictest/test_files/projection.slt
+++ b/datafusion/sqllogictest/test_files/projection.slt
@@ -217,6 +217,39 @@ SELECT column1 as a from (values (1), (2)) f where f.column1 = 2;
 ----
 2
 
+# Regression: one optimizer pass must preserve anonymous nested projections.
+statement ok
+CREATE TABLE nested_projection(i INT);
+
+statement ok
+INSERT INTO nested_projection VALUES (3), (4), (5);
+
+statement ok
+SET datafusion.optimizer.max_passes = 1;
+
+query I rowsort
+SELECT i
+FROM (
+    SELECT i + 1 AS i
+    FROM (
+        SELECT i + 1 AS i
+        FROM (
+            SELECT i + 1 AS i
+            FROM nested_projection
+        )
+    )
+)
+----
+6
+7
+8
+
+statement ok
+RESET datafusion.optimizer.max_passes;
+
+statement ok
+DROP TABLE nested_projection;
+
 # clean data
 statement ok
 DROP TABLE aggregate_simple;


### PR DESCRIPTION
## Which issue does this PR close?

- No issue has been filed.

## Rationale for this change

Anonymous nested projections that reuse the same output name can return wrong results. For example, each `i + 1 AS i` layer must be evaluated independently, but the projection optimizer could drop one layer when two consecutive projection expression vectors were structurally equal.

Structural equality does not imply that a projection is safe to elide: repeated computations such as `i + 1 AS i` have the same expression shape but must still be evaluated twice.

## What changes are included in this PR?

- Remove the structural-equality fast path that directly elided one of two consecutive projections.
- Keep the existing iterative whole-chain merge, so deep projection chains still collapse within one optimizer rule invocation.
- Continue using the normal projection rewrite path, which composes repeated expressions and preserves aliases and field metadata.
- Add focused regressions for repeated non-idempotent projections, one-pass collapse of a 12-level chain, and metadata-bearing aliases.
- Add an execution-level SQLLogicTest with six anonymous `i + 1 AS i` layers under both `max_passes = 1` and the default optimizer configuration.

## What is the testing strategy for this PR?

The focused unit tests verify that:

- two structurally equal `i + 1 AS i` projections retain both additions;
- a 12-level chain preserves all 12 additions and collapses to one `Projection` with `max_passes = 1`;
- a metadata-bearing `Alias(Column)` is merged without losing field metadata.

The SQLLogicTest executes a six-level anonymous projection chain against a temporary table with both one optimizer pass and the default pass count.

Verified with:

```text
cargo fmt --all --check
cargo test -p datafusion-optimizer optimize_projections
# 58 passed; 0 failed

cargo test -p datafusion-optimizer --test optimizer_integration
# 26 passed; 0 failed

cargo test --profile ci -p datafusion-sqllogictest --test sqllogictests -- projection.slt
# 1/1 files completed; 0 failures

cargo clippy -p datafusion-optimizer --all-targets --all-features -- -D warnings
# passed

git diff --check
# passed
```

## Are there any user-facing changes?

Yes. Deep anonymous nested projections that reuse an output name now preserve every projection expression and return the correct result. There are no public API or configuration changes.
