### PR TITLE
feat: preserving grouped state reads

### DIFF
--- a/datafusion/expr-common/src/groups_accumulator.rs
+++ b/datafusion/expr-common/src/groups_accumulator.rs
@@ -18,7 +18,7 @@
 //! Vectorized [`GroupsAccumulator`]
 
 use arrow::array::{ArrayRef, BooleanArray};
-use datafusion_common::{Result, utils::split_vec_min_alloc};
+use datafusion_common::{Result, exec_err, not_impl_err, utils::split_vec_min_alloc};
 
 /// Describes how many rows should be emitted during grouping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +47,91 @@ impl EmitTo {
             }
             Self::First(n) => split_vec_min_alloc(v, *n),
         }
+    }
+}
+
+/// Selects groups for a non-destructive grouped aggregation read.
+///
+/// Unlike [`EmitTo`], this selection does not remove groups or change their
+/// indices. Selections created by [`Self::try_from_indices`] preserve the
+/// requested order and support duplicate indices.
+///
+/// A selection is validated once when it is constructed and can then be reused
+/// for the group values and accumulators participating in the same snapshot.
+/// Construct a new selection if the number or indexing of those groups changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GroupSelection<'a> {
+    total_num_groups: usize,
+    indices: Option<&'a [usize]>,
+}
+
+impl<'a> GroupSelection<'a> {
+    /// Selects all `total_num_groups` groups in group-index order.
+    pub fn all(total_num_groups: usize) -> Self {
+        Self {
+            total_num_groups,
+            indices: None,
+        }
+    }
+
+    /// Selects groups in the order specified by `indices`.
+    ///
+    /// Returns an error if an index is not less than `total_num_groups`. Empty
+    /// selections are valid, and duplicate indices are preserved.
+    pub fn try_from_indices(
+        indices: &'a [usize],
+        total_num_groups: usize,
+    ) -> Result<Self> {
+        if let Some(index) = indices.iter().find(|&&index| index >= total_num_groups) {
+            return exec_err!(
+                "Group index {index} is out of bounds for {total_num_groups} groups"
+            );
+        }
+        Ok(Self {
+            total_num_groups,
+            indices: Some(indices),
+        })
+    }
+
+    /// Returns the group count against which this selection was constructed.
+    pub fn total_num_groups(self) -> usize {
+        self.total_num_groups
+    }
+
+    /// Ensures this selection is being applied to the same number of groups
+    /// against which it was constructed.
+    ///
+    /// Preserving-read implementations should call this method with their
+    /// stored group count before using [`Self::iter`]. This check is `O(1)`;
+    /// the selected indices were already checked by [`Self::try_from_indices`].
+    pub fn validate_num_groups(self, actual_num_groups: usize) -> Result<()> {
+        if actual_num_groups != self.total_num_groups {
+            return exec_err!(
+                "Group selection was constructed for {} groups but applied to {actual_num_groups} groups",
+                self.total_num_groups
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns the number of selected groups.
+    pub fn len(self) -> usize {
+        self.indices
+            .map_or(self.total_num_groups, |indices| indices.len())
+    }
+
+    /// Returns `true` if no groups are selected.
+    pub fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the selected group indices in output order.
+    pub fn iter(self) -> impl Iterator<Item = usize> + 'a {
+        let (all, indices): (_, &'a [usize]) = match self.indices {
+            None => (0..self.total_num_groups, &[]),
+            Some(indices) => (0..0, indices),
+        };
+        all.chain(indices.iter().copied())
     }
 }
 
@@ -154,6 +239,27 @@ pub trait GroupsAccumulator: Send + std::any::Any {
     /// `n`. See [`EmitTo::First`] for more details.
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef>;
 
+    /// Returns final aggregate values without changing the logical state or
+    /// group indices.
+    ///
+    /// Rows are returned in the order specified by `selection`. An empty
+    /// selection returns a correctly typed array with no rows.
+    ///
+    /// This method requires exclusive access because implementations may mutate
+    /// internal caches or builders. However, repeated calls and later updates
+    /// must observe the same logical accumulator state.
+    fn evaluate_preserving(
+        &mut self,
+        _selection: GroupSelection<'_>,
+    ) -> Result<ArrayRef> {
+        not_impl_err!("Preserving grouped evaluation is not implemented")
+    }
+
+    /// Returns `true` if [`Self::evaluate_preserving`] is implemented.
+    fn supports_evaluate_preserving(&self) -> bool {
+        false
+    }
+
     /// Returns the intermediate aggregate state for this accumulator,
     /// used for multi-phase grouping, resetting its internal state.
     ///
@@ -171,6 +277,28 @@ pub trait GroupsAccumulator: Send + std::any::Any {
     ///
     /// [`Accumulator::state`]: crate::accumulator::Accumulator::state
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>>;
+
+    /// Returns intermediate aggregate state without changing the logical state
+    /// or group indices.
+    ///
+    /// Each returned array has one row per selected group, in the order
+    /// specified by `selection`. An empty selection returns the normal number
+    /// of correctly typed state arrays, each with no rows.
+    ///
+    /// This method requires exclusive access because implementations may mutate
+    /// internal caches or builders. However, repeated calls and later updates
+    /// must observe the same logical accumulator state.
+    fn state_preserving(
+        &mut self,
+        _selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        not_impl_err!("Preserving grouped state is not implemented")
+    }
+
+    /// Returns `true` if [`Self::state_preserving`] is implemented.
+    fn supports_state_preserving(&self) -> bool {
+        false
+    }
 
     /// Merges intermediate state (the output from [`Self::state`])
     /// into this accumulator's current state.
@@ -247,7 +375,7 @@ pub trait GroupsAccumulator: Send + std::any::Any {
 
 #[cfg(test)]
 mod tests {
-    use super::EmitTo;
+    use super::{EmitTo, GroupSelection};
 
     /// When `n` is small relative to `len`, the old `split_off(n) + swap` pattern had
     /// two allocation problems:
@@ -292,5 +420,37 @@ mod tests {
             v.capacity(),
             original_capacity,
         );
+    }
+
+    #[test]
+    fn group_selection_is_validated_once_and_reusable() {
+        let values = [10, 20, 30, 40];
+        let selected =
+            GroupSelection::try_from_indices(&[3, 1, 3], values.len()).unwrap();
+        assert_eq!(selected.total_num_groups(), values.len());
+        assert_eq!(selected.len(), 3);
+        assert_eq!(
+            selected
+                .iter()
+                .map(|index| values[index])
+                .collect::<Vec<_>>(),
+            vec![40, 20, 40]
+        );
+        selected.validate_num_groups(values.len()).unwrap();
+        let error = selected.validate_num_groups(values.len() - 1).unwrap_err();
+        assert!(error.to_string().contains("constructed for 4 groups"));
+
+        let all = GroupSelection::all(values.len());
+        assert_eq!(
+            all.iter().map(|index| values[index]).collect::<Vec<_>>(),
+            values
+        );
+
+        let empty = GroupSelection::try_from_indices(&[], values.len()).unwrap();
+        assert!(empty.is_empty());
+        assert!(empty.iter().next().is_none());
+
+        let error = GroupSelection::try_from_indices(&[4], values.len()).unwrap_err();
+        assert!(error.to_string().contains("out of bounds"));
     }
 }

--- a/datafusion/expr/src/lib.rs
+++ b/datafusion/expr/src/lib.rs
@@ -103,7 +103,9 @@ pub use datafusion_doc::{
 };
 pub use datafusion_expr_common::accumulator::Accumulator;
 pub use datafusion_expr_common::columnar_value::ColumnarValue;
-pub use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+pub use datafusion_expr_common::groups_accumulator::{
+    EmitTo, GroupSelection, GroupsAccumulator,
+};
 pub use datafusion_expr_common::operator::Operator;
 pub use datafusion_expr_common::placement::ExpressionPlacement;
 pub use datafusion_expr_common::signature::{

--- a/datafusion/functions-aggregate-common/src/aggregate/count_distinct/groups.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/count_distinct/groups.rs
@@ -23,7 +23,9 @@ use arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{ArrowPrimitiveType, Field};
 use datafusion_common::HashSet;
 use datafusion_common::hash_utils::RandomState;
-use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+use datafusion_expr_common::groups_accumulator::{
+    EmitTo, GroupSelection, GroupsAccumulator,
+};
 use std::hash::Hash;
 use std::mem::size_of;
 use std::sync::Arc;
@@ -101,6 +103,22 @@ where
         }
 
         Ok(Arc::new(Int64Array::from(counts)))
+    }
+
+    fn evaluate_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> datafusion_common::Result<ArrayRef> {
+        selection.validate_num_groups(self.counts.len())?;
+        let counts = selection
+            .iter()
+            .map(|index| self.counts[index])
+            .collect::<Vec<_>>();
+        Ok(Arc::new(Int64Array::from(counts)))
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
     }
 
     fn state(&mut self, emit_to: EmitTo) -> datafusion_common::Result<Vec<ArrayRef>> {
@@ -220,6 +238,47 @@ mod tests {
     use arrow::array::Int32Array;
     use arrow::datatypes::Int32Type;
     use datafusion_common::Result;
+
+    #[test]
+    fn preserving_reads_keep_distinct_state() -> Result<()> {
+        let mut accumulator = PrimitiveDistinctCountGroupsAccumulator::<Int32Type>::new();
+        let values = Arc::new(Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(1),
+            None,
+            Some(3),
+        ]));
+        accumulator.update_batch(&[values], &[0, 0, 1, 2, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[2, 0, 3, 2], 4)?;
+        let expected = Int64Array::from(vec![1, 2, 0, 1]);
+        for _ in 0..2 {
+            assert_eq!(
+                accumulator
+                    .evaluate_preserving(selection)?
+                    .as_primitive::<arrow::datatypes::Int64Type>(),
+                &expected
+            );
+        }
+        assert!(
+            accumulator
+                .evaluate_preserving(GroupSelection::try_from_indices(&[], 4)?)?
+                .is_empty()
+        );
+
+        let values = Arc::new(Int32Array::from(vec![2, 4, 1]));
+        accumulator.update_batch(&[values], &[0, 0, 1], None, 4)?;
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(GroupSelection::all(4))?
+                .as_primitive::<arrow::datatypes::Int64Type>(),
+            &Int64Array::from(vec![3, 1, 1, 0])
+        );
+        assert!(accumulator.supports_evaluate_preserving());
+        assert!(!accumulator.supports_state_preserving());
+        Ok(())
+    }
 
     #[test]
     fn convert_to_state_roundtrips_through_merge() -> Result<()> {

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator.rs
@@ -34,7 +34,9 @@ use arrow::{
 };
 use datafusion_common::{Result, ScalarValue, arrow_datafusion_err};
 use datafusion_expr_common::accumulator::Accumulator;
-use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+use datafusion_expr_common::groups_accumulator::{
+    EmitTo, GroupSelection, GroupsAccumulator,
+};
 
 /// An adapter that implements [`GroupsAccumulator`] for any [`Accumulator`]
 ///
@@ -335,6 +337,34 @@ impl GroupsAccumulator for GroupsAccumulatorAdapter {
         result
     }
 
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.states.len())?;
+        let selected_len = selection.len();
+        if selected_len == 0 {
+            // ScalarValue::iter_to_array needs at least one value to infer the
+            // output type, so evaluate a temporary empty accumulator.
+            let mut accumulator = (self.factory)()?;
+            return Ok(ScalarValue::iter_to_array([accumulator.evaluate()?])?.slice(0, 0));
+        }
+
+        let mut results = Vec::with_capacity(selected_len);
+        for group_index in selection.iter() {
+            let (result, size_pre, size_post) = {
+                let state = &mut self.states[group_index];
+                let size_pre = state.size();
+                let result = state.accumulator.evaluate()?;
+                (result, size_pre, state.size())
+            };
+            self.adjust_allocation(size_pre, size_post);
+            results.push(result);
+        }
+        ScalarValue::iter_to_array(results)
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
+    }
+
     // filtered_null_mask(opt_filter, &values);
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         let vec_size_pre = self.states.allocated_size();
@@ -497,5 +527,53 @@ pub(crate) fn slice_and_maybe_filter(
             .collect()
     } else {
         Ok(sliced_arrays)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::min_max::MaxAccumulator;
+    use arrow::array::{AsArray, Int64Array};
+    use arrow::datatypes::{DataType, Int64Type};
+
+    #[test]
+    fn adapter_preserving_evaluation_uses_accumulator_contract() -> Result<()> {
+        let mut accumulator = GroupsAccumulatorAdapter::new(|| {
+            Ok(Box::new(MaxAccumulator::try_new(&DataType::Int64)?)
+                as Box<dyn Accumulator>)
+        });
+        let values = Arc::new(Int64Array::from(vec![Some(1), Some(5), Some(2), None]));
+        accumulator.update_batch(&[values], &[0, 0, 1, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[1, 0, 3, 1], 4)?;
+        let expected = Int64Array::from(vec![Some(2), Some(5), None, Some(2)]);
+        for _ in 0..2 {
+            assert_eq!(
+                accumulator
+                    .evaluate_preserving(selection)?
+                    .as_primitive::<Int64Type>(),
+                &expected
+            );
+        }
+
+        let empty =
+            accumulator.evaluate_preserving(GroupSelection::try_from_indices(&[], 4)?)?;
+        assert_eq!(empty.data_type(), &DataType::Int64);
+        assert!(empty.is_empty());
+
+        let values = Arc::new(Int64Array::from(vec![7, 4, 9]));
+        accumulator.update_batch(&[values], &[0, 2, 3], None, 4)?;
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(GroupSelection::all(4))?
+                .as_primitive::<Int64Type>(),
+            &Int64Array::from(vec![Some(7), Some(2), Some(4), Some(9)])
+        );
+        assert!(accumulator.supports_evaluate_preserving());
+        assert!(!accumulator.supports_state_preserving());
+        Ok(())
     }
 }

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/accumulate.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/accumulate.rs
@@ -24,7 +24,8 @@ use arrow::buffer::NullBuffer;
 use arrow::datatypes::ArrowPrimitiveType;
 
 use crate::aggregate::groups_accumulator::nulls::filter_to_validity;
-use datafusion_expr_common::groups_accumulator::EmitTo;
+use datafusion_common::Result;
+use datafusion_expr_common::groups_accumulator::{EmitTo, GroupSelection};
 
 /// If the input has nulls, then the accumulator must potentially
 /// handle each input null value specially (e.g. for `SUM` to mark the
@@ -285,6 +286,28 @@ impl NullState {
                             value_fn(group_index, new_value)
                         }
                     })
