### PR TITLE
fix: prevent CSE from extracting window functions

### DIFF
--- a/datafusion/core/tests/dataframe/mod.rs
+++ b/datafusion/core/tests/dataframe/mod.rs
@@ -207,6 +207,23 @@ async fn with_column_window_functions() -> DataFusionResult<()> {
 }
 
 #[tokio::test]
+async fn duplicated_window_functions_can_be_executed() -> Result<()> {
+    let wexpr = datafusion::functions_window::row_number::row_number_udwf().call(vec![]);
+
+    let plan = LogicalPlanBuilder::empty(true)
+        .window(vec![wexpr.clone(), wexpr.alias("aliased")])?
+        .build()?;
+
+    let ctx = SessionContext::new();
+
+    let collected = DataFrame::new(ctx.state(), plan).collect().await?;
+
+    assert_eq!(collected.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_coalesce_schema() -> Result<()> {
     let ctx = SessionContext::new();
 

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -732,6 +732,7 @@ impl CSEController for ExprCSEController<'_> {
                 | Expr::Wildcard { .. }
                 | Expr::Lambda(_)
                 | Expr::LambdaVariable(_)
+                | Expr::WindowFunction(..)
         );
 
         let is_aggr = matches!(node, Expr::AggregateFunction(..));
@@ -856,6 +857,7 @@ mod test {
     use crate::test::udfs::leaf_udf_expr;
     use crate::test::*;
     use datafusion_expr::test::function_stub::{avg, sum};
+    use datafusion_functions_window::row_number::row_number_udwf;
 
     macro_rules! assert_optimized_plan_equal {
         (
@@ -1929,6 +1931,23 @@ mod test {
         Projection: __common_expr_1 AS c1, __common_expr_1 AS c2
           Projection: leaf_udf(test.a) + test.b AS __common_expr_1, test.a, test.b, test.c
             TableScan: test
+        "
+        )
+    }
+
+    #[test]
+    fn test_window_function_is_not_extracted() -> Result<()> {
+        let wexpr = row_number_udwf().call(vec![]);
+
+        let plan = LogicalPlanBuilder::empty(true)
+            .window(vec![wexpr.clone(), wexpr.alias("aliased")])?
+            .build()?;
+
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        WindowAggr: windowExpr=[[row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING, row_number() ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING AS aliased]]
+          EmptyRelation: rows=1
         "
         )
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #15190 

## Rationale for this change

Common subexpression elimination can extract duplicated window functions into an intermediate Projection. Since window functions cannot be evaluated by a projection, this produces a plan that fails during physical planning.

## What changes are included in this PR?

Exclude WindowFunction expressions themselves from CSE extraction and add a regression test.

## Are these changes tested?

Yes. A regression test verifies that duplicated window functions remain in the WindowAggr node.

## Are there any user-facing changes?

Queries affected by #15190 no longer fail during physical planning.  No documentation changes are required.