### PR TITLE
fix: do not preallocate `max_size` centroids in `TDigest`

### DIFF
--- a/datafusion/functions-aggregate-common/src/tdigest.rs
+++ b/datafusion/functions-aggregate-common/src/tdigest.rs
@@ -235,7 +235,13 @@ impl TDigest {
             result.max = maybe_max;
         }
 
-        let mut compressed: Vec<Centroid> = Vec::with_capacity(self.max_size);
+        // The compressed digest never has more centroids than the inputs it
+        // merges, so bound the allocation by that as well: `max_size` is user
+        // supplied and can be large enough for `with_capacity` to overflow.
+        let mut compressed: Vec<Centroid> = Vec::with_capacity(
+            self.max_size
+                .min(self.centroids.len() + sorted_values.len()),
+        );
 
         let mut k_limit: u64 = 1;
         let mut q_limit_times_count =
@@ -405,7 +411,8 @@ impl TDigest {
         }
 
         let mut result = TDigest::new(max_size);
-        let mut compressed: Vec<Centroid> = Vec::with_capacity(max_size);
+        // See `merge_sorted_f64`: never allocate more than the input size.
+        let mut compressed: Vec<Centroid> = Vec::with_capacity(max_size.min(n_centroids));
 
         let mut k_limit = 1;
         let mut q_limit_times_count = Self::k_to_q(k_limit, max_size) * count;
@@ -797,6 +804,21 @@ mod tests {
         assert_error_bounds!(t, quantile = 0.01, want = 10_000.0);
         assert_error_bounds!(t, quantile = 0.5, want = 500_000.0);
         assert_state_roundtrip!(t);
+    }
+
+    #[test]
+    fn test_huge_max_size_does_not_preallocate() {
+        // `max_size` is user supplied (the `centroids` argument of
+        // `approx_percentile_cont`). Allocating `Vec::with_capacity(max_size)`
+        // for a value this large used to panic with "capacity overflow".
+        let t = TDigest::new(usize::MAX);
+        let t = t.merge_unsorted_f64(vec![1.0, 2.0, 3.0]);
+        assert_eq!(t.count(), 3.0);
+        assert_eq!(t.estimate_quantile(0.5), 2.0);
+
+        let merged = TDigest::merge_digests([&t, &t]);
+        assert_eq!(merged.count(), 6.0);
+        assert_eq!(merged.estimate_quantile(0.5), 2.0);
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24900.

## Rationale for this change

`TDigest::merge_sorted_f64` and `TDigest::merge_digests` allocated the compressed centroid list with `Vec::with_capacity(max_size)`. `max_size` is the user supplied `centroids` argument of `approx_percentile_cont`, so `approx_percentile_cont(x, 0.5, 9223372036854775807)` panicked with "capacity overflow" (and a merely huge value would abort on allocation failure).

## What changes are included in this PR?

The compressed digest never holds more centroids than the inputs being merged, so the preallocation is now `max_size.min(<input size>)` in both places. Behaviour for ordinary `max_size` values is unchanged.

## Are these changes tested?

Yes. `test_huge_max_size_does_not_preallocate` builds a digest with `max_size = usize::MAX`, merges values and digests into it, and checks the estimates; it used to panic.

## Are there any user-facing changes?

`approx_percentile_cont` with a very large `centroids` argument returns a result instead of panicking.
