### PR TITLE
Read primitive values directly in branchless IN LIST filters

### DIFF
--- a/datafusion/physical-expr/src/expressions/in_list/branchless_filter.rs
+++ b/datafusion/physical-expr/src/expressions/in_list/branchless_filter.rs
@@ -339,12 +339,9 @@ fn branchless_values<T>(array: &PrimitiveArray<T>) -> ScalarBuffer<BranchlessNat
 where
     T: BranchlessFilterType,
 {
-    let data = array.to_data();
-    ScalarBuffer::<BranchlessNative<T>>::new(
-        data.buffers()[0].clone(),
-        data.offset(),
-        data.len(),
-    )
+    let values = array.values();
+    // `values.inner()` already reflects any slice applied to the array.
+    ScalarBuffer::<BranchlessNative<T>>::new(values.inner().clone(), 0, values.len())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #19241.

## Rationale for this change

The branchless IN LIST filter only needs the primitive values in an array. It currently rebuilds `ArrayData` for every batch before recovering the same value buffer, which adds fixed work to each filter evaluation.

## What changes are included in this PR?

Read the primitive value buffer directly. The value buffer already accounts for array slices, so behavior is unchanged.

### Why is the new offset zero?

By the time DataFusion receives a `PrimitiveArray`, its values buffer already starts at the first logical value. Arrow applies offsets while constructing or slicing the array:

```rust
// Adapted from arrow-rs 59.2.0; unrelated fields omitted.

// ArrayData -> PrimitiveArray
let values = ScalarBuffer::new(buffer, offset, len);

// PrimitiveArray::slice
values: self.values.slice(offset, length),

// PrimitiveArray -> ArrayData
ArrayDataBuilder::new(/* ... */)
    .len(array.values.len())
    .buffers(vec![array.values.into_inner()])
```

The last conversion is what `to_data()` uses, and the new `ArrayDataBuilder` defaults to offset zero. See the upstream [import](https://github.com/apache/arrow-rs/blob/59.2.0/arrow-array/src/array/primitive_array.rs#L1615-L1634), [slice](https://github.com/apache/arrow-rs/blob/59.2.0/arrow-array/src/array/primitive_array.rs#L850-L856), [export](https://github.com/apache/arrow-rs/blob/59.2.0/arrow-array/src/array/primitive_array.rs#L1196-L1215), and [builder default](https://github.com/apache/arrow-rs/blob/59.2.0/arrow-data/src/data.rs#L2106-L2122).

Thus the old `data.offset()` was zero, just like the new explicit `0`; no offset is discarded.

## Are these changes tested?

Yes. Existing branchless filter tests cover slices, nulls, and all supported physical widths.

The benchmark bot independently confirms the fixed-cost reduction: plain branchless probes had 35–37% lower latency for batches of 1–64 rows and roughly 3–4% lower latency at 8,192 rows ([full results](https://github.com/apache/datafusion/pull/24747#issuecomment-5451210769)).

## Are there any user-facing changes?

No. Results and public APIs are unchanged.