### PR TITLE
Allow a non-distinct count alongside the single distinct aggregate in SingleDistinctToGroupBy

### DIFF
--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -253,6 +253,16 @@ impl AggregateUDF {
         self.inner.groups_accumulator_supported(args)
     }
 
+    /// See [`AggregateUDFImpl::groups_accumulator_supported_for_types`] for more details.
+    pub fn groups_accumulator_supported_for_types(
+        &self,
+        arg_types: &[DataType],
+        is_distinct: bool,
+    ) -> bool {
+        self.inner
+            .groups_accumulator_supported_for_types(arg_types, is_distinct)
+    }
+
     /// See [`AggregateUDFImpl::create_groups_accumulator`] for more details.
     pub fn create_groups_accumulator(
         &self,
@@ -614,6 +624,32 @@ pub trait AggregateUDFImpl: Debug + DynEq + DynHash + Send + Sync + Any {
     /// used as a window function or when there no GROUP BY columns in the
     /// query.
     fn groups_accumulator_supported(&self, _args: AccumulatorArgs) -> bool {
+        false
+    }
+
+    /// The same question as [`Self::groups_accumulator_supported`], asked with
+    /// only the information a logical plan carries.
+    ///
+    /// Physical planning has an [`AccumulatorArgs`] to ask with; an optimizer
+    /// rule does not, and cannot fabricate one, so this is how a logical
+    /// caller learns whether a call would get a specialized
+    /// [`GroupsAccumulator`] or fall back to one boxed [`Accumulator`] per
+    /// group in `GroupsAccumulatorAdapter`. That distinction is worth a rule
+    /// changing its mind over: the adapter's per-group state can be orders of
+    /// magnitude larger.
+    ///
+    /// The default is `false`, matching the default of
+    /// [`Self::groups_accumulator_supported`]. An implementation that
+    /// overrides that one and whose answer is decided by the argument types
+    /// and `DISTINCT` alone should override this one too, and have the
+    /// physical method call it so the two cannot disagree. An implementation
+    /// whose answer needs more than the argument types should leave this at
+    /// `false`, which claims nothing.
+    fn groups_accumulator_supported_for_types(
+        &self,
+        _arg_types: &[DataType],
+        _is_distinct: bool,
+    ) -> bool {
         false
     }
 
@@ -1550,6 +1586,15 @@ impl AggregateUDFImpl for AliasedAggregateUDFImpl {
 
     fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
         self.inner.groups_accumulator_supported(args)
+    }
+
+    fn groups_accumulator_supported_for_types(
+        &self,
+        arg_types: &[DataType],
+        is_distinct: bool,
+    ) -> bool {
+        self.inner
+            .groups_accumulator_supported_for_types(arg_types, is_distinct)
     }
 
     fn create_groups_accumulator(

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -258,7 +258,7 @@ impl AggregateUDF {
         &self,
         arg_types: &[DataType],
         is_distinct: bool,
-    ) -> bool {
+    ) -> Option<bool> {
         self.inner
             .groups_accumulator_supported_for_types(arg_types, is_distinct)
     }
@@ -638,19 +638,25 @@ pub trait AggregateUDFImpl: Debug + DynEq + DynHash + Send + Sync + Any {
     /// changing its mind over: the adapter's per-group state can be orders of
     /// magnitude larger.
     ///
-    /// The default is `false`, matching the default of
-    /// [`Self::groups_accumulator_supported`]. An implementation that
-    /// overrides that one and whose answer is decided by the argument types
-    /// and `DISTINCT` alone should override this one too, and have the
-    /// physical method call it so the two cannot disagree. An implementation
-    /// whose answer needs more than the argument types should leave this at
-    /// `false`, which claims nothing.
+    /// The default is `None`, which means the implementation does not answer
+    /// this question. An implementation that overrides
+    /// [`Self::groups_accumulator_supported`], and whose answer is decided by
+    /// the argument types and `DISTINCT` alone, should override this one too,
+    /// and have the physical method call it so the two cannot disagree. An
+    /// implementation whose answer needs more than the argument types should
+    /// leave this at `None`.
+    ///
+    /// `None` is not a third answer to the question. A caller must not read it
+    /// as either `Some(true)` or `Some(false)`, because both readings are
+    /// wrong for some implementation that returns it. A caller that has to act
+    /// on an unanswered question must take the action that is safe when either
+    /// answer turns out to be the true one.
     fn groups_accumulator_supported_for_types(
         &self,
         _arg_types: &[DataType],
         _is_distinct: bool,
-    ) -> bool {
-        false
+    ) -> Option<bool> {
+        None
     }
 
     /// Return a specialized [`GroupsAccumulator`] that manages state
@@ -1592,7 +1598,7 @@ impl AggregateUDFImpl for AliasedAggregateUDFImpl {
         &self,
         arg_types: &[DataType],
         is_distinct: bool,
-    ) -> bool {
+    ) -> Option<bool> {
         self.inner
             .groups_accumulator_supported_for_types(arg_types, is_distinct)
     }

--- a/datafusion/expr/src/udaf.rs
+++ b/datafusion/expr/src/udaf.rs
@@ -631,26 +631,20 @@ pub trait AggregateUDFImpl: Debug + DynEq + DynHash + Send + Sync + Any {
     /// only the information a logical plan carries.
     ///
     /// Physical planning has an [`AccumulatorArgs`] to ask with; an optimizer
-    /// rule does not, and cannot fabricate one, so this is how a logical
-    /// caller learns whether a call would get a specialized
-    /// [`GroupsAccumulator`] or fall back to one boxed [`Accumulator`] per
-    /// group in `GroupsAccumulatorAdapter`. That distinction is worth a rule
-    /// changing its mind over: the adapter's per-group state can be orders of
-    /// magnitude larger.
+    /// rule does not. This is how a logical caller learns whether a call would
+    /// get a specialized [`GroupsAccumulator`] or fall back to one boxed
+    /// [`Accumulator`] per group in `GroupsAccumulatorAdapter`, whose per-group
+    /// state can be orders of magnitude larger.
     ///
-    /// The default is `None`, which means the implementation does not answer
-    /// this question. An implementation that overrides
-    /// [`Self::groups_accumulator_supported`], and whose answer is decided by
-    /// the argument types and `DISTINCT` alone, should override this one too,
-    /// and have the physical method call it so the two cannot disagree. An
-    /// implementation whose answer needs more than the argument types should
-    /// leave this at `None`.
+    /// An implementation whose answer is decided by the argument types and
+    /// `DISTINCT` alone should override this and have
+    /// [`Self::groups_accumulator_supported`] call it, so the two cannot
+    /// disagree. One whose answer needs more than that should leave the `None`
+    /// default.
     ///
-    /// `None` is not a third answer to the question. A caller must not read it
-    /// as either `Some(true)` or `Some(false)`, because both readings are
-    /// wrong for some implementation that returns it. A caller that has to act
-    /// on an unanswered question must take the action that is safe when either
-    /// answer turns out to be the true one.
+    /// `None` means unanswered, not "no": a caller must not read it as either
+    /// `Some(true)` or `Some(false)`, since both readings are wrong for some
+    /// implementation that returns it.
     fn groups_accumulator_supported_for_types(
         &self,
         _arg_types: &[DataType],

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -354,21 +354,22 @@ impl AggregateUDFImpl for Count {
             .map(|field| field.data_type().clone())
             .collect::<Vec<_>>();
         self.groups_accumulator_supported_for_types(&arg_types, args.is_distinct)
+            .unwrap_or(false)
     }
 
     fn groups_accumulator_supported_for_types(
         &self,
         arg_types: &[DataType],
         is_distinct: bool,
-    ) -> bool {
+    ) -> Option<bool> {
         if arg_types.len() != 1 {
-            return false;
+            return Some(false);
         }
         if !is_distinct {
-            return true;
+            return Some(true);
         }
         // Keep in step with `create_distinct_count_groups_accumulator`.
-        matches!(
+        Some(matches!(
             arg_types[0],
             DataType::Int8
                 | DataType::Int16
@@ -378,7 +379,7 @@ impl AggregateUDFImpl for Count {
                 | DataType::UInt16
                 | DataType::UInt32
                 | DataType::UInt64
-        )
+        ))
     }
 
     fn create_groups_accumulator(

--- a/datafusion/functions-aggregate/src/count.rs
+++ b/datafusion/functions-aggregate/src/count.rs
@@ -346,14 +346,30 @@ impl AggregateUDFImpl for Count {
     }
 
     fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
-        if args.exprs.len() != 1 {
+        // The answer depends on nothing but the argument types and `DISTINCT`,
+        // so defer to the logical form and keep one list of supported types.
+        let arg_types = args
+            .expr_fields
+            .iter()
+            .map(|field| field.data_type().clone())
+            .collect::<Vec<_>>();
+        self.groups_accumulator_supported_for_types(&arg_types, args.is_distinct)
+    }
+
+    fn groups_accumulator_supported_for_types(
+        &self,
+        arg_types: &[DataType],
+        is_distinct: bool,
+    ) -> bool {
+        if arg_types.len() != 1 {
             return false;
         }
-        if !args.is_distinct {
+        if !is_distinct {
             return true;
         }
+        // Keep in step with `create_distinct_count_groups_accumulator`.
         matches!(
-            args.expr_fields[0].data_type(),
+            arg_types[0],
             DataType::Int8
                 | DataType::Int16
                 | DataType::Int32

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -28,9 +28,11 @@ use datafusion_common::{
 use datafusion_expr::builder::project;
 use datafusion_expr::expr::AggregateFunctionParams;
 use datafusion_expr::{
-    Expr, col,
+    AggregateUDF, Expr, col,
     expr::AggregateFunction,
+    lit,
     logical_plan::{Aggregate, LogicalPlan},
+    when,
 };
 
 /// single distinct to group by optimizer rule
@@ -49,6 +51,33 @@ use datafusion_expr::{
 ///    )
 ///    GROUP BY a
 ///  ```
+///
+/// A non-distinct `count` is also allowed alongside the distinct aggregate. It
+/// is the one supported function whose outer phase is a *different* function:
+/// the inner group-by counts rows per `(group, distinct value)` pair and the
+/// outer phase adds those partial counts up with `sum`.
+///
+///  ```text
+///    Before:
+///    SELECT a, count(*), count(DISTINCT b)
+///    FROM t
+///    GROUP BY a
+///
+///    After:
+///    SELECT a,
+///           CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE 0 END,
+///           count(alias1)
+///    FROM (
+///      SELECT a, b as alias1, count(*) as alias2
+///      FROM t
+///      GROUP BY a, b
+///    )
+///    GROUP BY a
+///  ```
+///
+/// The `CASE` covers the one input on which the two phases disagree: over an
+/// empty input the inner group by produces no rows at all, and a `sum` of no
+/// rows is NULL where `count` is 0.
 #[derive(Default, Debug)]
 pub struct SingleDistinctToGroupBy {}
 
@@ -61,8 +90,38 @@ impl SingleDistinctToGroupBy {
     }
 }
 
+/// The pair of functions used to compute a non-distinct `count` in two phases:
+/// `count` identifies the aggregates that need the treatment, `sum` combines
+/// the partial counts the inner group-by produces.
+///
+/// Both are resolved from the session's function registry, so a plan built
+/// without one keeps the previous behaviour of bailing out on `count`.
+struct CountRollup {
+    count: Arc<AggregateUDF>,
+    sum: Arc<AggregateUDF>,
+}
+
+impl CountRollup {
+    fn try_new(config: &dyn OptimizerConfig) -> Option<Self> {
+        let registry = config.function_registry()?;
+        Some(Self {
+            count: registry.udaf("count").ok()?,
+            sum: registry.udaf("sum").ok()?,
+        })
+    }
+
+    /// Whether `func` is the registry's `count`, and so decomposes into
+    /// `sum` over per-partition counts.
+    fn is_count(&self, func: &AggregateUDF) -> bool {
+        self.count.as_ref() == func
+    }
+}
+
 /// Check whether all aggregate exprs are distinct on a single field.
-fn is_single_distinct_agg(aggr_expr: &[Expr]) -> Result<bool> {
+fn is_single_distinct_agg(
+    aggr_expr: &[Expr],
+    count_rollup: Option<&CountRollup>,
+) -> Result<bool> {
     let mut fields_set = HashSet::new();
     let mut aggregate_count = 0;
     for expr in aggr_expr {
@@ -89,6 +148,7 @@ fn is_single_distinct_agg(aggr_expr: &[Expr]) -> Result<bool> {
             } else if func.name() != "sum"
                 && func.name().to_lowercase() != "min"
                 && func.name().to_lowercase() != "max"
+                && !count_rollup.is_some_and(|rollup| rollup.is_count(func))
             {
                 return Ok(false);
             }
@@ -120,8 +180,12 @@ impl OptimizerRule for SingleDistinctToGroupBy {
     fn rewrite(
         &self,
         plan: LogicalPlan,
-        _config: &dyn OptimizerConfig,
+        config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>, DataFusionError> {
+        if !matches!(plan, LogicalPlan::Aggregate(_)) {
+            return Ok(Transformed::no(plan));
+        }
+        let count_rollup = CountRollup::try_new(config);
         match plan {
             LogicalPlan::Aggregate(Aggregate {
                 input,
@@ -129,7 +193,7 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                 schema,
                 group_expr,
                 ..
-            }) if is_single_distinct_agg(&aggr_expr)?
+            }) if is_single_distinct_agg(&aggr_expr, count_rollup.as_ref())?
                 && !contains_grouping_set(&group_expr) =>
             {
                 let group_size = group_expr.len();
@@ -177,7 +241,11 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                 let mut index = 1;
                 let mut group_fields_set = HashSet::new();
                 let mut inner_aggr_exprs = vec![];
-                let outer_aggr_exprs = aggr_expr
+                // Each aggregate yields the expression the outer `Aggregate`
+                // computes and the expression the projection above it selects.
+                // They differ only for `count`, whose projection restores the
+                // zero that `sum` reports as NULL over an empty input.
+                let (outer_aggr_exprs, outer_proj_exprs): (Vec<Expr>, Vec<Expr>) = aggr_expr
                     .into_iter()
                     .map(|aggr_expr| match aggr_expr {
                         Expr::AggregateFunction(AggregateFunction {
@@ -204,18 +272,32 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                                     inner_group_exprs
                                         .push(arg.alias(SINGLE_DISTINCT_ALIAS));
                                 }
-                                Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
-                                    func,
-                                    vec![col(SINGLE_DISTINCT_ALIAS)],
-                                    false, // intentional to remove distinct here
-                                    filter,
-                                    order_by,
-                                    null_treatment,
-                                )))
+                                let outer =
+                                    Expr::AggregateFunction(AggregateFunction::new_udf(
+                                        func,
+                                        vec![col(SINGLE_DISTINCT_ALIAS)],
+                                        false, // intentional to remove distinct here
+                                        filter,
+                                        order_by,
+                                        null_treatment,
+                                    ));
+                                Ok((outer.clone(), outer))
                                 // if the aggregate function is not distinct, we need to rewrite it like two phase aggregation
                             } else {
                                 index += 1;
                                 let alias_str = format!("alias{index}");
+                                // `count` is the one function whose two phases
+                                // use different aggregates: the inner group-by
+                                // counts the rows of each `(group, distinct
+                                // value)` partition and the outer phase adds
+                                // those partial counts up.
+                                let rollup = count_rollup
+                                    .as_ref()
+                                    .filter(|rollup| rollup.is_count(&func));
+                                let outer_func = match rollup {
+                                    Some(rollup) => Arc::clone(&rollup.sum),
+                                    None => Arc::clone(&func),
+                                };
                                 inner_aggr_exprs.push(
                                     Expr::AggregateFunction(AggregateFunction::new_udf(
                                         Arc::clone(&func),
@@ -227,19 +309,34 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                                     ))
                                     .alias(&alias_str),
                                 );
-                                Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
-                                    func,
-                                    vec![col(&alias_str)],
-                                    false,
-                                    None,
-                                    vec![],
-                                    None,
-                                )))
+                                let outer =
+                                    Expr::AggregateFunction(AggregateFunction::new_udf(
+                                        outer_func,
+                                        vec![col(&alias_str)],
+                                        false,
+                                        None,
+                                        vec![],
+                                        None,
+                                    ));
+                                if rollup.is_none() {
+                                    return Ok((outer.clone(), outer));
+                                }
+                                // The inner group-by produces no rows at all
+                                // for an empty input, and `sum` reports that as
+                                // NULL where `count` reports 0. Restore the 0,
+                                // which also keeps the column non-nullable as
+                                // `count` had it.
+                                let proj =
+                                    when(outer.clone().is_not_null(), outer.clone())
+                                        .otherwise(lit(0_i64))?;
+                                Ok((outer, proj))
                             }
                         }
-                        _ => Ok(aggr_expr),
+                        _ => Ok((aggr_expr.clone(), aggr_expr)),
                     })
-                    .collect::<Result<Vec<_>>>()?;
+                    .collect::<Result<Vec<_>>>()?
+                    .into_iter()
+                    .unzip();
 
                 // construct the inner AggrPlan
                 let inner_agg = LogicalPlan::Aggregate(Aggregate::try_new(
@@ -265,13 +362,11 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                         }
                         None => group_expr,
                     })
-                    .chain(outer_aggr_exprs.iter().cloned().enumerate().map(
-                        |(idx, expr)| {
-                            let idx = idx + group_size;
-                            let (qualifier, field) = schema.qualified_field(idx);
-                            expr.alias_qualified(qualifier.cloned(), field.name())
-                        },
-                    ))
+                    .chain(outer_proj_exprs.into_iter().enumerate().map(|(idx, expr)| {
+                        let idx = idx + group_size;
+                        let (qualifier, field) = schema.qualified_field(idx);
+                        expr.alias_qualified(qualifier.cloned(), field.name())
+                    }))
                     .collect();
 
                 let outer_aggr = LogicalPlan::Aggregate(Aggregate::try_new(
@@ -291,8 +386,13 @@ mod tests {
     use super::*;
     use crate::assert_optimized_plan_eq_display_indent_snapshot;
     use crate::test::*;
+    use crate::{Optimizer, OptimizerContext};
+    use chrono::{DateTime, Utc};
+    use datafusion_common::alias::AliasGenerator;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ExprFunctionExt;
     use datafusion_expr::expr::GroupingSet;
+    use datafusion_expr::registry::{FunctionRegistry, MemoryFunctionRegistry};
     use datafusion_expr::{lit, logical_plan::builder::LogicalPlanBuilder};
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_functions_aggregate::expr_fn::{count, count_distinct, max, min, sum};
@@ -310,17 +410,70 @@ mod tests {
         ))
     }
 
+    fn count_star() -> Expr {
+        Expr::AggregateFunction(AggregateFunction::new_udf(
+            count_udaf(),
+            vec![lit(1_i64)],
+            false,
+            None,
+            vec![],
+            None,
+        ))
+    }
+
+    /// An [`OptimizerConfig`] that resolves functions the way a session does.
+    /// The rule needs `count` and `sum` from the registry to rewrite a
+    /// non-distinct `count`.
+    #[derive(Debug)]
+    struct RegistryOptimizerContext {
+        inner: OptimizerContext,
+        registry: MemoryFunctionRegistry,
+    }
+
+    impl RegistryOptimizerContext {
+        fn new() -> Self {
+            let mut registry = MemoryFunctionRegistry::new();
+            registry.register_udaf(count_udaf()).unwrap();
+            registry.register_udaf(sum_udaf()).unwrap();
+            Self {
+                inner: OptimizerContext::new(),
+                registry,
+            }
+        }
+    }
+
+    impl OptimizerConfig for RegistryOptimizerContext {
+        fn query_execution_start_time(&self) -> Option<DateTime<Utc>> {
+            self.inner.query_execution_start_time()
+        }
+
+        fn alias_generator(&self) -> &Arc<AliasGenerator> {
+            self.inner.alias_generator()
+        }
+
+        fn options(&self) -> Arc<ConfigOptions> {
+            self.inner.options()
+        }
+
+        fn function_registry(&self) -> Option<&dyn FunctionRegistry> {
+            Some(&self.registry)
+        }
+    }
+
     macro_rules! assert_optimized_plan_equal {
         (
             $plan:expr,
             @ $expected:literal $(,)?
         ) => {{
-            let rule: Arc<dyn crate::OptimizerRule + Send + Sync> = Arc::new(SingleDistinctToGroupBy::new());
-            assert_optimized_plan_eq_display_indent_snapshot!(
-                rule,
-                $plan,
-                @ $expected,
-            )
+            let rule: Arc<dyn crate::OptimizerRule + Send + Sync> =
+                Arc::new(SingleDistinctToGroupBy::new());
+            let optimizer = Optimizer::with_rules(vec![rule]);
+            let optimized_plan = optimizer
+                .optimize($plan, &RegistryOptimizerContext::new(), |_, _| {})
+                .expect("failed to optimize plan");
+            insta::assert_snapshot!(optimized_plan.display_indent_schema(), @ $expected);
+
+            Ok::<(), DataFusionError>(())
         }};
     }
 
@@ -523,12 +676,15 @@ mod tests {
             )?
             .build()?;
 
-        // Do nothing
+        // Should work: the non-distinct count becomes a sum of the counts the
+        // inner group-by produces per (test.a, test.b) pair
         assert_optimized_plan_equal!(
             plan,
             @r"
-        Aggregate: groupBy=[[test.a]], aggr=[[count(DISTINCT test.b), count(test.c)]] [a:UInt32, count(DISTINCT test.b):Int64, count(test.c):Int64]
-          TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        Projection: test.a, count(alias1) AS count(DISTINCT test.b), CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS count(test.c) [a:UInt32, count(DISTINCT test.b):Int64, count(test.c):Int64]
+          Aggregate: groupBy=[[test.a]], aggr=[[count(alias1), sum(alias2)]] [a:UInt32, count(alias1):Int64, sum(alias2):Int64;N]
+            Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[count(test.c) AS alias2]] [a:UInt32, alias1:UInt32, alias2:Int64]
+              TableScan: test [a:UInt32, b:UInt32, c:UInt32]
         "
         )
     }
@@ -750,6 +906,130 @@ mod tests {
         Aggregate: groupBy=[[test.c]], aggr=[[sum(test.a), count(DISTINCT test.a) FILTER (WHERE test.a > Int32(5)) ORDER BY [test.a ASC NULLS LAST]]] [c:UInt32, sum(test.a):UInt64;N, count(DISTINCT test.a) FILTER (WHERE test.a > Int32(5)) ORDER BY [test.a ASC NULLS LAST]:Int64]
           TableScan: test [a:UInt32, b:UInt32, c:UInt32]
         "
+        )
+    }
+
+    #[test]
+    fn count_star_and_distinct_without_groupby() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(
+                Vec::<Expr>::new(),
+                vec![count_star(), count_distinct(col("b"))],
+            )?
+            .build()?;
+
+        // Should work. Without a group by the outer aggregate sees no rows at
+        // all for an empty input, so the projection has to turn the NULL that
+        // `sum` reports there back into the 0 `count` reports.
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS count(Int64(1)), count(alias1) AS count(DISTINCT test.b) [count(Int64(1)):Int64, count(DISTINCT test.b):Int64]
+          Aggregate: groupBy=[[]], aggr=[[sum(alias2), count(alias1)]] [sum(alias2):Int64;N, count(alias1):Int64]
+            Aggregate: groupBy=[[test.b AS alias1]], aggr=[[count(Int64(1)) AS alias2]] [alias1:UInt32, alias2:Int64]
+              TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn count_star_min_max_sum_and_distinct_with_groupby() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(
+                vec![col("a")],
+                vec![
+                    count_star(),
+                    count_distinct(col("b")),
+                    min(col("c")),
+                    max(col("c")),
+                    sum(col("c")),
+                ],
+            )?
+            .build()?;
+
+        // Should work: this is the shape a `count(*)` alongside a
+        // `count(DISTINCT ..)`, a min, a max and a sum produces
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: test.a, CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS count(Int64(1)), count(alias1) AS count(DISTINCT test.b), min(alias3) AS min(test.c), max(alias4) AS max(test.c), sum(alias5) AS sum(test.c) [a:UInt32, count(Int64(1)):Int64, count(DISTINCT test.b):Int64, min(test.c):UInt32;N, max(test.c):UInt32;N, sum(test.c):UInt64;N]
+          Aggregate: groupBy=[[test.a]], aggr=[[sum(alias2), count(alias1), min(alias3), max(alias4), sum(alias5)]] [a:UInt32, sum(alias2):Int64;N, count(alias1):Int64, min(alias3):UInt32;N, max(alias4):UInt32;N, sum(alias5):UInt64;N]
+            Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[count(Int64(1)) AS alias2, min(test.c) AS alias3, max(test.c) AS alias4, sum(test.c) AS alias5]] [a:UInt32, alias1:UInt32, alias2:Int64, alias3:UInt32;N, alias4:UInt32;N, alias5:UInt64;N]
+              TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn count_with_filter_is_not_rewritten() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        // count(a) FILTER (WHERE a > 5)
+        let expr = count_udaf()
+            .call(vec![col("a")])
+            .filter(col("a").gt(lit(5)))
+            .build()?;
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(vec![col("c")], vec![expr, count_distinct(col("b"))])?
+            .build()?;
+
+        // Do nothing: the filter would have to be applied per input row, but
+        // the inner aggregate has already collapsed them
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Aggregate: groupBy=[[test.c]], aggr=[[count(test.a) FILTER (WHERE test.a > Int32(5)), count(DISTINCT test.b)]] [c:UInt32, count(test.a) FILTER (WHERE test.a > Int32(5)):Int64, count(DISTINCT test.b):Int64]
+          TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn count_with_order_by_is_not_rewritten() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        // count(a ORDER BY a)
+        let expr = count_udaf()
+            .call(vec![col("a")])
+            .order_by(vec![col("a").sort(true, false)])
+            .build()?;
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(vec![col("c")], vec![expr, count_distinct(col("b"))])?
+            .build()?;
+
+        // Do nothing
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Aggregate: groupBy=[[test.c]], aggr=[[count(test.a) ORDER BY [test.a ASC NULLS LAST], count(DISTINCT test.b)]] [c:UInt32, count(test.a) ORDER BY [test.a ASC NULLS LAST]:Int64, count(DISTINCT test.b):Int64]
+          TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn count_without_function_registry_is_not_rewritten() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(vec![col("a")], vec![count_star(), count_distinct(col("b"))])?
+            .build()?;
+
+        // Do nothing: without a registry the rule cannot resolve the `sum` the
+        // outer phase needs
+        let rule: Arc<dyn OptimizerRule + Send + Sync> =
+            Arc::new(SingleDistinctToGroupBy::new());
+        assert_optimized_plan_eq_display_indent_snapshot!(
+            rule,
+            plan,
+            @r"
+        Aggregate: groupBy=[[test.a]], aggr=[[count(Int64(1)), count(DISTINCT test.b)]] [a:UInt32, count(Int64(1)):Int64, count(DISTINCT test.b):Int64]
+          TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        ",
         )
     }
 }

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -81,10 +81,12 @@ use datafusion_expr::{
 /// empty input the inner group by produces no rows at all, and a `sum` of no
 /// rows is NULL where `count` is 0.
 ///
-/// That `count` is allowed only when the distinct argument has no specialized
-/// `GroupsAccumulator` of its own, so that the rewrite is taking the distinct
-/// aggregate off `GroupsAccumulatorAdapter` rather than only adding an inner
-/// group by. See `rewrite_pays_for_count` for the measurements behind that.
+/// That `count` is allowed only when the distinct aggregate reports that it has
+/// no specialized `GroupsAccumulator` for its argument types, so that the
+/// rewrite is taking the distinct aggregate off `GroupsAccumulatorAdapter`
+/// rather than only adding an inner group by. A function that does not report
+/// on this at all keeps the previous behaviour and is left alone. See
+/// `rewrite_pays_for_count` for the measurements behind that.
 #[derive(Default, Debug)]
 pub struct SingleDistinctToGroupBy {}
 
@@ -190,6 +192,19 @@ fn is_single_distinct_agg(
 /// Q22, whose `count(DISTINCT "UserID")` is over an `Int64`, measured a 132%
 /// increase in peak memory pool reservation when the rewrite applied to it.
 ///
+/// `Some(false)` is the only answer that buys anything. `Some(true)` says the
+/// call never reaches the adapter. `None` says the function does not answer the
+/// question from the argument types, which is the default and so the answer for
+/// almost every function. Silence is not evidence, and reading it as `Some(false)`
+/// would open this path to every such function: `sum(DISTINCT int_col)` beside a
+/// `count(*)` measured 3.15x the peak memory once rewritten, over 4,000,000 rows
+/// in 2,000 groups.
+///
+/// The predicate is a proxy, not the true discriminator. What decides the
+/// outcome is the cost per distinct value on each side, which this rule cannot
+/// see. The proxy is deliberately conservative in the direction that leaves a
+/// plan alone.
+///
 /// The existing tolerance of a non-distinct `sum`, `min` or `max` predates this
 /// and is left alone: narrowing it would change plans that have always been
 /// rewritten, which no measurement here calls for.
@@ -202,7 +217,7 @@ fn rewrite_pays_for_count(
             .iter()
             .map(|arg| arg.get_type(input_schema))
             .collect::<Result<Vec<_>>>()?;
-        if !func.groups_accumulator_supported_for_types(&arg_types, true) {
+        if func.groups_accumulator_supported_for_types(&arg_types, true) == Some(false) {
             return Ok(true);
         }
     }
@@ -446,7 +461,9 @@ mod tests {
     use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ExprFunctionExt;
     use datafusion_expr::expr::GroupingSet;
+    use datafusion_expr::function::AccumulatorArgs;
     use datafusion_expr::registry::{FunctionRegistry, MemoryFunctionRegistry};
+    use datafusion_expr::{Accumulator, AggregateUDFImpl, Signature, Volatility};
     use datafusion_expr::{
         lit,
         logical_plan::builder::{LogicalPlanBuilder, table_scan},
@@ -459,6 +476,65 @@ mod tests {
     fn max_distinct(expr: Expr) -> Expr {
         Expr::AggregateFunction(AggregateFunction::new_udf(
             max_udaf(),
+            vec![expr],
+            true,
+            None,
+            vec![],
+            None,
+        ))
+    }
+
+    fn sum_distinct(expr: Expr) -> Expr {
+        Expr::AggregateFunction(AggregateFunction::new_udf(
+            sum_udaf(),
+            vec![expr],
+            true,
+            None,
+            vec![],
+            None,
+        ))
+    }
+
+    /// An aggregate that leaves
+    /// [`AggregateUDFImpl::groups_accumulator_supported_for_types`] at its
+    /// default, which is what almost every function in the wild does.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    struct SilentUdaf {
+        signature: Signature,
+    }
+
+    impl SilentUdaf {
+        fn new() -> Self {
+            Self {
+                signature: Signature::any(1, Volatility::Immutable),
+            }
+        }
+    }
+
+    impl AggregateUDFImpl for SilentUdaf {
+        fn name(&self) -> &str {
+            "silent"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+            Ok(DataType::UInt32)
+        }
+
+        fn accumulator(
+            &self,
+            _acc_args: AccumulatorArgs,
+        ) -> Result<Box<dyn Accumulator>> {
+            unimplemented!("not needed for this test")
+        }
+    }
+
+    fn silent_distinct(expr: Expr) -> Expr {
+        Expr::AggregateFunction(AggregateFunction::new_udf(
+            Arc::new(AggregateUDF::from(SilentUdaf::new())),
             vec![expr],
             true,
             None,
@@ -804,6 +880,54 @@ mod tests {
           Aggregate: groupBy=[[test.a]], aggr=[[count(alias1), sum(alias2)]] [a:UInt32, count(alias1):Int64, sum(alias2):UInt64;N]
             Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[sum(test.c) AS alias2]] [a:UInt32, alias1:UInt32, alias2:UInt64;N]
               TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn distinct_over_a_function_with_no_opinion_is_not_rewritten() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(
+                vec![col("a")],
+                vec![silent_distinct(col("b")), count(col("c"))],
+            )?
+            .build()?;
+
+        // Should not work: `silent` leaves
+        // `groups_accumulator_supported_for_types` at its default, so it
+        // reports nothing about `GroupsAccumulatorAdapter`. Silence is not
+        // evidence that the rewrite pays, and the rule must not read it as
+        // permission
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Aggregate: groupBy=[[test.a]], aggr=[[silent(DISTINCT test.b), count(test.c)]] [a:UInt32, silent(DISTINCT test.b):UInt32;N, count(test.c):Int64]
+          TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn distinct_sum_and_count_is_not_rewritten() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(
+                vec![col("a")],
+                vec![sum_distinct(col("b")), count(col("c"))],
+            )?
+            .build()?;
+
+        // Should not work: `sum` reports nothing about
+        // `GroupsAccumulatorAdapter` either, and measurement says this shape
+        // costs 3.15x the peak memory once rewritten
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Aggregate: groupBy=[[test.a]], aggr=[[sum(DISTINCT test.b), count(test.c)]] [a:UInt32, sum(DISTINCT test.b):UInt64;N, count(test.c):Int64]
+          TableScan: test [a:UInt32, b:UInt32, c:UInt32]
         "
         )
     }

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -23,10 +23,12 @@ use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 
 use datafusion_common::{
-    DataFusionError, HashSet, Result, assert_eq_or_internal_err, tree_node::Transformed,
+    DFSchema, DataFusionError, HashSet, Result, assert_eq_or_internal_err,
+    tree_node::Transformed,
 };
 use datafusion_expr::builder::project;
 use datafusion_expr::expr::AggregateFunctionParams;
+use datafusion_expr::expr_schema::ExprSchemable;
 use datafusion_expr::{
     AggregateUDF, Expr, col,
     expr::AggregateFunction,
@@ -78,6 +80,9 @@ use datafusion_expr::{
 /// The `CASE` covers the one input on which the two phases disagree: over an
 /// empty input the inner group by produces no rows at all, and a `sum` of no
 /// rows is NULL where `count` is 0.
+///
+/// That `count` is allowed only when the distinct argument has no specialized
+/// `GroupsAccumulator` of its own. See [`rewrite_pays_for_count`].
 #[derive(Default, Debug)]
 pub struct SingleDistinctToGroupBy {}
 
@@ -120,10 +125,13 @@ impl CountRollup {
 /// Check whether all aggregate exprs are distinct on a single field.
 fn is_single_distinct_agg(
     aggr_expr: &[Expr],
+    input_schema: &DFSchema,
     count_rollup: Option<&CountRollup>,
 ) -> Result<bool> {
     let mut fields_set = HashSet::new();
     let mut aggregate_count = 0;
+    let mut distinct_aggs = vec![];
+    let mut has_count_rollup = false;
     for expr in aggr_expr {
         if let Expr::AggregateFunction(AggregateFunction {
             func,
@@ -145,10 +153,12 @@ fn is_single_distinct_agg(
                 for e in args {
                     fields_set.insert(e);
                 }
+                distinct_aggs.push((func, args));
+            } else if count_rollup.is_some_and(|rollup| rollup.is_count(func)) {
+                has_count_rollup = true;
             } else if func.name() != "sum"
                 && func.name().to_lowercase() != "min"
                 && func.name().to_lowercase() != "max"
-                && !count_rollup.is_some_and(|rollup| rollup.is_count(func))
             {
                 return Ok(false);
             }
@@ -156,7 +166,45 @@ fn is_single_distinct_agg(
             return Ok(false);
         }
     }
-    Ok(aggregate_count == aggr_expr.len() && fields_set.len() == 1)
+    if aggregate_count != aggr_expr.len() || fields_set.len() != 1 {
+        return Ok(false);
+    }
+    if has_count_rollup && !rewrite_pays_for_count(&distinct_aggs, input_schema)? {
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+/// Whether the rewrite is worth extending to a plan that only qualifies because
+/// of the non-distinct `count`.
+///
+/// The rewrite is not free: every other aggregate moves down to the inner group
+/// by, which has a row per `(group, distinct value)` pair rather than per group,
+/// and each one keeps its state at that finer grain. What pays for it is taking
+/// the distinct aggregate off `GroupsAccumulatorAdapter`, whose one boxed
+/// accumulator per group is the expensive shape. A distinct aggregate that
+/// already has a specialized `GroupsAccumulator` never went near the adapter, so
+/// there is nothing to buy and only the inner group by to pay for: ClickBench
+/// Q22, whose `count(DISTINCT "UserID")` is over an `Int64`, measured a 132%
+/// increase in peak memory pool reservation when the rewrite applied to it.
+///
+/// The existing tolerance of a non-distinct `sum`, `min` or `max` predates this
+/// and is left alone: narrowing it would change plans that have always been
+/// rewritten, which no measurement here calls for.
+fn rewrite_pays_for_count(
+    distinct_aggs: &[(&Arc<AggregateUDF>, &Vec<Expr>)],
+    input_schema: &DFSchema,
+) -> Result<bool> {
+    for (func, args) in distinct_aggs {
+        let arg_types = args
+            .iter()
+            .map(|arg| arg.get_type(input_schema))
+            .collect::<Result<Vec<_>>>()?;
+        if !func.groups_accumulator_supported_for_types(&arg_types, true) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Check if the first expr is [Expr::GroupingSet].
@@ -193,8 +241,11 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                 schema,
                 group_expr,
                 ..
-            }) if is_single_distinct_agg(&aggr_expr, count_rollup.as_ref())?
-                && !contains_grouping_set(&group_expr) =>
+            }) if is_single_distinct_agg(
+                &aggr_expr,
+                input.schema(),
+                count_rollup.as_ref(),
+            )? && !contains_grouping_set(&group_expr) =>
             {
                 let group_size = group_expr.len();
                 // alias all original group_by exprs
@@ -387,13 +438,17 @@ mod tests {
     use crate::assert_optimized_plan_eq_display_indent_snapshot;
     use crate::test::*;
     use crate::{Optimizer, OptimizerContext};
+    use arrow::datatypes::{DataType, Field, Schema};
     use chrono::{DateTime, Utc};
     use datafusion_common::alias::AliasGenerator;
     use datafusion_common::config::ConfigOptions;
     use datafusion_expr::ExprFunctionExt;
     use datafusion_expr::expr::GroupingSet;
     use datafusion_expr::registry::{FunctionRegistry, MemoryFunctionRegistry};
-    use datafusion_expr::{lit, logical_plan::builder::LogicalPlanBuilder};
+    use datafusion_expr::{
+        lit,
+        logical_plan::builder::{LogicalPlanBuilder, table_scan},
+    };
     use datafusion_functions_aggregate::count::count_udaf;
     use datafusion_functions_aggregate::expr_fn::{count, count_distinct, max, min, sum};
     use datafusion_functions_aggregate::min_max::max_udaf;
@@ -419,6 +474,20 @@ mod tests {
             vec![],
             None,
         ))
+    }
+
+    /// `test` with a `Utf8` `b`, the column the distinct aggregate reads.
+    ///
+    /// `count(DISTINCT b)` over a string has no specialized
+    /// `GroupsAccumulator`, so it is the case a non-distinct `count` may join.
+    /// The `UInt32` `b` of [`test_table_scan`] is the case it may not.
+    fn test_table_scan_utf8_b() -> Result<LogicalPlan> {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::UInt32, false),
+            Field::new("b", DataType::Utf8, false),
+            Field::new("c", DataType::UInt32, false),
+        ]);
+        table_scan(Some("test"), &schema, None)?.build()
     }
 
     /// An [`OptimizerConfig`] that resolves functions the way a session does.
@@ -667,7 +736,7 @@ mod tests {
 
     #[test]
     fn distinct_and_common() -> Result<()> {
-        let table_scan = test_table_scan()?;
+        let table_scan = test_table_scan_utf8_b()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .aggregate(
@@ -683,7 +752,55 @@ mod tests {
             @r"
         Projection: test.a, count(alias1) AS count(DISTINCT test.b), CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS count(test.c) [a:UInt32, count(DISTINCT test.b):Int64, count(test.c):Int64]
           Aggregate: groupBy=[[test.a]], aggr=[[count(alias1), sum(alias2)]] [a:UInt32, count(alias1):Int64, sum(alias2):Int64;N]
-            Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[count(test.c) AS alias2]] [a:UInt32, alias1:UInt32, alias2:Int64]
+            Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[count(test.c) AS alias2]] [a:UInt32, alias1:Utf8, alias2:Int64]
+              TableScan: test [a:UInt32, b:Utf8, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn distinct_and_common_over_a_natively_supported_type() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(
+                vec![col("a")],
+                vec![count_distinct(col("b")), count(col("c"))],
+            )?
+            .build()?;
+
+        // Should not work: `count(DISTINCT b)` over a `UInt32` has its own
+        // `GroupsAccumulator`, so the rewrite would add an inner group-by
+        // without taking anything off `GroupsAccumulatorAdapter`
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Aggregate: groupBy=[[test.a]], aggr=[[count(DISTINCT test.b), count(test.c)]] [a:UInt32, count(DISTINCT test.b):Int64, count(test.c):Int64]
+          TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+        "
+        )
+    }
+
+    #[test]
+    fn distinct_over_a_natively_supported_type_without_a_count() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(table_scan)
+            .aggregate(
+                vec![col("a")],
+                vec![count_distinct(col("b")), sum(col("c"))],
+            )?
+            .build()?;
+
+        // Should work: the gate covers only the `count` this change added, so a
+        // plan that already qualified through `sum`, `min` or `max` is rewritten
+        // exactly as before
+        assert_optimized_plan_equal!(
+            plan,
+            @r"
+        Projection: test.a, count(alias1) AS count(DISTINCT test.b), sum(alias2) AS sum(test.c) [a:UInt32, count(DISTINCT test.b):Int64, sum(test.c):UInt64;N]
+          Aggregate: groupBy=[[test.a]], aggr=[[count(alias1), sum(alias2)]] [a:UInt32, count(alias1):Int64, sum(alias2):UInt64;N]
+            Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[sum(test.c) AS alias2]] [a:UInt32, alias1:UInt32, alias2:UInt64;N]
               TableScan: test [a:UInt32, b:UInt32, c:UInt32]
         "
         )
@@ -911,7 +1028,7 @@ mod tests {
 
     #[test]
     fn count_star_and_distinct_without_groupby() -> Result<()> {
-        let table_scan = test_table_scan()?;
+        let table_scan = test_table_scan_utf8_b()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .aggregate(
@@ -928,15 +1045,15 @@ mod tests {
             @r"
         Projection: CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS count(Int64(1)), count(alias1) AS count(DISTINCT test.b) [count(Int64(1)):Int64, count(DISTINCT test.b):Int64]
           Aggregate: groupBy=[[]], aggr=[[sum(alias2), count(alias1)]] [sum(alias2):Int64;N, count(alias1):Int64]
-            Aggregate: groupBy=[[test.b AS alias1]], aggr=[[count(Int64(1)) AS alias2]] [alias1:UInt32, alias2:Int64]
-              TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+            Aggregate: groupBy=[[test.b AS alias1]], aggr=[[count(Int64(1)) AS alias2]] [alias1:Utf8, alias2:Int64]
+              TableScan: test [a:UInt32, b:Utf8, c:UInt32]
         "
         )
     }
 
     #[test]
     fn count_star_min_max_sum_and_distinct_with_groupby() -> Result<()> {
-        let table_scan = test_table_scan()?;
+        let table_scan = test_table_scan_utf8_b()?;
 
         let plan = LogicalPlanBuilder::from(table_scan)
             .aggregate(
@@ -958,8 +1075,8 @@ mod tests {
             @r"
         Projection: test.a, CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS count(Int64(1)), count(alias1) AS count(DISTINCT test.b), min(alias3) AS min(test.c), max(alias4) AS max(test.c), sum(alias5) AS sum(test.c) [a:UInt32, count(Int64(1)):Int64, count(DISTINCT test.b):Int64, min(test.c):UInt32;N, max(test.c):UInt32;N, sum(test.c):UInt64;N]
           Aggregate: groupBy=[[test.a]], aggr=[[sum(alias2), count(alias1), min(alias3), max(alias4), sum(alias5)]] [a:UInt32, sum(alias2):Int64;N, count(alias1):Int64, min(alias3):UInt32;N, max(alias4):UInt32;N, sum(alias5):UInt64;N]
-            Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[count(Int64(1)) AS alias2, min(test.c) AS alias3, max(test.c) AS alias4, sum(test.c) AS alias5]] [a:UInt32, alias1:UInt32, alias2:Int64, alias3:UInt32;N, alias4:UInt32;N, alias5:UInt64;N]
-              TableScan: test [a:UInt32, b:UInt32, c:UInt32]
+            Aggregate: groupBy=[[test.a, test.b AS alias1]], aggr=[[count(Int64(1)) AS alias2, min(test.c) AS alias3, max(test.c) AS alias4, sum(test.c) AS alias5]] [a:UInt32, alias1:Utf8, alias2:Int64, alias3:UInt32;N, alias4:UInt32;N, alias5:UInt64;N]
+              TableScan: test [a:UInt32, b:Utf8, c:UInt32]
         "
         )
     }

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -82,7 +82,9 @@ use datafusion_expr::{
 /// rows is NULL where `count` is 0.
 ///
 /// That `count` is allowed only when the distinct argument has no specialized
-/// `GroupsAccumulator` of its own. See [`rewrite_pays_for_count`].
+/// `GroupsAccumulator` of its own, so that the rewrite is taking the distinct
+/// aggregate off `GroupsAccumulatorAdapter` rather than only adding an inner
+/// group by. See `rewrite_pays_for_count` for the measurements behind that.
 #[derive(Default, Debug)]
 pub struct SingleDistinctToGroupBy {}
 

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -54,10 +54,10 @@ use datafusion_expr::{
 ///    GROUP BY a
 ///  ```
 ///
-/// A non-distinct `count` is also allowed alongside the distinct aggregate. It
-/// is the one supported function whose outer phase is a *different* function:
-/// the inner group-by counts rows per `(group, distinct value)` pair and the
-/// outer phase adds those partial counts up with `sum`.
+/// A non-distinct `count` may also appear alongside the distinct aggregate. It
+/// is the one supported function whose outer phase is a different function: the
+/// inner group-by counts rows per `(group, distinct value)` pair, and the outer
+/// phase sums those partial counts.
 ///
 ///  ```text
 ///    Before:
@@ -77,16 +77,10 @@ use datafusion_expr::{
 ///    GROUP BY a
 ///  ```
 ///
-/// The `CASE` covers the one input on which the two phases disagree: over an
-/// empty input the inner group by produces no rows at all, and a `sum` of no
-/// rows is NULL where `count` is 0.
+/// The `CASE` restores the 0 that `count` reports over an empty input, where a
+/// `sum` of no rows is NULL.
 ///
-/// That `count` is allowed only when the distinct aggregate reports that it has
-/// no specialized `GroupsAccumulator` for its argument types, so that the
-/// rewrite is taking the distinct aggregate off `GroupsAccumulatorAdapter`
-/// rather than only adding an inner group by. A function that does not report
-/// on this at all keeps the previous behaviour and is left alone. See
-/// `rewrite_pays_for_count` for the measurements behind that.
+/// See `rewrite_pays_for_count` for when the `count` is allowed.
 #[derive(Default, Debug)]
 pub struct SingleDistinctToGroupBy {}
 
@@ -184,30 +178,22 @@ fn is_single_distinct_agg(
 ///
 /// The rewrite is not free: every other aggregate moves down to the inner group
 /// by, which has a row per `(group, distinct value)` pair rather than per group,
-/// and each one keeps its state at that finer grain. What pays for it is taking
-/// the distinct aggregate off `GroupsAccumulatorAdapter`, whose one boxed
-/// accumulator per group is the expensive shape. A distinct aggregate that
-/// already has a specialized `GroupsAccumulator` never went near the adapter, so
-/// there is nothing to buy and only the inner group by to pay for: ClickBench
-/// Q22, whose `count(DISTINCT "UserID")` is over an `Int64`, measured a 132%
-/// increase in peak memory pool reservation when the rewrite applied to it.
+/// and keeps its state at that finer grain. What pays for that is taking the
+/// distinct aggregate off `GroupsAccumulatorAdapter` and its one boxed
+/// accumulator per group. An aggregate that already has a specialized
+/// `GroupsAccumulator` never went near the adapter, so there is nothing to buy
+/// and only the inner group by to pay for.
 ///
-/// `Some(false)` is the only answer that buys anything. `Some(true)` says the
-/// call never reaches the adapter. `None` says the function does not answer the
-/// question from the argument types, which is the default and so the answer for
-/// almost every function. Silence is not evidence, and reading it as `Some(false)`
-/// would open this path to every such function: `sum(DISTINCT int_col)` beside a
-/// `count(*)` measured 3.15x the peak memory once rewritten, over 4,000,000 rows
-/// in 2,000 groups.
+/// `Some(false)` is therefore the only answer that permits the rewrite. `None`,
+/// the default for almost every function, is not evidence that it pays.
 ///
-/// The predicate is a proxy, not the true discriminator. What decides the
-/// outcome is the cost per distinct value on each side, which this rule cannot
-/// see. The proxy is deliberately conservative in the direction that leaves a
-/// plan alone.
+/// This is a proxy: what actually decides the outcome is the cost per distinct
+/// value on each side, which this rule cannot see. It is deliberately
+/// conservative in the direction that leaves a plan alone. The pre-existing
+/// tolerance of a non-distinct `sum`, `min` or `max` is not gated, since
+/// narrowing it would change plans that have always been rewritten.
 ///
-/// The existing tolerance of a non-distinct `sum`, `min` or `max` predates this
-/// and is left alone: narrowing it would change plans that have always been
-/// rewritten, which no measurement here calls for.
+/// Measured in <https://github.com/apache/datafusion/pull/24859>.
 fn rewrite_pays_for_count(
     distinct_aggs: &[(&Arc<AggregateUDF>, &[Expr])],
     input_schema: &DFSchema,
@@ -354,11 +340,8 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                             } else {
                                 index += 1;
                                 let alias_str = format!("alias{index}");
-                                // `count` is the one function whose two phases
-                                // use different aggregates: the inner group-by
-                                // counts the rows of each `(group, distinct
-                                // value)` partition and the outer phase adds
-                                // those partial counts up.
+                                // `count`'s outer phase is `sum`, over the
+                                // partial counts the inner group-by produced.
                                 let rollup = count_rollup
                                     .as_ref()
                                     .filter(|rollup| rollup.is_count(&func));
@@ -389,11 +372,9 @@ impl OptimizerRule for SingleDistinctToGroupBy {
                                 if rollup.is_none() {
                                     return Ok((outer.clone(), outer));
                                 }
-                                // The inner group-by produces no rows at all
-                                // for an empty input, and `sum` reports that as
-                                // NULL where `count` reports 0. Restore the 0,
-                                // which also keeps the column non-nullable as
-                                // `count` had it.
+                                // `sum` of no rows is NULL where `count` is 0.
+                                // Restoring the 0 also keeps the column
+                                // non-nullable, as `count` had it.
                                 let proj =
                                     when(outer.clone().is_not_null(), outer.clone())
                                         .otherwise(lit(0_i64))?;
@@ -921,8 +902,7 @@ mod tests {
             .build()?;
 
         // Should not work: `sum` reports nothing about
-        // `GroupsAccumulatorAdapter` either, and measurement says this shape
-        // costs 3.15x the peak memory once rewritten
+        // `GroupsAccumulatorAdapter` either, so the rewrite is not known to pay
         assert_optimized_plan_equal!(
             plan,
             @r"

--- a/datafusion/optimizer/src/single_distinct_to_groupby.rs
+++ b/datafusion/optimizer/src/single_distinct_to_groupby.rs
@@ -157,7 +157,7 @@ fn is_single_distinct_agg(
                 for e in args {
                     fields_set.insert(e);
                 }
-                distinct_aggs.push((func, args));
+                distinct_aggs.push((func, args.as_slice()));
             } else if count_rollup.is_some_and(|rollup| rollup.is_count(func)) {
                 has_count_rollup = true;
             } else if func.name() != "sum"
@@ -209,7 +209,7 @@ fn is_single_distinct_agg(
 /// and is left alone: narrowing it would change plans that have always been
 /// rewritten, which no measurement here calls for.
 fn rewrite_pays_for_count(
-    distinct_aggs: &[(&Arc<AggregateUDF>, &Vec<Expr>)],
+    distinct_aggs: &[(&Arc<AggregateUDF>, &[Expr])],
     input_schema: &DFSchema,
 ) -> Result<bool> {
     for (func, args) in distinct_aggs {

--- a/datafusion/sqllogictest/test_files/clickbench.slt
+++ b/datafusion/sqllogictest/test_files/clickbench.slt
@@ -616,21 +616,25 @@ EXPLAIN SELECT "SearchPhrase", MIN("URL"), MIN("Title"), COUNT(*) AS c, COUNT(DI
 ----
 logical_plan
 01)Sort: c DESC NULLS FIRST, fetch=10
-02)--Projection: hits.SearchPhrase, min(hits.URL), min(hits.Title), count(Int64(1)) AS count(*) AS c, count(DISTINCT hits.UserID)
-03)----Aggregate: groupBy=[[hits.SearchPhrase]], aggr=[[min(hits.URL), min(hits.Title), count(Int64(1)), count(DISTINCT hits.UserID)]]
-04)------SubqueryAlias: hits
-05)--------Filter: hits_raw.SearchPhrase != Utf8View("") AND hits_raw.Title LIKE Utf8View("%Google%") AND hits_raw.URL NOT LIKE Utf8View("%.google.%")
-06)----------TableScan: hits_raw projection=[Title, UserID, URL, SearchPhrase], partial_filters=[hits_raw.SearchPhrase != Utf8View(""), hits_raw.Title LIKE Utf8View("%Google%"), hits_raw.URL NOT LIKE Utf8View("%.google.%")]
+02)--Projection: hits.SearchPhrase, min(alias2) AS min(hits.URL), min(alias3) AS min(hits.Title), CASE WHEN sum(alias4) IS NOT NULL THEN sum(alias4) ELSE Int64(0) END AS c, count(alias1) AS count(DISTINCT hits.UserID)
+03)----Aggregate: groupBy=[[hits.SearchPhrase]], aggr=[[min(alias2), min(alias3), sum(alias4), count(alias1)]]
+04)------Aggregate: groupBy=[[hits.SearchPhrase, hits.UserID AS alias1]], aggr=[[min(hits.URL) AS alias2, min(hits.Title) AS alias3, count(Int64(1)) AS alias4]]
+05)--------SubqueryAlias: hits
+06)----------Filter: hits_raw.SearchPhrase != Utf8View("") AND hits_raw.Title LIKE Utf8View("%Google%") AND hits_raw.URL NOT LIKE Utf8View("%.google.%")
+07)------------TableScan: hits_raw projection=[Title, UserID, URL, SearchPhrase], partial_filters=[hits_raw.SearchPhrase != Utf8View(""), hits_raw.Title LIKE Utf8View("%Google%"), hits_raw.URL NOT LIKE Utf8View("%.google.%")]
 physical_plan
 01)SortPreservingMergeExec: [c@3 DESC], fetch=10
-02)--ProjectionExec: expr=[SearchPhrase@0 as SearchPhrase, min(hits.URL)@1 as min(hits.URL), min(hits.Title)@2 as min(hits.Title), count(Int64(1))@3 as c, count(DISTINCT hits.UserID)@4 as count(DISTINCT hits.UserID)]
-03)----SortExec: TopK(fetch=10), expr=[count(Int64(1))@3 DESC], preserve_partitioning=[true]
-04)------AggregateExec: mode=FinalPartitioned, gby=[SearchPhrase@0 as SearchPhrase], aggr=[min(hits.URL), min(hits.Title), count(Int64(1)), count(DISTINCT hits.UserID)]
+02)--SortExec: TopK(fetch=10), expr=[c@3 DESC], preserve_partitioning=[true]
+03)----ProjectionExec: expr=[SearchPhrase@0 as SearchPhrase, min(alias2)@1 as min(hits.URL), min(alias3)@2 as min(hits.Title), CASE WHEN sum(alias4)@3 IS NOT NULL THEN sum(alias4)@3 ELSE 0 END as c, count(alias1)@4 as count(DISTINCT hits.UserID)]
+04)------AggregateExec: mode=FinalPartitioned, gby=[SearchPhrase@0 as SearchPhrase], aggr=[min(alias2), min(alias3), sum(alias4), count(alias1)]
 05)--------RepartitionExec: partitioning=Hash([SearchPhrase@0], 4), input_partitions=4
-06)----------AggregateExec: mode=Partial, gby=[SearchPhrase@3 as SearchPhrase], aggr=[min(hits.URL), min(hits.Title), count(Int64(1)), count(DISTINCT hits.UserID)]
-07)------------FilterExec: SearchPhrase@3 !=  AND Title@0 LIKE %Google% AND URL@2 NOT LIKE %.google.%
-08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-09)----------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/clickbench_hits_10.parquet]]}, projection=[Title, UserID, URL, SearchPhrase], file_type=parquet, predicate=SearchPhrase@39 !=  AND Title@2 LIKE %Google% AND URL@13 NOT LIKE %.google.%, pruning_predicate=SearchPhrase_null_count@2 != row_count@3 AND (SearchPhrase_min@0 !=  OR  != SearchPhrase_max@1), required_guarantees=[SearchPhrase not in ()]
+06)----------AggregateExec: mode=Partial, gby=[SearchPhrase@0 as SearchPhrase], aggr=[min(alias2), min(alias3), sum(alias4), count(alias1)]
+07)------------AggregateExec: mode=FinalPartitioned, gby=[SearchPhrase@0 as SearchPhrase, alias1@1 as alias1], aggr=[min(hits.URL) as alias2, min(hits.Title) as alias3, count(1) as alias4]
+08)--------------RepartitionExec: partitioning=Hash([SearchPhrase@0, alias1@1], 4), input_partitions=4
+09)----------------AggregateExec: mode=Partial, gby=[SearchPhrase@3 as SearchPhrase, UserID@1 as alias1], aggr=[min(hits.URL) as alias2, min(hits.Title) as alias3, count(1) as alias4]
+10)------------------FilterExec: SearchPhrase@3 !=  AND Title@0 LIKE %Google% AND URL@2 NOT LIKE %.google.%
+11)--------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+12)----------------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/clickbench_hits_10.parquet]]}, projection=[Title, UserID, URL, SearchPhrase], file_type=parquet, predicate=SearchPhrase@39 !=  AND Title@2 LIKE %Google% AND URL@13 NOT LIKE %.google.%, pruning_predicate=SearchPhrase_null_count@2 != row_count@3 AND (SearchPhrase_min@0 !=  OR  != SearchPhrase_max@1), required_guarantees=[SearchPhrase not in ()]
 
 query TTTII
 SELECT "SearchPhrase", MIN("URL"), MIN("Title"), COUNT(*) AS c, COUNT(DISTINCT "UserID") FROM hits WHERE "Title" LIKE '%Google%' AND "URL" NOT LIKE '%.google.%' AND "SearchPhrase" <> '' GROUP BY "SearchPhrase" ORDER BY c DESC LIMIT 10;

