### PR TITLE
fix: Unnest must not keep its input's uniqueness

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -4896,8 +4896,15 @@ impl Unnest {
 
         let metadata = input_schema.metadata().clone();
         let df_schema = DFSchema::new_with_metadata(fields, metadata)?;
-        // We can use the existing functional dependencies:
-        let deps = input_schema.functional_dependencies().clone();
+        // Unnesting a list turns one input row into several, so a determinant
+        // that occurred once in the input can now occur many times. It still
+        // determines the same columns, so downgrade the dependency instead of
+        // dropping it. Unnesting a struct keeps one row per input row, and so
+        // keeps the dependencies as they are.
+        let mut deps = input_schema.functional_dependencies().clone();
+        if !list_columns.is_empty() {
+            deps = deps.with_dependency(Dependency::Multi);
+        }
         let schema = Arc::new(df_schema.with_functional_dependencies(deps)?);
 
         Ok(Unnest {

--- a/datafusion/sqllogictest/test_files/functional_dependencies.slt
+++ b/datafusion/sqllogictest/test_files/functional_dependencies.slt
@@ -297,6 +297,52 @@ statement ok
 drop table t_probe;
 
 ##########
+## Unnest
+##########
+
+# Unnesting a list turns one row into several, so the key of the input no
+# longer identifies a row of the output. Trusting it here made the join below
+# a semi join, which dropped the repeated rows.
+statement ok
+CREATE TABLE t_list (k INT, vals INT[], PRIMARY KEY (k)) AS VALUES (1, [10, 20, 30]), (2, [40]);
+
+statement ok
+CREATE TABLE t_join (k INT) AS VALUES (1), (2);
+
+query II
+SELECT u.k, u.v FROM (SELECT k, unnest(vals) AS v FROM t_list) u
+JOIN t_join j ON u.k = j.k
+ORDER BY u.k, u.v;
+----
+1 10
+1 20
+1 30
+2 40
+
+# Unnesting a struct keeps one row per input row, so the key still holds.
+statement ok
+CREATE TABLE t_struct (k INT, s STRUCT<a INT, b INT>, PRIMARY KEY (k)) AS VALUES (1, {'a': 1, 'b': 2}), (2, {'a': 3, 'b': 4});
+
+query TT
+EXPLAIN SELECT DISTINCT k FROM (SELECT k, unnest(s) FROM t_struct) t;
+----
+logical_plan
+01)SubqueryAlias: t
+02)--Projection: t_struct.k
+03)----Unnest: lists[] structs[__unnest_placeholder(t_struct.s)]
+04)------Projection: t_struct.k, t_struct.s AS __unnest_placeholder(t_struct.s)
+05)--------TableScan: t_struct projection=[k, s]
+
+statement ok
+drop table t_list;
+
+statement ok
+drop table t_join;
+
+statement ok
+drop table t_struct;
+
+##########
 ## Cleanup
 ##########
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

`Unnest::try_new` copies its input's functional dependencies unchanged:

```rust
// We can use the existing functional dependencies:
let deps = input_schema.functional_dependencies().clone();
```

That is not true for a list unnest, which turns one input row into several. A
determinant that occurred once in the input can occur many times in the output,
so it is no longer a unique key.

Optimizer rules that read those dependencies then produce wrong results:

```sql
CREATE TABLE t_list (k INT, vals INT[], PRIMARY KEY (k))
  AS VALUES (1, [10, 20, 30]), (2, [40]);
CREATE TABLE t_join (k INT) AS VALUES (1), (2);

SELECT u.k, u.v FROM (SELECT k, unnest(vals) AS v FROM t_list) u
JOIN t_join j ON u.k = j.k;
```

returns 2 rows. The correct answer is 4, and removing the `PRIMARY KEY` gives
4. `eliminate_join` sees `u` as unique on `k`, rewrites the inner join into a
semi join, and the repeated rows are dropped.

## What changes are included in this PR?

The dependency still holds in the weaker sense: every row produced from one
input row carries the same determinant, so it determines the same columns. It
is downgraded to `Dependency::Multi` rather than dropped, which keeps it useful
for other purposes and stops it being read as a uniqueness guarantee.

Unnesting a struct produces one row per input row, so those dependencies are
left as they are.

## Are these changes tested?

Yes. `functional_dependencies.slt` gains the query above, which returns 4 rows,
and a plan assertion that a struct unnest still keeps its input's dependencies.
The full sqllogictest suite (504 files) passes.

## Are there any user-facing changes?

Queries that unnest a list from a table with a declared key and then join or
aggregate on that key now return correct results.
