### PR TITLE
fix(sql): reject unsupported relation modifiers

### DIFF
--- a/datafusion/core/tests/user_defined/relation_planner.rs
+++ b/datafusion/core/tests/user_defined/relation_planner.rs
@@ -462,9 +462,9 @@ mod tests {
     }
 
     // A planner that declines a relation must not cause the default planner to
-    // silently discard syntax that changes which rows the relation represents.
+    // silently discard syntax that changes the relation's meaning.
     #[tokio::test]
-    async fn unsupported_table_modifiers_fail_closed_after_delegation() {
+    async fn unsupported_relation_modifiers_fail_closed_after_delegation() {
         let contexts = [
             (
                 "without an extension planner",
@@ -478,14 +478,44 @@ mod tests {
         ];
         let cases = [
             (
-                "generic",
-                "SELECT * FROM real_table TABLESAMPLE SYSTEM (10 PERCENT)",
-                "TABLESAMPLE is not supported by the default relation planner",
+                "mssql",
+                "SELECT * FROM real_table WITH (NOLOCK)",
+                "Table hints are not supported by the default relation planner",
             ),
             (
                 "snowflake",
                 "SELECT * FROM real_table VERSION AS OF 1",
                 "Table version qualifiers are not supported by the default relation planner",
+            ),
+            (
+                "postgres",
+                "SELECT * FROM generate_series(1, 2) WITH ORDINALITY",
+                "WITH ORDINALITY is not supported by the default relation planner",
+            ),
+            (
+                "mysql",
+                "SELECT * FROM real_table PARTITION (p0)",
+                "Table partition selection is not supported by the default relation planner",
+            ),
+            (
+                "snowflake",
+                "SELECT * FROM real_table['items']",
+                "Table JSON paths are not supported by the default relation planner",
+            ),
+            (
+                "generic",
+                "SELECT * FROM real_table TABLESAMPLE SYSTEM (10 PERCENT)",
+                "TABLESAMPLE is not supported by the default relation planner",
+            ),
+            (
+                "mysql",
+                "SELECT * FROM real_table USE INDEX (idx)",
+                "Table index hints are not supported by the default relation planner",
+            ),
+            (
+                "clickhouse",
+                "SELECT * FROM generate_series(1, 2, SETTINGS send_chunk_header = false)",
+                "Table function SETTINGS are not supported by the default relation planner",
             ),
             (
                 "generic",
@@ -495,12 +525,7 @@ mod tests {
             (
                 "postgres",
                 "SELECT * FROM LATERAL generate_series(1, 2) WITH ORDINALITY",
-                "WITH ORDINALITY is not supported by the default relation planner for table functions",
-            ),
-            (
-                "clickhouse",
-                "SELECT * FROM executable('generate_random.py', TabSeparated, 'id UInt32', SETTINGS send_chunk_header = false)",
-                "Table function SETTINGS are not supported by the default relation planner",
+                "WITH ORDINALITY is not supported by the default relation planner",
             ),
         ];
 

--- a/datafusion/core/tests/user_defined/relation_planner.rs
+++ b/datafusion/core/tests/user_defined/relation_planner.rs
@@ -461,6 +461,73 @@ mod tests {
         ");
     }
 
+    // A planner that declines a relation must not cause the default planner to
+    // silently discard syntax that changes which rows the relation represents.
+    #[tokio::test]
+    async fn unsupported_table_modifiers_fail_closed_after_delegation() {
+        let contexts = [
+            (
+                "without an extension planner",
+                create_context_with_simple_table("real_table", vec![42]),
+            ),
+            (
+                "after a pass-through extension planner",
+                create_context_with_simple_table("real_table", vec![42])
+                    .with_planner(PassThroughPlanner),
+            ),
+        ];
+        let cases = [
+            (
+                "generic",
+                "SELECT * FROM real_table TABLESAMPLE SYSTEM (10 PERCENT)",
+                "TABLESAMPLE is not supported by the default relation planner",
+            ),
+            (
+                "snowflake",
+                "SELECT * FROM real_table VERSION AS OF 1",
+                "Table version qualifiers are not supported by the default relation planner",
+            ),
+            (
+                "generic",
+                "SELECT * FROM (SELECT * FROM real_table) TABLESAMPLE (1 ROWS)",
+                "TABLESAMPLE on derived tables is not supported by the default relation planner",
+            ),
+            (
+                "postgres",
+                "SELECT * FROM LATERAL generate_series(1, 2) WITH ORDINALITY",
+                "WITH ORDINALITY is not supported by the default relation planner for table functions",
+            ),
+            (
+                "clickhouse",
+                "SELECT * FROM executable('generate_random.py', TabSeparated, 'id UInt32', SETTINGS send_chunk_header = false)",
+                "Table function SETTINGS are not supported by the default relation planner",
+            ),
+        ];
+
+        for (context_description, ctx) in contexts {
+            for (dialect, sql, expected) in cases {
+                execute_sql(
+                    &ctx,
+                    &format!("SET datafusion.sql_parser.dialect = '{dialect}'"),
+                )
+                .await
+                .unwrap_or_else(|error| {
+                    panic!("{dialect} dialect should be enabled: {error}")
+                });
+                let error = match ctx.sql(sql).await {
+                    Ok(_) => {
+                        panic!("Expected `{sql}` to be rejected {context_description}")
+                    }
+                    Err(error) => error.to_string(),
+                };
+                assert!(
+                    error.contains(expected),
+                    "Expected `{sql}` to report `{expected}` {context_description}, got: {error}"
+                );
+            }
+        }
+    }
+
     // Catalog is used when no planner claims the relation.
     #[tokio::test]
     async fn catalog_fallback_when_no_planner() {

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -176,7 +176,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
                 if with_ordinality {
                     return not_impl_err!(
-                        "WITH ORDINALITY is not supported by the default relation planner for named tables"
+                        "WITH ORDINALITY is not supported by the default relation planner"
                     );
                 }
                 if !partitions.is_empty() {
@@ -201,9 +201,9 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
 
                 if let Some(func_args) = args {
-                    // Keep this exhaustive for the same reason as the outer
-                    // TableFactor match: new table-function modifiers should
-                    // require an explicit planning decision.
+                    // Keep this exhaustive for the same reason as the
+                    // `TableFactor::Table` pattern: new table-function modifiers
+                    // should require an explicit planning decision.
                     let TableFunctionArgs { args, settings } = func_args;
                     if settings.is_some() {
                         return not_impl_err!(
@@ -337,7 +337,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             } => {
                 if with_ordinality {
                     return not_impl_err!(
-                        "WITH ORDINALITY is not supported by the default relation planner for table functions"
+                        "WITH ORDINALITY is not supported by the default relation planner"
                     );
                 }
                 let tbl_func_ref = self.object_name_to_table_reference(name)?;

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -29,7 +29,9 @@ use datafusion_expr::planner::{
 };
 use datafusion_expr::{Expr, LogicalPlan, LogicalPlanBuilder, expr::Unnest};
 use datafusion_expr::{Subquery, SubqueryAlias};
-use sqlparser::ast::{FunctionArg, FunctionArgExpr, Spanned, TableFactor};
+use sqlparser::ast::{
+    FunctionArg, FunctionArgExpr, Spanned, TableFactor, TableFunctionArgs,
+};
 
 mod join;
 
@@ -148,13 +150,69 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         let relation_span = relation.span();
         let (plan, alias) = match relation {
             TableFactor::Table {
-                name, alias, args, ..
+                name,
+                alias,
+                args,
+                with_hints,
+                version,
+                with_ordinality,
+                partitions,
+                json_path,
+                sample,
+                index_hints,
             } => {
+                // Falling back must not turn a modified relation into an
+                // ordinary scan. Extension planners may consume these
+                // modifiers, but the default planner should fail closed.
+                if !with_hints.is_empty() {
+                    return not_impl_err!(
+                        "Table hints are not supported by the default relation planner"
+                    );
+                }
+                if version.is_some() {
+                    return not_impl_err!(
+                        "Table version qualifiers are not supported by the default relation planner"
+                    );
+                }
+                if with_ordinality {
+                    return not_impl_err!(
+                        "WITH ORDINALITY is not supported by the default relation planner for named tables"
+                    );
+                }
+                if !partitions.is_empty() {
+                    return not_impl_err!(
+                        "Table partition selection is not supported by the default relation planner"
+                    );
+                }
+                if json_path.is_some() {
+                    return not_impl_err!(
+                        "Table JSON paths are not supported by the default relation planner"
+                    );
+                }
+                if sample.is_some() {
+                    return not_impl_err!(
+                        "TABLESAMPLE is not supported by the default relation planner"
+                    );
+                }
+                if !index_hints.is_empty() {
+                    return not_impl_err!(
+                        "Table index hints are not supported by the default relation planner"
+                    );
+                }
+
                 if let Some(func_args) = args {
+                    // Keep this exhaustive for the same reason as the outer
+                    // TableFactor match: new table-function modifiers should
+                    // require an explicit planning decision.
+                    let TableFunctionArgs { args, settings } = func_args;
+                    if settings.is_some() {
+                        return not_impl_err!(
+                            "Table function SETTINGS are not supported by the default relation planner"
+                        );
+                    }
                     let tbl_func_name =
                         name.0.first().unwrap().as_ident().unwrap().to_string();
-                    let args = func_args
-                        .args
+                    let args = args
                         .into_iter()
                         .map(|arg| {
                             if let FunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) = arg
@@ -211,8 +269,16 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
             }
             TableFactor::Derived {
-                subquery, alias, ..
+                lateral: _,
+                subquery,
+                alias,
+                sample,
             } => {
+                if sample.is_some() {
+                    return not_impl_err!(
+                        "TABLESAMPLE on derived tables is not supported by the default relation planner"
+                    );
+                }
                 let logical_plan = self.query_to_plan(*subquery, planner_context)?;
                 (logical_plan, alias)
             }
@@ -263,8 +329,17 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 );
             }
             TableFactor::Function {
-                name, args, alias, ..
+                lateral: _,
+                name,
+                args,
+                with_ordinality,
+                alias,
             } => {
+                if with_ordinality {
+                    return not_impl_err!(
+                        "WITH ORDINALITY is not supported by the default relation planner for table functions"
+                    );
+                }
                 let tbl_func_ref = self.object_name_to_table_reference(name)?;
                 let schema = planner_context
                     .outer_queries_schemas()


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24754.

## Rationale for this change

DataFusion's built-in SQL planner ignored some relation modifiers that sqlparser successfully parsed. For example, `TABLESAMPLE` could silently become an ordinary full table scan. This happened in vanilla DataFusion when no `RelationPlanner` was registered, and also after every registered planner declined the relation.

Queries should not succeed after silently changing their meaning. The built-in fallback should reject modifiers it cannot implement.

## What changes are included in this PR?

When the built-in planner handles a relation, it now rejects unsupported modifiers on:

- table references: hints, version qualifiers, partition selection, JSON paths, `TABLESAMPLE`, and index hints;
- derived tables: `TABLESAMPLE`;
- table functions: `WITH ORDINALITY` and `SETTINGS`.

Registered `RelationPlanner`s still run before the built-in fallback. An extension can continue to handle any modifier it supports; the new errors apply only when no extension plans the relation.

The affected sqlparser structures are destructured exhaustively. If sqlparser adds another field, the compiler will require an explicit planning decision.

## Are these changes tested?

Yes. The regression test covers every new rejection path both in vanilla DataFusion and after a pass-through extension planner. A separate example test confirms that an extension can still handle `TABLESAMPLE`.

## Are there any user-facing changes?

Yes. Relation modifiers that the built-in planner previously accepted but ignored now return a clear unsupported-planning error. Queries without these modifiers are unchanged, as are queries whose modifiers are handled by an extension planner. There are no public API changes.