--- a/datafusion/sqllogictest/test_files/clickbench.slt
+++ b/datafusion/sqllogictest/test_files/clickbench.slt
@@ -616,25 +616,21 @@ EXPLAIN SELECT "SearchPhrase", MIN("URL"), MIN("Title"), COUNT(*) AS c, COUNT(DI
 ----
 logical_plan
 01)Sort: c DESC NULLS FIRST, fetch=10
-02)--Projection: hits.SearchPhrase, min(alias2) AS min(hits.URL), min(alias3) AS min(hits.Title), CASE WHEN sum(alias4) IS NOT NULL THEN sum(alias4) ELSE Int64(0) END AS c, count(alias1) AS count(DISTINCT hits.UserID)
-03)----Aggregate: groupBy=[[hits.SearchPhrase]], aggr=[[min(alias2), min(alias3), sum(alias4), count(alias1)]]
-04)------Aggregate: groupBy=[[hits.SearchPhrase, hits.UserID AS alias1]], aggr=[[min(hits.URL) AS alias2, min(hits.Title) AS alias3, count(Int64(1)) AS alias4]]
-05)--------SubqueryAlias: hits
-06)----------Filter: hits_raw.SearchPhrase != Utf8View("") AND hits_raw.Title LIKE Utf8View("%Google%") AND hits_raw.URL NOT LIKE Utf8View("%.google.%")
-07)------------TableScan: hits_raw projection=[Title, UserID, URL, SearchPhrase], partial_filters=[hits_raw.SearchPhrase != Utf8View(""), hits_raw.Title LIKE Utf8View("%Google%"), hits_raw.URL NOT LIKE Utf8View("%.google.%")]
+02)--Projection: hits.SearchPhrase, min(hits.URL), min(hits.Title), count(Int64(1)) AS count(*) AS c, count(DISTINCT hits.UserID)
+03)----Aggregate: groupBy=[[hits.SearchPhrase]], aggr=[[min(hits.URL), min(hits.Title), count(Int64(1)), count(DISTINCT hits.UserID)]]
+04)------SubqueryAlias: hits
+05)--------Filter: hits_raw.SearchPhrase != Utf8View("") AND hits_raw.Title LIKE Utf8View("%Google%") AND hits_raw.URL NOT LIKE Utf8View("%.google.%")
+06)----------TableScan: hits_raw projection=[Title, UserID, URL, SearchPhrase], partial_filters=[hits_raw.SearchPhrase != Utf8View(""), hits_raw.Title LIKE Utf8View("%Google%"), hits_raw.URL NOT LIKE Utf8View("%.google.%")]
 physical_plan
 01)SortPreservingMergeExec: [c@3 DESC], fetch=10
