### PR TITLE
fix: Show unique valid field names when an invalid one is provided

### DIFF
--- a/datafusion/common/src/column.rs
+++ b/datafusion/common/src/column.rs
@@ -22,6 +22,7 @@ use crate::utils::parse_identifiers_normalized;
 use crate::utils::quote_identifier;
 use crate::{DFSchema, Diagnostic, Result, SchemaError, Spans, TableReference};
 use arrow::datatypes::{Field, FieldRef};
+use itertools::Itertools;
 use std::collections::HashSet;
 use std::fmt;
 
@@ -295,6 +296,7 @@ impl Column {
                 .iter()
                 .flat_map(|s| s.iter())
                 .flat_map(|s| s.columns())
+                .unique()
                 .collect(),
         })
     }

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -195,8 +195,8 @@ drop table a;
 
 # Test valid fields in a nested query when providing an invalid column name
 # (https://github.com/apache/datafusion/issues/24773)
-query error DataFusion error: Schema error: No field named y.\nValid fields are t.x.
+query error DataFusion error: Schema error: No field named y\.\nValid fields are t\.x\.$
 select * from (select 1 as x) t order by y;
 
-query error DataFusion error: Schema error: No field named t.y. Did you mean 't.x'\?\nValid fields are t.x.
+query error DataFusion error: Schema error: No field named t\.y\. Did you mean 't\.x'\?\nValid fields are t\.x\.$
 select * from (select 1 as x) t order by t.y;

--- a/datafusion/sqllogictest/test_files/errors.slt
+++ b/datafusion/sqllogictest/test_files/errors.slt
@@ -191,3 +191,12 @@ select ammp from a;
 
 statement ok
 drop table a;
+
+
+# Test valid fields in a nested query when providing an invalid column name
+# (https://github.com/apache/datafusion/issues/24773)
+query error DataFusion error: Schema error: No field named y.\nValid fields are t.x.
+select * from (select 1 as x) t order by y;
+
+query error DataFusion error: Schema error: No field named t.y. Did you mean 't.x'\?\nValid fields are t.x.
+select * from (select 1 as x) t order by t.y;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24773.

## Rationale for this change

Minor fix to show a valid field name only once in the "Valid fields" error message.

## What changes are included in this PR?

- Add `unique` when collecting valid fields for the `FieldNotFound` error at `normalize_with_schemas_and_ambiguity_check`. Since multiple levels of schema are tested in that function, the same field can appear multiple times.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No.