### PR TITLE
docs: fix the Substrait round-trip instructions in the sqllogictest README

### DIFF
--- a/datafusion/sqllogictest/README.md
+++ b/datafusion/sqllogictest/README.md
@@ -397,17 +397,18 @@ generated DataFusion logical plan (SQL statement → DF logical → Substrait �
 Not all statements will be round-tripped, some statements like CREATE, INSERT, SET or EXPLAIN statements will be
 issued as is, but any other statement will be round-tripped to/from Substrait.
 
-_WARNING_: as there are still a lot of failures in this mode (https://github.com/apache/datafusion/issues/16248),
-it is not enforced in the CI, instead, it needs to be run manually with the following command:
+_WARNING_: this mode lives behind the `substrait` feature, and it still reports failures, so it is not enforced
+in the CI and needs to be run manually. Some of the failures are collected in
+https://github.com/apache/datafusion/issues/16248.
 
 ```shell
-cargo test --test sqllogictests -- --substrait-round-trip
+cargo test --test sqllogictests --features substrait -- --substrait-round-trip
 ```
 
 For focusing on one specific failing test, a file:line filter can be used:
 
 ```shell
-cargo test --test sqllogictests -- --substrait-round-trip binary.slt:23
+cargo test --test sqllogictests --features substrait -- --substrait-round-trip binary.slt:23
 ```
 
 ## `.slt` file format

--- a/datafusion/sqllogictest/README.md
+++ b/datafusion/sqllogictest/README.md
@@ -397,9 +397,9 @@ generated DataFusion logical plan (SQL statement → DF logical → Substrait �
 Not all statements will be round-tripped, some statements like CREATE, INSERT, SET or EXPLAIN statements will be
 issued as is, but any other statement will be round-tripped to/from Substrait.
 
-_WARNING_: this mode lives behind the `substrait` feature, and it still reports failures, so it is not enforced
-in the CI and needs to be run manually. Some of the failures are collected in
-https://github.com/apache/datafusion/issues/16248.
+_WARNING_: this mode lives behind the `substrait` feature, and the full suite still reports failures. CI therefore
+runs it over a single file, through `cargo xtask ci step test substrait`, which filters to `limit.slt`. Some of the
+failures are collected in https://github.com/apache/datafusion/issues/16248. To run it over every file:
 
 ```shell
 cargo test --test sqllogictests --features substrait -- --substrait-round-trip

--- a/datafusion/sqllogictest/README.md
+++ b/datafusion/sqllogictest/README.md
@@ -391,7 +391,7 @@ running tests.
 
 ## Running tests: Substrait round-trip mode
 
-This mode will run all the .slt test files in validation mode, adding a Substrait conversion round-trip for each
+This mode runs the selected `.slt` test files in validation mode, adding a Substrait conversion round-trip for each
 generated DataFusion logical plan (SQL statement → DF logical → Substrait → DF logical → DF physical → execute).
 
 Not all statements will be round-tripped, some statements like CREATE, INSERT, SET or EXPLAIN statements will be
@@ -399,7 +399,7 @@ issued as is, but any other statement will be round-tripped to/from Substrait.
 
 _WARNING_: this mode lives behind the `substrait` feature, and the full suite still reports failures. CI therefore
 runs it over a single file, through `cargo xtask ci step test substrait`, which filters to `limit.slt`. Some of the
-failures are collected in https://github.com/apache/datafusion/issues/16248. To run it over every file:
+failures are collected in https://github.com/apache/datafusion/issues/16248. To run the default suite in this mode:
 
 ```shell
 cargo test --test sqllogictests --features substrait -- --substrait-round-trip


### PR DESCRIPTION
## Which issue does this PR close?

None — the documented command does not run and the paragraph around it is out of date, so this is a straight documentation fix.

## Rationale for this change

The sqllogictest README documents the Substrait round-trip mode as

```shell
cargo test --test sqllogictests -- --substrait-round-trip
```

but the round-trip path is behind the `substrait` feature, which is not in `default`. Run as documented, every file fails with `Cannot run substrait round-trip: the 'substrait' feature is not enabled` — 505 of them on today's `main`, which reads as the mode being thoroughly broken rather than as a missing flag. The `xtask` step that CI uses gets this right (`--features substrait`); only the README does not.

The same paragraph says the mode "is not enforced in the CI, instead, it needs to be run manually". It is enforced, over one file: `rust.yml` runs `cargo xtask ci step test substrait`, which filters to `limit.slt`, with a comment saying the filter stays until most of #16248 is addressed. So a reader is told the mode has no CI coverage when it has a smoke test.

It also points at #16248 for the failures. That epic now has 16 of its 21 sub-issues closed, and several of the classes the mode reports most often today — `Analyze`, `Unnest`, `USING` join constraints, `Distinct::On` — have no sub-issue under it, so the sentence promises more than the link delivers.

## What changes are included in this PR?

Both documented commands get `--features substrait`. The warning now says where the mode lives, that CI runs it over `limit.slt` through the `xtask` step, and that #16248 collects some of the failures rather than all of them.

## What is the testing strategy for this PR?

Ran both documented forms on `main`: the full form runs the whole suite and reports its failures instead of stopping on the feature error, and the `binary.slt` filter runs three files. Ran `cargo xtask ci step test substrait` to confirm the CI step passes over `limit.slt` (it needs the `testing` submodule; without it the file fails on missing `aggregate_test_100` data). `ci/scripts/doc_prettier_check.sh` passes.

## Are there any user-facing changes?

Documentation only.