-02)--SortExec: TopK(fetch=10), expr=[c@3 DESC], preserve_partitioning=[true]
-03)----ProjectionExec: expr=[SearchPhrase@0 as SearchPhrase, min(alias2)@1 as min(hits.URL), min(alias3)@2 as min(hits.Title), CASE WHEN sum(alias4)@3 IS NOT NULL THEN sum(alias4)@3 ELSE 0 END as c, count(alias1)@4 as count(DISTINCT hits.UserID)]
-04)------AggregateExec: mode=FinalPartitioned, gby=[SearchPhrase@0 as SearchPhrase], aggr=[min(alias2), min(alias3), sum(alias4), count(alias1)]
+02)--ProjectionExec: expr=[SearchPhrase@0 as SearchPhrase, min(hits.URL)@1 as min(hits.URL), min(hits.Title)@2 as min(hits.Title), count(Int64(1))@3 as c, count(DISTINCT hits.UserID)@4 as count(DISTINCT hits.UserID)]
+03)----SortExec: TopK(fetch=10), expr=[count(Int64(1))@3 DESC], preserve_partitioning=[true]
+04)------AggregateExec: mode=FinalPartitioned, gby=[SearchPhrase@0 as SearchPhrase], aggr=[min(hits.URL), min(hits.Title), count(Int64(1)), count(DISTINCT hits.UserID)]
 05)--------RepartitionExec: partitioning=Hash([SearchPhrase@0], 4), input_partitions=4
