### PR TITLE
Prevent array_position panic for minimum start positions

### DIFF
--- a/datafusion/functions-nested/src/position.rs
+++ b/datafusion/functions-nested/src/position.rs
@@ -201,9 +201,13 @@ fn array_position_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 }
 
 fn resolve_zero_based_start_from(start_from: i64) -> Result<i64> {
-    start_from
-        .checked_sub(1)
-        .ok_or_else(|| exec_datafusion_err!("start_from out of bounds: {start_from}"))
+    start_from.checked_sub(1).ok_or_else(|| {
+        exec_datafusion_err!(
+            "start_from out of bounds: {start_from}, expected {} to {}",
+            i64::MIN + 1,
+            i64::MAX
+        )
+    })
 }
 
 /// Resolves the optional `start_from` argument into a `Vec<i64>` of

--- a/datafusion/functions-nested/src/position.rs
+++ b/datafusion/functions-nested/src/position.rs
@@ -40,7 +40,9 @@ use arrow::array::{
 use datafusion_common::cast::{
     as_generic_list_array, as_int64_array, as_large_list_array, as_list_array,
 };
-use datafusion_common::{Result, exec_err, utils::take_function_args};
+use datafusion_common::{
+    Result, exec_datafusion_err, exec_err, utils::take_function_args,
+};
 use itertools::Itertools;
 
 use crate::utils::{compare_element_to_list, make_scalar_function};
@@ -198,6 +200,12 @@ fn array_position_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     }
 }
 
+fn resolve_zero_based_start_from(start_from: i64) -> Result<i64> {
+    start_from
+        .checked_sub(1)
+        .ok_or_else(|| exec_datafusion_err!("start_from out of bounds: {start_from}"))
+}
+
 /// Resolves the optional `start_from` argument into a `Vec<i64>` of
 /// 0-indexed starting positions.
 fn resolve_start_from(
@@ -207,14 +215,16 @@ fn resolve_start_from(
     match third_arg {
         None => Ok(vec![0i64; num_rows]),
         Some(ColumnarValue::Scalar(ScalarValue::Int64(Some(v)))) => {
-            Ok(vec![v - 1; num_rows])
+            Ok(vec![resolve_zero_based_start_from(*v)?; num_rows])
         }
         Some(ColumnarValue::Scalar(s)) => {
             exec_err!("array_position expected Int64 for start_from, got {s}")
         }
-        Some(ColumnarValue::Array(a)) => {
-            Ok(as_int64_array(a)?.values().iter().map(|&x| x - 1).collect())
-        }
+        Some(ColumnarValue::Array(a)) => as_int64_array(a)?
+            .values()
+            .iter()
+            .map(|&x| resolve_zero_based_start_from(x))
+            .collect(),
     }
 }
 
@@ -309,8 +319,8 @@ fn general_position_dispatch<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<Ar
         as_int64_array(&args[2])?
             .values()
             .iter()
-            .map(|&x| x - 1)
-            .collect::<Vec<_>>()
+            .map(|&x| resolve_zero_based_start_from(x))
+            .collect::<Result<Vec<_>>>()?
     } else {
         vec![0; haystack.len()]
     };

--- a/datafusion/sqllogictest/test_files/array/array_position.slt
+++ b/datafusion/sqllogictest/test_files/array/array_position.slt
@@ -282,14 +282,14 @@ select array_position([1, 2, 3], 3, 4), array_position([1], 1, 2);
 ----
 NULL NULL
 
-query error start_from out of bounds: -9223372036854775808
+query error start_from out of bounds: -9223372036854775808, expected -9223372036854775807 to 9223372036854775807
 select array_position([1], 1, -9223372036854775808);
 
-query error start_from out of bounds: -9223372036854775808
+query error start_from out of bounds: -9223372036854775808, expected -9223372036854775807 to 9223372036854775807
 select array_position([1], 1, start_from)
 from (values (-9223372036854775808)) as t(start_from);
 
-query error start_from out of bounds: -9223372036854775808
+query error start_from out of bounds: -9223372036854775808, expected -9223372036854775807 to 9223372036854775807
 select array_position([1], needle, start_from)
 from (values (1, -9223372036854775808)) as t(needle, start_from);
 

--- a/datafusion/sqllogictest/test_files/array/array_position.slt
+++ b/datafusion/sqllogictest/test_files/array/array_position.slt
@@ -282,6 +282,17 @@ select array_position([1, 2, 3], 3, 4), array_position([1], 1, 2);
 ----
 NULL NULL
 
+query error start_from out of bounds: -9223372036854775808
+select array_position([1], 1, -9223372036854775808);
+
+query error start_from out of bounds: -9223372036854775808
+select array_position([1], 1, start_from)
+from (values (-9223372036854775808)) as t(start_from);
+
+query error start_from out of bounds: -9223372036854775808
+select array_position([1], needle, start_from)
+from (values (1, -9223372036854775808)) as t(needle, start_from);
+
 # array_position with empty array in various contexts
 query II
 select array_position(arrow_cast(make_array(), 'List(Int64)'), 1), array_position(arrow_cast(make_array(), 'LargeList(Int64)'), 1);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/22220.

## Rationale for this change

`array_position` accepts an optional one-based start position. Passing `-9223372036854775808` currently aborts evaluation with:

```text
datafusion/functions-nested/src/position.rs:210:21:
attempt to subtract with overflow
```

It now returns the normal execution error `start_from out of bounds: -9223372036854775808`.

## What changes are included in this PR?

The one-based-to-zero-based conversion now uses checked subtraction in both optimized and generic execution paths.

## What is the testing strategy for this PR?

SQL regressions exercise a scalar start position, a column start position with a scalar needle, and column start and needle values.

<details>
<summary>Raw results</summary>

```console
$ git checkout upstream/main -- datafusion/functions-nested/src/position.rs
$ cargo test -p datafusion-sqllogictest --test sqllogictests -- array_position
thread 'tokio-rt-worker' panicked at datafusion/functions-nested/src/position.rs:210:21:
attempt to subtract with overflow
Error: Execution("1 failures")

$ git checkout HEAD -- datafusion/functions-nested/src/position.rs
$ cargo test -p datafusion-sqllogictest --test sqllogictests -- array_position
Running with 12 test threads (available parallelism: 12)
Progress: 1/1 files completed (100%)

$ RUST_BACKTRACE=1 cargo test --profile ci \
    --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-cli \
    --workspace --lib --tests --bins \
    --features avro,json,backtrace,extended_tests,recursive_protection,parquet_encryption
passed=10997 ignored=8
```

</details>

## Are there any user-facing changes?

Yes. An invalid minimum `Int64` start position returns an execution error instead of panicking.
