### PR TITLE
fix: preserve narrowing TRY_CAST comparison semantics

### DIFF
--- a/datafusion/expr-common/src/casts.rs
+++ b/datafusion/expr-common/src/casts.rs
@@ -157,6 +157,38 @@ pub fn is_date_narrowing_cast(from_type: &DataType, to_type: &DataType) -> bool 
     matches!((from_type, to_type), (DataType::Date64, DataType::Date32))
 }
 
+/// Returns true when the source integer domain is not fully representable in
+/// the target integer type.
+///
+/// Comparison cast unwrapping must retain a narrowing `TRY_CAST`: source values
+/// outside the target domain become `NULL`, while the unwrapped comparison
+/// would evaluate those values directly. This check includes signed/unsigned
+/// transitions as well as casts to a smaller integer width.
+pub fn is_integer_narrowing_cast(from_type: &DataType, to_type: &DataType) -> bool {
+    let Some((from_min, from_max)) = integer_bounds(from_type) else {
+        return false;
+    };
+    let Some((to_min, to_max)) = integer_bounds(to_type) else {
+        return false;
+    };
+
+    from_min < to_min || from_max > to_max
+}
+
+fn integer_bounds(data_type: &DataType) -> Option<(i128, i128)> {
+    match data_type {
+        DataType::Int8 => Some((i8::MIN.into(), i8::MAX.into())),
+        DataType::Int16 => Some((i16::MIN.into(), i16::MAX.into())),
+        DataType::Int32 => Some((i32::MIN.into(), i32::MAX.into())),
+        DataType::Int64 => Some((i64::MIN.into(), i64::MAX.into())),
+        DataType::UInt8 => Some((u8::MIN.into(), u8::MAX.into())),
+        DataType::UInt16 => Some((u16::MIN.into(), u16::MAX.into())),
+        DataType::UInt32 => Some((u32::MIN.into(), u32::MAX.into())),
+        DataType::UInt64 => Some((u64::MIN.into(), u64::MAX.into())),
+        _ => None,
+    }
+}
+
 fn timestamp_unit_scale(unit: &TimeUnit) -> i128 {
     match unit {
         TimeUnit::Second => 1,
@@ -1034,6 +1066,34 @@ mod tests {
             &DataType::Date64
         ));
         assert!(!is_date_narrowing_cast(&DataType::Int64, &DataType::Date32));
+    }
+
+    #[test]
+    fn test_is_integer_narrowing_cast() {
+        assert!(is_integer_narrowing_cast(
+            &DataType::Int64,
+            &DataType::Int32
+        ));
+        assert!(is_integer_narrowing_cast(
+            &DataType::Int32,
+            &DataType::UInt32
+        ));
+        assert!(is_integer_narrowing_cast(
+            &DataType::UInt32,
+            &DataType::Int32
+        ));
+        assert!(!is_integer_narrowing_cast(
+            &DataType::Int32,
+            &DataType::Int64
+        ));
+        assert!(!is_integer_narrowing_cast(
+            &DataType::UInt32,
+            &DataType::Int64
+        ));
+        assert!(!is_integer_narrowing_cast(
+            &DataType::Utf8,
+            &DataType::Int32
+        ));
     }
 
     #[test]