-06)----------AggregateExec: mode=Partial, gby=[SearchPhrase@0 as SearchPhrase], aggr=[min(alias2), min(alias3), sum(alias4), count(alias1)]
-07)------------AggregateExec: mode=FinalPartitioned, gby=[SearchPhrase@0 as SearchPhrase, alias1@1 as alias1], aggr=[min(hits.URL) as alias2, min(hits.Title) as alias3, count(1) as alias4]
-08)--------------RepartitionExec: partitioning=Hash([SearchPhrase@0, alias1@1], 4), input_partitions=4
-09)----------------AggregateExec: mode=Partial, gby=[SearchPhrase@3 as SearchPhrase, UserID@1 as alias1], aggr=[min(hits.URL) as alias2, min(hits.Title) as alias3, count(1) as alias4]
-10)------------------FilterExec: SearchPhrase@3 !=  AND Title@0 LIKE %Google% AND URL@2 NOT LIKE %.google.%
-11)--------------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-12)----------------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/clickbench_hits_10.parquet]]}, projection=[Title, UserID, URL, SearchPhrase], file_type=parquet, predicate=SearchPhrase@39 !=  AND Title@2 LIKE %Google% AND URL@13 NOT LIKE %.google.%, pruning_predicate=SearchPhrase_null_count@2 != row_count@3 AND (SearchPhrase_min@0 !=  OR  != SearchPhrase_max@1), required_guarantees=[SearchPhrase not in ()]
+06)----------AggregateExec: mode=Partial, gby=[SearchPhrase@3 as SearchPhrase], aggr=[min(hits.URL), min(hits.Title), count(Int64(1)), count(DISTINCT hits.UserID)]
+07)------------FilterExec: SearchPhrase@3 !=  AND Title@0 LIKE %Google% AND URL@2 NOT LIKE %.google.%
+08)--------------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+09)----------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/clickbench_hits_10.parquet]]}, projection=[Title, UserID, URL, SearchPhrase], file_type=parquet, predicate=SearchPhrase@39 !=  AND Title@2 LIKE %Google% AND URL@13 NOT LIKE %.google.%, pruning_predicate=SearchPhrase_null_count@2 != row_count@3 AND (SearchPhrase_min@0 !=  OR  != SearchPhrase_max@1), required_guarantees=[SearchPhrase not in ()]
 
 query TTTII
 SELECT "SearchPhrase", MIN("URL"), MIN("Title"), COUNT(*) AS c, COUNT(DISTINCT "UserID") FROM hits WHERE "Title" LIKE '%Google%' AND "URL" NOT LIKE '%.google.%' AND "SearchPhrase" <> '' GROUP BY "SearchPhrase" ORDER BY c DESC LIMIT 10;

