### PR TITLE
Add ComposedNamedPhysicalExtensionCodec

### DIFF
--- a/datafusion-examples/examples/proto/composed_extension_codec.rs
+++ b/datafusion-examples/examples/proto/composed_extension_codec.rs
@@ -43,7 +43,7 @@ use datafusion::physical_plan::{ChildrenPropertiesMode, ReplaceChildrenOptions};
 use datafusion::physical_plan::{DisplayAs, ExecutionPlan};
 use datafusion::prelude::SessionContext;
 use datafusion_proto::physical_plan::{
-    AsExecutionPlan, ComposedPhysicalExtensionCodec, PhysicalExtensionCodec,
+    AsExecutionPlan, ComposedNamedPhysicalExtensionCodec, PhysicalExtensionCodec,
     PhysicalProtoConverterExtension,
 };
 use datafusion_proto::protobuf;
@@ -58,12 +58,9 @@ pub fn composed_extension_codec() -> Result<()> {
     });
     let ctx = SessionContext::new();
 
-    // Position in this list is important as it will be used for decoding.
-    // If new codec is added it should go to last position.
-    let composed_codec = ComposedPhysicalExtensionCodec::new(vec![
-        Arc::new(ParentPhysicalExtensionCodec {}),
-        Arc::new(ChildPhysicalExtensionCodec {}),
-    ]);
+    let composed_codec = ComposedNamedPhysicalExtensionCodec::default()
+        .with_type_named_codec(ParentPhysicalExtensionCodec {})?
+        .with_type_named_codec(ChildPhysicalExtensionCodec {})?;
 
     // Serialize execution plan to proto
     let proto: protobuf::PhysicalPlanNode =

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -25,8 +26,8 @@ use arrow::datatypes::{IntervalMonthDayNanoType, Schema, SchemaRef};
 use datafusion_catalog::memory::MemorySourceConfig;
 use datafusion_common::utils::{usize_from_wire, usize_to_wire};
 use datafusion_common::{
-    DataFusionError, Result, internal_datafusion_err, internal_err, not_impl_err,
-    plan_err,
+    DataFusionError, Result, config_err, internal_datafusion_err, internal_err,
+    not_impl_err, plan_err,
 };
 use datafusion_datasource_arrow::source::ArrowSource;
 #[cfg(feature = "avro")]
@@ -1771,6 +1772,19 @@ struct DataEncoderTuple {
     pub blob: Vec<u8>,
 }
 
+/// NamedDataEncoderTuple captures the name of the encoder
+/// in the codec map that was used to encode the data and actual encoded data
+#[derive(Clone, PartialEq, prost::Message)]
+struct NamedDataEncoderTuple {
+    /// The name of the encoder used to encode data
+    /// (to be used for decoding)
+    #[prost(string, tag = 1)]
+    pub name: String,
+
+    #[prost(bytes, tag = 2)]
+    pub blob: Vec<u8>,
+}
+
 pub struct DefaultPhysicalProtoConverter {}
 
 impl PhysicalProtoConverterExtension for DefaultPhysicalProtoConverter {
@@ -1951,11 +1965,16 @@ impl PhysicalProtoConverterExtension for DeduplicatingProtoConverter {
 
 /// A PhysicalExtensionCodec that tries one of multiple inner codecs
 /// until one works
+#[deprecated(
+    since = "56.0.0",
+    note = "Please use `ComposedNamedPhysicalExtensionCodec`"
+)]
 #[derive(Debug)]
 pub struct ComposedPhysicalExtensionCodec {
     codecs: Vec<Arc<dyn PhysicalExtensionCodec>>,
 }
 
+#[expect(deprecated)]
 impl ComposedPhysicalExtensionCodec {
     // Position in this codecs list is important as it will be used for decoding.
     // If new codec is added it should go to last position.
@@ -2017,7 +2036,148 @@ impl ComposedPhysicalExtensionCodec {
     }
 }
 
