### PR TITLE
docs: fix three dead links to datafusion.apache.org

### DIFF
--- a/docs/source/contributor-guide/gsoc/gsoc_project_ideas_2025.md
+++ b/docs/source/contributor-guide/gsoc/gsoc_project_ideas_2025.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Welcome to the Apache DataFusion Google Summer of Code (GSoC) 2025 project ideas list. Below you can find information about the projects. Please refer to [this page](https://datafusion.apache.org/contributor-guide/gsoc_application_guidelines.html) for application guidelines.
+Welcome to the Apache DataFusion Google Summer of Code (GSoC) 2025 project ideas list. Below you can find information about the projects. Please refer to [this page](https://datafusion.apache.org/contributor-guide/gsoc/gsoc_application_guidelines_2025.html) for application guidelines.
 
 ## Projects
 

--- a/docs/source/user-guide/concepts-readings-events.md
+++ b/docs/source/user-guide/concepts-readings-events.md
@@ -53,13 +53,13 @@ This is a list of DataFusion related blog posts, articles, and other resources. 
 
 - **2026-03-31** [Blog: Writing Custom Table Providers in Apache DataFusion](https://datafusion.apache.org/blog/2026/03/31/writing-table-providers/)
 
-- **2026-03-20** [Blog: Turning LIMIT into an I/O Optimization: Inside DataFusion’s Multi-Layer Pruning Stack](https://datafusion.apache.org/blog/2026/03/20/multi-layer-pruning/)
+- **2026-03-20** [Blog: Turning LIMIT into an I/O Optimization: Inside DataFusion’s Multi-Layer Pruning Stack](https://datafusion.apache.org/blog/2026/03/20/limit-pruning/)
 
 - **2026-02-23** [Blog: Apache DataFusion: A Data Engineer's Guide to the Query Engine Reshaping How We Build Data Systems](https://andrewmadson.substack.com/p/apache-datafusion-a-data-engineers)
 
 - **2026-02-09** [Blog: Vector search using only Parquet and DataFusion](https://blog.xiangpeng.systems/posts/vector-search-with-parquet-datafusion/)
 
-- **2026-02-02** [Blog: Optimizing SQL CASE Expression Evaluation](https://datafusion.apache.org/blog/2026/02/02/case-expression/)
+- **2026-02-02** [Blog: Optimizing SQL CASE Expression Evaluation](https://datafusion.apache.org/blog/2026/02/02/datafusion_case/)
 
 - **2026-01-12** [Blog: Extending SQL in DataFusion: from ->> to TABLESAMPLE](https://datafusion.apache.org/blog/2026/01/12/extending-sql)
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24871.

## Rationale for this change

Three links in the docs point at pages on our own site that return 404, so a reader following them from the readings list or the GSoC project ideas page lands on an error.

## What changes are included in this PR?

- `concepts-readings-events.md`: `blog/2026/03/20/multi-layer-pruning/` becomes `blog/2026/03/20/limit-pruning/`, and `blog/2026/02/02/case-expression/` becomes `blog/2026/02/02/datafusion_case/`. Those are the slugs the two posts were actually published under.
- `gsoc/gsoc_project_ideas_2025.md`: `contributor-guide/gsoc_application_guidelines.html` becomes `contributor-guide/gsoc/gsoc_application_guidelines_2025.html`, matching the file the GSoC `index.rst` toctree includes.

## What is the testing strategy for this PR?

No tests; this is three URL strings in markdown. Each old URL was requested and returns 404, each new one returns 200.

## Are there any user-facing changes?

Docs only. Three links that were broken now resolve.

Disclosure: this was written with AI assistance (Claude, via Claude Code). I verified every URL by request rather than inferring it, and the issue lists the three further dead links I deliberately did not touch because the right replacement is your call.