--- a/datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt
+++ b/datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt
@@ -20,25 +20,30 @@
 # asserted twice: once with the optimizer disabled
 # (`datafusion.optimizer.max_passes = 0`, so the aggregate runs as written) and
 # once with it enabled. The two must agree.
+#
+# A non-distinct `count` may only join the distinct aggregate when the distinct
+# argument has no specialized `GroupsAccumulator` of its own. `x` is the
+# `VARCHAR` that qualifies, `xi` the `INT` that does not; both hold the same
+# values so the two sides can be compared directly.
 
 statement ok
-CREATE TABLE t(g INT, x INT, v INT);
+CREATE TABLE t(g INT, x VARCHAR, xi INT, v INT);
 
 # g = 1: four rows, two distinct x, one NULL x, one NULL v
 # g = 2: two rows, x is NULL throughout
 # g = 3: a single row
 statement ok
 INSERT INTO t VALUES
-  (1, 10, 100),
-  (1, 10, NULL),
-  (1, NULL, 5),
-  (1, 20, 7),
-  (2, NULL, NULL),
-  (2, NULL, 3),
-  (3, 30, 1);
+  (1, '10', 10, 100),
+  (1, '10', 10, NULL),
+  (1, NULL, NULL, 5),
+  (1, '20', 20, 7),
+  (2, NULL, NULL, NULL),
+  (2, NULL, NULL, 3),
+  (3, '30', 30, 1);
 
 statement ok
-CREATE TABLE empty_t(g INT, x INT, v INT);
+CREATE TABLE empty_t(g INT, x VARCHAR, xi INT, v INT);
 
 statement ok
 set datafusion.explain.logical_plan_only = true;
@@ -87,6 +92,33 @@ logical_plan
 01)Projection: t.g, avg(t.v) AS avg_v, count(DISTINCT t.x) AS distinct_x
 02)--Aggregate: groupBy=[[t.g]], aggr=[[avg(CAST(t.v AS Float64)), count(DISTINCT t.x)]]
 03)----TableScan: t projection=[g, x, v]
+
+########
+# The other side of the gate: a distinct argument that has its own
+# `GroupsAccumulator` keeps the count out
+########
+
+# `count(DISTINCT xi)` over an INT is served by
+# `PrimitiveDistinctCountGroupsAccumulator`, so the rewrite would add an inner
+# group by without taking anything off `GroupsAccumulatorAdapter`
+query TT
+EXPLAIN SELECT g, count(*) AS records, count(DISTINCT xi) AS distinct_xi FROM t GROUP BY g;
+----
+logical_plan
+01)Projection: t.g, count(Int64(1)) AS count(*) AS records, count(DISTINCT t.xi) AS distinct_xi
+02)--Aggregate: groupBy=[[t.g]], aggr=[[count(Int64(1)), count(DISTINCT t.xi)]]
+03)----TableScan: t projection=[g, xi]
+
+# The gate covers only the count. A plan that already qualified through sum,
+# min or max is still rewritten over the same INT column
+query TT
+EXPLAIN SELECT g, sum(v) AS sum_v, count(DISTINCT xi) AS distinct_xi FROM t GROUP BY g;
+----
+logical_plan
+01)Projection: t.g, sum(alias2) AS sum_v, count(alias1) AS distinct_xi
+02)--Aggregate: groupBy=[[t.g]], aggr=[[sum(alias2), count(alias1)]]
+03)----Aggregate: groupBy=[[t.g, t.xi AS alias1]], aggr=[[sum(CAST(t.v AS Int64)) AS alias2]]
+04)------TableScan: t projection=[g, xi, v]
 
 statement ok
 set datafusion.explain.logical_plan_only = false;
@@ -265,10 +297,10 @@ ORDER BY count(*) DESC, g;
 ########
 
 statement ok
-CREATE TABLE failed(x INT);
+CREATE TABLE failed(x VARCHAR);
 
 statement ok
-INSERT INTO failed VALUES (10), (30);
+INSERT INTO failed VALUES ('10'), ('30');
 
 statement ok
 set datafusion.optimizer.max_passes = 0;
@@ -293,6 +325,80 @@ GROUP BY t.g ORDER BY t.g;
 ----
 1 2 1 100 100 100
 3 1 1 1 1 1
