### PR TITLE
main branch test fix: adjust dynamic filter assertion for hash collisions handling

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -7736,10 +7736,17 @@ mod tests {
         let filter = dynamic_filter.current()?.to_string();
         // The aggregated build-side NULL must widen the routed filter once, at the
         // top: `c2 IS NULL OR CASE hash(c2) % 4 WHEN ... END`.
-        assert!(
-            filter.contains("CASE"),
-            "expected a routed partitioned filter, got: {filter}"
-        );
+        //
+        // Under `force_hash_collisions` every key hashes to the same value, so the
+        // repartition routes all build rows to a single partition and
+        // `build_partitioned_filter` collapses to that partition's filter with no
+        // routing `CASE`. The NULL widening this test guards is asserted either way.
+        if cfg!(not(feature = "force_hash_collisions")) {
+            assert!(
+                filter.contains("CASE"),
+                "expected a routed partitioned filter, got: {filter}"
+            );
+        }
         assert!(
             filter.starts_with("c2@0 IS NULL OR"),
             "expected the IS NULL disjunct to wrap the whole routed filter, got: {filter}"


### PR DESCRIPTION
## Which issue does this PR close?

- resolved https://github.com/apache/datafusion/issues/24734

https://github.com/apache/datafusion/pull/24587 is auto merged with failed test, this fix the test. The issue is something from `feature = "force_hash_collisions"`

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
