### PR TITLE
test: add regression coverage for terminal hash aggregate drain

### DIFF
--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -3252,8 +3252,8 @@ mod tests {
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
     use datafusion_expr::{
-        Accumulator, AggregateUDF, AggregateUDFImpl, EmitTo, GroupsAccumulator,
-        Signature, Volatility,
+        Accumulator, AggregateUDF, AggregateUDFImpl, EmitTo, GroupSelection,
+        GroupsAccumulator, Signature, Volatility,
     };
     use datafusion_functions_aggregate::approx_percentile_cont::approx_percentile_cont_udaf;
     use datafusion_functions_aggregate::array_agg::array_agg_udaf;
@@ -4333,6 +4333,72 @@ mod tests {
         | 2   | 1                           |
         | 3   | 1                           |
         +-----+-----------------------------+
+        ");
+
+        Ok(())
+    }
+
+    /// Single and Final hash aggregation share the same terminal drain helper. Single
+    /// exercises it directly from raw input without coupling this test to partial state.
+    #[tokio::test]
+    async fn single_grouped_aggregate_avoids_destructive_terminal_drain() -> Result<()> {
+        const BATCH_SIZE: usize = 2;
+        const NUM_GROUPS: usize = 3;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+        let input_batches = vec![RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 1, 2, 3])),
+                Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50, 60])),
+            ],
+        )?];
+        let input =
+            TestMemoryExec::try_new_exec(&[input_batches], Arc::clone(&schema), None)?;
+        let group_by =
+            PhysicalGroupBy::new_single(vec![(col("key", &schema)?, "key".to_string())]);
+        let udaf = Arc::new(AggregateUDF::from(NoFirstEmitUdaf::new()));
+        let aggregates: Vec<Arc<AggregateFunctionExpr>> = vec![Arc::new(
+            AggregateExprBuilder::new(udaf, vec![col("value", &schema)?])
+                .schema(Arc::clone(&schema))
+                .alias("no_first_emit(value)")
+                .build()?,
+        )];
+        let aggregate = Arc::new(AggregateExec::try_new(
+            AggregateMode::Single,
+            group_by,
+            aggregates,
+            vec![None],
+            input,
+            Arc::clone(&schema),
+        )?);
+        let task_ctx = new_migrated_hash_ctx(BATCH_SIZE);
+
+        let stream = aggregate.execute_typed(0, &task_ctx)?;
+        assert!(matches!(stream, StreamType::SingleHash(_)));
+
+        let stream: SendableRecordBatchStream = stream.into();
+        let batches = collect(stream).await?;
+        assert!(batches.len() > 1, "expected terminal output to be chunked");
+        assert!(
+            batches.iter().all(|batch| batch.num_rows() <= BATCH_SIZE),
+            "terminal output exceeded the configured batch size"
+        );
+        assert_eq!(
+            batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+            NUM_GROUPS
+        );
+        assert_snapshot!(batches_to_sort_string(&batches), @r"
+        +-----+----------------------+
+        | key | no_first_emit(value) |
+        +-----+----------------------+
+        | 1   | 2                    |
+        | 2   | 2                    |
+        | 3   | 2                    |
+        +-----+----------------------+
         ");
 
         Ok(())
@@ -8105,7 +8171,7 @@ mod tests {
                     Ok(Arc::new(Int64Array::from(counts)))
                 }
                 EmitTo::First(_) => internal_err!(
-                    "partial grouped aggregate output must materialize with EmitTo::All before slicing"
+                    "grouped aggregate terminal output must not use EmitTo::First"
                 ),
             }
         }
@@ -8130,8 +8196,35 @@ mod tests {
             self.emit_counts(emit_to)
         }
 
+        fn evaluate_preserving(
+            &mut self,
+            selection: GroupSelection<'_>,
+        ) -> Result<ArrayRef> {
+            selection.validate_num_groups(self.counts.len())?;
+            let counts = selection
+                .iter()
+                .map(|index| self.counts[index])
+                .collect::<Vec<_>>();
+            Ok(Arc::new(Int64Array::from(counts)))
+        }
+
+        fn supports_evaluate_preserving(&self) -> bool {
+            true
+        }
+
         fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
             Ok(vec![self.emit_counts(emit_to)?])