+
+########
+# Both sides of the gate produce the same results as the unoptimized plan
+########
+
+statement ok
+set datafusion.optimizer.max_passes = 0;
+
+# gated: the count keeps the INT distinct unrewritten
+query IIIII
+SELECT g, count(*) AS records, count(DISTINCT xi) AS distinct_xi, sum(v) AS sum_v, max(v) AS max_v
+FROM t GROUP BY g ORDER BY g;
+----
+1 4 2 112 100
+2 2 0 3 3
+3 1 1 1 1
+
+# rewritten: the same shape over the VARCHAR distinct
+query IIIII
+SELECT g, count(*) AS records, count(DISTINCT x) AS distinct_x, sum(v) AS sum_v, max(v) AS max_v
+FROM t GROUP BY g ORDER BY g;
+----
+1 4 2 112 100
+2 2 0 3 3
+3 1 1 1 1
+
+# rewritten through sum alone, over the INT distinct the gate excludes
+query III
+SELECT g, count(DISTINCT xi) AS distinct_xi, sum(v) AS sum_v
+FROM t GROUP BY g ORDER BY g;
+----
+1 2 112
+2 0 3
+3 1 1
+
+query II
+SELECT count(*) AS records, count(DISTINCT xi) AS distinct_xi FROM empty_t;
+----
+0 0
+
+statement ok
+set datafusion.optimizer.max_passes = 3;
+
+# gated: the count keeps the INT distinct unrewritten
+query IIIII
+SELECT g, count(*) AS records, count(DISTINCT xi) AS distinct_xi, sum(v) AS sum_v, max(v) AS max_v
+FROM t GROUP BY g ORDER BY g;
+----
+1 4 2 112 100
+2 2 0 3 3
+3 1 1 1 1
+
+# rewritten: the same shape over the VARCHAR distinct
+query IIIII
+SELECT g, count(*) AS records, count(DISTINCT x) AS distinct_x, sum(v) AS sum_v, max(v) AS max_v
+FROM t GROUP BY g ORDER BY g;
+----
+1 4 2 112 100
+2 2 0 3 3
+3 1 1 1 1
+
+# rewritten through sum alone, over the INT distinct the gate excludes
+query III
+SELECT g, count(DISTINCT xi) AS distinct_xi, sum(v) AS sum_v
+FROM t GROUP BY g ORDER BY g;
+----
+1 2 112
+2 0 3
+3 1 1
+
+query II
+SELECT count(*) AS records, count(DISTINCT xi) AS distinct_xi FROM empty_t;
+----
+0 0
 
 statement ok
 DROP TABLE failed;

--- a/datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt
+++ b/datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt
@@ -1,0 +1,304 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tests for the `single_distinct_aggregation_to_group_by` rule, which rewrites a
+# single `AGG(DISTINCT x)` into a two phase group by. Every result here is
+# asserted twice: once with the optimizer disabled
+# (`datafusion.optimizer.max_passes = 0`, so the aggregate runs as written) and
+# once with it enabled. The two must agree.
+
+statement ok
+CREATE TABLE t(g INT, x INT, v INT);
+
+# g = 1: four rows, two distinct x, one NULL x, one NULL v
+# g = 2: two rows, x is NULL throughout
+# g = 3: a single row
+statement ok
+INSERT INTO t VALUES
+  (1, 10, 100),
+  (1, 10, NULL),
+  (1, NULL, 5),
+  (1, 20, 7),
+  (2, NULL, NULL),
+  (2, NULL, 3),
+  (3, 30, 1);
+
+statement ok
+CREATE TABLE empty_t(g INT, x INT, v INT);
+
+statement ok
+set datafusion.explain.logical_plan_only = true;
+
+########
+# The rewrite fires for a non-distinct count next to the distinct aggregate
+########
+
+query TT
+EXPLAIN SELECT g, count(*) AS records, count(DISTINCT x) AS distinct_x FROM t GROUP BY g;
+----
+logical_plan
+01)Projection: t.g, CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS records, count(alias1) AS distinct_x
+02)--Aggregate: groupBy=[[t.g]], aggr=[[sum(alias2), count(alias1)]]
+03)----Aggregate: groupBy=[[t.g, t.x AS alias1]], aggr=[[count(Int64(1)) AS alias2]]
+04)------TableScan: t projection=[g, x]
+
+# The production shape: a count next to min, max, sum and the distinct count
+query TT
+EXPLAIN
+SELECT g, count(*) AS records, count(DISTINCT x) AS distinct_x,
+       min(v) AS min_v, max(v) AS max_v, sum(v) AS sum_v
+FROM t GROUP BY g;
+----
+logical_plan
+01)Projection: t.g, CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS records, count(alias1) AS distinct_x, min(alias3) AS min_v, max(alias4) AS max_v, sum(alias5) AS sum_v
+02)--Aggregate: groupBy=[[t.g]], aggr=[[sum(alias2), count(alias1), min(alias3), max(alias4), sum(alias5)]]
+03)----Aggregate: groupBy=[[t.g, t.x AS alias1]], aggr=[[count(Int64(1)) AS alias2, min(t.v) AS alias3, max(t.v) AS alias4, sum(CAST(t.v AS Int64)) AS alias5]]
+04)------TableScan: t projection=[g, x, v]
+
+# A count with a FILTER still blocks the rewrite: the filter is per input row,
+# and the inner aggregate has already collapsed those rows
+query TT
+EXPLAIN SELECT g, count(*) FILTER (WHERE v > 1) AS records, count(DISTINCT x) AS distinct_x FROM t GROUP BY g;
+----
+logical_plan
+01)Projection: t.g, count(Int64(1)) FILTER (WHERE t.v > Int64(1)) AS count(*) FILTER (WHERE t.v > Int64(1)) AS records, count(DISTINCT t.x) AS distinct_x
+02)--Aggregate: groupBy=[[t.g]], aggr=[[count(Int64(1)) FILTER (WHERE t.v > Int32(1)) AS count(Int64(1)) FILTER (WHERE t.v > Int64(1)), count(DISTINCT t.x)]]
+03)----TableScan: t projection=[g, x, v]
+
+# An unsupported non-distinct aggregate still blocks the rewrite
+query TT
+EXPLAIN SELECT g, avg(v) AS avg_v, count(DISTINCT x) AS distinct_x FROM t GROUP BY g;
+----
+logical_plan
+01)Projection: t.g, avg(t.v) AS avg_v, count(DISTINCT t.x) AS distinct_x
+02)--Aggregate: groupBy=[[t.g]], aggr=[[avg(CAST(t.v AS Float64)), count(DISTINCT t.x)]]
+03)----TableScan: t projection=[g, x, v]
+
+statement ok
+set datafusion.explain.logical_plan_only = false;
+
+########
+# count(*) vs count(col) vs count(1), grouped
+########
+
+statement ok
+set datafusion.optimizer.max_passes = 0;
+
+query IIIIII
+SELECT g, count(*) AS star, count(1) AS one, count(x) AS cnt_x, count(v) AS cnt_v,
+       count(DISTINCT x) AS distinct_x
+FROM t GROUP BY g ORDER BY g;
+----
+1 4 4 3 3 2
+2 2 2 0 1 0
+3 1 1 1 1 1
+
+statement ok
+set datafusion.optimizer.max_passes = 3;
+
+query IIIIII
+SELECT g, count(*) AS star, count(1) AS one, count(x) AS cnt_x, count(v) AS cnt_v,
+       count(DISTINCT x) AS distinct_x
+FROM t GROUP BY g ORDER BY g;
+----
+1 4 4 3 3 2
+2 2 2 0 1 0
+3 1 1 1 1 1
+
+########
+# count(*) vs count(col) vs count(1), no GROUP BY
+########
+
+statement ok
+set datafusion.optimizer.max_passes = 0;
+
+query IIIII
+SELECT count(*) AS star, count(1) AS one, count(x) AS cnt_x, count(v) AS cnt_v,
+       count(DISTINCT x) AS distinct_x
+FROM t;
+----
+7 7 4 5 3
+
+statement ok
+set datafusion.optimizer.max_passes = 3;
+
+query IIIII
+SELECT count(*) AS star, count(1) AS one, count(x) AS cnt_x, count(v) AS cnt_v,
+       count(DISTINCT x) AS distinct_x
+FROM t;
+----
+7 7 4 5 3
+
+########
+# The distinct column is NULL for every row of the group
+########
+
+statement ok
+set datafusion.optimizer.max_passes = 0;
+
+query IIIII
+SELECT count(*) AS star, count(x) AS cnt_x, count(v) AS cnt_v, count(DISTINCT x) AS distinct_x,
+       max(v) AS max_v
+FROM t WHERE g = 2;
+----
+2 0 1 0 3
+
+statement ok
+set datafusion.optimizer.max_passes = 3;
+
+query IIIII
+SELECT count(*) AS star, count(x) AS cnt_x, count(v) AS cnt_v, count(DISTINCT x) AS distinct_x,
+       max(v) AS max_v
+FROM t WHERE g = 2;
+----
+2 0 1 0 3
+
+########
+# Empty input. Without a GROUP BY the aggregate still emits one row, and the
+# counts on it must be 0 rather than the NULL an unguarded `sum` would give.
+########
+
+statement ok
+set datafusion.optimizer.max_passes = 0;
+
+query IIIII
+SELECT count(*) AS star, count(1) AS one, count(x) AS cnt_x, count(DISTINCT x) AS distinct_x,
+       max(v) AS max_v
+FROM empty_t;
+----
+0 0 0 0 NULL
+
+query IIIII
+SELECT count(*) AS star, count(1) AS one, count(x) AS cnt_x, count(DISTINCT x) AS distinct_x,
+       max(v) AS max_v
+FROM t WHERE g = 99;
+----
+0 0 0 0 NULL
+
+query IIII
+SELECT g, count(*) AS star, count(x) AS cnt_x, count(DISTINCT x) AS distinct_x
+FROM empty_t GROUP BY g ORDER BY g;
+----
+
+statement ok
+set datafusion.optimizer.max_passes = 3;
+
+query IIIII
+SELECT count(*) AS star, count(1) AS one, count(x) AS cnt_x, count(DISTINCT x) AS distinct_x,
+       max(v) AS max_v
+FROM empty_t;
+----
+0 0 0 0 NULL
+
+query IIIII
+SELECT count(*) AS star, count(1) AS one, count(x) AS cnt_x, count(DISTINCT x) AS distinct_x,
+       max(v) AS max_v
+FROM t WHERE g = 99;
+----
+0 0 0 0 NULL
+
+query IIII
+SELECT g, count(*) AS star, count(x) AS cnt_x, count(DISTINCT x) AS distinct_x
+FROM empty_t GROUP BY g ORDER BY g;
+----
+
+########
+# HAVING and ORDER BY read the rewritten count by name from the node above
+########
+
+statement ok
+set datafusion.explain.logical_plan_only = true;
+
+query TT
+EXPLAIN
+SELECT g, count(*) AS records, count(DISTINCT x) AS distinct_x
+FROM t GROUP BY g HAVING count(*) > 1 AND count(DISTINCT x) > 0
+ORDER BY count(*) DESC, g;
+----
+logical_plan
+01)Sort: records DESC NULLS FIRST, t.g ASC NULLS LAST
+02)--Projection: t.g, CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS records, count(alias1) AS distinct_x
+03)----Filter: CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END > Int64(1) AND count(alias1) > Int64(0)
+04)------Aggregate: groupBy=[[t.g]], aggr=[[sum(alias2), count(alias1)]]
+05)--------Aggregate: groupBy=[[t.g, t.x AS alias1]], aggr=[[count(Int64(1)) AS alias2]]
+06)----------TableScan: t projection=[g, x]
+
+statement ok
+set datafusion.explain.logical_plan_only = false;
+
+statement ok
+set datafusion.optimizer.max_passes = 0;
+
+query III
+SELECT g, count(*) AS records, count(DISTINCT x) AS distinct_x
+FROM t GROUP BY g HAVING count(*) > 1 AND count(DISTINCT x) > 0
+ORDER BY count(*) DESC, g;
+----
+1 4 2
+
+statement ok
+set datafusion.optimizer.max_passes = 3;
+
+query III
+SELECT g, count(*) AS records, count(DISTINCT x) AS distinct_x
+FROM t GROUP BY g HAVING count(*) > 1 AND count(DISTINCT x) > 0
+ORDER BY count(*) DESC, g;
+----
+1 4 2
+
+########
+# The whole production shape, aggregating over a join
+########
+
+statement ok
+CREATE TABLE failed(x INT);
+
+statement ok
+INSERT INTO failed VALUES (10), (30);
+
+statement ok
+set datafusion.optimizer.max_passes = 0;
+
+query IIIIII
+SELECT t.g, count(*) AS records, count(DISTINCT t.x) AS distinct_x,
+       min(t.v) AS min_v, max(t.v) AS max_v, sum(t.v) AS sum_v
+FROM t JOIN failed f ON t.x = f.x
+GROUP BY t.g ORDER BY t.g;
+----
+1 2 1 100 100 100
+3 1 1 1 1 1
+
+statement ok
+set datafusion.optimizer.max_passes = 3;
+
+query IIIIII
+SELECT t.g, count(*) AS records, count(DISTINCT t.x) AS distinct_x,
+       min(t.v) AS min_v, max(t.v) AS max_v, sum(t.v) AS sum_v
+FROM t JOIN failed f ON t.x = f.x
+GROUP BY t.g ORDER BY t.g;
+----
+1 2 1 100 100 100
+3 1 1 1 1 1
+
+statement ok
+DROP TABLE failed;
+
+statement ok
+DROP TABLE empty_t;
+
+statement ok
+DROP TABLE t;

--- a/datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt
+++ b/datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt
@@ -21,10 +21,12 @@
 # (`datafusion.optimizer.max_passes = 0`, so the aggregate runs as written) and
 # once with it enabled. The two must agree.
 #
-# A non-distinct `count` may only join the distinct aggregate when the distinct
-# argument has no specialized `GroupsAccumulator` of its own. `x` is the
-# `VARCHAR` that qualifies, `xi` the `INT` that does not; both hold the same
-# values so the two sides can be compared directly.
+# A non-distinct `count` may only join the distinct aggregate when that
+# aggregate reports that it has no specialized `GroupsAccumulator` for its
+# argument types. `x` is the `VARCHAR` that qualifies, `xi` the `INT` that does
+# not; both hold the same values so the two sides can be compared directly.
+# An aggregate that reports nothing, which is every aggregate but `count`, also
+# does not qualify.
 
 statement ok
 CREATE TABLE t(g INT, x VARCHAR, xi INT, v INT);