--- a/datafusion/optimizer/src/simplify_expressions/unwrap_cast.rs
+++ b/datafusion/optimizer/src/simplify_expressions/unwrap_cast.rs
@@ -60,8 +60,8 @@ use datafusion_common::{internal_err, tree_node::Transformed};
 use datafusion_expr::{BinaryExpr, lit};
 use datafusion_expr::{Cast, Expr, Operator, TryCast, simplify::SimplifyContext};
 use datafusion_expr_common::casts::{
-    is_date_narrowing_cast, is_supported_type, is_timestamp_precision_narrowing_cast,
-    try_cast_literal_to_type,
+    is_date_narrowing_cast, is_integer_narrowing_cast, is_supported_type,
+    is_timestamp_precision_narrowing_cast, try_cast_literal_to_type,
 };
 
 pub(super) fn unwrap_cast_in_comparison_for_binary(
@@ -113,18 +113,20 @@ pub(super) fn is_cast_expr_and_support_unwrap_cast_in_comparison_for_binary(
     op: Operator,
     literal: &Expr,
 ) -> bool {
-    match (expr, literal) {
-        (
-            Expr::TryCast(TryCast {
-                expr: left_expr,
-                field,
-            })
-            | Expr::Cast(Cast {
-                expr: left_expr,
-                field,
-            }),
-            Expr::Literal(lit_val, _),
-        ) => {
+    let (left_expr, field, is_try_cast) = match expr {
+        Expr::TryCast(TryCast {
+            expr: left_expr,
+            field,
+        }) => (left_expr, field, true),
+        Expr::Cast(Cast {
+            expr: left_expr,
+            field,
+        }) => (left_expr, field, false),
+        _ => return false,
+    };
+
+    match literal {
+        Expr::Literal(lit_val, _) => {
             let Ok(expr_type) = info.get_data_type(left_expr) else {
                 return false;
             };
@@ -135,6 +137,8 @@ pub(super) fn is_cast_expr_and_support_unwrap_cast_in_comparison_for_binary(
 
             if is_timestamp_precision_narrowing_cast(&expr_type, field.data_type())
                 || is_date_narrowing_cast(&expr_type, field.data_type())
+                || (is_try_cast
+                    && is_integer_narrowing_cast(&expr_type, field.data_type()))
             {
                 return false;
             }
@@ -156,16 +160,16 @@ pub(super) fn is_cast_expr_and_support_unwrap_cast_in_comparison_for_inlist(
     expr: &Expr,
     list: &[Expr],
 ) -> bool {
-    let (Expr::TryCast(TryCast {
-        expr: left_expr,
-        field,
-    })
-    | Expr::Cast(Cast {
-        expr: left_expr,
-        field,
-    })) = expr
-    else {
-        return false;
+    let (left_expr, field, is_try_cast) = match expr {
+        Expr::TryCast(TryCast {
+            expr: left_expr,
+            field,
+        }) => (left_expr, field, true),
+        Expr::Cast(Cast {
+            expr: left_expr,
+            field,
+        }) => (left_expr, field, false),
+        _ => return false,
     };
 
     let Ok(expr_type) = info.get_data_type(left_expr) else {
@@ -178,6 +182,7 @@ pub(super) fn is_cast_expr_and_support_unwrap_cast_in_comparison_for_inlist(
 
     if is_timestamp_precision_narrowing_cast(&expr_type, field.data_type())
         || is_date_narrowing_cast(&expr_type, field.data_type())
+        || (is_try_cast && is_integer_narrowing_cast(&expr_type, field.data_type()))
     {
         return false;
     }
@@ -334,6 +339,21 @@ mod tests {
         let expr_input = cast(col("c1"), DataType::Utf8).eq(lit(ScalarValue::Utf8(None)));
         let expected = null_bool();
         assert_eq!(optimize_test(expr_input, &schema), expected);
+    }
+
+    #[test]
+    fn test_not_unwrap_narrowing_integer_try_cast() {
+        let schema = expr_test_schema();
+
+        let comparison = try_cast(col("c2"), DataType::Int32).gt(lit(1i32));
+        assert_eq!(optimize_test(comparison.clone(), &schema), comparison);
+
+        let in_list_expr = in_list(
+            try_cast(col("c2"), DataType::Int32),
+            vec![lit(1i32), lit(2i32), lit(3i32), lit(4i32), lit(5i32)],
+            true,
+        );
+        assert_eq!(optimize_test(in_list_expr.clone(), &schema), in_list_expr);
     }
 
     #[test]

--- a/datafusion/physical-expr/src/simplifier/unwrap_cast.rs
+++ b/datafusion/physical-expr/src/simplifier/unwrap_cast.rs
@@ -37,8 +37,8 @@ use arrow::datatypes::{DataType, Schema};
 use datafusion_common::{Result, ScalarValue, tree_node::Transformed};
 use datafusion_expr::Operator;
 use datafusion_expr_common::casts::{
-    is_date_narrowing_cast, is_timestamp_precision_narrowing_cast,
-    try_cast_literal_to_type,
+    is_date_narrowing_cast, is_integer_narrowing_cast,
+    is_timestamp_precision_narrowing_cast, try_cast_literal_to_type,
 };
 
 use crate::PhysicalExpr;
@@ -63,7 +63,7 @@ fn try_unwrap_cast_binary(
     schema: &Schema,
 ) -> Result<Option<Arc<dyn PhysicalExpr>>> {
     // Case 1: cast(left_expr) op literal
-    if let (Some((inner_expr, cast_type)), Some(literal)) = (
+    if let (Some((inner_expr, cast_type, is_try_cast)), Some(literal)) = (
         extract_cast_info(binary.left()),
         binary.right().downcast_ref::<Literal>(),
     ) && binary.op().supports_propagation()
@@ -71,6 +71,7 @@ fn try_unwrap_cast_binary(
             Arc::clone(inner_expr),
             literal.value(),
             cast_type,
+            is_try_cast,
             *binary.op(),
             schema,
         )?
@@ -79,7 +80,7 @@ fn try_unwrap_cast_binary(
     }
 
     // Case 2: literal op cast(right_expr)
-    if let (Some(literal), Some((inner_expr, cast_type))) = (
+    if let (Some(literal), Some((inner_expr, cast_type, is_try_cast))) = (
         binary.left().downcast_ref::<Literal>(),
         extract_cast_info(binary.right()),
     ) {
@@ -90,6 +91,7 @@ fn try_unwrap_cast_binary(
                 Arc::clone(inner_expr),
                 literal.value(),
                 cast_type,
+                is_try_cast,
                 swapped_op,
                 schema,
             )?
@@ -106,14 +108,15 @@ fn try_unwrap_cast_binary(
 /// Extract cast information from a physical expression
 ///
 /// If the expression is a CAST(expr, datatype) or TRY_CAST(expr, datatype),
-/// returns Some((inner_expr, target_datatype)). Otherwise returns None.
+/// returns the inner expression, target datatype, and whether the cast is a
+/// TRY_CAST. Otherwise returns None.
 fn extract_cast_info(
     expr: &Arc<dyn PhysicalExpr>,
-) -> Option<(&Arc<dyn PhysicalExpr>, &DataType)> {
+) -> Option<(&Arc<dyn PhysicalExpr>, &DataType, bool)> {
     if let Some(cast) = expr.downcast_ref::<CastExpr>() {
-        Some((cast.expr(), cast.cast_type()))
+        Some((cast.expr(), cast.cast_type(), false))
     } else if let Some(try_cast) = expr.downcast_ref::<TryCastExpr>() {
-        Some((try_cast.expr(), try_cast.cast_type()))
+        Some((try_cast.expr(), try_cast.cast_type(), true))
     } else {
         None
     }
@@ -124,6 +127,7 @@ fn try_unwrap_cast_comparison(
     inner_expr: Arc<dyn PhysicalExpr>,
     literal_value: &ScalarValue,
     cast_type: &DataType,
+    is_try_cast: bool,
     op: Operator,
     schema: &Schema,
 ) -> Result<Option<Arc<dyn PhysicalExpr>>> {
@@ -132,6 +136,7 @@ fn try_unwrap_cast_comparison(
 
     if is_timestamp_precision_narrowing_cast(&inner_type, cast_type)
         || is_date_narrowing_cast(&inner_type, cast_type)
+        || (is_try_cast && is_integer_narrowing_cast(&inner_type, cast_type))
     {
         return Ok(None);
     }
@@ -463,6 +468,20 @@ mod tests {
         let result = unwrap_cast_in_comparison(binary_expr, &schema).unwrap();
 
         // Should NOT be transformed (string to int cast not supported)
+        assert!(!result.transformed);
+    }
+
+    #[test]
+    fn test_no_unwrap_narrowing_integer_try_cast() {
+        let schema = Schema::new(vec![Field::new("int_col", DataType::Int64, false)]);
+
+        let column_expr = col("int_col", &schema).unwrap();
+        let try_cast_expr = Arc::new(TryCastExpr::new(column_expr, DataType::Int32));
+        let literal_expr = lit(1i32);
+        let binary_expr =
+            Arc::new(BinaryExpr::new(try_cast_expr, Operator::Gt, literal_expr));
+
+        let result = unwrap_cast_in_comparison(binary_expr, &schema).unwrap();
         assert!(!result.transformed);
     }
 

--- a/datafusion/sqllogictest/test_files/cast.slt
+++ b/datafusion/sqllogictest/test_files/cast.slt
@@ -21,6 +21,40 @@ SELECT cast(c as varchar) FROM (SELECT 1 as c)
 ----
 1
 
+# Narrowing TRY_CAST comparisons must preserve NULL-on-overflow semantics.
+statement ok
+CREATE TABLE try_cast_narrowing AS VALUES
+    (5::BIGINT),
+    (9999999999::BIGINT);
+
+query IIB rowsort
+SELECT column1,
+       try_cast(column1 AS INT),
+       try_cast(column1 AS INT) > 1
+FROM try_cast_narrowing;
+----
+5 5 true
+9999999999 NULL NULL
+
+query I
+SELECT column1
+FROM try_cast_narrowing
+WHERE try_cast(column1 AS INT) > 1;
+----
+5
+
+query IIB rowsort
+SELECT column1,
+       try_cast(column1 AS INT) IN (5),
+       try_cast(column1 AS INT) NOT IN (5)
+FROM try_cast_narrowing;
+----
+5 true false
+9999999999 NULL NULL
+
+statement ok
+DROP TABLE try_cast_narrowing;
+
 # cast tinyint
 query I
 SELECT cast(10 as tinyint)


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24702.

## Rationale for this change

A narrowing `TRY_CAST` can return `NULL` for source values outside the target integer range. Unwrapping that cast from a comparison made those values participate in the comparison directly, producing self-contradictory results such as a projected `NULL` alongside `TRY_CAST(...) > 1 = true`.

## What changes are included in this PR?

- Add a shared signed/unsigned integer-domain check for narrowing casts.
- Keep narrowing integer `TRY_CAST` expressions intact in logical binary and `IN`-list simplification.
- Apply the same guard in physical comparison simplification used by pushed-down filters.
- Add logical, physical, helper, and SQL regression coverage. Ordinary `CAST` behavior is unchanged.

## Are these changes tested?

Yes. The following checks passed locally:

- `cargo test -p datafusion-expr-common test_is_integer_narrowing_cast`
- `CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 cargo test -p datafusion-optimizer test_not_unwrap_narrowing_integer_try_cast`
- `CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 cargo test -p datafusion-physical-expr test_no_unwrap_narrowing_integer_try_cast`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_INCREMENTAL=0 cargo clippy -p datafusion-expr-common -p datafusion-optimizer -p datafusion-physical-expr --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The focused `cast.slt` case was not run locally because the workspace has about 3 GiB free and `protoc` is unavailable. It is included for CI; the two rewrite layers it exercises compile and pass their direct regression tests.

## Are there any user-facing changes?

Yes. Comparisons and `IN` predicates over narrowing integer `TRY_CAST` expressions now preserve SQL `NULL`-on-overflow semantics instead of admitting out-of-range rows.

## AI-assisted contribution disclosure

This change was prepared with AI assistance and has not yet received human review. The implementation was traced end-to-end across both affected simplifiers; the local SQL-test limitation is called out above.
