### PR TITLE
SQL benchmark configuration parity updates

### DIFF
--- a/benchmarks/sql_benchmarks/clickbench_sorted/init/load.sql
+++ b/benchmarks/sql_benchmarks/clickbench_sorted/init/load.sql
@@ -1,6 +1,8 @@
 -- Run benchmark with prefer_existing_sort configuration
 -- This allows DataFusion to optimize away redundant sorts while maintaining parallelism
 
+SET datafusion.execution.parquet.pushdown_filters = true;
+SET datafusion.execution.parquet.reorder_filters = true;
 set datafusion.optimizer.prefer_existing_sort=true;
 
 CREATE EXTERNAL TABLE hits_raw STORED AS PARQUET LOCATION '${DATA_DIR:-data}/hits_sorted.parquet' WITH ORDER ("${SORTED_BY:-EventTime}" ${SORTED_ORDER:-ASC});

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q01.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q01.benchmark
@@ -1,6 +1,8 @@
 name Q01
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q02.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q02.benchmark
@@ -1,6 +1,8 @@
 name Q02
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q03.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q03.benchmark
@@ -1,6 +1,8 @@
 name Q03
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q04.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q04.benchmark
@@ -1,6 +1,8 @@
 name Q04
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q05.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q05.benchmark
@@ -1,6 +1,8 @@
 name Q05
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q06.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q06.benchmark
@@ -1,6 +1,8 @@
 name Q06
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q07.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q07.benchmark
@@ -1,6 +1,8 @@
 name Q07
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q08.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q08.benchmark
@@ -1,6 +1,8 @@
 name Q08
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q09.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q09.benchmark
@@ -1,6 +1,8 @@
 name Q09
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q10.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q10.benchmark
@@ -1,6 +1,8 @@
 name Q10
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q11.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q11.benchmark
@@ -1,6 +1,8 @@
 name Q11
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q12.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q12.benchmark
@@ -1,6 +1,8 @@
 name Q12
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q13.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q13.benchmark
@@ -1,6 +1,8 @@
 name Q13
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q14.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q14.benchmark
@@ -1,6 +1,8 @@
 name Q14
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I

--- a/benchmarks/sql_benchmarks/hj/benchmarks/q15.benchmark
+++ b/benchmarks/sql_benchmarks/hj/benchmarks/q15.benchmark
@@ -1,6 +1,8 @@
 name Q15
 group hj
 
+init sql_benchmarks/hj/init/set_config.sql
+
 load sql_benchmarks/hj/init/load.sql
 
 assert I


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #21706

## Rationale for this change

Restore parity for clickbench_sorted and hj benchmarks between native and sql benchmarks

## What changes are included in this PR?

sql benchmark updates.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No