@@ -108,6 +110,29 @@ logical_plan
 01)Projection: t.g, count(Int64(1)) AS count(*) AS records, count(DISTINCT t.xi) AS distinct_xi
 02)--Aggregate: groupBy=[[t.g]], aggr=[[count(Int64(1)), count(DISTINCT t.xi)]]
 03)----TableScan: t projection=[g, xi]
+
+# `sum` reports nothing about `GroupsAccumulator` support from the argument
+# types, and neither does any aggregate but `count`. Silence is not evidence
+# that the rewrite pays, so the count keeps this plan unrewritten as well.
+# Rewritten, this shape measured 3.15x the peak memory over 4,000,000 rows in
+# 2,000 groups
+query TT
+EXPLAIN SELECT g, count(*) AS records, sum(DISTINCT v) AS distinct_v FROM t GROUP BY g;
+----
+logical_plan
+01)Projection: t.g, count(Int64(1)) AS count(*) AS records, sum(DISTINCT t.v) AS distinct_v
+02)--Aggregate: groupBy=[[t.g]], aggr=[[count(Int64(1)), sum(DISTINCT CAST(t.v AS Int64))]]
+03)----TableScan: t projection=[g, v]
+
+# `min(DISTINCT v)` is the same value as `min(v)`, so the unrewritten plan keeps
+# one scalar per group while the rewrite would build a row per distinct pair
+query TT
+EXPLAIN SELECT g, count(*) AS records, min(DISTINCT v) AS distinct_min_v FROM t GROUP BY g;
+----
+logical_plan
+01)Projection: t.g, count(Int64(1)) AS count(*) AS records, min(DISTINCT t.v) AS distinct_min_v
+02)--Aggregate: groupBy=[[t.g]], aggr=[[count(Int64(1)), min(DISTINCT t.v)]]
+03)----TableScan: t projection=[g, v]
 
 # The gate covers only the count. A plan that already qualified through sum,
 # min or max is still rewritten over the same INT column
@@ -365,6 +390,15 @@ SELECT count(*) AS records, count(DISTINCT xi) AS distinct_xi FROM empty_t;
 ----
 0 0
 
+# gated: the count keeps a distinct aggregate that reports nothing unrewritten
+query III
+SELECT g, count(*) AS records, sum(DISTINCT v) AS distinct_v
+FROM t GROUP BY g ORDER BY g;
+----
+1 4 112
+2 2 3
+3 1 1
+
 statement ok
 set datafusion.optimizer.max_passes = 3;
 
@@ -399,6 +433,15 @@ query II
 SELECT count(*) AS records, count(DISTINCT xi) AS distinct_xi FROM empty_t;
 ----
 0 0
+
+# gated: the count keeps a distinct aggregate that reports nothing unrewritten
+query III
+SELECT g, count(*) AS records, sum(DISTINCT v) AS distinct_v
+FROM t GROUP BY g ORDER BY g;
+----
+1 4 112
+2 2 3
+3 1 1
 
 statement ok
 DROP TABLE failed;

--- a/datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt
+++ b/datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt
@@ -63,7 +63,7 @@ logical_plan
 03)----Aggregate: groupBy=[[t.g, t.x AS alias1]], aggr=[[count(Int64(1)) AS alias2]]
 04)------TableScan: t projection=[g, x]
 
-# The production shape: a count next to min, max, sum and the distinct count
+# A count next to min, max and sum, all beside the distinct count
 query TT
 EXPLAIN
 SELECT g, count(*) AS records, count(DISTINCT x) AS distinct_x,
@@ -318,14 +318,14 @@ ORDER BY count(*) DESC, g;
 1 4 2
 
 ########
-# The whole production shape, aggregating over a join
+# The same set of aggregates, over a join rather than a bare scan
 ########
 
 statement ok
-CREATE TABLE failed(x VARCHAR);
+CREATE TABLE join_t(x VARCHAR);
 
 statement ok
-INSERT INTO failed VALUES ('10'), ('30');
+INSERT INTO join_t VALUES ('10'), ('30');
 
 statement ok
 set datafusion.optimizer.max_passes = 0;
@@ -333,7 +333,7 @@ set datafusion.optimizer.max_passes = 0;
 query IIIIII
 SELECT t.g, count(*) AS records, count(DISTINCT t.x) AS distinct_x,
        min(t.v) AS min_v, max(t.v) AS max_v, sum(t.v) AS sum_v
-FROM t JOIN failed f ON t.x = f.x
+FROM t JOIN join_t f ON t.x = f.x
 GROUP BY t.g ORDER BY t.g;
 ----
 1 2 1 100 100 100
@@ -345,7 +345,7 @@ set datafusion.optimizer.max_passes = 3;
 query IIIIII
 SELECT t.g, count(*) AS records, count(DISTINCT t.x) AS distinct_x,
        min(t.v) AS min_v, max(t.v) AS max_v, sum(t.v) AS sum_v
-FROM t JOIN failed f ON t.x = f.x
+FROM t JOIN join_t f ON t.x = f.x
 GROUP BY t.g ORDER BY t.g;
 ----
 1 2 1 100 100 100
@@ -444,7 +444,7 @@ FROM t GROUP BY g ORDER BY g;
 3 1 1
 
 statement ok