+            }
+        }
+    }
+
+    /// Creates a [`NullBuffer`] for `selection` without changing this state.
+    pub fn build_preserving(
+        &self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Option<NullBuffer>> {
+        let selected_len = selection.len();
+        match &self.seen_values {
+            SeenValues::All { num_values } => {
+                selection.validate_num_groups(*num_values)?;
+                Ok(None)
+            }
+            SeenValues::Some { values } => {
+                selection.validate_num_groups(values.len())?;
+                let mut selected = BooleanBufferBuilder::new(selected_len);
+                for index in selection.iter() {
+                    selected.append(values.get_bit(index));
+                }
+                Ok(Some(NullBuffer::new(selected.finish())))
             }
         }
     }

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/bool_op.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/bool_op.rs
@@ -21,7 +21,9 @@ use crate::aggregate::groups_accumulator::nulls::filtered_null_mask;
 use arrow::array::{ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder};
 use arrow::buffer::BooleanBuffer;
 use datafusion_common::Result;
-use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+use datafusion_expr_common::groups_accumulator::{
+    EmitTo, GroupSelection, GroupsAccumulator,
+};
 
 use super::accumulate::NullState;
 
@@ -124,8 +126,33 @@ where
         Ok(Arc::new(values))
     }
 
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.values.len())?;
+        let mut values = BooleanBufferBuilder::new(selection.len());
+        for index in selection.iter() {
+            values.append(self.values.get_bit(index));
+        }
+        let nulls = self.null_state.build_preserving(selection)?;
+        Ok(Arc::new(BooleanArray::new(values.finish(), nulls)))
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
+    }
+
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         self.evaluate(emit_to).map(|arr| vec![arr])
+    }
+
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        self.evaluate_preserving(selection).map(|arr| vec![arr])
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
     }
 
     fn merge_batch(
@@ -155,5 +182,52 @@ where
         let values_filtered = BooleanArray::new(values_buf, values_null_buffer_filtered);
 
         Ok(vec![Arc::new(values_filtered)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boolean_groups_preserving_reads() -> Result<()> {
+        let mut accumulator =
+            BooleanGroupsAccumulator::new(|current, value| current && value, true);
+        let values = Arc::new(BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            None,
+            Some(true),
+        ]));
+        accumulator.update_batch(&[values], &[0, 0, 1, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[2, 0, 3, 2], 4)?;
+        let expected =
+            BooleanArray::from(vec![Some(true), Some(false), None, Some(true)]);
+        for _ in 0..2 {
+            assert_eq!(
+                accumulator.evaluate_preserving(selection)?.as_boolean(),
+                &expected
+            );
+            assert_eq!(
+                accumulator.state_preserving(selection)?[0].as_boolean(),
+                &expected
+            );
+        }
+
+        let empty =
+            accumulator.evaluate_preserving(GroupSelection::try_from_indices(&[], 4)?)?;
+        assert!(empty.is_empty());
+
+        let values = Arc::new(BooleanArray::from(vec![false, true]));
+        accumulator.update_batch(&[values], &[1, 3], None, 4)?;
+        let expected = BooleanArray::from(vec![false, false, true, true]);
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(GroupSelection::all(4))?
+                .as_boolean(),
+            &expected
+        );
+        Ok(())
     }
 }

--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/prim_op.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator/prim_op.rs
@@ -24,7 +24,9 @@ use arrow::compute;
 use arrow::datatypes::ArrowPrimitiveType;
 use arrow::datatypes::DataType;
 use datafusion_common::{DataFusionError, Result, internal_datafusion_err};
-use datafusion_expr_common::groups_accumulator::{EmitTo, GroupsAccumulator};
+use datafusion_expr_common::groups_accumulator::{
+    EmitTo, GroupSelection, GroupsAccumulator,
+};
 
 use super::accumulate::NullState;
 
@@ -123,8 +125,33 @@ where
         Ok(Arc::new(values))
     }
 
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.values.len())?;
+        let values: Vec<T::Native> =
+            selection.iter().map(|index| self.values[index]).collect();
+        let nulls = self.null_state.build_preserving(selection)?;
+        let values = PrimitiveArray::<T>::new(values.into(), nulls)
+            .with_data_type(self.data_type.clone());
+        Ok(Arc::new(values))
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
+    }
+
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         self.evaluate(emit_to).map(|arr| vec![arr])
+    }
+
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        self.evaluate_preserving(selection).map(|arr| vec![arr])
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
     }
 
     fn merge_batch(
@@ -191,5 +218,45 @@ where
     }
     fn size(&self) -> usize {
         self.values.capacity() * size_of::<T::Native>() + self.null_state.size()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int64Array;
+    use arrow::datatypes::Int64Type;
+
+    #[test]
+    fn preserving_reads_do_not_change_accumulator_state() -> Result<()> {
+        let mut accumulator = PrimitiveGroupsAccumulator::<Int64Type, _>::new(
+            &DataType::Int64,
+            |current, value| *current += value,
+        );
+        let values = Arc::new(Int64Array::from(vec![Some(1), None, Some(3)]));
+        accumulator.update_batch(&[values], &[0, 1, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[3, 0, 1, 1], 4)?;
+        let expected = Int64Array::from(vec![None, Some(1), None, None]);
+        for _ in 0..2 {
+            let actual = accumulator.evaluate_preserving(selection)?;
+            assert_eq!(actual.as_primitive::<Int64Type>(), &expected);
+            let state = accumulator.state_preserving(selection)?;
+            assert_eq!(state[0].as_primitive::<Int64Type>(), &expected);
+        }
+
+        // Group indices and unselected state remain valid after repeated reads.
+        let values = Arc::new(Int64Array::from(vec![5, 7]));
+        accumulator.update_batch(&[values], &[1, 3], None, 4)?;
+        let expected = Int64Array::from(vec![Some(1), Some(5), Some(3), Some(7)]);
+        let actual = accumulator.evaluate_preserving(GroupSelection::all(4))?;
+        assert_eq!(actual.as_primitive::<Int64Type>(), &expected);
+
+        // A destructive read still sees all state after preserving reads.
+        let actual = accumulator.evaluate(EmitTo::All)?;
+        assert_eq!(actual.as_primitive::<Int64Type>(), &expected);
+        assert!(accumulator.supports_evaluate_preserving());
+        assert!(accumulator.supports_state_preserving());
+        Ok(())
     }
 }

--- a/datafusion/functions-aggregate/src/average.rs
+++ b/datafusion/functions-aggregate/src/average.rs
@@ -22,6 +22,7 @@ use arrow::array::{
     BooleanArray, PrimitiveArray, PrimitiveBuilder, UInt64Array,
 };
 
+use arrow::buffer::NullBuffer;
 use arrow::compute::{DecimalCast, sum};
 use arrow::datatypes::{
     ArrowNativeType, DECIMAL32_MAX_PRECISION, DECIMAL64_MAX_PRECISION,
@@ -37,7 +38,7 @@ use datafusion_common::{
 use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
-    Accumulator, AggregateUDFImpl, Coercion, Documentation, EmitTo, Expr,
+    Accumulator, AggregateUDFImpl, Coercion, Documentation, EmitTo, Expr, GroupSelection,
     GroupsAccumulator, ReversedUDAF, Signature, TypeSignature, TypeSignatureClass,
     Volatility,
 };
@@ -1028,6 +1029,58 @@ where
             _phantom: PhantomData,
         }
     }
+
+    fn evaluate_values(
+        &self,
+        counts: Vec<u64>,
+        sums: Vec<S::Native>,
+        nulls: Option<NullBuffer>,
+    ) -> Result<ArrayRef> {
+        if let Some(nulls) = &nulls {
+            assert_eq!(nulls.len(), sums.len());
+        }
+        assert_eq!(counts.len(), sums.len());
+
+        // Don't evaluate averages with null inputs to avoid errors on null values.
+        let array: PrimitiveArray<O> = if let Some(nulls) = &nulls
+            && nulls.null_count() > 0
+        {
+            let mut builder = PrimitiveBuilder::<O>::with_capacity(nulls.len())
+                .with_data_type(self.return_data_type.clone());
+            let iter = sums.into_iter().zip(counts).zip(nulls.iter());
+
+            for ((sum, count), is_valid) in iter {
+                if is_valid {
+                    builder.append_value((self.avg_fn)(sum, count)?)
+                } else {
+                    builder.append_null();
+                }
+            }
+            builder.finish()
+        } else {
+            let averages: Vec<O::Native> = sums
+                .into_iter()
+                .zip(counts)
+                .map(|(sum, count)| (self.avg_fn)(sum, count))
+                .collect::<Result<Vec<_>>>()?;
+            PrimitiveArray::new(averages.into(), nulls)
+                .with_data_type(self.return_data_type.clone())
+        };
+
+        Ok(Arc::new(array))
+    }
+
+    fn state_values(
+        &self,
+        counts: Vec<u64>,
+        sums: Vec<S::Native>,
+        nulls: Option<NullBuffer>,
+    ) -> Vec<ArrayRef> {
+        let counts = UInt64Array::new(counts.into(), nulls.clone());
+        let sums = PrimitiveArray::<S>::new(sums.into(), nulls)
+            .with_data_type(self.sum_data_type.clone());
+        vec![Arc::new(counts), Arc::new(sums)]
+    }
 }
 
 impl<I, F, S, O> GroupsAccumulator for AvgGroupsAccumulator<I, F, S, O>
@@ -1073,57 +1126,44 @@ where
         let counts = emit_to.take_needed(&mut self.counts);
         let sums = emit_to.take_needed(&mut self.sums);
         let nulls = self.null_state.build(emit_to);
+        self.evaluate_values(counts, sums, nulls)
+    }
 
-        if let Some(nulls) = &nulls {
-            assert_eq!(nulls.len(), sums.len());
-        }
-        assert_eq!(counts.len(), sums.len());
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        debug_assert_eq!(self.counts.len(), self.sums.len());
+        selection.validate_num_groups(self.counts.len())?;
+        let counts = selection.iter().map(|index| self.counts[index]).collect();
+        let sums = selection.iter().map(|index| self.sums[index]).collect();
+        let nulls = self.null_state.build_preserving(selection)?;
+        self.evaluate_values(counts, sums, nulls)
+    }
 
-        // don't evaluate averages with null inputs to avoid errors on null values
-
-        let array: PrimitiveArray<O> = if let Some(nulls) = &nulls
-            && nulls.null_count() > 0
-        {
-            let mut builder = PrimitiveBuilder::<O>::with_capacity(nulls.len())
-                .with_data_type(self.return_data_type.clone());
-            let iter = sums.into_iter().zip(counts).zip(nulls.iter());
-
-            for ((sum, count), is_valid) in iter {
-                if is_valid {
-                    builder.append_value((self.avg_fn)(sum, count)?)
-                } else {
-                    builder.append_null();
-                }
-            }
-            builder.finish()
-        } else {
-            let averages: Vec<O::Native> = sums
-                .into_iter()
-                .zip(counts)
-                .map(|(sum, count)| (self.avg_fn)(sum, count))
-                .collect::<Result<Vec<_>>>()?;
-            PrimitiveArray::new(averages.into(), nulls) // no copy
-                .with_data_type(self.return_data_type.clone())
-        };
-
-        Ok(Arc::new(array))
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
     }
 
     // return arrays for sums and counts
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         let nulls = self.null_state.build(emit_to);
-
         let counts = emit_to.take_needed(&mut self.counts);
-        let counts = UInt64Array::new(counts.into(), nulls.clone()); // zero copy
-
         let sums = emit_to.take_needed(&mut self.sums);
-        let sums = PrimitiveArray::<S>::new(sums.into(), nulls) // zero copy
-            .with_data_type(self.sum_data_type.clone());
+        Ok(self.state_values(counts, sums, nulls))
+    }
 
-        Ok(vec![
-            Arc::new(counts) as ArrayRef,
-            Arc::new(sums) as ArrayRef,
-        ])
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        debug_assert_eq!(self.counts.len(), self.sums.len());
+        selection.validate_num_groups(self.counts.len())?;
+        let counts = selection.iter().map(|index| self.counts[index]).collect();
+        let sums = selection.iter().map(|index| self.sums[index]).collect();
+        let nulls = self.null_state.build_preserving(selection)?;
+        Ok(self.state_values(counts, sums, nulls))
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
     }
 
     fn merge_batch(
@@ -1600,6 +1640,55 @@ mod tests {
             ScalarValue::Decimal64(Some(9_999_999_990_000), 13, 4)
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn average_groups_preserving_reads() -> Result<()> {
+        let mut accumulator = AvgGroupsAccumulator::<Float64Type, _>::new(
+            &DataType::Float64,
+            &DataType::Float64,
+            |sum, count| Ok(sum / count as f64),
+        );
+        let values = Arc::new(Float64Array::from(vec![
+            Some(2.0),
+            Some(4.0),
+            None,
+            Some(8.0),
+        ]));
+        accumulator.update_batch(&[values], &[0, 0, 1, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[2, 0, 3, 2], 4)?;
+        let expected = Float64Array::from(vec![Some(8.0), Some(3.0), None, Some(8.0)]);
+        for _ in 0..2 {
+            assert_eq!(
+                accumulator
+                    .evaluate_preserving(selection)?
+                    .as_primitive::<Float64Type>(),
+                &expected
+            );
+        }
+
+        let state = accumulator.state_preserving(selection)?;
+        assert_eq!(
+            state[0].as_primitive::<UInt64Type>(),
+            &UInt64Array::from(vec![Some(1), Some(2), None, Some(1)])
+        );
+        assert_eq!(
+            state[1].as_primitive::<Float64Type>(),
+            &Float64Array::from(vec![Some(8.0), Some(6.0), None, Some(8.0)])
+        );
+
+        let values = Arc::new(Float64Array::from(vec![10.0, 6.0]));
+        accumulator.update_batch(&[values], &[1, 3], None, 4)?;
+        let expected =
+            Float64Array::from(vec![Some(3.0), Some(10.0), Some(8.0), Some(6.0)]);
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(GroupSelection::all(4))?
+                .as_primitive::<Float64Type>(),
+            &expected
+        );
         Ok(())
     }
 }

--- a/datafusion/functions-aggregate/src/correlation.rs
+++ b/datafusion/functions-aggregate/src/correlation.rs
@@ -31,7 +31,7 @@ use arrow::{
     array::ArrayRef,
     datatypes::{DataType, Field},
 };
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupSelection, GroupsAccumulator};
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::accumulate::accumulate_multiple;
 use log::debug;
 
@@ -305,9 +305,64 @@ pub struct CorrelationGroupsAccumulator {
     sum_yy: Vec<f64>,
 }
 
