### PR TITLE
refactor(proto): destructure Arrow and Avro source serde hooks

### DIFF
--- a/datafusion/datasource-arrow/src/source.rs
+++ b/datafusion/datasource-arrow/src/source.rs
@@ -414,6 +414,9 @@ impl FileSource for ArrowSource {
         use datafusion_proto_models::protobuf;
         use protobuf::physical_plan_node::PhysicalPlanType;
 
+        // Exhaustive destructure: adding a field to `ArrowSource` without
+        // deciding how it is serialized is a compile error, not a silent
+        // round-trip gap.
         let Self {
             format,
             // Runtime metrics, not part of the plan.

--- a/datafusion/datasource-arrow/src/source.rs
+++ b/datafusion/datasource-arrow/src/source.rs
@@ -414,7 +414,17 @@ impl FileSource for ArrowSource {
         use datafusion_proto_models::protobuf;
         use protobuf::physical_plan_node::PhysicalPlanType;
 
-        let format = match self.format {
+        let Self {
+            format,
+            // Runtime metrics, not part of the plan.
+            metrics: _,
+            // Serialized in `base` and reapplied on decode.
+            projection: _,
+            // Serialized in `base` and used to rebuild the source on decode.
+            table_schema: _,
+        } = self;
+
+        let format = match format {
             ArrowFormat::File => protobuf::ArrowIpcFormat::File,
             ArrowFormat::Stream => protobuf::ArrowIpcFormat::Stream,
         };
@@ -452,16 +462,18 @@ impl ArrowSource {
             );
         };
 
-        let base_conf = scan.base_conf.as_ref().ok_or_else(|| {
+        let protobuf::ArrowScanExecNode { base_conf, format } = scan;
+
+        let base_conf = base_conf.as_ref().ok_or_else(|| {
             datafusion_common::internal_datafusion_err!(
                 "ArrowScanExecNode is missing required field 'base_conf'"
             )
         })?;
 
-        let format = protobuf::ArrowIpcFormat::try_from(scan.format).map_err(|_| {
+        let format = protobuf::ArrowIpcFormat::try_from(*format).map_err(|_| {
             datafusion_common::internal_datafusion_err!(
                 "Unknown ArrowIpcFormat: {}",
-                scan.format
+                format
             )
         })?;
 

--- a/datafusion/datasource-avro/src/source.rs
+++ b/datafusion/datasource-avro/src/source.rs
@@ -189,6 +189,17 @@ impl FileSource for AvroSource {
         use datafusion_proto_models::protobuf;
         use protobuf::physical_plan_node::PhysicalPlanType;
 
+        let Self {
+            // Serialized in `base` and used to rebuild the source on decode.
+            table_schema: _,
+            // Set from `FileScanConfig` when the scan is opened.
+            batch_size: _,
+            // Serialized in `base` and reapplied on decode.
+            projection: _,
+            // Runtime metrics, not part of the plan.
+            metrics: _,
+        } = self;
+
         let node = protobuf::AvroScanExecNode {
             base_conf: Some(base.try_to_proto(ctx)?),
         };
@@ -216,7 +227,9 @@ impl AvroSource {
             );
         };
 
-        let base_conf = scan.base_conf.as_ref().ok_or_else(|| {
+        let protobuf::AvroScanExecNode { base_conf } = scan;
+
+        let base_conf = base_conf.as_ref().ok_or_else(|| {
             datafusion_common::internal_datafusion_err!(
                 "AvroScanExecNode is missing required field 'base_conf'"
             )

--- a/datafusion/datasource-avro/src/source.rs
+++ b/datafusion/datasource-avro/src/source.rs
@@ -189,6 +189,9 @@ impl FileSource for AvroSource {
         use datafusion_proto_models::protobuf;
         use protobuf::physical_plan_node::PhysicalPlanType;
 
+        // Exhaustive destructure: adding a field to `AvroSource` without
+        // deciding how it is serialized is a compile error, not a silent
+        // round-trip gap.
         let Self {
             // Serialized in `base` and used to rebuild the source on decode.
             table_schema: _,


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24622.

## Rationale for this change

Proto hooks that access fields individually can silently omit newly added state. Exhaustive destructuring makes such omissions compile errors.

## What changes are included in this PR?

- Exhaustively destructure `ArrowSource` and `AvroSource` in their encoders.
- Exhaustively destructure their protobuf nodes in the decoders.
- Document why non-serialized fields are excluded.

The wire format is unchanged.

## Are these changes tested?

Covered by the existing Arrow and Avro round-trip tests:

```bash
cargo test -p datafusion-proto --test proto_integration --features avro roundtrip_arrow
cargo test -p datafusion-proto --test proto_integration --features avro roundtrip_avro
```

The standard lint suite also passes:

```bash
./dev/rust_lint.sh
```

## Are there any user-facing changes?

No.
