### PR TITLE
fix(examples): apply relation aliases once

### DIFF
--- a/datafusion-examples/examples/relation_planner/table_sample.rs
+++ b/datafusion-examples/examples/relation_planner/table_sample.rs
@@ -279,6 +279,24 @@ async fn run_examples(ctx: &SessionContext) -> Result<()> {
     +---------+---------+---------+---------+
     ");
 
+    // Verify that relation and column aliases wrap the sampled relation once.
+    let plan = ctx
+        .sql(
+            "SELECT * FROM sample_data AS sampled(first, second) \
+             TABLESAMPLE (3 ROWS)",
+        )
+        .await?
+        .logical_plan()
+        .display_indent()
+        .to_string();
+    assert_snapshot!(plan, @r"
+    Projection: sampled.first, sampled.second
+      SubqueryAlias: sampled
+        Projection: sample_data.column1 AS first, sample_data.column2 AS second
+          Limit: skip=0, fetch=3
+            TableScan: sample_data
+    ");
+
     Ok(())
 }
 
@@ -373,10 +391,13 @@ impl RelationPlanner for TableSamplePlanner {
             })
             .transpose()?;
 
-        // Plan the underlying table without the sample clause
+        // Plan the underlying table without the sample clause or alias. The
+        // alias belongs to the complete TABLESAMPLE relation, so we return it
+        // with `PlannedRelation` below and let DataFusion apply it once, after
+        // the sampling node has been added.
         let base_relation = TableFactor::Table {
             sample: None,
-            alias: alias.clone(),
+            alias: None,
             name,
             args,
             with_hints,

--- a/datafusion/expr/src/planner.rs
+++ b/datafusion/expr/src/planner.rs
@@ -359,13 +359,20 @@ pub enum PlannerResult<T> {
 pub struct PlannedRelation {
     /// The logical plan for the relation
     pub plan: LogicalPlan,
-    /// Optional table alias for the relation
+    /// Optional alias for the completed relation.
+    ///
+    /// DataFusion applies this alias after the extension planner returns. If the
+    /// planner also passes this alias to [`RelationPlannerContext::plan`], it will
+    /// be applied twice.
     pub alias: Option<TableAlias>,
 }
 
 #[cfg(feature = "sql")]
 impl PlannedRelation {
-    /// Create a new `PlannedRelation` with the given plan and alias
+    /// Create a new `PlannedRelation` with the given plan and optional alias.
+    ///
+    /// DataFusion applies `alias` after the relation planner returns. The same
+    /// alias must therefore not already have been applied to `plan`.
     pub fn new(plan: LogicalPlan, alias: Option<TableAlias>) -> Self {
         Self { plan, alias }
     }
@@ -414,6 +421,11 @@ pub trait RelationPlannerContext {
 
     /// Plans the specified relation through the full planner pipeline, starting
     /// from the first registered relation planner.
+    ///
+    /// This method applies any alias present on `relation`. A planner that returns
+    /// an alias in [`PlannedRelation`] must therefore not also include the same
+    /// alias in a relation passed to this method, or DataFusion will apply it
+    /// twice.
     fn plan(&mut self, relation: TableFactor) -> Result<LogicalPlan>;
 
     /// Converts a SQL expression into a logical expression using the current

--- a/docs/source/library-user-guide/extending-sql.md
+++ b/docs/source/library-user-guide/extending-sql.md
@@ -285,6 +285,12 @@ There are two main approaches when implementing a [`RelationPlanner`]:
    represent the operation in the logical plan, along with a custom [`ExecutionPlan`]
    to execute it. Both are required for end-to-end execution.
 
+DataFusion applies the alias returned in a [`PlannedRelation`] to the completed
+plan. Because `ctx.plan(...)` also applies the alias on the relation it receives,
+do not both pass and return the same outer alias. For example, when rebuilding a
+table factor without a modifier such as `TABLESAMPLE`, set the rebuilt factor's
+alias to `None` and return the original alias with the completed plan.
+
 #### Example: Basic RelationPlanner Structure
 
 ```rust
@@ -314,11 +320,13 @@ impl RelationPlanner for MyRelationPlanner {
                 // Transform or wrap the plan as needed
                 // ...
 
-                Ok(RelationPlanning::Planned(PlannedRelation::new(input, alias)))
+                Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
+                    input, alias,
+                ))))
             }
 
             // Return Original for relations you don't handle
-            other => Ok(RelationPlanning::Original(other)),
+            other => Ok(RelationPlanning::Original(Box::new(other))),
         }
     }
 }
@@ -380,6 +388,7 @@ SELECT * FROM sales
 [`sessioncontext`]: https://docs.rs/datafusion/latest/datafusion/execution/context/struct.SessionContext.html
 [`sessionstatebuilder`]: https://docs.rs/datafusion/latest/datafusion/execution/session_state/struct.SessionStateBuilder.html
 [`relationplannercontext`]: https://docs.rs/datafusion/latest/datafusion/logical_expr/planner/trait.RelationPlannerContext.html
+[`plannedrelation`]: https://docs.rs/datafusion/latest/datafusion/logical_expr/planner/struct.PlannedRelation.html
 [exprplanner api documentation]: https://docs.rs/datafusion/latest/datafusion/logical_expr/planner/trait.ExprPlanner.html
 [typeplanner api documentation]: https://docs.rs/datafusion/latest/datafusion/logical_expr/planner/trait.TypePlanner.html
 [relationplanner api documentation]: https://docs.rs/datafusion/latest/datafusion/logical_expr/planner/trait.RelationPlanner.html


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24753.

## Rationale for this change

The `TABLESAMPLE` relation-planner example recursively planned the underlying table with its outer alias still attached, then returned the same alias with the completed sampled plan. DataFusion therefore applied the alias twice, producing duplicate alias and column-renaming nodes in the logical plan. Query results were unchanged, but the official example demonstrated the wrong integration pattern for extension authors.

## What changes are included in this PR?

- Plan the underlying table without the outer `TABLESAMPLE` alias, then return that alias with the completed `PlannedRelation` so DataFusion applies it once.
- Document that a `RelationPlanner` must not both recursively apply and return the same outer alias.
- Update the guide's `RelationPlanning` example to use the current boxed variants.
- Add a logical-plan regression assertion to the normal example path exercised by CI.

## Are these changes tested?

Yes. The `TABLESAMPLE` example now verifies that the relation alias and column renaming appear exactly once in the logical plan, and the assertion runs as part of the existing examples CI job.

## Are there any user-facing changes?

DataFusion's built-in alias behavior is unchanged. The official `TABLESAMPLE` extension example now produces a simpler logical plan, and the extension-author documentation describes the correct alias-handling pattern.
