### PR TITLE
fix: reject negative `INTERVAL` offsets in RANGE window frames

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -1135,6 +1135,31 @@ fn coerce_window_frame(
     window_frame.start_bound =
         coerce_frame_bound(&target_type, window_frame.start_bound)?;
     window_frame.end_bound = coerce_frame_bound(&target_type, window_frame.end_bound)?;
+    if window_frame.units == WindowFrameUnits::Range {
+        // ROWS and GROUPS offsets are parsed as `UInt64`, so they can never be
+        // negative. RANGE offsets are only typed here, once the ORDER BY type is
+        // known, and an interval literal such as `INTERVAL '-1 day'` carries its
+        // sign inside the string. A negative offset makes the frame start after
+        // it ends, which the execution code does not expect.
+        for bound in [&window_frame.start_bound, &window_frame.end_bound] {
+            let (WindowFrameBound::Preceding(offset)
+            | WindowFrameBound::Following(offset)) = bound
+            else {
+                continue;
+            };
+            if offset.is_null() {
+                // UNBOUNDED PRECEDING / FOLLOWING
+                continue;
+            }
+            if let Ok(zero) = ScalarValue::new_zero(&offset.data_type())
+                && *offset < zero
+            {
+                return plan_err!(
+                    "Invalid window frame: frame offsets for RANGE must not be negative"
+                );
+            }
+        }
+    }
     Ok(window_frame)
 }
 

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -2480,6 +2480,24 @@ select row_number() over (rows between null preceding and current row) from (sel
 statement error DataFusion error: Error during planning: Invalid window frame: frame offsets for ROWS / GROUPS must be non negative integers
 select row_number() over (rows between current row and -1 following) from (select 1 a) x
 
+# invalid window frame. negative interval offsets in RANGE frames. Unlike
+# ROWS / GROUPS offsets, RANGE offsets are typed after the ORDER BY column is
+# known, and an interval literal carries its sign inside the string.
+statement error Error during planning: Invalid window frame: frame offsets for RANGE must not be negative
+select count(*) over (order by a range between interval '-1 day' preceding and current row) from (select date '2020-01-01' a) x
+
+statement error Error during planning: Invalid window frame: frame offsets for RANGE must not be negative
+select count(*) over (order by a range between current row and interval '-1 month' following) from (select timestamp '2020-01-01' a) x
+
+statement error Error during planning: Invalid window frame: frame offsets for RANGE must not be negative
+select count(*) over (order by a range between interval '-1 day' preceding and interval '-1 day' following) from (select now() a) x
+
+# a non-negative interval offset is still accepted
+query I
+select count(*) over (order by a range between interval '1 day' preceding and current row) from (select date '2020-01-01' a) x
+----
+1
+
 # invalid window frame. null as preceding
 statement error DataFusion error: Error during planning: Invalid window frame: frame offsets for ROWS / GROUPS must be non negative integers
 select row_number() over (order by a groups between null preceding and current row) from (select 1 a) x


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24902.

## Rationale for this change

ROWS and GROUPS frame offsets are parsed as `UInt64`, so a negative offset is a planning error. RANGE offsets are only typed once the ORDER BY type is known, and an interval literal such as `INTERVAL '-1 day'` carries its sign inside the string, so it was accepted. The resulting frame starts after it ends, which the execution code does not expect: it panics with "attempt to subtract with overflow" in debug builds (`sliding_aggregate.rs`, `window_state.rs`) and returns wrong results in release builds.

## What changes are included in this PR?

After the RANGE offsets have been coerced in `coerce_window_frame`, compare each finite offset with the zero of its type and reject negative ones with a planning error, matching what ROWS / GROUPS already do at parse time (and what PostgreSQL does).

## Are these changes tested?

Yes. `window.slt` gains three negative-offset cases (`PRECEDING`, `FOLLOWING`, both) that now fail at planning, plus a non-negative interval offset that still runs.

## Are there any user-facing changes?

Queries with a negative interval offset in a RANGE frame now fail at planning instead of panicking or returning wrong results.
