### PR TITLE
fix: disable aggregate dynamic filter when unsupported expressions are present (#24816)

### DIFF
--- a/datafusion/core/tests/parquet/dynamic_row_group_pruning.rs
+++ b/datafusion/core/tests/parquet/dynamic_row_group_pruning.rs
@@ -804,3 +804,67 @@ async fn topk_pushdown_does_not_reread_delivered_row_group() {
         "p4096 emitted more than once — rg_plan/decoder desync; got:\n{formatted}",
     );
 }
+
+/// Regression test for issue #24816: Aggregate dynamic filter must be disabled
+/// when an unsupported aggregate expression (e.g., `MIN(c + 1)`) is present alongside
+/// supported ones (`MIN(a)`, `MAX(a)`, `MAX(b)`).
+/// Otherwise, dynamic filter pushed to input scan prunes row groups required by the
+/// unsupported aggregate expression and produces incorrect results.
+#[tokio::test]
+async fn dynamic_rg_pruning_disabled_when_unsupported_aggregate_present() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int64, false),
+        Field::new("b", DataType::Int64, false),
+        Field::new("c", DataType::Int64, false),
+    ]));
+
+    // File with 2 row groups:
+    // RG 0: (1, 12, 100), (8, 4, 70)
+    // RG 1: (1, 6, 90), (8, 12, 110)
+    let batch_0 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 8])) as ArrayRef,
+            Arc::new(Int64Array::from(vec![12, 4])) as ArrayRef,
+            Arc::new(Int64Array::from(vec![100, 70])) as ArrayRef,
+        ],
+    )
+    .unwrap();
+
+    let batch_1 = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 8])) as ArrayRef,
+            Arc::new(Int64Array::from(vec![6, 12])) as ArrayRef,
+            Arc::new(Int64Array::from(vec![90, 110])) as ArrayRef,
+        ],
+    )
+    .unwrap();
+
+    let mut ctx = ContextWithParquet::with_custom_data(
+        Scenario::Int,
+        RowGroup(2),
+        Arc::clone(&schema),
+        vec![batch_0, batch_1],
+    )
+    .await;
+
+    let output = ctx
+        .query("SELECT MIN(a), MAX(a), MAX(b), MIN(c + 1) FROM t")
+        .await;
+
+    assert_eq!(output.result_rows, 1, "query must return 1 aggregate row");
+    let formatted = output.pretty_results();
+    assert!(
+        formatted.contains("| 1 | 8 | 12 | 71 |"),
+        "expected output row '| 1 | 8 | 12 | 71 |'; got:\n{formatted}"
+    );
+
+    let pruned = output.row_groups_pruned_dynamic_filter().unwrap_or(0);
+    assert_eq!(
+        pruned,
+        0,
+        "dynamic filter should be disabled when unsupported aggregate is present; pruned={pruned}\n{}",
+        output.description()
+    );
+}

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -1852,6 +1852,8 @@ impl AggregateExec {
                     aggr_index: i,
                     shared_bound: Arc::new(Mutex::new(ScalarValue::Null)),
                 });
+            } else {
+                return;
             }
         }
 
@@ -8309,6 +8311,51 @@ mod tests {
             lit(true),
         ));
         assert!(agg.set_dynamic_filter(df).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_dynamic_filter_disabled_when_unsupported_expr_present() -> Result<()> {
+        use datafusion_expr::Operator;
+        use datafusion_physical_expr::expressions::binary;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let child = Arc::new(EmptyExec::new(Arc::clone(&schema)));
+
+        let col_a = col("a", &schema)?;
+        let col_a_plus_1 = binary(
+            Arc::clone(&col_a),
+            Operator::Plus,
+            lit(ScalarValue::Int64(Some(1))),
+            &schema,
+        )?;
+
+        // AggregateExec with MIN(a) (supported) and MIN(a + 1) (unsupported expr)
+        let agg = AggregateExec::try_new(
+            AggregateMode::Partial,
+            PhysicalGroupBy::new_single(vec![]),
+            vec![
+                Arc::new(
+                    AggregateExprBuilder::new(min_udaf(), vec![col_a])
+                        .schema(Arc::clone(&schema))
+                        .alias("min_a")
+                        .build()?,
+                ),
+                Arc::new(
+                    AggregateExprBuilder::new(min_udaf(), vec![col_a_plus_1])
+                        .schema(Arc::clone(&schema))
+                        .alias("min_a_plus_1")
+                        .build()?,
+                ),
+            ],
+            vec![None, None],
+            child,
+            Arc::clone(&schema),
+        )?;
+
+        // Dynamic filter must NOT be initialized because of the unsupported MIN(a + 1)
+        assert!(agg.dynamic_expressions_produced().is_empty());
+        assert!(agg.dynamic_filter.is_none());
         Ok(())
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #24816

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

When an aggregate query contains both supported expressions (such as `MIN(a)`) and unsupported expressions (such as `MIN(c + 1)`), DataFusion previously built a dynamic filter using only the supported expressions.

Because all aggregate expressions in an `AggregateExec` share the same input scan stream, pushing a dynamic filter constructed from a subset of aggregate expressions prunes rows required by the unsupported expressions, producing incorrect aggregate results.

Aggregate dynamic filter pushdown must be an all-or-nothing optimization: if any aggregate expression in the `AggregateExec` cannot produce a valid dynamic filter predicate, dynamic filtering must be disabled (`dynamic_filter = None`) for that node.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Updated `AggregateExec::init_dynamic_filter` in `datafusion/physical-plan/src/aggregates/mod.rs` to return early when an aggregate argument is not a single `Column` reference.
- Added unit test `test_dynamic_filter_disabled_when_unsupported_expr_present` in `datafusion/physical-plan/src/aggregates/mod.rs`.
- Added integration test `dynamic_rg_pruning_disabled_when_unsupported_aggregate_present` in `datafusion/core/tests/parquet/dynamic_row_group_pruning.rs` reproducing issue #24816.

## What is the testing strategy for this PR?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

Briefly describe how this PR is tested, and point to the specific tests you added. For example: 'This new feature is covered by the `sqllogictest` cases added in `foo.slt`'.

If this PR does not add tests, explain why. For example, if the change is already covered by existing tests, please mention it.

You should also check the `codecov` bot reply on this PR to confirm the changed code is exercised.
-->

- Unit test: `test_dynamic_filter_disabled_when_unsupported_expr_present` in `datafusion-physical-plan` checks that `dynamic_filter` remains `None` when an unsupported expression like `MIN(a + 1)` is present.
- Integration test: `dynamic_rg_pruning_disabled_when_unsupported_aggregate_present` in `datafusion/core/tests/parquet/dynamic_row_group_pruning.rs` verifies that queries with `MIN(a), MAX(a), MAX(b), MIN(c + 1)` evaluate correctly (`71`) without row groups being pruned.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

No breaking API or user-facing changes. Correctness fix for aggregate queries with dynamic filter pushdown.
