### PR TITLE
chore: update chacha20 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,9 +1244,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
This is a *very* minor update to the Cargo.lock file to resolve a warning when running `cargo audit` as in our CI suite. v0.10.0 was yanked from crates.io so this bumps to 0.10.2.