+fn copy_selected<T: Copy>(selection: GroupSelection<'_>, values: &[T]) -> Vec<T> {
+    debug_assert_eq!(selection.total_num_groups(), values.len());
+    selection.iter().map(|index| values[index]).collect()
+}
+
 impl CorrelationGroupsAccumulator {
     pub fn new() -> Self {
         Default::default()
+    }
+
+    fn evaluate_values(
+        counts: &[u64],
+        sum_xs: &[f64],
+        sum_ys: &[f64],
+        sum_xys: &[f64],
+        sum_xxs: &[f64],
+        sum_yys: &[f64],
+    ) -> ArrayRef {
+        let n = counts.len();
+        let mut values = Vec::with_capacity(n);
+        let mut nulls = NullBufferBuilder::new(n);
+
+        for i in 0..n {
+            let count = counts[i];
+            let sum_x = sum_xs[i];
+            let sum_y = sum_ys[i];
+            let sum_xy = sum_xys[i];
+            let sum_xx = sum_xxs[i];
+            let sum_yy = sum_yys[i];
+
+            // If both inputs are NaN, return NaN. If only one input is NaN,
+            // or there are too few values, return NULL.
+            if sum_x.is_nan() && sum_y.is_nan() {
+                values.push(f64::NAN);
+                nulls.append_non_null();
+                continue;
+            } else if count < 2 || sum_x.is_nan() || sum_y.is_nan() {
+                values.push(0.0);
+                nulls.append_null();
+                continue;
+            }
+
+            let mean_x = sum_x / count as f64;
+            let mean_y = sum_y / count as f64;
+            let numerator = sum_xy - sum_x * mean_y;
+            let denominator =
+                ((sum_xx - sum_x * mean_x) * (sum_yy - sum_y * mean_y)).sqrt();
+
+            if denominator == 0.0 {
+                values.push(0.0);
+                nulls.append_null();
+            } else {
+                values.push(numerator / denominator);
+                nulls.append_non_null();
+            }
+        }
+
+        Arc::new(Float64Array::new(values.into(), nulls.finish()))
     }
 }
 
@@ -409,65 +464,30 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
     }
 
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
-        // Drain the state vectors for the groups being emitted
-        let counts = emit_to.take_needed(&mut self.count);
-        let sum_xs = emit_to.take_needed(&mut self.sum_x);
-        let sum_ys = emit_to.take_needed(&mut self.sum_y);
-        let sum_xys = emit_to.take_needed(&mut self.sum_xy);
-        let sum_xxs = emit_to.take_needed(&mut self.sum_xx);
-        let sum_yys = emit_to.take_needed(&mut self.sum_yy);
+        Ok(Self::evaluate_values(
+            &emit_to.take_needed(&mut self.count),
+            &emit_to.take_needed(&mut self.sum_x),
+            &emit_to.take_needed(&mut self.sum_y),
+            &emit_to.take_needed(&mut self.sum_xy),
+            &emit_to.take_needed(&mut self.sum_xx),
+            &emit_to.take_needed(&mut self.sum_yy),
+        ))
+    }
 
-        let n = counts.len();
-        let mut values = Vec::with_capacity(n);
-        let mut nulls = NullBufferBuilder::new(n);
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.count.len())?;
+        Ok(Self::evaluate_values(
+            &copy_selected(selection, &self.count),
+            &copy_selected(selection, &self.sum_x),
+            &copy_selected(selection, &self.sum_y),
+            &copy_selected(selection, &self.sum_xy),
+            &copy_selected(selection, &self.sum_xx),
+            &copy_selected(selection, &self.sum_yy),
+        ))
+    }
 
-        // Notes for `Null` handling:
-        // - If the `count` state of a group is 0, no valid records are accumulated
-        //   for this group, so the aggregation result is `Null`.
-        // - Correlation can't be calculated when a group only has 1 record, or when
-        //   the `denominator` state is 0. In these cases, the final aggregation
-        //   result should be `Null` (according to PostgreSQL's behavior).
-        // - However, if any of the accumulated values contain NaN, the result should
-        //   be NaN regardless of the count (even for single-row groups).
-        for i in 0..n {
-            let count = counts[i];
-            let sum_x = sum_xs[i];
-            let sum_y = sum_ys[i];
-            let sum_xy = sum_xys[i];
-            let sum_xx = sum_xxs[i];
-            let sum_yy = sum_yys[i];
-
-            // If BOTH sum_x AND sum_y are NaN, then both input values are NaN → return NaN
-            // If only ONE of them is NaN, then only one input value is NaN → return NULL
-            if sum_x.is_nan() && sum_y.is_nan() {
-                // Both inputs are NaN → return NaN
-                values.push(f64::NAN);
-                nulls.append_non_null();
-                continue;
-            } else if count < 2 || sum_x.is_nan() || sum_y.is_nan() {
-                // Only one input is NaN → return NULL
-                values.push(0.0);
-                nulls.append_null();
-                continue;
-            }
-
-            let mean_x = sum_x / count as f64;
-            let mean_y = sum_y / count as f64;
-
-            let numerator = sum_xy - sum_x * mean_y;
-            let denominator =
-                ((sum_xx - sum_x * mean_x) * (sum_yy - sum_y * mean_y)).sqrt();
-
-            if denominator == 0.0 {
-                values.push(0.0);
-                nulls.append_null();
-            } else {
-                values.push(numerator / denominator);
-                nulls.append_non_null();
-            }
-        }
-
-        Ok(Arc::new(Float64Array::new(values.into(), nulls.finish())))
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
     }
 
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
@@ -539,6 +559,25 @@ impl GroupsAccumulator for CorrelationGroupsAccumulator {
             Arc::new(Float64Array::from(sum_yy)),
         ])
     }
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        selection.validate_num_groups(self.count.len())?;
+        Ok(vec![
+            Arc::new(UInt64Array::from(copy_selected(selection, &self.count))),
+            Arc::new(Float64Array::from(copy_selected(selection, &self.sum_x))),
+            Arc::new(Float64Array::from(copy_selected(selection, &self.sum_y))),
+            Arc::new(Float64Array::from(copy_selected(selection, &self.sum_xy))),
+            Arc::new(Float64Array::from(copy_selected(selection, &self.sum_xx))),
+            Arc::new(Float64Array::from(copy_selected(selection, &self.sum_yy))),
+        ])
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
+    }
+
     fn merge_batch(
         &mut self,
         values: &[ArrayRef],
@@ -642,6 +681,71 @@ mod tests {
             )
         });
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn correlation_groups_preserving_reads() -> Result<()> {
+        let mut accumulator = CorrelationGroupsAccumulator::new();
+        let x = Arc::new(Float64Array::from(vec![1.0, 2.0, 1.0, 1.0, 2.0]));
+        let y = Arc::new(Float64Array::from(vec![2.0, 4.0, 2.0, 3.0, 1.0]));
+        accumulator.update_batch(&[x, y], &[0, 0, 1, 2, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[2, 0, 3, 2], 4)?;
+        let expected = Float64Array::from(vec![Some(-1.0), Some(1.0), None, Some(-1.0)]);
+        for _ in 0..2 {
+            assert_eq!(
+                accumulator
+                    .evaluate_preserving(selection)?
+                    .as_primitive::<Float64Type>(),
+                &expected
+            );
+            let state = accumulator.state_preserving(selection)?;
+            assert_eq!(state.len(), 6);
+            assert_eq!(
+                state[0].as_primitive::<UInt64Type>(),
+                &UInt64Array::from(vec![2, 2, 0, 2])
+            );
+            assert_eq!(
+                state[1].as_primitive::<Float64Type>(),
+                &Float64Array::from(vec![3.0, 3.0, 0.0, 3.0])
+            );
+            assert_eq!(
+                state[2].as_primitive::<Float64Type>(),
+                &Float64Array::from(vec![4.0, 6.0, 0.0, 4.0])
+            );
+            assert_eq!(
+                state[3].as_primitive::<Float64Type>(),
+                &Float64Array::from(vec![5.0, 10.0, 0.0, 5.0])
+            );
+            assert_eq!(
+                state[4].as_primitive::<Float64Type>(),
+                &Float64Array::from(vec![5.0, 5.0, 0.0, 5.0])
+            );
+            assert_eq!(
+                state[5].as_primitive::<Float64Type>(),
+                &Float64Array::from(vec![10.0, 20.0, 0.0, 10.0])
+            );
+        }
+
+        let empty_selection = GroupSelection::try_from_indices(&[], 4)?;
+        assert!(accumulator.evaluate_preserving(empty_selection)?.is_empty());
+        assert!(
+            accumulator
+                .state_preserving(empty_selection)?
+                .iter()
+                .all(|array| array.is_empty())
+        );
+
+        let x = Arc::new(Float64Array::from(vec![2.0, 1.0, 4.0]));
+        let y = Arc::new(Float64Array::from(vec![4.0, 2.0, 8.0]));
+        accumulator.update_batch(&[x, y], &[1, 3, 3], None, 4)?;
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(GroupSelection::all(4))?
+                .as_primitive::<Float64Type>(),
+            &Float64Array::from(vec![1.0, 1.0, -1.0, 1.0])
+        );
+        Ok(())
     }
 
     #[test]

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -35,9 +35,9 @@ use datafusion_common::{
     stats::Precision, utils::expr::COUNT_STAR_EXPANSION,
 };
 use datafusion_expr::{
-    Accumulator, AggregateUDFImpl, Documentation, EmitTo, Expr, GroupsAccumulator,
-    ReversedUDAF, SetMonotonicity, Signature, StatisticsArgs, TypeSignature, Volatility,
-    WindowFunctionDefinition,
+    Accumulator, AggregateUDFImpl, Documentation, EmitTo, Expr, GroupSelection,
+    GroupsAccumulator, ReversedUDAF, SetMonotonicity, Signature, StatisticsArgs,
+    TypeSignature, Volatility, WindowFunctionDefinition,
     expr::WindowFunction,
     function::{AccumulatorArgs, StateFieldsArgs},
     utils::format_state_name,
@@ -707,11 +707,35 @@ impl GroupsAccumulator for CountGroupsAccumulator {
         Ok(Arc::new(array))
     }
 
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.counts.len())?;
+        let counts = selection
+            .iter()
+            .map(|index| self.counts[index])
+            .collect::<Vec<_>>();
+        Ok(Arc::new(Int64Array::from(counts)))
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
+    }
+
     // return arrays for counts
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         let counts = emit_to.take_needed(&mut self.counts);
         let counts: PrimitiveArray<Int64Type> = Int64Array::from(counts); // zero copy, no nulls
         Ok(vec![Arc::new(counts) as ArrayRef])
+    }
+
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        self.evaluate_preserving(selection).map(|array| vec![array])
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
     }
 
     /// Converts an input batch directly to a state batch
@@ -913,7 +937,7 @@ mod tests {
 
     use super::*;
     use arrow::{
-        array::{DictionaryArray, Int32Array, NullArray, StringArray},
+        array::{DictionaryArray, Int32Array, Int64Array, NullArray, StringArray},
         datatypes::{DataType, Field, Int32Type, Schema},
     };
     use datafusion_expr::function::AccumulatorArgs;
@@ -955,6 +979,39 @@ mod tests {
         let mut accumulator = CountAccumulator::new();
         accumulator.update_batch(&[Arc::new(NullArray::new(10))])?;
         assert_eq!(accumulator.evaluate()?, ScalarValue::Int64(Some(0)));
+        Ok(())
+    }
+
+    #[test]
+    fn count_groups_preserving_reads() -> Result<()> {
+        let mut accumulator = CountGroupsAccumulator::new();
+        let values = Arc::new(Int32Array::from(vec![Some(1), None, Some(2), Some(3)]));
+        accumulator.update_batch(&[values], &[0, 1, 0, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[2, 0, 3, 2], 4)?;
+        let expected = Int64Array::from(vec![1, 2, 0, 1]);
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(selection)?
+                .as_primitive::<Int64Type>(),
+            &expected
+        );
+        assert_eq!(
+            accumulator.state_preserving(selection)?[0].as_primitive::<Int64Type>(),
+            &expected
+        );
+
+        let values = Arc::new(Int32Array::from(vec![4]));
+        accumulator.update_batch(&[values], &[3], None, 4)?;
+        let expected = Int64Array::from(vec![2, 0, 1, 1]);
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(
+                    GroupSelection::try_from_indices(&[0, 1, 2, 3], 4,)?
+                )?
+                .as_primitive::<Int64Type>(),
+            &expected
+        );
         Ok(())
     }
 

--- a/datafusion/functions-aggregate/src/min_max/min_max_bytes.rs
+++ b/datafusion/functions-aggregate/src/min_max/min_max_bytes.rs
@@ -22,7 +22,7 @@ use arrow::array::{
 use arrow::datatypes::DataType;
 use datafusion_common::hash_map::Entry;
 use datafusion_common::{HashMap, Result, internal_err};
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupSelection, GroupsAccumulator};
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::apply_filter_as_nulls;
 use std::mem::size_of;
 use std::sync::Arc;
@@ -61,6 +61,100 @@ impl MinMaxBytesAccumulator {
             inner: MinMaxBytesState::new(data_type),
             is_min: false,
         }
