### PR TITLE
fix: count `aggregation_time` once per batch instead of once per accumulator

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/metrics.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/metrics.rs
@@ -475,6 +475,81 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_groupby_aggregation_time_not_inflated_by_accumulator_count()
+    -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::UInt32, false),
+            Field::new("v", DataType::Float64, false),
+        ]));
+
+        const ROWS: usize = 8192;
+        let batches = (0..20)
+            .map(|_| {
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![
+                        Arc::new(UInt32Array::from(
+                            (0..ROWS).map(|r| (r % 8) as u32).collect::<Vec<_>>(),
+                        )),
+                        Arc::new(Float64Array::from(
+                            (0..ROWS).map(|r| r as f64).collect::<Vec<_>>(),
+                        )),
+                    ],
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let input = TestMemoryExec::try_new_exec(&[batches], Arc::clone(&schema), None)?;
+        let group_by =
+            PhysicalGroupBy::new_single(vec![(col("k", &schema)?, "k".to_string())]);
+
+        let aggregates = (0..8)
+            .map(|i| sum_aggregate(&schema, "v", &format!("SUM{i}(v)")))
+            .collect::<Result<Vec<_>>>()?;
+        let filters = vec![None; aggregates.len()];
+
+        let aggregate_exec = Arc::new(AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by,
+            aggregates,
+            filters,
+            input,
+            schema,
+        )?);
+
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_limit(64 * 1024 * 1024, 1.0)
+            .build_arc()?;
+        let task_ctx =
+            Arc::new(
+                TaskContext::default()
+                    .with_runtime(runtime)
+                    .with_session_config(SessionConfig::new().set_bool(
+                        "datafusion.execution.enable_migration_aggregate",
+                        false,
+                    )),
+            );
+        let _result =
+            collect(Arc::clone(&aggregate_exec) as _, Arc::clone(&task_ctx)).await?;
+
+        let metrics = aggregate_exec.metrics().unwrap();
+        let aggregation_time =
+            metrics.sum_by_name("aggregation_time").unwrap().as_usize();
+        let elapsed_compute = metrics.elapsed_compute().unwrap();
+        println!(
+            "aggregation_time={aggregation_time} elapsed_compute={elapsed_compute} ratio={:.2}",
+            aggregation_time as f64 / elapsed_compute as f64
+        );
+        assert!(
+            aggregation_time <= elapsed_compute,
+            "aggregation_time {aggregation_time} exceeds elapsed_compute {elapsed_compute}"
+        );
+
+        Ok(())
+    }
+
     async fn assert_groupby_metrics_final_mode(
         enable_migration_aggregate: bool,
     ) -> Result<()> {

--- a/datafusion/physical-plan/src/aggregates/group_values/metrics.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/metrics.rs
@@ -519,18 +519,12 @@ mod tests {
             schema,
         )?);
 
-        let runtime = RuntimeEnvBuilder::new()
-            .with_memory_limit(64 * 1024 * 1024, 1.0)
-            .build_arc()?;
-        let task_ctx =
-            Arc::new(
-                TaskContext::default()
-                    .with_runtime(runtime)
-                    .with_session_config(SessionConfig::new().set_bool(
-                        "datafusion.execution.enable_migration_aggregate",
-                        false,
-                    )),
-            );
+        let task_ctx = Arc::new(
+            TaskContext::default().with_session_config(
+                SessionConfig::new()
+                    .set_bool("datafusion.execution.enable_migration_aggregate", false),
+            ),
+        );
         let _result =
             collect(Arc::clone(&aggregate_exec) as _, Arc::clone(&task_ctx)).await?;
 
@@ -538,10 +532,6 @@ mod tests {
         let aggregation_time =
             metrics.sum_by_name("aggregation_time").unwrap().as_usize();
         let elapsed_compute = metrics.elapsed_compute().unwrap();
-        println!(
-            "aggregation_time={aggregation_time} elapsed_compute={elapsed_compute} ratio={:.2}",
-            aggregation_time as f64 / elapsed_compute as f64
-        );
         assert!(
             aggregation_time <= elapsed_compute,
             "aggregation_time {aggregation_time} exceeds elapsed_compute {elapsed_compute}"

--- a/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs
@@ -978,10 +978,13 @@ impl GroupedHashAggregateStream {
                         || acc.merge_batch(values, group_indices, total_num_groups),
                     )?;
                 }
-                self.group_by_metrics
-                    .aggregation_time
-                    .add_elapsed(agg_start_time);
             }
+            // Once per batch, after every accumulator ran: adding inside the loop
+            // would count accumulator k's elapsed time k times over, inflating the
+            // metric by up to (N+1)/2 on a node with N aggregate functions.
+            self.group_by_metrics
+                .aggregation_time
+                .add_elapsed(agg_start_time);
         }
 
         Ok(())

--- a/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs
@@ -979,9 +979,7 @@ impl GroupedHashAggregateStream {
                     )?;
                 }
             }
-            // Once per batch, after every accumulator ran: adding inside the loop
-            // would count accumulator k's elapsed time k times over, inflating the
-            // metric by up to (N+1)/2 on a node with N aggregate functions.
+            // Recorded once per grouping set, after all its accumulators ran
             self.group_by_metrics
                 .aggregation_time
                 .add_elapsed(agg_start_time);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24735.

## Rationale for this change

`aggregation_time` on `GroupedHashAggregateStream` is added inside the per-accumulator loop while `agg_start_time` is taken once before it, so with N aggregate functions the k-th accumulator re-adds the elapsed time of all k accumulators so far, inflating the metric by up to (N+1)/2. On a 28-function GROUP BY a single task reported 4m22s of `aggregation_time` inside a 2m0s stage. Single-aggregate plans are unaffected. The newer `aggregate_hash_table` implementations already scope the timer around the whole loop.

## What changes are included in this PR?

Move the `add_elapsed` call after the accumulator loop, once per interned batch. `time_calculating_group_ids`, which shares `agg_start_time` as its end point, is unchanged, and the per-accumulator `aggregate_accumulator_metrics` timings are unaffected.

## Are these changes tested?

Covered by the existing aggregate tests (`cargo test -p datafusion-physical-plan aggregates`, 193 passed). The metric's value is wall-clock time, which the existing tests do not assert exactly; the inflation itself was measured on a 28-aggregate workload where the fixed metric now stays within the operator's elapsed time.

## Are there any user-facing changes?

`aggregation_time` (shown in `EXPLAIN ANALYZE` as elapsed_compute subset time) now reports the actual time spent in accumulators on plans with more than one aggregate function; previously it over-reported on such plans.
