### PR TITLE
minor: reenable failing mark join test

### DIFF
--- a/datafusion/sqllogictest/test_files/mark_join_matrix.slt
+++ b/datafusion/sqllogictest/test_files/mark_join_matrix.slt
@@ -118,13 +118,12 @@ WHERE l.v > 35 OR l.k NOT IN (SELECT r.k FROM mk_r_nn r);
 4 40
 NULL 50
 
-# https://github.com/apache/datafusion/issues/24854
-# query II rowsort
-# SELECT l.k, l.v FROM mk_l l
-# WHERE l.v > 35 OR l.k NOT IN (SELECT r.k FROM mk_r r);
-# ----
-# 4 40
-# NULL 50
+query II rowsort
+SELECT l.k, l.v FROM mk_l l
+WHERE l.v > 35 OR l.k NOT IN (SELECT r.k FROM mk_r r);
+----
+4 40
+NULL 50
 
 # Empty subquery: EXISTS is always false, so the result is just the predicate.
 query II rowsort


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Related #24854 .

## Rationale for this change

Reenable test for slt join matrix test, after #21585 merged

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## What is the testing strategy for this PR?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

Briefly describe how this PR is tested, and point to the specific tests you added. For example: 'This new feature is covered by the `sqllogictest` cases added in `foo.slt`'.

If this PR does not add tests, explain why. For example, if the change is already covered by existing tests, please mention it.

You should also check the `codecov` bot reply on this PR to confirm the changed code is exercised.
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