+    }
+
+    fn build_array<'a>(
+        &self,
+        min_maxes: impl Iterator<Item = Option<&'a [u8]>>,
+        num_values: usize,
+        data_capacity: usize,
+    ) -> Result<ArrayRef> {
+        let result: ArrayRef = match self.inner.data_type {
+            DataType::Utf8 => {
+                let mut builder = StringBuilder::with_capacity(num_values, data_capacity);
+                for value in min_maxes {
+                    match value {
+                        None => builder.append_null(),
+                        // SAFETY: update_batch only accepts the configured input type.
+                        Some(value) => builder.append_value(unsafe {
+                            std::str::from_utf8_unchecked(value)
+                        }),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            DataType::LargeUtf8 => {
+                let mut builder =
+                    LargeStringBuilder::with_capacity(num_values, data_capacity);
+                for value in min_maxes {
+                    match value {
+                        None => builder.append_null(),
+                        // SAFETY: update_batch only accepts the configured input type.
+                        Some(value) => builder.append_value(unsafe {
+                            std::str::from_utf8_unchecked(value)
+                        }),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            DataType::Utf8View => {
+                let block_size = capacity_to_view_block_size(data_capacity);
+                let mut builder = StringViewBuilder::with_capacity(num_values)
+                    .with_fixed_block_size(block_size);
+                for value in min_maxes {
+                    match value {
+                        None => builder.append_null(),
+                        // SAFETY: update_batch only accepts the configured input type.
+                        Some(value) => builder.append_value(unsafe {
+                            std::str::from_utf8_unchecked(value)
+                        }),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            DataType::Binary => {
+                let mut builder = BinaryBuilder::with_capacity(num_values, data_capacity);
+                for value in min_maxes {
+                    match value {
+                        None => builder.append_null(),
+                        Some(value) => builder.append_value(value),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            DataType::LargeBinary => {
+                let mut builder =
+                    LargeBinaryBuilder::with_capacity(num_values, data_capacity);
+                for value in min_maxes {
+                    match value {
+                        None => builder.append_null(),
+                        Some(value) => builder.append_value(value),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            DataType::BinaryView => {
+                let block_size = capacity_to_view_block_size(data_capacity);
+                let mut builder = BinaryViewBuilder::with_capacity(num_values)
+                    .with_fixed_block_size(block_size);
+                for value in min_maxes {
+                    match value {
+                        None => builder.append_null(),
+                        Some(value) => builder.append_value(value),
+                    }
+                }
+                Arc::new(builder.finish())
+            }
+            _ => {
+                return internal_err!(
+                    "Unexpected data type for MinMaxBytesAccumulator: {:?}",
+                    self.inner.data_type
+                );
+            }
+        };
+
+        assert_eq!(&self.inner.data_type, result.data_type());
+        Ok(result)
     }
 }
 
@@ -203,106 +297,45 @@ impl GroupsAccumulator for MinMaxBytesAccumulator {
 
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
         let (data_capacity, min_maxes) = self.inner.emit_to(emit_to);
+        self.build_array(
+            min_maxes.iter().map(|value| value.as_deref()),
+            min_maxes.len(),
+            data_capacity,
+        )
+    }
 
-        // Convert the Vec of bytes to a vec of Strings (at no cost)
-        fn bytes_to_str(
-            min_maxes: Vec<Option<Vec<u8>>>,
-        ) -> impl Iterator<Item = Option<String>> {
-            min_maxes.into_iter().map(|opt| {
-                opt.map(|bytes| {
-                    // Safety: only called on data added from update_batch which ensures
-                    // the input type matched the output type
-                    unsafe { String::from_utf8_unchecked(bytes) }
-                })
-            })
-        }
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        let num_groups = self.inner.min_max.len();
+        selection.validate_num_groups(num_groups)?;
+        let num_values = selection.len();
+        let data_capacity = selection
+            .iter()
+            .filter_map(|index| self.inner.min_max[index].as_ref().map(Vec::len))
+            .sum();
+        let min_maxes = selection
+            .iter()
+            .map(|index| self.inner.min_max[index].as_deref());
+        self.build_array(min_maxes, num_values, data_capacity)
+    }
 
-        let result: ArrayRef = match self.inner.data_type {
-            DataType::Utf8 => {
-                let mut builder =
-                    StringBuilder::with_capacity(min_maxes.len(), data_capacity);
-                for opt in bytes_to_str(min_maxes) {
-                    match opt {
-                        None => builder.append_null(),
-                        Some(s) => builder.append_value(s.as_str()),
-                    }
-                }
-                Arc::new(builder.finish())
-            }
-            DataType::LargeUtf8 => {
-                let mut builder =
-                    LargeStringBuilder::with_capacity(min_maxes.len(), data_capacity);
-                for opt in bytes_to_str(min_maxes) {
-                    match opt {
-                        None => builder.append_null(),
-                        Some(s) => builder.append_value(s.as_str()),
-                    }
-                }
-                Arc::new(builder.finish())
-            }
-            DataType::Utf8View => {
-                let block_size = capacity_to_view_block_size(data_capacity);
-
-                let mut builder = StringViewBuilder::with_capacity(min_maxes.len())
-                    .with_fixed_block_size(block_size);
-                for opt in bytes_to_str(min_maxes) {
-                    match opt {
-                        None => builder.append_null(),
-                        Some(s) => builder.append_value(s.as_str()),
-                    }
-                }
-                Arc::new(builder.finish())
-            }
-            DataType::Binary => {
-                let mut builder =
-                    BinaryBuilder::with_capacity(min_maxes.len(), data_capacity);
-                for opt in min_maxes {
-                    match opt {
-                        None => builder.append_null(),
-                        Some(s) => builder.append_value(s.as_ref() as &[u8]),
-                    }
-                }
-                Arc::new(builder.finish())
-            }
-            DataType::LargeBinary => {
-                let mut builder =
-                    LargeBinaryBuilder::with_capacity(min_maxes.len(), data_capacity);
-                for opt in min_maxes {
-                    match opt {
-                        None => builder.append_null(),
-                        Some(s) => builder.append_value(s.as_ref() as &[u8]),
-                    }
-                }
-                Arc::new(builder.finish())
-            }
-            DataType::BinaryView => {
-                let block_size = capacity_to_view_block_size(data_capacity);
-
-                let mut builder = BinaryViewBuilder::with_capacity(min_maxes.len())
-                    .with_fixed_block_size(block_size);
-                for opt in min_maxes {
-                    match opt {
-                        None => builder.append_null(),
-                        Some(s) => builder.append_value(s.as_ref() as &[u8]),
-                    }
-                }
-                Arc::new(builder.finish())
-            }
-            _ => {
-                return internal_err!(
-                    "Unexpected data type for MinMaxBytesAccumulator: {:?}",
-                    self.inner.data_type
-                );
-            }
-        };
-
-        assert_eq!(&self.inner.data_type, result.data_type());
-        Ok(result)
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
     }
 
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         // min/max are their own states (no transition needed)
         self.evaluate(emit_to).map(|arr| vec![arr])
+    }
+
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        self.evaluate_preserving(selection).map(|array| vec![array])
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
     }
 
     fn merge_batch(
@@ -502,5 +535,48 @@ impl MinMaxBytesState {
 
     fn size(&self) -> usize {
         self.total_data_bytes + self.min_max.len() * size_of::<Option<Vec<u8>>>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::StringArray;
+
+    #[test]
+    fn preserving_selected_min_values() -> Result<()> {
+        let mut accumulator = MinMaxBytesAccumulator::new_min(DataType::Utf8);
+        let values = Arc::new(StringArray::from(vec![
+            Some("z"),
+            Some("b"),
+            None,
+            Some("c"),
+            Some("a"),
+            Some("x"),
+        ]));
+        accumulator.update_batch(&[values], &[0, 0, 1, 2, 2, 3], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[3, 0, 1, 2, 3], 4)?;
+        let expected =
+            StringArray::from(vec![Some("x"), Some("b"), None, Some("a"), Some("x")]);
+        for _ in 0..2 {
+            assert_eq!(
+                accumulator
+                    .evaluate_preserving(selection)?
+                    .as_string::<i32>(),
+                &expected
+            );
+        }
+
+        let values = Arc::new(StringArray::from(vec!["aa", "w"]));
+        accumulator.update_batch(&[values], &[0, 3], None, 4)?;
+        let expected = StringArray::from(vec![Some("aa"), None, Some("a"), Some("w")]);
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(GroupSelection::all(4))?
+                .as_string::<i32>(),
+            &expected
+        );
+        Ok(())
     }
 }

--- a/datafusion/functions-aggregate/src/min_max/min_max_struct.rs
+++ b/datafusion/functions-aggregate/src/min_max/min_max_struct.rs
@@ -20,6 +20,7 @@ use std::{cmp::Ordering, sync::Arc};
 use arrow::{
     array::{
         Array, ArrayData, ArrayRef, AsArray, BooleanArray, MutableArrayData, StructArray,
+        new_empty_array,
     },
     datatypes::DataType,
 };
@@ -27,7 +28,7 @@ use datafusion_common::{
     Result, internal_err,
     scalar::{copy_array_data, partial_cmp_struct},
 };
-use datafusion_expr::{EmitTo, GroupsAccumulator};
+use datafusion_expr::{EmitTo, GroupSelection, GroupsAccumulator};
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::apply_filter_as_nulls;
 
 use datafusion_common::utils::split_vec_min_alloc;
@@ -58,6 +59,35 @@ impl MinMaxStructAccumulator {
             inner: MinMaxStructState::new(data_type),
             is_min: false,
         }
+    }
+
+    fn build_array<'a>(
+        &self,
+        min_maxes: impl Iterator<Item = Option<&'a StructArray>>,
+        num_values: usize,
+    ) -> Result<ArrayRef> {
+        let DataType::Struct(fields) = &self.inner.data_type else {
+            return internal_err!("Data type is not a struct");
+        };
+        if num_values == 0 {
+            return Ok(new_empty_array(&self.inner.data_type));
+        }
+        let null_array = StructArray::new_null(fields.clone(), 1);
+        let min_maxes_data: Vec<ArrayData> = min_maxes
+            .map(|value| match value {
+                Some(value) => value.to_data(),
+                None => null_array.to_data(),
+            })
+            .collect();
+        let min_maxes_refs: Vec<&ArrayData> = min_maxes_data.iter().collect();
+        let mut copy = MutableArrayData::new(min_maxes_refs, true, num_values);
+
+        for (index, item) in min_maxes_data.iter().enumerate() {
+            copy.try_extend(index, 0, item.len())?;
+        }
+        let result = copy.freeze();
+        assert_eq!(&self.inner.data_type, result.data_type());
+        Ok(Arc::new(StructArray::from(result)))
     }
 }
 
@@ -102,31 +132,40 @@ impl GroupsAccumulator for MinMaxStructAccumulator {
 
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
         let (_, min_maxes) = self.inner.emit_to(emit_to);
-        let DataType::Struct(fields) = &self.inner.data_type else {
-            return internal_err!("Data type is not a struct");
-        };
-        let null_array = StructArray::new_null(fields.clone(), 1);
-        let min_maxes_data: Vec<ArrayData> = min_maxes
-            .iter()
-            .map(|v| match v {
-                Some(v) => v.to_data(),
-                None => null_array.to_data(),
-            })
-            .collect();
-        let min_maxes_refs: Vec<&ArrayData> = min_maxes_data.iter().collect();
-        let mut copy = MutableArrayData::new(min_maxes_refs, true, min_maxes_data.len());
+        self.build_array(
+            min_maxes.iter().map(|value| value.as_ref()),
+            min_maxes.len(),
+        )
+    }
 
-        for (i, item) in min_maxes_data.iter().enumerate() {
-            copy.try_extend(i, 0, item.len())?;
-        }
-        let result = copy.freeze();
-        assert_eq!(&self.inner.data_type, result.data_type());
-        Ok(Arc::new(StructArray::from(result)))
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        let num_groups = self.inner.min_max.len();
+        selection.validate_num_groups(num_groups)?;
+        let num_values = selection.len();
+        let min_maxes = selection
+            .iter()
+            .map(|index| self.inner.min_max[index].as_ref());
+        self.build_array(min_maxes, num_values)
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
     }
 
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         // min/max are their own states (no transition needed)
         self.evaluate(emit_to).map(|arr| vec![arr])
+    }
+
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        self.evaluate_preserving(selection).map(|array| vec![array])
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
     }
 
     fn merge_batch(
@@ -493,6 +532,70 @@ mod tests {
         assert_eq!(str_array.value(0), "c");
         assert_eq!(int_array.value(1), 4);
         assert_eq!(str_array.value(1), "d");
+    }
+
+    #[test]
+    fn test_min_struct_preserving_reads_and_empty_selection() -> Result<()> {
+        let array = create_test_struct_array(
+            vec![Some(3), Some(2), Some(1)],
+            vec![Some("c"), Some("b"), Some("a")],
+        );
+        let data_type = array.data_type().clone();
+        let mut accumulator = MinMaxStructAccumulator::new_min(data_type.clone());
+        accumulator.update_batch(&[Arc::new(array)], &[0, 1, 0], None, 3)?;
+
+        let selection = GroupSelection::try_from_indices(&[1, 0, 2, 1], 3)?;
+        for _ in 0..2 {
+            let actual = accumulator.evaluate_preserving(selection)?;
+            let actual = actual.as_struct();
+            assert_eq!(actual.len(), 4);
+            assert_eq!(
+                actual
+                    .column(0)
+                    .as_primitive::<Int32Type>()
+                    .iter()
+                    .collect::<Vec<_>>(),
+                vec![Some(2), Some(1), None, Some(2)]
+            );
+            assert_eq!(
+                actual
+                    .column(1)
+                    .as_string::<i32>()
+                    .iter()
+                    .collect::<Vec<_>>(),
+                vec![Some("b"), Some("a"), None, Some("b")]
+            );
+            assert!(actual.is_null(2));
+        }
+
+        let empty_selection = GroupSelection::try_from_indices(&[], 3)?;
+        let actual = accumulator.evaluate_preserving(empty_selection)?;
+        assert_eq!(actual.data_type(), &data_type);
+        assert!(actual.is_empty());
+        let state = accumulator.state_preserving(empty_selection)?;
+        assert_eq!(state.len(), 1);
+        assert_eq!(state[0].data_type(), &data_type);
+        assert!(state[0].is_empty());
+
+        let update = create_test_struct_array(vec![Some(0)], vec![Some("z")]);
+        accumulator.update_batch(&[Arc::new(update)], &[2], None, 3)?;
+        let actual = accumulator.evaluate_preserving(GroupSelection::all(3))?;
+        assert_eq!(
+            actual
+                .as_struct()
+                .column(0)
+                .as_primitive::<Int32Type>()
+                .values(),
+            &[1, 2, 0]
+        );
+
+        let mut empty_accumulator = MinMaxStructAccumulator::new_min(data_type);
+        assert!(
+            empty_accumulator
+                .evaluate_preserving(GroupSelection::all(0))?
+                .is_empty()
+        );
+        Ok(())
     }
 
     #[test]

--- a/datafusion/functions-aggregate/src/stddev.rs
+++ b/datafusion/functions-aggregate/src/stddev.rs
@@ -30,8 +30,8 @@ use datafusion_common::{Result, internal_err, not_impl_err};
 use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
-    Accumulator, AggregateUDFImpl, Documentation, GroupsAccumulator, Signature,
-    Volatility,
+    Accumulator, AggregateUDFImpl, Documentation, GroupSelection, GroupsAccumulator,
+    Signature, Volatility,
 };
 use datafusion_functions_aggregate_common::stats::StatsType;
 use datafusion_macros::user_doc;
@@ -343,6 +343,18 @@ impl GroupsAccumulator for StddevGroupsAccumulator {
         Ok(Arc::new(Float64Array::new(variances.into(), Some(nulls))))
     }
 
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        let (mut variances, nulls) = self.variance.variance_preserving(selection)?;
+        for value in &mut variances {
+            *value = value.sqrt();
+        }
+        Ok(Arc::new(Float64Array::new(variances.into(), Some(nulls))))
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
+    }
+
     fn state(&mut self, emit_to: datafusion_expr::EmitTo) -> Result<Vec<ArrayRef>> {
         self.variance.state(emit_to)
     }
@@ -354,6 +366,17 @@ impl GroupsAccumulator for StddevGroupsAccumulator {
     ) -> Result<Vec<ArrayRef>> {
         self.variance.convert_to_state(values, opt_filter)
     }
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        self.variance.state_preserving(selection)
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
+    }
+
     fn size(&self) -> usize {
         self.variance.size()
     }
@@ -366,6 +389,38 @@ mod tests {
     use datafusion_expr::AggregateUDF;
     use datafusion_functions_aggregate_common::utils::get_accum_scalar_values_as_arrays;
     use datafusion_physical_expr::expressions::col;
+
+    #[test]
+    fn stddev_groups_preserving_reads() -> Result<()> {
+        let mut accumulator = StddevGroupsAccumulator::new(StatsType::Population);
+        let values = Arc::new(Float64Array::from(vec![1.0, 3.0, 2.0, 2.0, 6.0]));
+        accumulator.update_batch(&[values], &[0, 0, 1, 2, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[2, 0, 3, 2], 4)?;
+        let expected = Float64Array::from(vec![Some(2.0), Some(1.0), None, Some(2.0)]);
+        for _ in 0..2 {
+            assert_eq!(
+                accumulator
+                    .evaluate_preserving(selection)?
+                    .as_primitive::<Float64Type>(),
+                &expected
+            );
+            assert_eq!(
+                accumulator.state_preserving(selection)?[0].as_primitive::<UInt64Type>(),
+                &UInt64Array::from(vec![2, 2, 0, 2])
+            );
+        }
+
+        let values = Arc::new(Float64Array::from(vec![4.0, 5.0, 7.0]));
+        accumulator.update_batch(&[values], &[1, 3, 3], None, 4)?;
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(GroupSelection::all(4))?
+                .as_primitive::<Float64Type>(),
+            &Float64Array::from(vec![1.0, 1.0, 2.0, 1.0])
+        );
+        Ok(())
+    }
 
     #[test]
     fn stddev_f64_merge_1() -> Result<()> {

--- a/datafusion/functions-aggregate/src/string_agg.rs
+++ b/datafusion/functions-aggregate/src/string_agg.rs
@@ -32,8 +32,8 @@ use datafusion_common::{
 use datafusion_expr::function::AccumulatorArgs;
 use datafusion_expr::utils::format_state_name;
 use datafusion_expr::{
-    Accumulator, AggregateUDFImpl, Documentation, EmitTo, GroupsAccumulator, Signature,
-    TypeSignature, Volatility,
+    Accumulator, AggregateUDFImpl, Documentation, EmitTo, GroupSelection,
+    GroupsAccumulator, Signature, TypeSignature, Volatility,
 };
 use datafusion_functions_aggregate_common::accumulator::StateFieldsArgs;
 use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::apply_filter_as_nulls;
@@ -405,8 +405,29 @@ impl GroupsAccumulator for StringAggGroupsAccumulator {
         Ok(result)
     }
 
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.values.len())?;
+        let values = selection.iter().map(|index| self.values[index].as_deref());
+        Ok(Arc::new(LargeStringArray::from_iter(values)))
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
+    }
+
     fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
         self.evaluate(emit_to).map(|arr| vec![arr])
+    }
+
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        self.evaluate_preserving(selection).map(|array| vec![array])
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
     }
 
     fn merge_batch(
@@ -795,6 +816,48 @@ mod tests {
         let result = acc.evaluate(emit_to).unwrap();
         let arr = result.as_any().downcast_ref::<LargeStringArray>().unwrap();
         arr.iter().map(|v| v.map(|s| s.to_string())).collect()
+    }
+
+    #[test]
+    fn groups_preserving_reads() -> Result<()> {
+        let mut acc = make_groups_acc(",");
+        let values: ArrayRef = Arc::new(LargeStringArray::from(vec![
+            Some("a"),
+            Some("b"),
+            None,
+            Some("c"),
+        ]));
+        acc.update_batch(&[values], &[0, 1, 2, 0], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[1, 0, 3, 1], 4)?;
+        let expected =
+            LargeStringArray::from(vec![Some("b"), Some("a,c"), None, Some("b")]);
+        let bytes_before = acc.total_data_bytes;
+        for _ in 0..2 {
+            assert_eq!(
+                acc.evaluate_preserving(selection)?.as_string::<i64>(),
+                &expected
+            );
+            assert_eq!(
+                acc.state_preserving(selection)?[0].as_string::<i64>(),
+                &expected
+            );
+            assert_eq!(acc.total_data_bytes, bytes_before);
+        }
+
+        assert!(
+            acc.evaluate_preserving(GroupSelection::try_from_indices(&[], 4)?)?
+                .is_empty()
+        );
+
+        let values: ArrayRef = Arc::new(LargeStringArray::from(vec!["d", "e"]));
+        acc.update_batch(&[values], &[2, 3], None, 4)?;
+        assert_eq!(
+            acc.evaluate_preserving(GroupSelection::all(4))?
+                .as_string::<i64>(),
+            &LargeStringArray::from(vec!["a,c", "b", "d", "e"])
+        );
+        Ok(())
     }
 
     #[test]

--- a/datafusion/functions-aggregate/src/variance.rs
+++ b/datafusion/functions-aggregate/src/variance.rs
@@ -27,8 +27,8 @@ use arrow::{
 use datafusion_common::cast::{as_float64_array, as_uint64_array};
 use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::{
-    Accumulator, AggregateUDFImpl, Documentation, GroupsAccumulator, Signature,
-    Volatility,
+    Accumulator, AggregateUDFImpl, Documentation, GroupSelection, GroupsAccumulator,
+    Signature, Volatility,
     function::{AccumulatorArgs, StateFieldsArgs},
     utils::format_state_name,
 };
@@ -476,16 +476,11 @@ impl VarianceGroupsAccumulator {
             });
     }
 
-    pub fn variance(
-        &mut self,
-        emit_to: datafusion_expr::EmitTo,
+    fn variance_values(
+        &self,
+        mut counts: Vec<u64>,
+        m2s: Vec<f64>,
     ) -> (Vec<f64>, NullBuffer) {
-        let mut counts = emit_to.take_needed(&mut self.counts);
-        // means are only needed for updating m2s and are not needed for the final result.
-        // But we still need to take them to ensure the internal state is consistent.
-        let _ = emit_to.take_needed(&mut self.means);
-        let m2s = emit_to.take_needed(&mut self.m2s);
-
         if self.stats_type == StatsType::Sample {
             for count in &mut counts {
                 *count = count.saturating_sub(1);
@@ -493,11 +488,35 @@ impl VarianceGroupsAccumulator {
         }
         let nulls = NullBuffer::from_iter(counts.iter().map(|&count| count != 0));
         let variance = m2s
-            .iter()
+            .into_iter()
             .zip(counts)
             .map(|(m2, count)| m2 / count as f64)
             .collect();
         (variance, nulls)
+    }
+
+    pub fn variance(
+        &mut self,
+        emit_to: datafusion_expr::EmitTo,
+    ) -> (Vec<f64>, NullBuffer) {
+        let counts = emit_to.take_needed(&mut self.counts);
+        // Means are only needed for updating m2s, but still need to be removed
+        // to keep the internal vectors aligned.
+        let _ = emit_to.take_needed(&mut self.means);
+        let m2s = emit_to.take_needed(&mut self.m2s);
+        self.variance_values(counts, m2s)
+    }
+
+    pub fn variance_preserving(
+        &self,
+        selection: GroupSelection<'_>,
+    ) -> Result<(Vec<f64>, NullBuffer)> {
+        debug_assert_eq!(self.counts.len(), self.means.len());
+        debug_assert_eq!(self.counts.len(), self.m2s.len());
+        selection.validate_num_groups(self.counts.len())?;
+        let counts = selection.iter().map(|index| self.counts[index]).collect();
+        let m2s = selection.iter().map(|index| self.m2s[index]).collect();
+        Ok(self.variance_values(counts, m2s))
     }
 }
 
@@ -571,6 +590,15 @@ impl GroupsAccumulator for VarianceGroupsAccumulator {
         Ok(Arc::new(Float64Array::new(variances.into(), Some(nulls))))
     }
 
+    fn evaluate_preserving(&mut self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        let (variances, nulls) = self.variance_preserving(selection)?;
+        Ok(Arc::new(Float64Array::new(variances.into(), Some(nulls))))
+    }
+
+    fn supports_evaluate_preserving(&self) -> bool {
+        true
+    }
+
     fn state(&mut self, emit_to: datafusion_expr::EmitTo) -> Result<Vec<ArrayRef>> {
         let counts = emit_to.take_needed(&mut self.counts);
         let means = emit_to.take_needed(&mut self.means);
@@ -616,6 +644,37 @@ impl GroupsAccumulator for VarianceGroupsAccumulator {
             Arc::new(Float64Array::new(m2s.into(), None)),
         ])
     }
+
+    fn state_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        debug_assert_eq!(self.counts.len(), self.means.len());
+        debug_assert_eq!(self.counts.len(), self.m2s.len());
+        selection.validate_num_groups(self.counts.len())?;
+        let counts = selection
+            .iter()
+            .map(|index| self.counts[index])
+            .collect::<Vec<_>>();
+        let means = selection
+            .iter()
+            .map(|index| self.means[index])
+            .collect::<Vec<_>>();
+        let m2s = selection
+            .iter()
+            .map(|index| self.m2s[index])
+            .collect::<Vec<_>>();
+        Ok(vec![
+            Arc::new(UInt64Array::new(counts.into(), None)),
+            Arc::new(Float64Array::new(means.into(), None)),
+            Arc::new(Float64Array::new(m2s.into(), None)),
+        ])
+    }
+
+    fn supports_state_preserving(&self) -> bool {
+        true
+    }
+
     fn size(&self) -> usize {
         self.m2s.capacity() * size_of::<f64>()
             + self.means.capacity() * size_of::<f64>()
@@ -690,6 +749,8 @@ impl Accumulator for DistinctVarianceAccumulator {
 
 #[cfg(test)]
 mod tests {
+    use arrow::array::AsArray;
+    use arrow::datatypes::UInt64Type;
     use datafusion_expr::EmitTo;
 
     use super::*;
@@ -760,6 +821,56 @@ mod tests {
             assert_eq!(acc.get_count(), 0);
             assert_eq!(acc.evaluate()?, ScalarValue::Float64(None));
         }
+        Ok(())
+    }
+
+    #[test]
+    fn variance_groups_preserving_reads() -> Result<()> {
+        let mut accumulator = VarianceGroupsAccumulator::new(StatsType::Population);
+        let values = Arc::new(Float64Array::from(vec![1.0, 3.0, 2.0, 2.0, 6.0]));
+        accumulator.update_batch(&[values], &[0, 0, 1, 2, 2], None, 4)?;
+
+        let selection = GroupSelection::try_from_indices(&[2, 0, 3, 2], 4)?;
+        let expected = Float64Array::from(vec![Some(4.0), Some(1.0), None, Some(4.0)]);
+        for _ in 0..2 {
+            assert_eq!(
+                accumulator
+                    .evaluate_preserving(selection)?
+                    .as_primitive::<Float64Type>(),
+                &expected
+            );
+            let state = accumulator.state_preserving(selection)?;
+            assert_eq!(
+                state[0].as_primitive::<UInt64Type>(),
+                &UInt64Array::from(vec![2, 2, 0, 2])
+            );
+            assert_eq!(
+                state[1].as_primitive::<Float64Type>(),
+                &Float64Array::from(vec![4.0, 2.0, 0.0, 4.0])
+            );
+            assert_eq!(
+                state[2].as_primitive::<Float64Type>(),
+                &Float64Array::from(vec![8.0, 2.0, 0.0, 8.0])
+            );
+        }
+
+        let empty_selection = GroupSelection::try_from_indices(&[], 4)?;
+        assert!(accumulator.evaluate_preserving(empty_selection)?.is_empty());
+        assert!(
+            accumulator
+                .state_preserving(empty_selection)?
+                .iter()
+                .all(|array| array.is_empty())
+        );
+
+        let values = Arc::new(Float64Array::from(vec![4.0, 5.0, 7.0]));
+        accumulator.update_batch(&[values], &[1, 3, 3], None, 4)?;
+        assert_eq!(
+            accumulator
+                .evaluate_preserving(GroupSelection::all(4))?
+                .as_primitive::<Float64Type>(),
+            &Float64Array::from(vec![1.0, 1.0, 4.0, 1.0])
+        );
         Ok(())
     }
 

--- a/datafusion/physical-expr-common/src/binary_map.rs
+++ b/datafusion/physical-expr-common/src/binary_map.rs
@@ -19,8 +19,8 @@
 //! StringArray / LargeStringArray / BinaryArray / LargeBinaryArray.
 
 use arrow::array::{
-    Array, ArrayRef, GenericBinaryArray, GenericStringArray, NullBufferBuilder,
-    OffsetSizeTrait,
+    Array, ArrayRef, BufferBuilder, GenericBinaryArray, GenericStringArray,
+    NullBufferBuilder, OffsetSizeTrait,
     cast::AsArray,
     types::{ByteArrayType, GenericBinaryType, GenericStringType},
 };
@@ -29,6 +29,7 @@ use arrow::datatypes::DataType;
 use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::utils::proxy::{HashTableAllocExt, VecAllocExt};
+use datafusion_common::{Result, exec_err};
 use std::any::type_name;
 use std::fmt::Debug;
 use std::mem::{size_of, swap};
@@ -523,6 +524,53 @@ where
             }
             _ => unreachable!("View types should use `ArrowBytesViewMap`"),
         }
+    }
+
+    /// Copies keys at `indices` into an array without changing this map.
+    ///
+    /// Keys are returned in index order, and duplicate indices are supported.
+    pub fn keys<I>(&self, indices: I) -> Result<ArrayRef>
+    where
+        I: IntoIterator<Item = usize>,
+    {
+        let indices = indices.into_iter();
+        let mut output_offsets = Vec::with_capacity(indices.size_hint().0 + 1);
+        let mut output_values = BufferBuilder::<u8>::new(0);
+        let mut output_nulls = NullBufferBuilder::new(indices.size_hint().0);
+        output_offsets.push(O::default());
+        let null_index = self.null.map(|(_, index)| index);
+        let num_keys = self.offsets.len() - 1;
+
+        for index in indices {
+            if index >= num_keys {
+                return exec_err!(
+                    "Key index {index} is out of bounds for {num_keys} keys"
+                );
+            }
+            let start = self.offsets[index].as_usize();
+            let end = self.offsets[index + 1].as_usize();
+            output_values.append_slice(&self.buffer.as_slice()[start..end]);
+            if O::from_usize(output_values.len()).is_none() {
+                return exec_err!("Offset overflow while copying byte map keys");
+            }
+            output_offsets.push(O::usize_as(output_values.len()));
+            output_nulls.append(index != null_index.unwrap_or(usize::MAX));
+        }
+
+        // SAFETY: offsets are constructed from the length of `output_values`.
+        let offsets =
+            unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(output_offsets)) };
+        let values = output_values.finish();
+        let nulls = output_nulls.finish();
+        Ok(match self.output_type {
+            OutputType::Binary => Arc::new(unsafe {
+                GenericBinaryArray::new_unchecked(offsets, values, nulls)
+            }),
+            OutputType::Utf8 => Arc::new(unsafe {
+                GenericStringArray::new_unchecked(offsets, values, nulls)
+            }),
+            _ => unreachable!("View types should use `ArrowBytesViewMap`"),
+        })
     }
 
     /// Total number of entries (including null, if present)