-DROP TABLE failed;
+DROP TABLE join_t;
 
 statement ok
 DROP TABLE empty_t;

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -333,8 +333,13 @@ async fn simple_aggregate() -> Result<()> {
 
 #[tokio::test]
 async fn aggregate_distinct_with_having() -> Result<()> {
-    roundtrip("SELECT a, count(distinct b) FROM data GROUP BY a, c HAVING count(b) > 100")
-        .await
+    let ctx = create_context_without_single_distinct_to_group_by().await?;
+    roundtrip_with_ctx(
+        "SELECT a, count(distinct b) FROM data GROUP BY a, c HAVING count(b) > 100",
+        ctx,
+    )
+    .await?;
+    Ok(())
 }
 
 #[tokio::test]
@@ -2933,6 +2938,31 @@ async fn roundtrip_all_types(sql: &str) -> Result<()> {
 
 async fn create_context() -> Result<SessionContext> {
     create_context_with_dialect(None).await
+}
+
+/// [`create_context`] with `single_distinct_aggregation_to_group_by` removed from
+/// the optimizer.
+///
+/// That rule rewrites a single `AGG(DISTINCT x)` into a two phase group by whose
+/// inner aggregate aliases its grouping and measure expressions (`alias1`,
+/// `alias2`). Substrait carries no names for those expressions, so the consumer
+/// derives them from the expressions themselves and a rewritten plan does not
+/// round trip to an identical plan. That holds for every output of the rule, not
+/// only for the query under test.
+async fn create_context_without_single_distinct_to_group_by() -> Result<SessionContext> {
+    let ctx = create_context().await?;
+    let rules = ctx
+        .state()
+        .optimizer()
+        .rules
+        .iter()
+        .filter(|rule| rule.name() != "single_distinct_aggregation_to_group_by")
+        .cloned()
+        .collect();
+    let state = SessionStateBuilder::new_from_existing(ctx.state())
+        .with_optimizer_rules(rules)
+        .build();
+    Ok(SessionContext::new_with_state(state))
 }
 
 async fn create_context_with_dialect(dialect: Option<Dialect>) -> Result<SessionContext> {

--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -342,6 +342,60 @@ async fn aggregate_distinct_with_having() -> Result<()> {
     Ok(())
 }
 
+/// The query in [`aggregate_distinct_with_having`], through the default
+/// optimizer, where `single_distinct_aggregation_to_group_by` rewrites it into
+/// a two phase group by.
+///
+/// A rewritten plan does not round trip to an identical plan, so the identity
+/// test above turns the rule off. This one leaves it on and asserts what
+/// Substrait does carry: the output schema and the rows. The `HAVING` threshold
+/// is lowered from the identity test's so that there are rows to compare.
+#[tokio::test]
+async fn aggregate_distinct_with_having_rewritten() -> Result<()> {
+    let ctx = create_context().await?;
+    let plan = ctx
+        .sql("SELECT a, count(distinct b) FROM data GROUP BY a, c HAVING count(b) > 0")
+        .await?
+        .into_optimized_plan()?;
+
+    // The rule applied: the distinct argument is a grouping key of an inner
+    // aggregate, and the non-distinct `count` became a `sum` of its partial
+    // counts. Without this the test would keep passing over an unrewritten
+    // plan, which the identity test already covers.
+    assert_snapshot!(
+        plan,
+        @r"
+    Projection: data.a, count(alias1) AS count(DISTINCT data.b)
+      Filter: CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END > Int64(0)
+        Projection: data.a, count(alias1), sum(alias2)
+          Aggregate: groupBy=[[data.a, data.c]], aggr=[[count(alias1), sum(alias2)]]
+            Aggregate: groupBy=[[data.a, data.c, data.b AS alias1]], aggr=[[count(data.b) AS alias2]]
+              TableScan: data projection=[a, b, c]
+    "
+    );
+
+    let proto = to_substrait_plan(&plan, &ctx.state())?;
+    let plan2 = from_substrait_plan(&ctx.state(), &proto).await?;
+    let plan2 = ctx.state().optimize(&plan2)?;
+
+    assert_eq!(plan.schema(), plan2.schema());
+
+    let results = DataFrame::new(ctx.state(), plan2).collect().await?;
+    datafusion::assert_batches_sorted_eq!(
+        [
+            "+---+------------------------+",
+            "| a | count(DISTINCT data.b) |",
+            "+---+------------------------+",
+            "| 1 | 1                      |",
+            "| 3 | 1                      |",
+            "+---+------------------------+",
+        ],
+        &results
+    );
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn aggregate_multiple_keys() -> Result<()> {
     roundtrip("SELECT a, c, avg(b) FROM data GROUP BY a, c").await
@@ -2949,6 +3003,9 @@ async fn create_context() -> Result<SessionContext> {
 /// derives them from the expressions themselves and a rewritten plan does not
 /// round trip to an identical plan. That holds for every output of the rule, not
 /// only for the query under test.
+///
+/// What a rewritten plan does carry through Substrait is covered by
+/// [`aggregate_distinct_with_having_rewritten`], on the default context.
 async fn create_context_without_single_distinct_to_group_by() -> Result<SessionContext> {
     let ctx = create_context().await?;
     let rules = ctx


### PR DESCRIPTION
## Which issue does this PR close?

No existing issue. We found this while investigating an out-of-memory. Happy to file one if you want a changelog entry.

## Rationale for this change

### The query

```sql
SELECT g, count(*), count(DISTINCT x) FROM t GROUP BY g;
```

A grouped `count(DISTINCT <string>)` next to a plain `count(*)`. It is a very common shape, and on `main` it uses several times more memory than it needs to.

To reproduce, in `datafusion-cli`. This writes 4,000,000 rows in 500,000 groups, with 2,000,000 distinct `(g, x)` pairs:

```sql
COPY (
  SELECT
    value % 500000 AS g,
    'id-' || CAST(value % 2000000 AS VARCHAR) AS x
  FROM generate_series(1, 4000000)
) TO 'repro.parquet' STORED AS PARQUET;

CREATE EXTERNAL TABLE t STORED AS PARQUET LOCATION 'repro.parquet';

EXPLAIN FORMAT INDENT SELECT g, count(*), count(DISTINCT x) FROM t GROUP BY g;
```

### The plan today

```text
Projection: t.g, count(Int64(1)) AS count(*), count(DISTINCT t.x)
  Aggregate: groupBy=[[t.g]], aggr=[[count(Int64(1)), count(DISTINCT t.x)]]
    TableScan: t projection=[g, x]
```

A single `Aggregate` that computes the distinct count directly. `count(DISTINCT x)` has a specialized `GroupsAccumulator` for the integer types and for no others, so over a string it falls back to `GroupsAccumulatorAdapter`, which holds one boxed `Accumulator` — and therefore one hash table — **for every group**. At 500,000 groups that is 500,000 hash tables.

There is a second effect once there is more than one partition. This plan's partial aggregate sees every group in every partition, so those per-group accumulators are duplicated `target_partitions` times.

### What already exists

DataFusion has a rule for exactly this, `SingleDistinctToGroupBy`. It rewrites `AGG(DISTINCT x)` into a two phase group by: an inner aggregate that groups by `(group keys, x)`, so the distinct-ing is done by the hash table that group by already builds, and an outer aggregate over its output. One hash table instead of one per group, and it hash-partitions, so distinct values are split across partitions rather than replicated.

The rule accepts a non-distinct `sum`, `min` or `max` alongside the distinct aggregate. **It rejects a non-distinct `count`.** So a single `count(*)` is enough to keep the slow plan.

### The change

Allow that `count`.

`count` is the one supported companion whose outer phase must be a *different* function. The inner group by counts the rows of each `(group, distinct value)` partition; the outer phase adds those partial counts with `sum`, because a count over a group is the sum of the counts of any partition of that group.

### The plan after

```text
Projection: t.g, CASE WHEN sum(alias2) IS NOT NULL THEN sum(alias2) ELSE Int64(0) END AS count(*), count(alias1) AS count(DISTINCT t.x)
  Aggregate: groupBy=[[t.g]], aggr=[[sum(alias2), count(alias1)]]
    Aggregate: groupBy=[[t.g, t.x AS alias1]], aggr=[[count(Int64(1)) AS alias2]]
      TableScan: t projection=[g, x]
```

Results are identical. The `CASE` is the one place the two phases disagree: over an empty input the inner group by emits no rows, and `sum` of no rows is NULL where `count` is `0`. Restoring the `0` also preserves `count`'s non-nullability.

### When this is allowed

The rewrite is not free. Every other aggregate moves down into the inner group by, which holds a row per `(group, distinct value)` pair rather than per group, and keeps its state at that finer grain. What pays for that is taking the distinct aggregate off the adapter — so if the distinct aggregate was never on the adapter, there is nothing to buy and only the inner group by to pay for.

So the new `count` is gated on the distinct aggregate reporting that it has **no** specialized `GroupsAccumulator` for its argument types. ClickBench q22 is the real case: its `count(DISTINCT "UserID")` is over an `Int64`, which has one, so q22 keeps its current plan.

## What changes are included in this PR?

Five files. The rule, the gate it needs, and tests.

### The rule

`datafusion/optimizer/src/single_distinct_to_groupby.rs` accepts a non-distinct `count` as a companion, and gives it `sum` as its outer phase.

`count` and `sum` are resolved from the session function registry, as `replace_distinct_aggregate` already does for `first_value`. The rewrite fires only for that exact `count`, compared by identity rather than by name, so a session with its own `count`, or with no registry, keeps the previous behaviour.

`FILTER` and `ORDER BY` still block the rewrite.

### The gate

An optimizer rule has no `AccumulatorArgs` to call `AggregateUDFImpl::groups_accumulator_supported` with, and `datafusion-optimizer` cannot depend on `datafusion-functions-aggregate` to read `count`'s type list. `datafusion/optimizer/Cargo.toml` names the intended way out:

> If you want to add special handling for a specific function, use the methods on the `ScalarUDFImpl` or `AggregateUDFImpl` traits (or add a new method to those traits).

So this adds one trait method:

```rust
fn groups_accumulator_supported_for_types(
    &self,
    arg_types: &[DataType],
    is_distinct: bool,
) -> Option<bool> { None }
```

`Count` is the only implementor, and `Count::groups_accumulator_supported` now delegates to it, so there is one list of supported types rather than two that can drift.

The default `None` means *the implementation does not answer this question*. It is not a third answer: a caller must not read it as either `Some(true)` or `Some(false)`. This rule rewrites only on `Some(false)`, the one answer that positively reports a call on the adapter. Every aggregate except `count` answers `None` today and so keeps its current behaviour.

The gate covers only the `count` this PR adds. A plan that already qualifies through a non-distinct `sum`, `min` or `max` is rewritten as before, over any distinct argument type — see [Pre-existing regressions](#pre-existing-regressions-not-introduced-here).

### Tests

- `datafusion/sqllogictest/test_files/single_distinct_to_groupby.slt`, new.
- `datafusion/substrait/tests/cases/roundtrip_logical_plan.rs`: `aggregate_distinct_with_having` builds its session without this rule, so it keeps round tripping the plan shape it was written for; a companion test covers the rewritten plan's schema and results through Substrait. (The rule's aliases have no Substrait representation, so a rewritten plan does not round trip to an *identical* plan.)

**No existing snapshot in the repository changes.**

## What is the testing strategy for this PR?

`single_distinct_to_groupby.slt` asserts every result **twice** — once under `datafusion.optimizer.max_passes = 0` and once under the default — with identical expected blocks. A null-handling or type error therefore shows up as a result mismatch, not only as a plan difference.

The table carries the same values in a `VARCHAR` column and an `INT` column, which are the two sides of the gate, and the file asserts both: the `VARCHAR` distinct rewrites with a `count` beside it, the `INT` distinct does not, and the `INT` distinct still rewrites when it qualifies through `sum`.

It also asserts that an aggregate answering `None` stays unrewritten (`sum(DISTINCT v)` and `min(DISTINCT v)` beside a `count(*)` keep the plan they have on `main`).

Remaining coverage: `count(*)` vs `count(1)` vs `count(col)`, grouped and ungrouped; a group whose distinct column is entirely NULL; NULLs in both the distinct and the summed column; empty input in three shapes; `HAVING` with `ORDER BY` on the rewritten count; and the same aggregates over a join.

The rule's unit tests cover both sides of the gate directly, and the `None` answer twice — once with `sum(DISTINCT b)`, once with a test aggregate that leaves the new method at its default.

Run locally on the rebased head, all passing: `datafusion-optimizer`, `datafusion-expr` and `datafusion-functions-aggregate` lib and integration tests, the substrait roundtrip suite, and the whole sqllogictest suite at 511 of 511 files.

## Benchmarks

### Macro: ClickBench

`clickbench_extended` q14 is the one query in any suite with this shape — a lone `COUNT(DISTINCT <string>)` next to a non-distinct `COUNT(*)`, grouped by a high cardinality string. It landed on `main` in #25026. Three runs of this branch against merge base `16ace4f`, `DATAFUSION_RUNTIME_MEMORY_LIMIT: 16G` ([trigger](https://github.com/apache/datafusion/pull/24859#issuecomment-5573802227)):

| run | q14 fastest | q14 median of 5 | q14 peak pool |
| --- | --- | --- | --- |
| 1 | 2471 ms → 546 ms, **4.53x** | 4.05x | 4.4 GiB → 1.3 GiB, **-70.5%** |
| 2 | 2534 ms → 575 ms, **4.40x** | 4.15x | 4.4 GiB → 1.3 GiB, **-69.7%** |
| 3 | 3909 ms → 1165 ms, **3.36x** | 3.39x | 4.4 GiB → 1.3 GiB, **-70.3%** |

100,000,000 rows of real ClickBench data. The memory figure reproduces to a tenth of a percent across the three runs.

The limit is 16G because the base side peaks at 4.4 GiB; at 4G the baseline OOMs and there is nothing to compare.

Run 3 was on a contended machine — its suite total is 42.1 s against 30.8 s and 31.0 s — and it reports q0 at 1.30x slower, q7 at 1.14x and q8 at 1.13x. None of those three can change plan here (q0 has three distinct arguments; q7 and q8 have no distinct aggregate at all), so they are an in-experiment control that says what that run's noise floor was.

#### The standard suite, and q22

`q22` is the only query in the standard suite that reaches the new gate, and the gate excludes it. A `clickbench_partitioned` run ([trigger](https://github.com/apache/datafusion/pull/24859#issuecomment-5585614783), `DATAFUSION_RUNTIME_MEMORY_LIMIT: 4G`):

| | base `16ace4f` | this branch | |
| --- | --- | --- | --- |
| q22 wall clock | 975.75 ms | 976.75 ms | no change |
| q22 peak pool | 2.5 MiB | 3.0 MiB | +22.0% |
| suite total | 25985 ms | 26073 ms | +0.3% |
| queries changed | — | — | **0 of 43** |

The `+22.0%` is measurement noise on a 2.5 MiB reservation, not an effect of this PR. Three things say so:

1. **The plan is unchanged.** `EXPLAIN` on q22's exact shape against this branch produces a single `Aggregate` — the rule does not fire, because `COUNT(DISTINCT "UserID")` is over an `Int64`, which has a specialized `GroupsAccumulator`:
   ```text
   Sort: c DESC NULLS FIRST, fetch=10
     Projection: hits.SearchPhrase, min(hits.URL), min(hits.Title), count(Int64(1)) AS count(*) AS c, count(DISTINCT hits.UserID)
       Aggregate: groupBy=[[hits.SearchPhrase]], aggr=[[min(hits.URL), min(hits.Title), count(Int64(1)), count(DISTINCT hits.UserID)]]
         Filter: ...
           TableScan: hits projection=[SearchPhrase, URL, Title, UserID]
   ```
2. **The wall clock is flat** at 0.1%.
3. **The run's memory noise floor is wider than the reading.** 9 of the 43 queries move by more than 5% in both directions, including q23 at **-26.1%** and q7 at **-19.7%** — neither of which can change plan under this rule.

**No other query changes plan, and that set is empty by construction, not by measurement.** The rule needs exactly one distinct argument and accepts only `sum`, `min`, `max` and now `count` as companions:

| query | why it cannot move |
| --- | --- |
| `extended` q0, q1, q2 | three, three and four distinct arguments, so `fields_set.len() != 1` |
| q4, q5, q8, q10, q11, q13 | a lone distinct aggregate with no non-distinct companion, so `main` already rewrites them |
| q9 | carries an `AVG`, which the rule has never accepted |
| q22 | the only standard query that reaches the new gate, and its `COUNT(DISTINCT "UserID")` is over an `Int64`, which has a specialized `GroupsAccumulator` |

### Micro: the reproduction above, swept

Base is `e1ca94fb11`, 12 commits behind the `16ace4f` merge base used for the ClickBench runs above; both are from the same day, and none of the 12 changes aggregate runtime behaviour (the only one touching `count_distinct` is #25020, which is test-gating only). Both sides are release builds of the same harness: a `GreedyMemoryPool` of 64 GiB (never reached) wrapped in the in-tree `PeakRecordingPool`; one parquet file; the result streamed rather than collected; the pool high-water mark and `getrusage` peak RSS reported. Every figure is the median of three runs. At `target_partitions = 1` the three runs agreed to the byte in every cell; at 8, to within 1%, except two branch cells at 7% and 19%.

Every shape is 4,000,000 rows, query `SELECT g, count(*), count(DISTINCT x) FROM t GROUP BY g`. Each file carries the distinct argument three times — as `Utf8`, `Utf8View` and `BIGINT` — written with an explicit `arrow_cast` so the type is the file's and not a reader setting.

**`target_partitions = 8`**

| groups | distinct values | argument | peak pool | peak RSS | wall clock |
| --- | --- | --- | --- | --- | --- |
| 500,000 | 2,000,000 | `Utf8` | 2.16x better | 2.56x better | 999 ms → 48 ms |
| 500,000 | 2,000,000 | `Utf8View` | 2.68x better | 2.76x better | 1036 ms → 40 ms |
| 500,000 | 1,000,000 | `Utf8` | 2.83x better | 3.40x better | 1020 ms → 41 ms |
| 500,000 | 1,000,000 | `Utf8View` | 3.15x better | 3.43x better | 966 ms → 34 ms |
| 10 | 2,000,000 | `Utf8` | 1.34x better | 1.85x better | 80 ms → 41 ms |
| 10 | 2,000,000 | `Utf8View` | 1.87x better | 2.24x better | 73 ms → 33 ms |
| 1 | 2,000,000 | `Utf8` | 1.55x better | 2.14x better | 202 ms → 45 ms |
| 1 | 2,000,000 | `Utf8View` | 1.88x better | 2.51x better | 158 ms → 34 ms |
| 2,000 | 4,000,000 | `Utf8` | **1.30x worse** | 2.03x better | 180 ms → 43 ms |
| 2,000 | 4,000,000 | `Utf8View` | **1.10x worse** | 2.55x better | 185 ms → 38 ms |
| 500,000 | 2,000,000 | `BIGINT` | 1.00x, plan unchanged | 1.01x | 43 ms → 43 ms |

**`target_partitions = 1`**

| groups | distinct values | argument | peak pool | peak RSS | wall clock |
| --- | --- | --- | --- | --- | --- |
| 500,000 | 2,000,000 | `Utf8` | 2.18x better | 1.77x better | 712 ms → 193 ms |
| 500,000 | 2,000,000 | `Utf8View` | 2.70x better | 2.05x better | 684 ms → 178 ms |
| 500,000 | 1,000,000 | `Utf8` | 3.31x better | 1.93x better | 626 ms → 160 ms |
| 500,000 | 1,000,000 | `Utf8View` | 4.42x better | 2.34x better | 599 ms → 138 ms |
| 500,000 | 4,000,000 | `Utf8` | 1.61x better | 1.70x better | 825 ms → 242 ms |
| 500,000 | 4,000,000 | `Utf8View` | 1.96x better | 2.17x better | 755 ms → 232 ms |
| 2,000 | 2,000,000 | `Utf8` | 1.01x better | 1.41x better | 402 ms → 161 ms |
| 2,000 | 2,000,000 | `Utf8View` | 1.26x better | 1.49x better | 358 ms → 139 ms |
| 2,000 | 4,000,000 | `Utf8` | 1.01x better | 1.17x better | 429 ms → 203 ms |
| 2,000 | 4,000,000 | `Utf8View` | 1.26x better | 1.36x better | 407 ms → 176 ms |

Three things worth calling out:

- **Wall clock was not the point of this PR and is the largest effect.** At 8 partitions and 500,000 groups the query goes from about a second to about 40 ms. That is the accumulator-per-group construction cost, which grows with partitions on the unrewritten side while the rewritten side parallelizes.
- **Peak RSS improves in every measured shape**, including the two where the pool peak regresses. The unrewritten plan's RSS sits far above what it reserves; millions of small independent hash tables fragment in a way one large table does not.
- **The `BIGINT` row is the control for the gate.** The plan is identical on both sides, and so is every measurement. This is the q22 case, measured directly.

### Where the rewrite stops paying

The crossover is in the *density* of distinct values, not the group count. It arrives only when nearly every row holds a distinct value, and the loss is bounded: 1.30x more peak pool for `Utf8` and 1.10x for `Utf8View`, at 2,000 groups over 4,000,000 fully distinct values at 8 partitions, and a wash at one partition. Those same two cells use about half the RSS and run four times faster.

At 500,000 groups over 4,000,000 fully distinct values — the same density — the rewrite is 1.61x to 1.96x better again, because the unrewritten side now also pays for 500,000 accumulators.

### The gate is a proxy

The gate asks which accumulator the distinct aggregate gets. That is not the true discriminator.

What decides the outcome is the cost per distinct value on each side. The rewrite materializes one hash table row per distinct `(group keys, x)` pair, plus one accumulator slot per companion aggregate at that grain. It wins when the unrewritten accumulator costs more than that per value, and loses when it costs less.

Proxy and discriminator agree for `count(DISTINCT x)`, which is the only case this PR opens. They disagree elsewhere.

#### Pre-existing regressions, not introduced here

Re-measured on the same base, over 4,000,000 rows in 2,000 groups with 2,000,000 distinct values, comparing the rewritten plan against the same query with a `count(*)` added to hold the rule off:

- `sum(DISTINCT int_col)` and `avg(DISTINCT int_col)` have no distinct groups accumulator, and `main` rewrites both today. Both regress: **2.67x** more peak pool at one partition, 1.79x at eight.
- `min(DISTINCT x)` is far worse. It is the same value as `min(x)`, and `min_max` correctly ignores `is_distinct`, so the unrewritten plan holds one scalar per group while the rewrite builds a hash table over every distinct pair: **543x** more peak pool at one partition, 126x at eight.

That regression predates this PR and this PR does not extend it — the gate keeps every one of those functions out of the path added here. Reported upstream separately. A cost model is out of scope.

## Are there any user-facing changes?

No public API break and no change to query results. `AggregateUDFImpl` gains one method with a default, which is not breaking for implementors.

Plans for `SELECT ..., count(...), count(DISTINCT x) ... GROUP BY ...` change shape when `x` has no specialized `GroupsAccumulator`. `EXPLAIN` output for that shape therefore differs, and such queries should use less memory and run faster.
