### PR TITLE
fix: do not panic when displaying a `Date64` scalar of `i64::MIN`

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -5658,7 +5658,11 @@ impl fmt::Display for ScalarValue {
                 f,
                 e.map(|v| {
                     let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-                    match epoch.checked_add_signed(Duration::try_milliseconds(v).unwrap())
+                    // `try_milliseconds` is `None` for `i64::MIN`, which is
+                    // out of range for `chrono::Duration`; treat it like any
+                    // other date that cannot be represented.
+                    match Duration::try_milliseconds(v)
+                        .and_then(|d| epoch.checked_add_signed(d))
                     {
                         Some(date) => date.to_string(),
                         None => "".to_string(),
@@ -10104,6 +10108,10 @@ mod tests {
             format!("{}", ScalarValue::Date64(Some(-790179464505600000))),
             ""
         );
+        // `i64::MIN` is out of range for `chrono::Duration` itself, so it
+        // used to panic before the epoch arithmetic even ran.
+        assert_eq!(format!("{}", ScalarValue::Date64(Some(i64::MIN))), "");
+        assert_eq!(format!("{}", ScalarValue::Date64(Some(i64::MAX))), "");
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24892.

## Rationale for this change

`ScalarValue::Date64` formatting unwraps `chrono::Duration::try_milliseconds`, which is `None` for `i64::MIN`. Printing such a literal, for example `EXPLAIN SELECT arrow_cast(-9223372036854775808, 'Date64')`, panics instead of producing a plan.

## What changes are included in this PR?

Chain `try_milliseconds` and `checked_add_signed` with `and_then`, so a value that `chrono::Duration` cannot hold is treated the same as a date that is out of range: it formats as an empty string, which is what the existing out-of-range handling (added for apache/arrow-rs#7728) already does.

## Are these changes tested?

Yes. `test_display_date64_large_values` now also covers `i64::MIN` (which used to panic) and `i64::MAX`.

## Are there any user-facing changes?

No panic when a `Date64` literal of `i64::MIN` is displayed.