--- a/datafusion/physical-expr-common/src/binary_view_map.rs
+++ b/datafusion/physical-expr-common/src/binary_view_map.rs
@@ -20,12 +20,16 @@
 use crate::binary_map::OutputType;
 use arrow::array::NullBufferBuilder;
 use arrow::array::cast::AsArray;
-use arrow::array::{Array, ArrayRef, BinaryViewArray, ByteView, make_view};
+use arrow::array::{
+    Array, ArrayRef, BinaryViewArray, BinaryViewBuilder, ByteView, StringViewBuilder,
+    make_view,
+};
 use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::{BinaryViewType, ByteViewType, DataType, StringViewType};
 use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::utils::proxy::{HashTableAllocExt, VecAllocExt};
+use datafusion_common::{Result, exec_err};
 use std::fmt::Debug;
 use std::mem::size_of;
 use std::sync::Arc;
@@ -378,6 +382,25 @@ where
         }
     }
 
+    /// Returns the bytes for the key at `index`, irrespective of nullness.
+    fn key(&self, index: usize) -> &[u8] {
+        let view = &self.views[index];
+        let byte_view = ByteView::from(*view);
+        let length = byte_view.length as usize;
+        if length <= 12 {
+            // SAFETY: `view` is a valid inline view with `length` bytes.
+            unsafe { BinaryViewArray::inline_value(view, length) }
+        } else {
+            let buffer_index = byte_view.buffer_index as usize;
+            let offset = byte_view.offset as usize;
+            if buffer_index < self.completed.len() {
+                &self.completed[buffer_index][offset..offset + length]
+            } else {
+                &self.in_progress[offset..offset + length]
+            }
+        }
+    }
+
     /// Converts this set into a `StringViewArray`, or `BinaryViewArray`,
     /// containing each distinct value
     /// that was inserted. This is done without copying the values.