+#[expect(deprecated)]
 impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        ctx: &TaskContext,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.decode_protobuf(buf, |codec, data| {
+            codec.try_decode(data, inputs, ctx, proto_converter)
+        })
+    }
+
+    fn try_encode(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        buf: &mut Vec<u8>,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<()> {
+        self.encode_protobuf(buf, |codec, data| {
+            codec.try_encode(Arc::clone(&node), data, proto_converter)
+        })
+    }
+
+    fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>> {
+        self.decode_protobuf(buf, |codec, data| codec.try_decode_udf(name, data))
+    }
+
+    fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<()> {
+        self.encode_protobuf(buf, |codec, data| codec.try_encode_udf(node, data))
+    }
+
+    fn try_decode_udaf(&self, name: &str, buf: &[u8]) -> Result<Arc<AggregateUDF>> {
+        self.decode_protobuf(buf, |codec, data| codec.try_decode_udaf(name, data))
+    }
+
+    fn try_encode_udaf(&self, node: &AggregateUDF, buf: &mut Vec<u8>) -> Result<()> {
+        self.encode_protobuf(buf, |codec, data| codec.try_encode_udaf(node, data))
+    }
+}
+
+/// A PhysicalExtensionCodec that tries one of multiple inner codecs until one works.
+/// The name of the codec that successfully encoded an [`ExecutionPlan`] is stored in the
+/// encoded payload, and the codec with that exact name will be used for decoding.
+#[derive(Default, Debug)]
+pub struct ComposedNamedPhysicalExtensionCodec {
+    codecs: HashMap<Cow<'static, str>, Arc<dyn PhysicalExtensionCodec>>,
+}
+
+impl ComposedNamedPhysicalExtensionCodec {
+    /// Registers a new [`PhysicalExtensionCodec`] with a name extracted from its Rust type.
+    /// For example, if the implementation is called `MyPhysicalExtensionCodec`, then the codec
+    /// will be registered with the "MyPhysicalExtensionCodec" name.
+    pub fn with_type_named_codec(
+        self,
+        codec: impl PhysicalExtensionCodec,
+    ) -> Result<Self> {
+        self.with_codec(std::any::type_name_of_val(&codec), Arc::new(codec))
+    }
+
+    /// Registers a new [`PhysicalExtensionCodec`] with the provided name.
+    pub fn with_codec(
+        mut self,
+        name: impl Into<Cow<'static, str>>,
+        codec: Arc<dyn PhysicalExtensionCodec>,
+    ) -> Result<Self> {
+        let name = name.into();
+        if self.codecs.contains_key(&name) {
+            return config_err!(
+                "Two PhysicalExtensionCodecs with the same name ('{name}') were registered"
+            );
+        }
+        self.codecs.insert(name, codec);
+        Ok(self)
+    }
+
+    fn decode_protobuf<R>(
+        &self,
+        buf: &[u8],
+        decode: impl FnOnce(&dyn PhysicalExtensionCodec, &[u8]) -> Result<R>,
+    ) -> Result<R> {
+        let proto = NamedDataEncoderTuple::decode(buf)
+            .map_err(|e| internal_datafusion_err!("{e}"))?;
+
+        let name = proto.name.as_str();
+
+        let Some(codec) = self.codecs.get(&Cow::Borrowed(name)) else {
+            let available_names = self
+                .codecs
+                .keys()
+                .map(|v| v.as_ref())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return internal_err!(
+                "The message was encoded by a codec with name '{name}', but this codec is not available in the current ComposedNamedPhysicalExtensionCodec. Available codecs are: {available_names}"
+            );
+        };
+
+        decode(codec.as_ref(), &proto.blob)
+    }
+
+    fn encode_protobuf(
+        &self,
+        buf: &mut Vec<u8>,
+        mut encode: impl FnMut(&dyn PhysicalExtensionCodec, &mut Vec<u8>) -> Result<()>,
+    ) -> Result<()> {
+        let mut data = vec![];
+        let mut last_err = None;
+        let mut encoder_name = None;
+
+        // find the encoder
+        for (name, codec) in &self.codecs {
+            match encode(codec.as_ref(), &mut data) {
+                Ok(_) => {
+                    encoder_name = Some(name);
+                    break;
+                }
+                Err(err) => last_err = Some(err),
+            }
+        }
+
+        let encoder_name = encoder_name.ok_or_else(|| {
+            last_err.unwrap_or_else(|| {
+                DataFusionError::NotImplemented(
+                    "Empty list of composed named codecs".to_owned(),
+                )
+            })
+        })?;
+
+        // encode with encoder position
+        let proto = NamedDataEncoderTuple {
+            name: encoder_name.to_string(),
+            blob: data,
+        };
+        proto
+            .encode(buf)
+            .map_err(|e| internal_datafusion_err!("{e}"))
+    }
+}
+
+impl PhysicalExtensionCodec for ComposedNamedPhysicalExtensionCodec {
     fn try_decode(
         &self,
         buf: &[u8],


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

The `ComposedPhysicalExtensionCodec` allowed to register multiple codecs, which are tried one by one until one works. When one works, the index of the list that occupies the codec that works is stored in the encoded payload for later decoding:

```text
## Encoding

[
  MyFirstCodec,  <- tried, but did not work
  MySecondCodec, <- tried, but did not work
  MyThirdCodec, <- tried, and it work, store index 2 in payload
  MyFourthCodec
]

payload { index: 2, data: ... }

## Decoding

payload { index: 2, data: ... }

[
  MyFirstCodec,
  MySecondCodec,
  MyThirdCodec, <- index is 2, just this codec is attempted
  MyFourthCodec
]
```

The issue with this setup is that codecs can only be added to the end of the list, otherwise, while decoding, the index will be messed up and decoding will fail. In a setup with progressive rollouts this is very likely to happen.

While working in a small team, it's reasonable to expect developers to behave and just add new codecs at the end, however, when there are many teams contributing to the same list, with a non-centralized piece of code that has mutable access to it, it's easy to be in the situation where new codecs are not added at the end.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Introduces a new `ComposedNamedPhysicalExtensionCodec` that identifies encoded payloads by codec name instead of by index in a list. This way, registration order does not matter, and this problem becomes irrepresentable:

```text
## Encoding

{
  "MyFirstCodec": MyFirstCodec,  <- tried, but did not work
  "MySecondCodec": MySecondCodec, <- tried, but did not work
  "MyThirdCodec": MyThirdCodec, <- it worked!
  "MyFourthCodec": MyFourthCodec
}

payload { name: "MyThirdCodec", data: ... }

## Decoding

payload { index: "MyThirdCodec", data: ... }

{
  "MyFourthCodec": MyFourthCodec,
  "MyThirdCodec": MyThirdCodec, <- use this one, no matter the order
  "MyFirstCodec": MyFirstCodec,
  "MySecondCodec": MySecondCodec
}
```


## What is the testing strategy for this PR?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

Briefly describe how this PR is tested, and point to the specific tests you added. For example: 'This new feature is covered by the `sqllogictest` cases added in `foo.slt`'.

If this PR does not add tests, explain why. For example, if the change is already covered by existing tests, please mention it.

You should also check the `codecov` bot reply on this PR to confirm the changed code is exercised.
-->

TODO

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

New `ComposedNamedPhysicalExtensionCodec` is added to the public API, while keeping the previous `ComposedPhysicalExtensionCodec` still available.
