### PR TITLE
test: enable `DurationSecond` fuzzing

### DIFF
--- a/datafusion/core/tests/fuzz_cases/record_batch_generator.rs
+++ b/datafusion/core/tests/fuzz_cases/record_batch_generator.rs
@@ -91,11 +91,7 @@ pub fn get_supported_types_columns(rng_seed: u64) -> Vec<ColumnDescr> {
             "interval_month_day_nano",
             DataType::Interval(IntervalUnit::MonthDayNano),
         ),
-        // Internal error: AggregationFuzzer task error: JoinError::Panic(Id(29108), "called `Option::unwrap()` on a `None` value", ...).
-        // ColumnDescr::new(
-        //     "duration_seconds",
-        //     DataType::Duration(TimeUnit::Second),
-        // ),
+        ColumnDescr::new("duration_seconds", DataType::Duration(TimeUnit::Second)),
         ColumnDescr::new(
             "duration_milliseconds",
             DataType::Duration(TimeUnit::Millisecond),

--- a/test-utils/src/array_gen/random_data.rs
+++ b/test-utils/src/array_gen/random_data.rs
@@ -133,9 +133,7 @@ impl RandomNativeData for IntervalMonthDayNanoType {
     }
 }
 
-// Restrict Duration(Seconds) to values that pretty-print as distinct durations.
-// Out-of-range values print as `<invalid>`, which could make unequal batches
-// compare equal after pretty-printing.
+// Keep values in the pretty-print range; all others render as `<invalid>`.
 impl RandomNativeData for DurationSecondType {
     fn generate_random_native_data(rng: &mut StdRng) -> Self::Native {
         rng.random::<i64>() / 1000

--- a/test-utils/src/array_gen/random_data.rs
+++ b/test-utils/src/array_gen/random_data.rs
@@ -133,9 +133,9 @@ impl RandomNativeData for IntervalMonthDayNanoType {
     }
 }
 
-// Restrict Duration(Seconds) to i64::MIN / 1000 to i64::MAX / 1000 to
-// avoid panics on pretty printing. See
-// https://github.com/apache/arrow-rs/issues/7533
+// Restrict Duration(Seconds) to values that pretty-print as distinct durations.
+// Out-of-range values print as `<invalid>`, which could make unequal batches
+// compare equal after pretty-printing.
 impl RandomNativeData for DurationSecondType {
     fn generate_random_native_data(rng: &mut StdRng) -> Self::Native {
         rng.random::<i64>() / 1000


### PR DESCRIPTION
## Which issue does this PR close?

N/A — this restores fuzz coverage disabled by a now resolved upstream Arrow issue.

## Rationale for this change

`DurationSecond` fuzzing was disabled after an Arrow pretty-printing panic ([arrow-rs#7533](https://github.com/apache/arrow-rs/issues/7533)). The panic was fixed in [arrow-rs#7534](https://github.com/apache/arrow-rs/pull/7534).

The existing generator range restriction remains necessary: out-of-range values print as `<invalid>`, which could make unequal batches compare equal in the fuzzer's pretty-print comparison.

## What changes are included in this PR?

- Re-enable the `duration_seconds` fuzz column.
- Clarify why its generated values remain range-restricted.

## Are these changes tested?

Yes. The existing scalar and aggregation fuzz tests pass with `DurationSecond` enabled.

## Are there any user-facing changes?

No.