@@ -407,6 +430,47 @@ where
             }
             _ => unreachable!("Utf8/Binary should use `ArrowBytesMap`"),
         }
+    }
+
+    /// Copies keys at `indices` into an array without changing this map.
+    ///
+    /// Keys are returned in index order, and duplicate indices are supported.
+    pub fn keys<I>(&self, indices: I) -> Result<ArrayRef>
+    where
+        I: IntoIterator<Item = usize>,
+    {
+        let indices = indices.into_iter();
+        let capacity = indices.size_hint().0;
+        let num_keys = self.views.len();
+        let null_index = self.null.map(|(_, index)| index);
+
+        macro_rules! build_keys {
+            ($builder:ty, $value:expr) => {{
+                let mut builder = <$builder>::with_capacity(capacity);
+                for index in indices {
+                    if index >= num_keys {
+                        return exec_err!(
+                            "Key index {index} is out of bounds for {num_keys} keys"
+                        );
+                    }
+                    if null_index == Some(index) {
+                        builder.append_null();
+                    } else {
+                        builder.append_value($value(self.key(index)));
+                    }
+                }
+                Arc::new(builder.finish()) as ArrayRef
+            }};
+        }
+
+        Ok(match self.output_type {
+            OutputType::BinaryView => build_keys!(BinaryViewBuilder, |value| value),
+            OutputType::Utf8View => build_keys!(StringViewBuilder, |value| unsafe {
+                // Inputs to an Utf8View map are validated UTF-8.
+                std::str::from_utf8_unchecked(value)
+            }),
+            _ => unreachable!("Utf8/Binary should use `ArrowBytesMap`"),
+        })
     }
 
     /// Append an already-computed inline view (len <= 12) directly, bypassing

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -240,7 +240,9 @@ pub fn new_group_values(
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{ArrayRef, AsArray, Int32Array, StringArray, StringViewArray};
+    use arrow::array::{
+        ArrayRef, AsArray, BooleanArray, Int32Array, StringArray, StringViewArray,
+    };
     use arrow::datatypes::{DataType, Field, Int32Type, Schema};
     use datafusion_expr::{EmitTo, GroupSelection};
 
@@ -303,6 +305,34 @@ mod tests {
 
         let actual = group_values.emit(EmitTo::All).unwrap();
         assert_eq!(actual[0].as_primitive::<Int32Type>(), &expected);
+    }
+
+    #[test]
+    fn preserving_non_nullable_primitive_and_boolean_values() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("primitive", DataType::Int32, false),
+            Field::new("boolean", DataType::Boolean, false),
+        ]));
+        let mut group_values = new_group_values(schema, &GroupOrdering::None).unwrap();
+        let input = vec![
+            Arc::new(Int32Array::from(vec![10, 20, 10])) as ArrayRef,
+            Arc::new(BooleanArray::from(vec![true, false, true])) as ArrayRef,
+        ];
+        let mut groups = vec![];
+        group_values.intern(&input, &mut groups).unwrap();
+        assert_eq!(groups, vec![0, 1, 0]);
+
+        let selection =
+            GroupSelection::try_from_indices(&[1, 0, 1], group_values.len()).unwrap();
+        let actual = group_values.values_preserving(selection).unwrap();
+        assert_eq!(
+            actual[0].as_primitive::<Int32Type>(),
+            &Int32Array::from(vec![20, 10, 20])
+        );
+        assert_eq!(
+            actual[1].as_boolean(),
+            &BooleanArray::from(vec![false, true, false])
+        );
     }
 
     #[test]

--- a/datafusion/physical-plan/src/aggregates/group_values/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/mod.rs
@@ -24,9 +24,9 @@ use arrow::array::types::{
 };
 use arrow::array::{ArrayRef, downcast_primitive};
 use arrow::datatypes::{DataType, SchemaRef, TimeUnit};
-use datafusion_common::Result;
+use datafusion_common::{Result, not_impl_err};
 
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupSelection};
 
 pub mod multi_group_by;
 
@@ -115,6 +115,26 @@ pub trait GroupValues: Send {
 
     /// Emits the group values
     fn emit(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>>;
+
+    /// Materializes selected group values without changing the stored values or
+    /// their group indices.
+    ///
+    /// Rows are returned in the order specified by `selection`. An empty
+    /// selection returns one correctly typed empty array per group-value column.
+    ///
+    /// This method requires exclusive access because implementations may mutate
+    /// internal caches or builders, even though stored values are unchanged.
+    fn values_preserving(
+        &mut self,
+        _selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        not_impl_err!("Preserving group values are not implemented")
+    }
+
+    /// Returns `true` if [`Self::values_preserving`] is implemented.
+    fn supports_values_preserving(&self) -> bool {
+        false
+    }
 
     /// Clear the contents and shrink the capacity to the size of the batch (free up memory usage)
     fn clear_shrink(&mut self, num_rows: usize);
@@ -213,5 +233,138 @@ pub fn new_group_values(
         }
     } else {
         Ok(Box::new(GroupValuesRows::try_new(schema)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{ArrayRef, AsArray, Int32Array, StringArray, StringViewArray};
+    use arrow::datatypes::{DataType, Field, Int32Type, Schema};
+    use datafusion_expr::{EmitTo, GroupSelection};
+
+    use super::new_group_values;
+    use crate::aggregates::order::GroupOrdering;
+
+    #[test]
+    fn preserving_values_keep_group_indices_valid() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "group",
+            DataType::Int32,
+            true,
+        )]));
+        let mut group_values = new_group_values(schema, &GroupOrdering::None).unwrap();
+        assert!(group_values.supports_values_preserving());
+
+        let input = Arc::new(Int32Array::from(vec![
+            Some(10),
+            Some(20),
+            Some(10),
+            None,
+            Some(30),
+        ])) as ArrayRef;
+        let mut groups = vec![];
+        group_values.intern(&[input], &mut groups).unwrap();
+        assert_eq!(groups, vec![0, 1, 0, 2, 3]);
+
+        let selection =
+            GroupSelection::try_from_indices(&[3, 0, 2, 0], group_values.len()).unwrap();
+        let expected = Int32Array::from(vec![Some(30), Some(10), None, Some(10)]);
+        for _ in 0..2 {
+            let actual = group_values.values_preserving(selection).unwrap();
+            assert_eq!(actual[0].as_primitive::<Int32Type>(), &expected);
+        }
+
+        let empty = group_values
+            .values_preserving(
+                GroupSelection::try_from_indices(&[], group_values.len()).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(empty.len(), 1);
+        assert_eq!(empty[0].data_type(), &DataType::Int32);
+        assert!(empty[0].is_empty());
+
+        let input =
+            Arc::new(Int32Array::from(vec![Some(20), Some(40), None])) as ArrayRef;
+        group_values.intern(&[input], &mut groups).unwrap();
+        assert_eq!(groups, vec![1, 4, 2]);
+
+        let expected =
+            Int32Array::from(vec![Some(10), Some(20), None, Some(30), Some(40)]);
+        let actual = group_values
+            .values_preserving(GroupSelection::all(group_values.len()))
+            .unwrap();
+        assert_eq!(actual[0].as_primitive::<Int32Type>(), &expected);
+
+        let error =
+            GroupSelection::try_from_indices(&[5], group_values.len()).unwrap_err();
+        assert!(error.to_string().contains("out of bounds"));
+
+        let actual = group_values.emit(EmitTo::All).unwrap();
+        assert_eq!(actual[0].as_primitive::<Int32Type>(), &expected);
+    }
+
+    #[test]
+    fn preserving_variable_width_values() {
+        for data_type in [DataType::Utf8, DataType::Utf8View] {
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "group",
+                data_type.clone(),
+                true,
+            )]));
+            let mut group_values =
+                new_group_values(schema, &GroupOrdering::None).unwrap();
+            let input: ArrayRef = match data_type {
+                DataType::Utf8 => Arc::new(StringArray::from(vec![
+                    Some("a"),
+                    None,
+                    Some("a long value that is not inline"),
+                    Some("a"),
+                ])),
+                DataType::Utf8View => Arc::new(StringViewArray::from(vec![
+                    Some("a"),
+                    None,
+                    Some("a long value that is not inline"),
+                    Some("a"),
+                ])),
+                _ => unreachable!(),
+            };
+            let mut groups = vec![];
+            group_values.intern(&[input], &mut groups).unwrap();
+            assert_eq!(groups, vec![0, 1, 2, 0]);
+
+            let selected = group_values
+                .values_preserving(
+                    GroupSelection::try_from_indices(&[2, 1, 0, 2], 3).unwrap(),
+                )
+                .unwrap();
+            let expected = vec![
+                Some("a long value that is not inline"),
+                None,
+                Some("a"),
+                Some("a long value that is not inline"),
+            ];
+            match data_type {
+                DataType::Utf8 => assert_eq!(
+                    selected[0].as_string::<i32>(),
+                    &StringArray::from(expected)
+                ),
+                DataType::Utf8View => assert_eq!(
+                    selected[0].as_string_view(),
+                    &StringViewArray::from(expected)
+                ),
+                _ => unreachable!(),
+            }
+
+            // Reading did not remove values or alter interned indices.
+            let input: ArrayRef = match data_type {
+                DataType::Utf8 => Arc::new(StringArray::from(vec!["new"])),
+                DataType::Utf8View => Arc::new(StringViewArray::from(vec!["new"])),
+                _ => unreachable!(),
+            };
+            group_values.intern(&[input], &mut groups).unwrap();
+            assert_eq!(groups, vec![3]);
+        }
     }
 }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
@@ -24,6 +24,7 @@ use arrow::array::{
     Array as _, ArrayRef, AsArray, BooleanArray, BooleanBufferBuilder, NullBufferBuilder,
 };
 use datafusion_common::Result;
+use datafusion_expr::GroupSelection;
 
 /// An implementation of [`GroupColumn`] for booleans
 ///
@@ -177,6 +178,16 @@ impl<const NULLABLE: bool> GroupColumn for BooleanGroupValueBuilder<NULLABLE> {
         let arr = BooleanArray::new(buffer.finish(), nulls);
 
         Arc::new(arr)
+    }
+
+    fn values_preserving(&self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.buffer.len())?;
+        let mut values = BooleanBufferBuilder::new(selection.len());
+        for index in selection.iter() {
+            values.append(self.buffer.get_bit(index));
+        }
+        let nulls = self.nulls.build_preserving(selection)?;
+        Ok(Arc::new(BooleanArray::new(values.finish(), nulls)))
     }
 
     fn take_n(&mut self, n: usize) -> ArrayRef {

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/boolean.rs
@@ -186,7 +186,11 @@ impl<const NULLABLE: bool> GroupColumn for BooleanGroupValueBuilder<NULLABLE> {
         for index in selection.iter() {
             values.append(self.buffer.get_bit(index));
         }
-        let nulls = self.nulls.build_preserving(selection)?;
+        let nulls = if NULLABLE {
+            self.nulls.build_preserving(selection)?
+        } else {
+            None
+        };
         Ok(Arc::new(BooleanArray::new(values.finish(), nulls)))
     }
 

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes.rs
@@ -29,10 +29,21 @@ use arrow::datatypes::{ByteArrayType, DataType, GenericBinaryType};
 use datafusion_common::utils::proxy::VecAllocExt;
 use datafusion_common::utils::split_vec_min_alloc;
 use datafusion_common::{Result, exec_datafusion_err};
+use datafusion_expr::GroupSelection;
 use datafusion_physical_expr_common::binary_map::{INITIAL_BUFFER_CAPACITY, OutputType};
 use std::mem::size_of;
 use std::sync::Arc;
 use std::vec;
+
+fn checked_output_offset<O: OffsetSizeTrait>(
+    current_len: usize,
+    additional_len: usize,
+) -> Result<O> {
+    current_len
+        .checked_add(additional_len)
+        .and_then(O::from_usize)
+        .ok_or_else(|| exec_datafusion_err!("Offset overflow while copying group values"))
+}
 
 /// An implementation of [`GroupColumn`] for binary and utf8 types.
 ///
@@ -374,6 +385,39 @@ where
         }
     }
 