+        }
+
+        fn state_preserving(
+            &mut self,
+            selection: GroupSelection<'_>,
+        ) -> Result<Vec<ArrayRef>> {
+            self.evaluate_preserving(selection).map(|array| vec![array])
+        }
+
+        fn supports_state_preserving(&self) -> bool {
+            true
         }
 
         fn convert_to_state(

--- a/datafusion/physical-plan/src/aggregates/mod.rs
+++ b/datafusion/physical-plan/src/aggregates/mod.rs
@@ -3252,8 +3252,8 @@ mod tests {
     use datafusion_execution::runtime_env::RuntimeEnvBuilder;
     use datafusion_expr::function::{AccumulatorArgs, StateFieldsArgs};
     use datafusion_expr::{
-        Accumulator, AggregateUDF, AggregateUDFImpl, EmitTo, GroupSelection,
-        GroupsAccumulator, Signature, Volatility,
+        Accumulator, AggregateUDF, AggregateUDFImpl, EmitTo, GroupsAccumulator,
+        Signature, Volatility,
     };
     use datafusion_functions_aggregate::approx_percentile_cont::approx_percentile_cont_udaf;
     use datafusion_functions_aggregate::array_agg::array_agg_udaf;
@@ -8196,35 +8196,8 @@ mod tests {
             self.emit_counts(emit_to)
         }
 
-        fn evaluate_preserving(
-            &mut self,
-            selection: GroupSelection<'_>,
-        ) -> Result<ArrayRef> {
-            selection.validate_num_groups(self.counts.len())?;
-            let counts = selection
-                .iter()
-                .map(|index| self.counts[index])
-                .collect::<Vec<_>>();
-            Ok(Arc::new(Int64Array::from(counts)))
-        }
-
-        fn supports_evaluate_preserving(&self) -> bool {
-            true
-        }
-
         fn state(&mut self, emit_to: EmitTo) -> Result<Vec<ArrayRef>> {
             Ok(vec![self.emit_counts(emit_to)?])
-        }
-
-        fn state_preserving(
-            &mut self,
-            selection: GroupSelection<'_>,
-        ) -> Result<Vec<ArrayRef>> {
-            self.evaluate_preserving(selection).map(|array| vec![array])
-        }
-
-        fn supports_state_preserving(&self) -> bool {
-            true
         }
 
         fn convert_to_state(


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24849.

## Rationale for this change

#23182 fixed a performance regression in terminal hash aggregate output by avoiding repeated destructive `EmitTo::First` calls. However, the remaining `MaterializedAggregateOutput` unit test only exercises the slicing helper and does not verify the behavior through `AggregateExec`.

A result-only integration test would pass with both the regressed and fixed implementations, while a wall-clock assertion would be unreliable in CI. This PR therefore uses a test `GroupsAccumulator` that returns an error if terminal output falls back to destructive `EmitTo::First`.

## What changes are included in this PR?

- Adds `single_grouped_aggregate_avoids_destructive_terminal_drain`, which runs unordered Single hash aggregation with more groups than the configured `batch_size`.
- Verifies that `AggregateExec` selects `SingleHash`, emits multiple bounded batches, and returns the correct aggregate results for repeated group keys.
- Keeps the test independent of `MaterializedAggregateOutput`; Single and Final hash aggregation exercise the same terminal drain helper.

## What is the testing strategy for this PR?

- Verified that temporarily restoring destructive `EmitTo::First(batch_size)` causes the new test to fail with the expected accumulator error, while the current implementation passes.
- Applied an equivalent FinalHash accumulator oracle to the historical regression: it fails on `d58e0c6d4^` and passes on `d58e0c6d4`. The migrated SingleHash stream did not exist at that historical revision.
- Ran `cargo fmt --all`.
- Ran `cargo clippy --all-targets --all-features -- -D warnings`.
- Ran the extended workspace test suite with `avro,json,backtrace,extended_tests,recursive_protection,parquet_encryption`; all tests passed after initializing the required Arrow and Parquet test fixtures.

## Are there any user-facing changes?

No. This PR only adds regression test coverage.
