### PR TITLE
feat: support dictionary in approx_distinct

### DIFF
--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -935,7 +935,8 @@ mod tests {
         use arrow::array::{
             AsArray, Decimal32Array, Decimal64Array, Decimal128Array, Decimal256Array,
             DictionaryArray, Int32Array, Int64Array, IntervalDayTimeArray,
-            IntervalMonthDayNanoArray, IntervalYearMonthArray, StringArray, StringViewArray,
+            IntervalMonthDayNanoArray, IntervalYearMonthArray, StringArray,
+            StringViewArray,
         };
         use arrow::datatypes::{Int32Type, IntervalDayTime, IntervalMonthDayNano, i256};
         use std::sync::Arc;
@@ -1252,7 +1253,7 @@ mod tests {
 
         #[test]
         fn dictionary_int32_utf8_per_row_and_groups_acc() {
-            // {"a", "b", "b", "c", "c", "c"} — 3 distinct logical values
+            // 3 distinct logical values
             let keys = Int32Array::from(vec![0, 1, 1, 2, 2, 2]);
             let values = StringArray::from(vec!["a", "b", "c"]);
             let array: ArrayRef = Arc::new(

--- a/datafusion/functions-aggregate/src/approx_distinct.rs
+++ b/datafusion/functions-aggregate/src/approx_distinct.rs
@@ -841,6 +841,7 @@ impl AggregateUDFImpl for ApproxDistinct {
             | DataType::Struct(_)
             | DataType::Union(_, _)
             | DataType::LargeBinary => Box::new(HLLAccumulator::new()),
+            DataType::Dictionary(_, _) => Box::new(HLLAccumulator::new()),
             DataType::Null => {
                 Box::new(NoopAccumulator::new(ScalarValue::UInt64(Some(0))))
             }
@@ -919,6 +920,7 @@ fn is_hll_groups_type(data_type: &DataType) -> bool {
             | DataType::Map(_, _)
             | DataType::Struct(_)
             | DataType::Union(_, _)
+            | DataType::Dictionary(_, _)
     )
 }
 
@@ -932,10 +934,10 @@ mod tests {
         use super::*;
         use arrow::array::{
             AsArray, Decimal32Array, Decimal64Array, Decimal128Array, Decimal256Array,
-            Int64Array, IntervalDayTimeArray, IntervalMonthDayNanoArray,
-            IntervalYearMonthArray, StringViewArray,
+            DictionaryArray, Int32Array, Int64Array, IntervalDayTimeArray,
+            IntervalMonthDayNanoArray, IntervalYearMonthArray, StringArray, StringViewArray,
         };
-        use arrow::datatypes::{IntervalDayTime, IntervalMonthDayNano, i256};
+        use arrow::datatypes::{Int32Type, IntervalDayTime, IntervalMonthDayNano, i256};
         use std::sync::Arc;
         // A string longer than the 12-byte inline limit
         const LONG: &str = "this string is definitely longer than twelve bytes";
@@ -1246,6 +1248,37 @@ mod tests {
             let result = acc.evaluate(EmitTo::All).unwrap();
             let counts = result.as_any().downcast_ref::<UInt64Array>().unwrap();
             assert_eq!(counts.value(0), 3);
+        }
+
+        #[test]
+        fn dictionary_int32_utf8_per_row_and_groups_acc() {
+            // {"a", "b", "b", "c", "c", "c"} — 3 distinct logical values
+            let keys = Int32Array::from(vec![0, 1, 1, 2, 2, 2]);
+            let values = StringArray::from(vec!["a", "b", "c"]);
+            let array: ArrayRef = Arc::new(
+                DictionaryArray::<Int32Type>::try_new(keys, Arc::new(values)).unwrap(),
+            );
+
+            assert!(is_hll_groups_type(array.data_type()));
+
+            let mut per_row = HLLAccumulator::new();
+            per_row.update_batch(&[Arc::clone(&array)]).unwrap();
+            assert_eq!(distinct_count(&mut per_row), 3);
+
+            let group_indices = vec![0usize; array.len()];
+            let mut groups = HllGroupsAccumulator::new();
+            groups
+                .update_batch(&[Arc::clone(&array)], &group_indices, None, 1)
+                .unwrap();
+            let result = groups.evaluate(EmitTo::All).unwrap();
+            assert_eq!(
+                result
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .value(0),
+                3
+            );
         }
 
         /// Regression: a short (≤ 12-byte) Utf8View string must hash identically


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #24730.

## Rationale for this change

see #24730

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?

 Two lines of change in `approx_distinct.rs`:
1. Add `DataType::Dictionary(_, _)` => `Box::new(HLLAccumulator::new())` arm in accumulator()
2. Add `DataType::Dictionary(_, _)` to the is_hll_groups_type match

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
yes, 1 test was added.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
yes, `approx-distinct(dictionary)` will no longer panic.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