+    fn values_preserving(&self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.len())?;
+        let mut buffer = BufferBuilder::<u8>::new(0);
+        let mut offsets = Vec::with_capacity(selection.len() + 1);
+        let mut nulls = NullBufferBuilder::new(selection.len());
+        offsets.push(O::default());
+
+        for index in selection.iter() {
+            let is_null = self.nulls.is_null(index);
+            let value = if is_null { &[] } else { self.value(index) };
+            let offset = checked_output_offset::<O>(buffer.len(), value.len())?;
+
+            nulls.append(!is_null);
+            buffer.append_slice(value);
+            offsets.push(offset);
+        }
+
+        // SAFETY: every offset was checked for representability and is the
+        // monotonically increasing length of `buffer` after an append.
+        let offsets = unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(offsets)) };
+        let values = buffer.finish();
+        let nulls = nulls.build();
+        Ok(match self.output_type {
+            OutputType::Binary => Arc::new(unsafe {
+                GenericBinaryArray::new_unchecked(offsets, values, nulls)
+            }),
+            OutputType::Utf8 => Arc::new(unsafe {
+                GenericStringArray::new_unchecked(offsets, values, nulls)
+            }),
+            _ => unreachable!("View types should use `ArrowBytesViewMap`"),
+        })
+    }
+
     fn take_n(&mut self, n: usize) -> ArrayRef {
         debug_assert!(self.len() >= n);
         let null_buffer = self.nulls.take_n(n);
@@ -434,7 +478,7 @@ mod tests {
     use datafusion_common::DataFusionError;
     use datafusion_physical_expr::binary_map::OutputType;
 
-    use super::GroupColumn;
+    use super::{GroupColumn, checked_output_offset};
 
     fn make_true_buffer(n: usize) -> BooleanBufferBuilder {
         let mut buf = BooleanBufferBuilder::new(n);
@@ -444,6 +488,19 @@ mod tests {
 
     fn to_vec(buf: &BooleanBufferBuilder) -> Vec<bool> {
         (0..buf.len()).map(|i| buf.get_bit(i)).collect()
+    }
+
+    #[test]
+    fn test_selected_copy_offset_overflow_is_checked() {
+        assert_eq!(
+            checked_output_offset::<i32>(i32::MAX as usize, 0).unwrap(),
+            i32::MAX
+        );
+        assert!(matches!(
+            checked_output_offset::<i32>(i32::MAX as usize, 1),
+            Err(DataFusionError::Execution(e)) if e.contains("Offset overflow")
+        ));
+        assert!(checked_output_offset::<i64>(usize::MAX, 1).is_err());
     }
 
     #[test]

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/bytes_view.rs
@@ -21,12 +21,13 @@ use crate::aggregates::group_values::multi_group_by::{
 use crate::aggregates::group_values::null_builder::NullBufferBuilderExt;
 use arrow::array::{
     Array, ArrayRef, AsArray, BooleanBufferBuilder, ByteView, GenericByteViewArray,
-    NullBufferBuilder,
+    NullBufferBuilder, make_view,
 };
 use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::datatypes::ByteViewType;
 use datafusion_common::Result;
 use datafusion_common::utils::split_vec_min_alloc;
+use datafusion_expr::GroupSelection;
 use std::marker::PhantomData;
 use std::mem::{replace, size_of};
 use std::sync::Arc;
@@ -328,6 +329,51 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
         }
     }
 
+    /// Returns the bytes stored at `index`, irrespective of nullness.
+    fn value(&self, index: usize) -> &[u8] {
+        let view = &self.views[index];
+        let byte_view = ByteView::from(*view);
+        let length = byte_view.length as usize;
+        if length <= 12 {
+            // SAFETY: `view` is a valid inline view with `length` bytes.
+            unsafe { GenericByteViewArray::<B>::inline_value(view, length) }
+        } else {
+            let buffer_index = byte_view.buffer_index as usize;
+            let offset = byte_view.offset as usize;
+            if buffer_index < self.completed.len() {
+                &self.completed[buffer_index][offset..offset + length]
+            } else {
+                &self.in_progress[offset..offset + length]
+            }
+        }
+    }
+
+    fn values_preserving_inner(&self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.len())?;
+        let mut selected = Self::new().with_max_block_size(self.max_block_size);
+        for index in selection.iter() {
+            let is_null = self.nulls.is_null(index);
+            selected.nulls.append(!is_null);
+            if is_null {
+                selected.views.push(0);
+                continue;
+            }
+
+            let value = self.value(index);
+            let view = if value.len() <= 12 {
+                make_view(value, 0, 0)
+            } else {
+                selected.ensure_in_progress_big_enough(value.len());
+                let buffer_index = selected.completed.len() as u32;
+                let offset = selected.in_progress.len() as u32;
+                selected.in_progress.extend_from_slice(value);
+                make_view(value, buffer_index, offset)
+            };
+            selected.views.push(view);
+        }
+        Ok(selected.build_inner())
+    }
+
     fn build_inner(self) -> ArrayRef {
         let Self {
             views,
@@ -600,6 +646,10 @@ impl<B: ByteViewType> GroupColumn for ByteViewGroupValueBuilder<B> {
 
     fn build(self: Box<Self>) -> ArrayRef {
         Self::build_inner(*self)
+    }
+
+    fn values_preserving(&self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        self.values_preserving_inner(selection)
     }
 
     fn take_n(&mut self, n: usize) -> ArrayRef {

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/dictionary.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/dictionary.rs
@@ -26,7 +26,8 @@ use arrow::error::ArrowError;
 use datafusion_common::hash_utils::{RandomState, create_hashes};
 use datafusion_common::{DataFusionError, Result, exec_err};
 use datafusion_execution::memory_pool::proxy::HashTableAllocExt;
-use hashbrown::hash_table::HashTable;
+use datafusion_expr::GroupSelection;
+use hashbrown::{HashMap, hash_table::HashTable};
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::sync::Arc;
@@ -478,6 +479,34 @@ impl<K: ArrowDictionaryKeyType + Send + Sync> GroupColumn
         Self::into_dict(values, &self.group_to_inner, null_inner_slot)
     }
 
+    fn values_preserving(&self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.group_to_inner.len())?;
+
+        let mut old_to_new = HashMap::with_capacity(selection.len());
+        let mut selected_inner = Vec::with_capacity(selection.len());
+        let mut selected_groups = Vec::with_capacity(selection.len());
+        for group_index in selection.iter() {
+            let old_slot = self.group_to_inner[group_index];
+            let new_slot = if let Some(&new_slot) = old_to_new.get(&old_slot) {
+                new_slot
+            } else {
+                let new_slot = selected_inner.len();
+                selected_inner.push(old_slot);
+                old_to_new.insert(old_slot, new_slot);
+                new_slot
+            };
+            selected_groups.push(new_slot);
+        }
+
+        let inner_selection =
+            GroupSelection::try_from_indices(&selected_inner, self.inner.len())?;
+        let values = self.inner.values_preserving(inner_selection)?;
+        let null_inner_slot = self
+            .null_inner_slot
+            .and_then(|slot| old_to_new.get(&slot).copied());
+        Ok(Self::into_dict(values, &selected_groups, null_inner_slot))
+    }
+
     fn take_n(&mut self, n: usize) -> ArrayRef {
         let old_inner_len = self.inner.len();
         let all_inner_values = self.inner.take_n(old_inner_len);
@@ -685,6 +714,37 @@ mod tests {
                 Some("a".into()),
                 Some("b".into()),
                 Some("a".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn values_preserving_reorders_and_reuses_dictionary_values() {
+        let mut col = utf8_col();
+        let input = i32_dict(&[Some(0), None, Some(1), Some(0)], &[Some("a"), Some("b")]);
+        col.vectorized_append(&input, &[0, 1, 2, 3]).unwrap();
+
+        let selection = GroupSelection::try_from_indices(&[2, 1, 0, 2], 4).unwrap();
+        for _ in 0..2 {
+            let selected = col.values_preserving(selection).unwrap();
+            assert_eq!(
+                str_values(&selected),
+                vec![Some("b".into()), None, Some("a".into()), Some("b".into())]
+            );
+            assert_eq!(selected.as_dictionary::<Int32Type>().values().len(), 2);
+        }
+
+        col.append_val(&i32_dict(&[Some(0)], &[Some("c")]), 0)
+            .unwrap();
+        let out = Box::new(col).build();
+        assert_eq!(
+            str_values(&out),
+            vec![
+                Some("a".into()),
+                None,
+                Some("b".into()),
+                Some("a".into()),
+                Some("c".into()),
             ]
         );
     }

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/fixed_size_binary.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/fixed_size_binary.rs
@@ -27,6 +27,7 @@ use arrow::buffer::{Buffer, NullBuffer};
 use datafusion_common::utils::proxy::VecAllocExt;
 use datafusion_common::utils::split_vec_min_alloc;
 use datafusion_common::{Result, exec_datafusion_err};
+use datafusion_expr::GroupSelection;
 use std::sync::Arc;
 
 /// An implementation of [`GroupColumn`] for `FixedSizeBinary` values
@@ -225,6 +226,23 @@ impl GroupColumn for FixedSizeBinaryGroupValueBuilder {
         Self::build_array(byte_width, buffer, nulls.build(), len)
     }
 
+    fn values_preserving(&self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.len)?;
+        let len = selection.len();
+        let mut values = Vec::with_capacity(len * self.byte_width);
+        let mut nulls = NullBufferBuilder::new(len);
+        for index in selection.iter() {
+            nulls.append(!self.nulls.is_null(index));
+            values.extend_from_slice(self.value(index));
+        }
+        Ok(Self::build_array(
+            self.byte_width,
+            values,
+            nulls.build(),
+            len,
+        ))
+    }
+
     fn take_n(&mut self, n: usize) -> ArrayRef {
         debug_assert!(self.len >= n);
 
@@ -242,6 +260,7 @@ mod tests {
 
     use crate::aggregates::group_values::multi_group_by::fixed_size_binary::FixedSizeBinaryGroupValueBuilder;
     use arrow::array::{ArrayRef, BooleanBufferBuilder, FixedSizeBinaryArray};
+    use datafusion_expr::GroupSelection;
 
     use super::GroupColumn;
 
@@ -473,6 +492,33 @@ mod tests {
         let output = builder.take_n(2);
         assert_eq!(&output, &expected);
         assert_eq!(builder.len(), 0);
+    }
+
+    #[test]
+    fn test_fixed_size_binary_values_preserving() {
+        let mut builder = FixedSizeBinaryGroupValueBuilder::new(2);
+        let input = make_array(
+            vec![Some(b"aa".as_slice()), None, Some(b"bb".as_slice())],
+            2,
+        );
+        builder.vectorized_append(&input, &[0, 1, 2]).unwrap();
+
+        let output = builder
+            .values_preserving(
+                GroupSelection::try_from_indices(&[2, 0, 1, 2], 3).unwrap(),
+            )
+            .unwrap();
+        let expected = make_array(
+            vec![
+                Some(b"bb".as_slice()),
+                Some(b"aa".as_slice()),
+                None,
+                Some(b"bb".as_slice()),
+            ],
+            2,
+        );
+        assert_eq!(&output, &expected);
+        assert_eq!(builder.len(), 3);
     }
 
     #[test]

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/mod.rs
@@ -34,7 +34,7 @@ use crate::aggregates::group_values::multi_group_by::{
     fixed_size_binary::FixedSizeBinaryGroupValueBuilder,
     primitive::PrimitiveGroupValueBuilder, row_backed::RowsGroupColumn,
 };
-use arrow::array::{Array, ArrayRef, BooleanBufferBuilder};
+use arrow::array::{Array, ArrayRef, BooleanBufferBuilder, new_empty_array};
 use arrow::datatypes::{
     BinaryViewType, DataType, Date32Type, Date64Type, Decimal128Type, Decimal256Type,
     DurationMicrosecondType, DurationMillisecondType, DurationNanosecondType,
@@ -50,7 +50,7 @@ use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::{Result, not_impl_err};
 use datafusion_execution::memory_pool::proxy::{HashTableAllocExt, VecAllocExt};
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupSelection};
 use datafusion_physical_expr::binary_map::OutputType;
 
 use hashbrown::hash_table::HashTable;
@@ -108,6 +108,10 @@ pub trait GroupColumn: Send + Sync {
 
     /// Builds a new array from all of the stored rows
     fn build(self: Box<Self>) -> ArrayRef;
+
+    /// Builds a new array from selected stored rows without changing this
+    /// column. Rows are returned in selection order.
+    fn values_preserving(&self, selection: GroupSelection<'_>) -> Result<ArrayRef>;
 
     /// Builds a new array from the first `n` stored rows, shifting the
     /// remaining rows to the start of the builder
@@ -1298,6 +1302,30 @@ impl<const STREAMING: bool> GroupValues for GroupValuesColumn<STREAMING> {
         Ok(output)
     }
 
+    fn values_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        selection.validate_num_groups(self.len())?;
+        if self.group_values.is_empty() {
+            return Ok(self
+                .schema
+                .fields()
+                .iter()
+                .map(|field| new_empty_array(field.data_type()))
+                .collect());
+        }
+
+        self.group_values
+            .iter()
+            .map(|column| column.values_preserving(selection))
+            .collect()
+    }
+
+    fn supports_values_preserving(&self) -> bool {
+        true
+    }
+
     fn clear_shrink(&mut self, num_rows: usize) {
         // Reset to a fresh column-builder vector. The schema was validated
         // in `try_new`, so rebuilding cannot fail unless something else
@@ -1346,12 +1374,15 @@ mod tests {
     use arrow::array::{
         Array, ArrayRef, DurationMicrosecondArray, FixedSizeBinaryArray, Float16Array,
         Int32Array, Int64Array, PrimitiveArray, RecordBatch, StringArray,
-        StringViewArray,
+        StringViewArray, UInt32Array,
     };
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-    use arrow::{compute::concat_batches, util::pretty::pretty_format_batches};
+    use arrow::{
+        compute::{concat_batches, take},
+        util::pretty::pretty_format_batches,
+    };
     use datafusion_common::utils::proxy::HashTableAllocExt;
-    use datafusion_expr::EmitTo;
+    use datafusion_expr::{EmitTo, GroupSelection};
 
     use crate::aggregates::group_values::{
         GroupValues, multi_group_by::GroupValuesColumn,
@@ -2065,6 +2096,39 @@ mod tests {
 
         assert_eq!(actual_batch.num_rows(), expected_batch.num_rows());
         check_result(&actual_batch, &expected_batch);
+    }
+
+    #[test]
+    fn test_preserving_selected_vectorized_group_values() {
+        let data_set = VectorizedTestDataSet::new();
+        let mut group_values =
+            GroupValuesColumn::<false>::try_new(data_set.schema()).unwrap();
+        data_set.load_to_group_values(&mut group_values);
+
+        let selection = [16, 0, 4, 0];
+        let group_selection =
+            GroupSelection::try_from_indices(&selection, group_values.len()).unwrap();
+        let actual = group_values.values_preserving(group_selection).unwrap();
+        let indices = UInt32Array::from_iter_values(selection.map(|index| index as u32));
+        let mut destructive_group_values =
+            GroupValuesColumn::<false>::try_new(data_set.schema()).unwrap();
+        data_set.load_to_group_values(&mut destructive_group_values);
+        let all = destructive_group_values.emit(EmitTo::All).unwrap();
+        let expected = all
+            .iter()
+            .map(|column| take(column.as_ref(), &indices, None).unwrap())
+            .collect::<Vec<_>>();
+        let expected = RecordBatch::try_new(data_set.schema(), expected).unwrap();
+        let actual = RecordBatch::try_new(data_set.schema(), actual).unwrap();
+        assert_eq!(actual, expected);
+
+        // A repeated preserving read returns the same rows and leaves all groups.
+        let repeated = group_values.values_preserving(group_selection).unwrap();
+        assert_eq!(
+            RecordBatch::try_new(data_set.schema(), repeated).unwrap(),
+            expected
+        );
+        assert_eq!(group_values.len(), data_set.expected_batch.num_rows());
     }
 
     #[test]

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -31,6 +31,7 @@ use arrow::util::bit_util::apply_bitwise_binary_op;
 use datafusion_common::Result;
 use datafusion_common::utils::split_vec_min_alloc;
 use datafusion_execution::memory_pool::proxy::VecAllocExt;
+use datafusion_expr::GroupSelection;
 use std::iter;
 use std::sync::Arc;
 
@@ -276,6 +277,19 @@ where
         let arr = PrimitiveArray::<T>::new(ScalarBuffer::from(group_values), nulls);
         // Set timezone information for timestamp
         Arc::new(arr.with_data_type(data_type))
+    }
+
+    fn values_preserving(&self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.group_values.len())?;
+        let values: Vec<T::Native> = selection
+            .iter()
+            .map(|index| self.group_values[index])
+            .collect();
+        let nulls = self.nulls.build_preserving(selection)?;
+        Ok(Arc::new(
+            PrimitiveArray::<T>::new(ScalarBuffer::from(values), nulls)
+                .with_data_type(self.data_type.clone()),
+        ))
     }
 
     fn take_n(&mut self, n: usize) -> ArrayRef {

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/primitive.rs
@@ -285,7 +285,11 @@ where
             .iter()
             .map(|index| self.group_values[index])
             .collect();
-        let nulls = self.nulls.build_preserving(selection)?;
+        let nulls = if NULLABLE {
+            self.nulls.build_preserving(selection)?
+        } else {
+            None
+        };
         Ok(Arc::new(
             PrimitiveArray::<T>::new(ScalarBuffer::from(values), nulls)
                 .with_data_type(self.data_type.clone()),

--- a/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/row_backed.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/multi_group_by/row_backed.rs
@@ -53,6 +53,7 @@ use arrow::array::{Array, ArrayRef, BooleanBufferBuilder};
 use arrow::datatypes::DataType;
 use arrow::row::{RowConverter, Rows, SortField};
 use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::GroupSelection;
 
 /// A [`GroupColumn`] that stores group values for a single column in the arrow
 /// [row format], backed by a single-field [`RowConverter`].
@@ -292,6 +293,12 @@ impl GroupColumn for RowsGroupColumn {
 
     fn build(self: Box<Self>) -> ArrayRef {
         self.rows_to_array(&self.group_values)
+    }
+
+    fn values_preserving(&self, selection: GroupSelection<'_>) -> Result<ArrayRef> {
+        selection.validate_num_groups(self.group_values.num_rows())?;
+        let rows = selection.iter().map(|index| self.group_values.row(index));
+        Ok(self.rows_to_array(rows))
     }
 
     fn take_n(&mut self, n: usize) -> ArrayRef {
@@ -555,6 +562,33 @@ mod tests {
         assert_eq!(col.len(), 2);
         assert!(col.equal_to(0, &input, 0));
         assert!(!col.equal_to(0, &input, 1));
+    }
+
+    #[test]
+    fn struct_values_preserving() {
+        let dt = DataType::Struct(vec![Field::new("a", DataType::Int32, true)].into());
+        let mut col = RowsGroupColumn::try_new(dt).unwrap();
+        let values: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(2)]));
+        let input: ArrayRef = Arc::new(StructArray::new(
+            vec![Field::new("a", DataType::Int32, true)].into(),
+            vec![values],
+            None,
+        ));
+        col.vectorized_append(&input, &[0, 1]).unwrap();
+
+        let output = col
+            .values_preserving(GroupSelection::try_from_indices(&[1, 0, 1], 2).unwrap())
+            .unwrap();
+        let output = output.as_any().downcast_ref::<StructArray>().unwrap();
+        assert_eq!(
+            output
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap(),
+            &Int32Array::from(vec![Some(2), Some(1), Some(2)])
+        );
+        assert_eq!(col.len(), 2);
     }
 
     #[test]

--- a/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/null_builder.rs
@@ -17,6 +17,8 @@
 
 use arrow::array::NullBufferBuilder;
 use arrow::buffer::NullBuffer;
+use datafusion_common::Result;
+use datafusion_expr::GroupSelection;
 
 /// Helper methods for NullBufferBuilder that are used in Group By columns
 pub(crate) trait NullBufferBuilderExt {
@@ -24,6 +26,12 @@ pub(crate) trait NullBufferBuilderExt {
 
     /// Return true if the row at index `row` is null
     fn is_null(&self, row: usize) -> bool;
+
+    /// Returns a null buffer for `selection` without changing this builder.
+    fn build_preserving(
+        &self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Option<NullBuffer>>;
 
     /// Returns a NullBuffer representing the first `n` rows accumulated so far
     /// shifting any remaining down by `n`
@@ -43,6 +51,22 @@ impl NullBufferBuilderExt for NullBufferBuilder {
 
     fn is_null(&self, row: usize) -> bool {
         !self.is_valid(row)
+    }
+
+    fn build_preserving(
+        &self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Option<NullBuffer>> {
+        selection.validate_num_groups(self.len())?;
+        if self.as_slice().is_none() {
+            return Ok(None);
+        }
+
+        let mut selected = NullBufferBuilder::new(selection.len());
+        for index in selection.iter() {
+            selected.append(self.is_valid(index));
+        }
+        Ok(selected.finish())
     }
 
     fn take_n(&mut self, n: usize) -> Option<NullBuffer> {

--- a/datafusion/physical-plan/src/aggregates/group_values/row.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/row.rs
@@ -29,7 +29,7 @@ use datafusion_common::hash_utils::RandomState;
 use datafusion_common::hash_utils::create_hashes;
 use datafusion_common::utils::normalize_float_zero;
 use datafusion_execution::memory_pool::proxy::{HashTableAllocExt, VecAllocExt};
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupSelection};
 use hashbrown::hash_table::HashTable;
 use log::debug;
 use std::mem::size_of;
@@ -255,6 +255,33 @@ impl GroupValues for GroupValuesRows {
         Ok(output)
     }
 
+    fn values_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        let empty_rows;
+        let group_values = if let Some(group_values) = self.group_values.as_ref() {
+            group_values
+        } else {
+            empty_rows = self.row_converter.empty_rows(0, 0);
+            &empty_rows
+        };
+        selection.validate_num_groups(group_values.num_rows())?;
+        let rows = selection.iter().map(|index| group_values.row(index));
+        let mut output = self.row_converter.convert_rows(rows)?;
+
+        // TODO: Materialize dictionaries in group keys
+        // https://github.com/apache/datafusion/issues/7647
+        for (field, array) in self.schema.fields.iter().zip(&mut output) {
+            *array = encode_array_if_necessary(array, field.data_type())?;
+        }
+        Ok(output)
+    }
+
+    fn supports_values_preserving(&self) -> bool {
+        true
+    }
+
     fn clear_shrink(&mut self, num_rows: usize) {
         self.group_values = self.group_values.take().map(|mut rows| {
             rows.clear();
@@ -410,5 +437,51 @@ pub(crate) fn encode_array_if_necessary(
         }
         (DataType::RunEndEncoded(_, _), _) => Ok(cast(array.as_ref(), expected)?),
         (_, _) => Ok(Arc::<dyn Array>::clone(array)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{AsArray, ListArray};
+    use arrow::datatypes::{Field, Int32Type, Schema};
+
+    #[test]
+    fn preserving_nested_row_values() -> Result<()> {
+        let field = Arc::new(Field::new_list_field(DataType::Int32, true));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "group",
+            DataType::List(field),
+            true,
+        )]));
+        let mut group_values = GroupValuesRows::try_new(schema)?;
+        let input = Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+            Some(vec![Some(1), Some(2)]),
+            None,
+            Some(vec![Some(3)]),
+            Some(vec![Some(1), Some(2)]),
+        ])) as ArrayRef;
+        let mut groups = vec![];
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![0, 1, 2, 0]);
+
+        let selection = GroupSelection::try_from_indices(&[2, 0, 1, 2], 3)?;
+        let expected = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+            Some(vec![Some(3)]),
+            Some(vec![Some(1), Some(2)]),
+            None,
+            Some(vec![Some(3)]),
+        ]);
+        for _ in 0..2 {
+            let actual = group_values.values_preserving(selection)?;
+            assert_eq!(actual[0].as_list::<i32>(), &expected);
+        }
+
+        let input = Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+            Some(vec![Some(4)]),
+        ])) as ArrayRef;
+        group_values.intern(&[input], &mut groups)?;
+        assert_eq!(groups, vec![3]);
+        Ok(())
     }
 }

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/boolean.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/boolean.rs
@@ -21,7 +21,7 @@ use arrow::array::{
     ArrayRef, AsArray as _, BooleanArray, BooleanBufferBuilder, NullBufferBuilder,
 };
 use datafusion_common::Result;
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupSelection};
 use std::{mem::size_of, sync::Arc};
 
 #[derive(Debug)]
@@ -143,6 +143,36 @@ impl GroupValues for GroupValuesBoolean {
         };
 
         Ok(vec![Arc::new(BooleanArray::new(values, nulls)) as _])
+    }
+
+    fn values_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        let num_groups = self.len();
+        selection.validate_num_groups(num_groups)?;
+        let mut values = BooleanBufferBuilder::new(selection.len());
+        let mut nulls = NullBufferBuilder::new(selection.len());
+        for index in selection.iter() {
+            if self.null_group == Some(index) {
+                values.append(false);
+                nulls.append_null();
+            } else {
+                debug_assert!(
+                    self.false_group == Some(index) || self.true_group == Some(index)
+                );
+                values.append(self.true_group == Some(index));
+                nulls.append_non_null();
+            }
+        }
+        Ok(vec![Arc::new(BooleanArray::new(
+            values.finish(),
+            nulls.finish(),
+        ))])
+    }
+
+    fn supports_values_preserving(&self) -> bool {
+        true
     }
 
     fn clear_shrink(&mut self, _num_rows: usize) {

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes.rs
@@ -21,7 +21,7 @@ use crate::aggregates::group_values::GroupValues;
 
 use arrow::array::{Array, ArrayRef, OffsetSizeTrait};
 use datafusion_common::Result;
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupSelection};
 use datafusion_physical_expr_common::binary_map::{ArrowBytesMap, OutputType};
 
 /// A [`GroupValues`] storing single column of Utf8/LargeUtf8/Binary/LargeBinary values
@@ -118,6 +118,18 @@ impl<O: OffsetSizeTrait> GroupValues for GroupValuesBytes<O> {
         };
 
         Ok(vec![group_values])
+    }
+
+    fn values_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        selection.validate_num_groups(self.len())?;
+        Ok(vec![self.map.keys(selection.iter())?])
+    }
+
+    fn supports_values_preserving(&self) -> bool {
+        true
     }
 
     fn clear_shrink(&mut self, _num_rows: usize) {

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes_view.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/bytes_view.rs
@@ -17,7 +17,7 @@
 
 use crate::aggregates::group_values::GroupValues;
 use arrow::array::{Array, ArrayRef};
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupSelection};
 use datafusion_physical_expr::binary_map::OutputType;
 use datafusion_physical_expr_common::binary_view_map::ArrowBytesViewMap;
 use std::mem::size_of;
@@ -120,6 +120,18 @@ impl GroupValues for GroupValuesBytesView {
         };
 
         Ok(vec![group_values])
+    }
+
+    fn values_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> datafusion_common::Result<Vec<ArrayRef>> {
+        selection.validate_num_groups(self.len())?;
+        Ok(vec![self.map.keys(selection.iter())?])
+    }
+
+    fn supports_values_preserving(&self) -> bool {
+        true
     }
 
     fn clear_shrink(&mut self, _num_rows: usize) {

--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -26,7 +26,7 @@ use datafusion_common::Result;
 use datafusion_common::hash_utils::RandomState;
 use datafusion_common::utils::split_vec_min_alloc;
 use datafusion_execution::memory_pool::proxy::VecAllocExt;
-use datafusion_expr::EmitTo;
+use datafusion_expr::{EmitTo, GroupSelection};
 use half::f16;
 use hashbrown::hash_table::HashTable;
 #[cfg(not(feature = "force_hash_collisions"))]
@@ -237,6 +237,35 @@ where
         };
 
         Ok(vec![Arc::new(array.with_data_type(self.data_type.clone()))])
