### PR TITLE
fix(physical-plan): CoalescePartitionsExec panic on wasm32-unknown-unknown

### DIFF
--- a/datafusion/physical-plan/src/coalesce_partitions.rs
+++ b/datafusion/physical-plan/src/coalesce_partitions.rs
@@ -21,9 +21,9 @@
 use std::sync::Arc;
 
 use super::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
-use super::stream::{
-    ObservedStream, RecordBatchReceiverStream, RecordBatchStreamAdapter,
-};
+#[cfg(target_arch = "wasm32")]
+use super::stream::RecordBatchStreamAdapter;
+use super::stream::{ObservedStream, RecordBatchReceiverStream};
 use super::{
     DisplayAs, ExecutionPlanProperties, PlanProperties, SendableRecordBatchStream,
     Statistics,
@@ -40,7 +40,6 @@ use crate::{
     ReplaceChildrenOptions, validate_child_count,
 };
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
-use futures::stream::{StreamExt, TryStreamExt};
 
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
@@ -233,21 +232,20 @@ impl ExecutionPlan for CoalescePartitionsExec {
             _ => {
                 let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
 
-                // Single-threaded path: drain sequentially to avoid
-                // `JoinSet::spawn`, which needs a tokio reactor and panics
-                // on wasm32-unknown-unknown.
-                if context.session_config().target_partitions() == 1 {
-                    // mirror the slow path so elapsed_compute isn't 0 here
+                // wasm has no tokio reactor, so avoid `JoinSet::spawn`; poll
+                // input partitions cooperatively via `select_all` instead.
+                #[cfg(target_arch = "wasm32")]
+                {
                     let elapsed_compute = baseline_metrics.elapsed_compute().clone();
                     let _timer = elapsed_compute.timer();
 
-                    let input = Arc::clone(&self.input);
-                    let ctx = Arc::clone(&context);
-                    let stream = futures::stream::iter(0..input_partitions)
-                        .map(move |i| input.execute(i, Arc::clone(&ctx)))
-                        .try_flatten();
+                    let mut streams = Vec::with_capacity(input_partitions);
+                    for i in 0..input_partitions {
+                        streams.push(self.input.execute(i, Arc::clone(&context))?);
+                    }
+                    let merged = futures::stream::select_all(streams);
                     return Ok(Box::pin(ObservedStream::new(
-                        Box::pin(RecordBatchStreamAdapter::new(self.schema(), stream)),
+                        Box::pin(RecordBatchStreamAdapter::new(self.schema(), merged)),
                         baseline_metrics,
                         self.fetch,
                     )));

--- a/datafusion/physical-plan/src/coalesce_partitions.rs
+++ b/datafusion/physical-plan/src/coalesce_partitions.rs
@@ -21,7 +21,9 @@
 use std::sync::Arc;
 
 use super::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
-use super::stream::{ObservedStream, RecordBatchReceiverStream};
+use super::stream::{
+    ObservedStream, RecordBatchReceiverStream, RecordBatchStreamAdapter,
+};
 use super::{
     DisplayAs, ExecutionPlanProperties, PlanProperties, SendableRecordBatchStream,
     Statistics,
@@ -38,6 +40,7 @@ use crate::{
     ReplaceChildrenOptions, validate_child_count,
 };
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
+use futures::stream::{StreamExt, TryStreamExt};
 
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::TreeNodeRecursion;
@@ -229,6 +232,27 @@ impl ExecutionPlan for CoalescePartitionsExec {
             }
             _ => {
                 let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+
+                // Single-threaded path: drain sequentially to avoid
+                // `JoinSet::spawn`, which needs a tokio reactor and panics
+                // on wasm32-unknown-unknown.
+                if context.session_config().target_partitions() == 1 {
+                    // mirror the slow path so elapsed_compute isn't 0 here
+                    let elapsed_compute = baseline_metrics.elapsed_compute().clone();
+                    let _timer = elapsed_compute.timer();
+
+                    let input = Arc::clone(&self.input);
+                    let ctx = Arc::clone(&context);
+                    let stream = futures::stream::iter(0..input_partitions)
+                        .map(move |i| input.execute(i, Arc::clone(&ctx)))
+                        .try_flatten();
+                    return Ok(Box::pin(ObservedStream::new(
+                        Box::pin(RecordBatchStreamAdapter::new(self.schema(), stream)),
+                        baseline_metrics,
+                        self.fetch,
+                    )));
+                }
+
                 // record the (very) minimal work done so that
                 // elapsed_compute is not reported as 0
                 let elapsed_compute = baseline_metrics.elapsed_compute().clone();

--- a/datafusion/wasmtest/src/lib.rs
+++ b/datafusion/wasmtest/src/lib.rs
@@ -235,6 +235,29 @@ mod test {
     }
 
     #[wasm_bindgen_test(unsupported = tokio::test)]
+    async fn test_union_all() {
+        // Regression: UNION ALL used to panic on wasm via `JoinSet::spawn`.
+        let ctx = get_ctx();
+        let result = ctx
+            .sql("SELECT 1 AS n UNION ALL SELECT 2 AS n")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            batches_to_string(&result),
+            "+---+\n\
+             | n |\n\
+             +---+\n\
+             | 1 |\n\
+             | 2 |\n\
+             +---+"
+        );
+    }
+
+    #[wasm_bindgen_test(unsupported = tokio::test)]
     async fn test_parquet_write() {
         let (schema, batch) = create_test_data();
         let mut buffer = Vec::new();

--- a/datafusion/wasmtest/src/lib.rs
+++ b/datafusion/wasmtest/src/lib.rs
@@ -90,7 +90,9 @@ mod test {
         execution::context::SessionContext,
         prelude::CsvReadOptions,
     };
-    use datafusion_common::{DataFusionError, test_util::batches_to_string};
+    use datafusion_common::{
+        DataFusionError, assert_batches_sorted_eq, test_util::batches_to_string,
+    };
     use datafusion_execution::{
         config::SessionConfig,
         disk_manager::{DiskManagerBuilder, DiskManagerMode},
@@ -246,15 +248,10 @@ mod test {
             .await
             .unwrap();
 
-        assert_eq!(
-            batches_to_string(&result),
-            "+---+\n\
-             | n |\n\
-             +---+\n\
-             | 1 |\n\
-             | 2 |\n\
-             +---+"
-        );
+        // CoalescePartitionsExec makes no output-order guarantee; sort
+        // before comparing so the assertion tolerates any valid interleaving.
+        let expected = ["+---+", "| n |", "+---+", "| 1 |", "| 2 |", "+---+"];
+        assert_batches_sorted_eq!(expected, &result);
     }
 
     #[wasm_bindgen_test(unsupported = tokio::test)]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24886.

## Rationale for this change

Multi-partition queries panic on `wasm32-unknown-unknown` when they go through `CoalescePartitionsExec`. The most common case is `UNION ALL`, but any plan with more than one partition feeding the operator hits it (e.g. a multi-file external table scan). The operator spawns a task per input partition via `JoinSet::spawn`, which needs a tokio reactor that isn't available under `wasm-bindgen-futures`:

```
panicked at datafusion/common-runtime/src/join_set.rs:69:20:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

This is a follow-up to #24275, which fixed the same class of panic in `collect_partitioned`.

## What is the testing strategy for this PR?

- On `wasm32` builds, `CoalescePartitionsExec::execute` no longer spawns tasks. It polls all input partitions together with `futures::stream::select_all` and merges their output into a single stream.
- Native builds keep the existing spawn-based path unchanged.

## Are these changes tested?

- Adds a `test_union_all` regression test in `datafusion/wasmtest`. It panics on unpatched `main` and passes with this change.
- CI runs it in the browser via `wasm-pack test --headless --firefox` and `--chrome`. The native `tokio::test` run covers the unchanged spawn path.
- The test sorts results before comparing, since `CoalescePartitionsExec` makes no output-order guarantee.

## Are there any user-facing changes?

No API changes. On `wasm32` targets, queries that coalesce multiple partitions no longer panic, regardless of `target_partitions`. Native behavior is unchanged.
