### PR TITLE
docs: fix 'sqllite' typo in sqllogictest README

### DIFF
--- a/datafusion/sqllogictest/README.md
+++ b/datafusion/sqllogictest/README.md
@@ -349,7 +349,7 @@ export RUST_MIN_STACK=30485760;
 PG_COMPAT=true INCLUDE_SQLITE=true cargo test --features=postgres --test sqllogictests
 ```
 
-To update the sqllite expected answers use the `datafusion/sqllogictest/regenerate_sqlite_files.sh` script.
+To update the sqlite expected answers use the `datafusion/sqllogictest/regenerate_sqlite_files.sh` script.
 
 Note this must be run with an empty postgres instance. For example
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A - trivial documentation fix.

## Rationale for this change

`datafusion/sqllogictest/README.md` misspells "sqlite" as "sqllite" in the instructions for regenerating expected answers. The script it references is `regenerate_sqlite_files.sh`, so the surrounding prose should match.

## What changes are included in this PR?

One-word spelling correction in `datafusion/sqllogictest/README.md`.

## Are these changes tested?

No code changes; documentation only.

## Are there any user-facing changes?

No.