+    }
+
+    fn values_preserving(
+        &mut self,
+        selection: GroupSelection<'_>,
+    ) -> Result<Vec<ArrayRef>> {
+        selection.validate_num_groups(self.values.len())?;
+        let values: Vec<T::Native> =
+            selection.iter().map(|index| self.values[index]).collect();
+        let nulls = if let Some(null_group) = self.null_group {
+            let mut nulls = NullBufferBuilder::new(values.len());
+            for index in selection.iter() {
+                if index == null_group {
+                    nulls.append_null();
+                } else {
+                    nulls.append_non_null();
+                }
+            }
+            nulls.finish()
+        } else {
+            None
+        };
+        let array = PrimitiveArray::<T>::new(values.into(), nulls)
+            .with_data_type(self.data_type.clone());
+        Ok(vec![Arc::new(array)])
+    }
+
+    fn supports_values_preserving(&self) -> bool {
+        true
     }
 
     fn clear_shrink(&mut self, num_rows: usize) {

--- a/docs/source/library-user-guide/upgrading/56.0.0.md
+++ b/docs/source/library-user-guide/upgrading/56.0.0.md
@@ -25,6 +25,19 @@
 in this section pertains to features and changes that have already been merged
 to the main branch and are awaiting release in this version.
 
+### `GroupColumn` now requires `values_preserving`
+
+Custom implementations of the public `GroupColumn` trait must implement
+`values_preserving`. This method returns selected rows without changing the stored
+values or their group indices. It preserves the requested order and supports
+repeated indices.
+
+**Migration guide:**
+
+Implement `values_preserving`, call
+`selection.validate_num_groups(self.len())?` before reading, and return rows in
+`selection.iter()` order without changing the builder state.
+
 ### `datafusion.optimizer.use_statistics_registry` is deprecated and ignored
 
 The `datafusion.optimizer.use_statistics_registry` config flag is deprecated and


### PR DESCRIPTION
## Which issue does this PR close?

- Closes: #24602

## Rationale for this change

Long-lived grouped aggregation state currently must be drained and rebuilt to read a subset of groups. Preserving reads avoid that full-state round trip.

Although the diff is quite large, the conceptual change is fairly contained. Most of the code updates apply the same preserving-read contract across DataFusion’s existing `GroupColumn` and `GroupsAccumulator` implementations.

## What changes are included in this PR?

- Adds validated `GroupSelection` API for all groups or ordered group indices.
- Adds optional preserving-read APIs and capability checks to `GroupValues` and `GroupsAccumulator`.
- Implements selected reads for built-in group values and grouped accumulators.
- Documents the required `GroupColumn` migration.

## Are these changes tested?

Yes

## Are there any user-facing changes?

`GroupColumn::values_preserving` is a new required public trait method, so this is technically a breaking change. However, I think the downstream impact is low since `GroupColumn` seems to be a fairly low-level trait, and DataFusion doesn't expose a public path for supplying a custom implementation to `GroupValuesColumn`