### PR TITLE
fix: propagate field metadata through coalesce, nvl, and nvl2

### DIFF
--- a/datafusion/functions/src/core/coalesce.rs
+++ b/datafusion/functions/src/core/coalesce.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::utils::unanimous_metadata;
 use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::{Result, exec_err, internal_err, plan_err};
 use datafusion_expr::binary::try_type_union_resolution;
@@ -86,7 +87,12 @@ impl ScalarUDFImpl for CoalesceFunc {
             .find_or_first(|d| !d.is_null())
             .unwrap()
             .clone();
-        Ok(Field::new(self.name(), return_type, nullable).into())
+        // Propagate field metadata (e.g. Arrow extension types) only when the
+        // arguments that can supply a value agree on it.
+        let metadata = unanimous_metadata(args.arg_fields.iter().map(|f| f.as_ref()));
+        Ok(Field::new(self.name(), return_type, nullable)
+            .with_metadata(metadata)
+            .into())
     }
 
     fn simplify(
@@ -144,5 +150,99 @@ impl ScalarUDFImpl for CoalesceFunc {
 
     fn documentation(&self) -> Option<&Documentation> {
         self.doc()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const EXTENSION_KEY: &str = "ARROW:extension:name";
+
+    fn field(name: &str, dt: DataType, nullable: bool) -> FieldRef {
+        Arc::new(Field::new(name, dt, nullable))
+    }
+
+    fn ext_field(name: &str, dt: DataType, extension_name: &str) -> FieldRef {
+        Arc::new(Field::new(name, dt, true).with_metadata(HashMap::from([(
+            EXTENSION_KEY.to_string(),
+            extension_name.to_string(),
+        )])))
+    }
+
+    fn return_field(arg_fields: &[FieldRef]) -> FieldRef {
+        let scalars = vec![None; arg_fields.len()];
+        CoalesceFunc::new()
+            .return_field_from_args(ReturnFieldArgs {
+                arg_fields,
+                scalar_arguments: &scalars,
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn propagates_metadata_when_arguments_agree() {
+        let ret = return_field(&[
+            ext_field("a", DataType::Binary, "geoarrow.wkb"),
+            ext_field("b", DataType::Binary, "geoarrow.wkb"),
+        ]);
+        assert_eq!(ret.data_type(), &DataType::Binary);
+        assert!(ret.is_nullable());
+        assert_eq!(
+            ret.metadata().get(EXTENSION_KEY).map(String::as_str),
+            Some("geoarrow.wkb")
+        );
+    }
+
+    #[test]
+    fn null_literal_argument_does_not_block_metadata() {
+        // An untyped NULL argument carries no metadata but cannot contribute
+        // a typed value either, so it does not participate in the agreement.
+        let ret = return_field(&[
+            field("null", DataType::Null, true),
+            ext_field("b", DataType::Binary, "geoarrow.wkb"),
+        ]);
+        assert_eq!(ret.data_type(), &DataType::Binary);
+        assert_eq!(
+            ret.metadata().get(EXTENSION_KEY).map(String::as_str),
+            Some("geoarrow.wkb")
+        );
+    }
+
+    #[test]
+    fn drops_metadata_when_arguments_disagree() {
+        let ret = return_field(&[
+            ext_field("a", DataType::Binary, "geoarrow.wkb"),
+            field("plain", DataType::Binary, true),
+        ]);
+        assert_eq!(ret.data_type(), &DataType::Binary);
+        assert!(ret.metadata().is_empty());
+    }
+
+    #[test]
+    fn no_metadata_when_all_arguments_are_null() {
+        let ret = return_field(&[
+            field("a", DataType::Null, true),
+            field("b", DataType::Null, true),
+        ]);
+        assert_eq!(ret.data_type(), &DataType::Null);
+        assert!(ret.metadata().is_empty());
+    }
+
+    #[test]
+    fn nullability_is_unchanged_by_metadata_propagation() {
+        let ret = return_field(&[
+            ext_field("a", DataType::Binary, "geoarrow.wkb"),
+            Arc::new(Field::new("b", DataType::Binary, false).with_metadata(
+                HashMap::from([(EXTENSION_KEY.to_string(), "geoarrow.wkb".to_string())]),
+            )),
+        ]);
+        assert!(!ret.is_nullable());
+        assert_eq!(
+            ret.metadata().get(EXTENSION_KEY).map(String::as_str),
+            Some("geoarrow.wkb")
+        );
     }
 }

--- a/datafusion/functions/src/core/nvl2.rs
+++ b/datafusion/functions/src/core/nvl2.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::utils::unanimous_metadata;
 use arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::{Result, internal_err, utils::take_function_args};
 use datafusion_expr::{
@@ -94,7 +95,15 @@ impl ScalarUDFImpl for NVL2Func {
         let nullable =
             args.arg_fields[1].is_nullable() || args.arg_fields[2].is_nullable();
         let return_type = args.arg_fields[1].data_type().clone();
-        Ok(Field::new(self.name(), return_type, nullable).into())
+        // The result value comes from the second or third argument; propagate
+        // field metadata (e.g. Arrow extension types) only when they agree on
+        // it. The first argument is only tested for NULL and does not
+        // contribute a value.
+        let metadata =
+            unanimous_metadata(args.arg_fields[1..3].iter().map(|f| f.as_ref()));
+        Ok(Field::new(self.name(), return_type, nullable)
+            .with_metadata(metadata)
+            .into())
     }
 
     fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -143,5 +152,58 @@ impl ScalarUDFImpl for NVL2Func {
 
     fn documentation(&self) -> Option<&Documentation> {
         self.doc()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const EXTENSION_KEY: &str = "ARROW:extension:name";
+
+    fn ext_field(name: &str, dt: DataType, extension_name: &str) -> FieldRef {
+        Arc::new(Field::new(name, dt, true).with_metadata(HashMap::from([(
+            EXTENSION_KEY.to_string(),
+            extension_name.to_string(),
+        )])))
+    }
+
+    fn return_field(arg_fields: &[FieldRef]) -> FieldRef {
+        let scalars = vec![None; arg_fields.len()];
+        NVL2Func::new()
+            .return_field_from_args(ReturnFieldArgs {
+                arg_fields,
+                scalar_arguments: &scalars,
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn propagates_metadata_from_value_arguments() {
+        // The first argument is only tested for NULL; its metadata must not
+        // leak into the result even when the value arguments agree.
+        let ret = return_field(&[
+            ext_field("test", DataType::Binary, "unrelated.type"),
+            ext_field("if_non_null", DataType::Binary, "geoarrow.wkb"),
+            ext_field("if_null", DataType::Binary, "geoarrow.wkb"),
+        ]);
+        assert_eq!(ret.data_type(), &DataType::Binary);
+        assert_eq!(
+            ret.metadata().get(EXTENSION_KEY).map(String::as_str),
+            Some("geoarrow.wkb")
+        );
+    }
+
+    #[test]
+    fn drops_metadata_when_value_arguments_disagree() {
+        let ret = return_field(&[
+            Arc::new(Field::new("test", DataType::Boolean, true)),
+            ext_field("if_non_null", DataType::Binary, "geoarrow.wkb"),
+            Arc::new(Field::new("if_null", DataType::Binary, true)),
+        ]);
+        assert_eq!(ret.data_type(), &DataType::Binary);
+        assert!(ret.metadata().is_empty());
     }
 }

--- a/datafusion/functions/src/utils.rs
+++ b/datafusion/functions/src/utils.rs
@@ -17,12 +17,13 @@
 
 use arrow::array::{Array, ArrayRef, ArrowPrimitiveType, AsArray, PrimitiveArray};
 use arrow::compute::try_binary;
-use arrow::datatypes::{DataType, DecimalType};
+use arrow::datatypes::{DataType, DecimalType, Field};
 use arrow::error::ArrowError;
 use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::ColumnarValue;
 use datafusion_expr::function::Hint;
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Creates a function to identify the optimal return type of a string function given
@@ -67,6 +68,26 @@ macro_rules! get_optimal_return_type {
             })
         }
     };
+}
+
+/// Returns the field metadata shared by every argument that can contribute a
+/// value to a conditional function's result.
+///
+/// Fields with a `Null` data type (untyped NULL literals) carry no metadata
+/// and are ignored. If the remaining fields disagree on metadata, the result
+/// carries none: propagating one argument's metadata (e.g. an Arrow extension
+/// type name) would claim a type identity for values that other arguments may
+/// supply without it.
+pub(crate) fn unanimous_metadata<'a>(
+    fields: impl Iterator<Item = &'a Field>,
+) -> HashMap<String, String> {
+    let mut candidates = fields.filter(|f| !f.data_type().is_null());
+    match candidates.next() {
+        Some(first) if candidates.all(|f| f.metadata() == first.metadata()) => {
+            first.metadata().clone()
+        }
+        _ => HashMap::new(),
+    }
 }
 
 // `utf8_to_str_type`: returns either a Utf8 or LargeUtf8 based on the input type size.


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #24860.

## Rationale for this change

`COALESCE`, `NVL`/`IFNULL`, and `NVL2` drop the field metadata of their arguments when computing their return field: `return_field_from_args` builds the output `Field` from the argument *data types* only. For columns carrying Arrow extension types (`ARROW:extension:name` / `ARROW:extension:metadata` — e.g. `arrow.uuid`, `geoarrow.wkb`), the planned schema of any expression containing these functions silently loses the extension-type identity, and metadata-aware UDFs that dispatch on their argument `Field`s fail to plan over them (see #24860 for a full reproducer).

This is one of several independent metadata drop sites listed in #24860. It is the plan-time schema fix for the conditional functions; it does not by itself change execution-time behavior, because these functions simplify into `CASE`, which has its own drop sites (also #24860) that I intend to address in follow-up PRs.

## What changes are included in this PR?

- A small `unanimous_metadata` helper in `datafusion/functions/src/utils.rs`: returns the metadata shared by every argument field that can contribute a value to the result. Fields with a `Null` data type (untyped NULL literals) are ignored; if the remaining fields disagree, the result carries no metadata rather than claiming a type identity that only some inputs have.
- `coalesce`: `return_field_from_args` now attaches the unanimous metadata of its arguments. Return type and nullability computation are unchanged. `NVL`/`IFNULL` delegate to `coalesce` and are fixed by the same change.
- `nvl2`: same, over the second and third arguments only — the first argument is only tested for NULL and never contributes a value, so its metadata is excluded.

## What is the testing strategy for this PR?

Unit tests in `coalesce.rs` and `nvl2.rs` directly exercise `return_field_from_args`: metadata propagated when the value arguments agree, dropped when they disagree, untyped NULL arguments not blocking propagation, NVL2's test argument excluded, and nullability unchanged.

There is deliberately no sqllogictest: `arrow_metadata()` reads its argument field at execution time, and at execution these functions have been simplified into `CASE`, whose own metadata drops (#24860) still lose the metadata en route. End-to-end SLT coverage lands with the `CASE` fix. (This ordering is safe: the optimizer's schema invariant intentionally ignores metadata — `assert_expected_schema` / `logically_equivalent_names_and_types` — so a plan whose `coalesce` carries metadata that the simplified `CASE` does not does not error; it just degrades to today's behavior until the `CASE` fix lands.)

## Are there any user-facing changes?

The planned schema (e.g. `DataFrame::schema()`) of expressions containing `COALESCE`/`NVL`/`IFNULL`/`NVL2` over metadata-bearing columns now preserves that metadata. No API changes.

---

cc @paleolimbot — this is the first slice of #24860, in the same family as your #22112; you'd mentioned on #21984 you could help shepherd this class of metadata fixes. This is my first DataFusion PR, so CI will need a committer to trigger it.
