### PR TITLE
fix: reject invalid parquet writer options instead of panicking

### DIFF
--- a/datafusion/common/src/file_options/parquet_writer.rs
+++ b/datafusion/common/src/file_options/parquet_writer.rs
@@ -1027,71 +1027,108 @@ mod tests {
     /// `WriterProperties` must surface as configuration errors instead.
     #[test]
     fn test_invalid_writer_options_are_rejected() {
-        fn err(options: &ParquetOptions) -> String {
+        fn err(options: ParquetOptions) -> String {
             options
                 .into_writer_properties_builder()
-                .err()
-                .expect("expected a configuration error")
+                .expect_err("expected a configuration error")
                 .to_string()
         }
 
-        let mut options = ParquetOptions::default();
-        options.write_batch_size = 0;
-        assert!(err(&options).contains("write_batch_size"));
-
-        let mut options = ParquetOptions::default();
-        options.max_row_group_size = 0;
-        assert!(err(&options).contains("max_row_group_size"));
-
-        let mut options = ParquetOptions::default();
-        options.column_index_truncate_length = Some(0);
-        assert!(err(&options).contains("column_index_truncate_length"));
-
-        let mut options = ParquetOptions::default();
-        options.statistics_truncate_length = Some(0);
-        assert!(err(&options).contains("statistics_truncate_length"));
-
+        assert!(
+            err(ParquetOptions {
+                write_batch_size: 0,
+                ..Default::default()
+            })
+            .contains("write_batch_size")
+        );
+        assert!(
+            err(ParquetOptions {
+                max_row_group_size: 0,
+                ..Default::default()
+            })
+            .contains("max_row_group_size")
+        );
+        assert!(
+            err(ParquetOptions {
+                column_index_truncate_length: Some(0),
+                ..Default::default()
+            })
+            .contains("column_index_truncate_length")
+        );
+        assert!(
+            err(ParquetOptions {
+                statistics_truncate_length: Some(0),
+                ..Default::default()
+            })
+            .contains("statistics_truncate_length")
+        );
         for fpp in [0.0, 1.0, 1.5, -1.0, f64::NAN] {
-            let mut options = ParquetOptions::default();
-            options.bloom_filter_fpp = Some(fpp);
-            assert!(err(&options).contains("bloom_filter_fpp"), "fpp {fpp}");
+            assert!(
+                err(ParquetOptions {
+                    bloom_filter_fpp: Some(fpp),
+                    ..Default::default()
+                })
+                .contains("bloom_filter_fpp"),
+                "fpp {fpp}"
+            );
         }
-
-        let mut options = ParquetOptions::default();
-        options.content_defined_chunking.enabled = true;
-        options.content_defined_chunking.min_chunk_size = 0;
-        assert!(err(&options).contains("min_chunk_size"));
-
-        let mut options = ParquetOptions::default();
-        options.content_defined_chunking.enabled = true;
-        options.content_defined_chunking.min_chunk_size = 10;
-        options.content_defined_chunking.max_chunk_size = 10;
-        assert!(err(&options).contains("max_chunk_size"));
+        assert!(
+            err(ParquetOptions {
+                content_defined_chunking: ParquetCdcOptions {
+                    enabled: true,
+                    min_chunk_size: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .contains("min_chunk_size")
+        );
+        assert!(
+            err(ParquetOptions {
+                content_defined_chunking: ParquetCdcOptions {
+                    enabled: true,
+                    min_chunk_size: 10,
+                    max_chunk_size: 10,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .contains("max_chunk_size")
+        );
 
         // A per-column bloom filter fpp goes through the same check.
-        let mut table_options = TableParquetOptions::default();
-        table_options.global.skip_arrow_metadata = true;
-        table_options.column_specific_options.insert(
-            COL_NAME.into(),
-            ParquetColumnOptions {
-                bloom_filter_fpp: Some(2.0),
+        let table_options = TableParquetOptions {
+            global: ParquetOptions {
+                skip_arrow_metadata: true,
                 ..Default::default()
             },
-        );
+            column_specific_options: HashMap::from([(
+                COL_NAME.to_string(),
+                ParquetColumnOptions {
+                    bloom_filter_fpp: Some(2.0),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
         let err = WriterPropertiesBuilder::try_from(&table_options)
-            .err()
-            .expect("expected a configuration error")
+            .expect_err("expected a configuration error")
             .to_string();
         assert!(err.contains("bloom_filter_fpp"), "{err}");
 
-        // The defaults, and the boundaries just inside the valid range, build.
+        // The defaults, and a value just inside the valid range, still build.
         assert!(
             ParquetOptions::default()
                 .into_writer_properties_builder()
                 .is_ok()
         );
-        let mut options = ParquetOptions::default();
-        options.bloom_filter_fpp = Some(f64::EPSILON);
-        assert!(options.into_writer_properties_builder().is_ok());
+        assert!(
+            ParquetOptions {
+                bloom_filter_fpp: Some(f64::EPSILON),
+                ..Default::default()
+            }
+            .into_writer_properties_builder()
+            .is_ok()
+        );
     }
 }

--- a/datafusion/common/src/file_options/parquet_writer.rs
+++ b/datafusion/common/src/file_options/parquet_writer.rs
@@ -152,6 +152,7 @@ impl TryFrom<&TableParquetOptions> for WriterPropertiesBuilder {
             }
 
             if let Some(bloom_filter_fpp) = options.bloom_filter_fpp {
+                validate_bloom_filter_fpp(bloom_filter_fpp)?;
                 builder =
                     builder.set_column_bloom_filter_fpp(path.clone(), bloom_filter_fpp);
             }
@@ -251,6 +252,54 @@ impl ParquetOptions {
             max_in_list_size: _,
         } = self;
 
+        // The `parquet` crate rejects these values with a panic (`assert!`)
+        // while the properties are being built, so check them here and report
+        // a configuration error instead.
+        if *write_batch_size == 0 {
+            return Err(DataFusionError::Configuration(
+                "datafusion.execution.parquet.write_batch_size must be greater than 0"
+                    .to_string(),
+            ));
+        }
+        if *max_row_group_size == 0 {
+            return Err(DataFusionError::Configuration(
+                "datafusion.execution.parquet.max_row_group_size must be greater than 0"
+                    .to_string(),
+            ));
+        }
+        if *column_index_truncate_length == Some(0) {
+            return Err(DataFusionError::Configuration(
+                "datafusion.execution.parquet.column_index_truncate_length must be                  greater than 0 (unset it to disable truncation)"
+                    .to_string(),
+            ));
+        }
+        if *statistics_truncate_length == Some(0) {
+            return Err(DataFusionError::Configuration(
+                "datafusion.execution.parquet.statistics_truncate_length must be                  greater than 0 (unset it to disable truncation)"
+                    .to_string(),
+            ));
+        }
+        if let Some(bloom_filter_fpp) = bloom_filter_fpp {
+            validate_bloom_filter_fpp(*bloom_filter_fpp)?;
+        }
+        if content_defined_chunking.enabled {
+            if content_defined_chunking.min_chunk_size == 0 {
+                return Err(DataFusionError::Configuration(
+                    "datafusion.execution.parquet.content_defined_chunking.min_chunk_size                      must be greater than 0"
+                        .to_string(),
+                ));
+            }
+            if content_defined_chunking.max_chunk_size
+                <= content_defined_chunking.min_chunk_size
+            {
+                return Err(DataFusionError::Configuration(format!(
+                    "datafusion.execution.parquet.content_defined_chunking.max_chunk_size                      ({}) must be greater than min_chunk_size ({})",
+                    content_defined_chunking.max_chunk_size,
+                    content_defined_chunking.min_chunk_size
+                )));
+            }
+        }
+
         let mut builder = WriterProperties::builder()
             .set_data_page_size_limit(*data_pagesize_limit)
             .set_write_batch_size(*write_batch_size)
@@ -291,6 +340,18 @@ impl ParquetOptions {
         builder = builder.set_content_defined_chunking(content_defined_chunking.into());
 
         Ok(builder)
+    }
+}
+
+/// Checks that a bloom filter false positive probability is strictly between
+/// 0 and 1, which is what the `parquet` crate requires (it panics otherwise).
+fn validate_bloom_filter_fpp(fpp: f64) -> Result<()> {
+    if fpp > 0.0 && fpp < 1.0 {
+        Ok(())
+    } else {
+        Err(DataFusionError::Configuration(format!(
+            "bloom_filter_fpp must be strictly between 0 and 1, got {fpp}"
+        )))
     }
 }
 
@@ -960,5 +1021,77 @@ mod tests {
             ),
             "should have only the ndv set, and the fpp at default",
         );
+    }
+
+    /// Values the `parquet` crate rejects with a panic while building
+    /// `WriterProperties` must surface as configuration errors instead.
+    #[test]
+    fn test_invalid_writer_options_are_rejected() {
+        fn err(options: &ParquetOptions) -> String {
+            options
+                .into_writer_properties_builder()
+                .err()
+                .expect("expected a configuration error")
+                .to_string()
+        }
+
+        let mut options = ParquetOptions::default();
+        options.write_batch_size = 0;
+        assert!(err(&options).contains("write_batch_size"));
+
+        let mut options = ParquetOptions::default();
+        options.max_row_group_size = 0;
+        assert!(err(&options).contains("max_row_group_size"));
+
+        let mut options = ParquetOptions::default();
+        options.column_index_truncate_length = Some(0);
+        assert!(err(&options).contains("column_index_truncate_length"));
+
+        let mut options = ParquetOptions::default();
+        options.statistics_truncate_length = Some(0);
+        assert!(err(&options).contains("statistics_truncate_length"));
+
+        for fpp in [0.0, 1.0, 1.5, -1.0, f64::NAN] {
+            let mut options = ParquetOptions::default();
+            options.bloom_filter_fpp = Some(fpp);
+            assert!(err(&options).contains("bloom_filter_fpp"), "fpp {fpp}");
+        }
+
+        let mut options = ParquetOptions::default();
+        options.content_defined_chunking.enabled = true;
+        options.content_defined_chunking.min_chunk_size = 0;
+        assert!(err(&options).contains("min_chunk_size"));
+
+        let mut options = ParquetOptions::default();
+        options.content_defined_chunking.enabled = true;
+        options.content_defined_chunking.min_chunk_size = 10;
+        options.content_defined_chunking.max_chunk_size = 10;
+        assert!(err(&options).contains("max_chunk_size"));
+
+        // A per-column bloom filter fpp goes through the same check.
+        let mut table_options = TableParquetOptions::default();
+        table_options.global.skip_arrow_metadata = true;
+        table_options.column_specific_options.insert(
+            COL_NAME.into(),
+            ParquetColumnOptions {
+                bloom_filter_fpp: Some(2.0),
+                ..Default::default()
+            },
+        );
+        let err = WriterPropertiesBuilder::try_from(&table_options)
+            .err()
+            .expect("expected a configuration error")
+            .to_string();
+        assert!(err.contains("bloom_filter_fpp"), "{err}");
+
+        // The defaults, and the boundaries just inside the valid range, build.
+        assert!(
+            ParquetOptions::default()
+                .into_writer_properties_builder()
+                .is_ok()
+        );
+        let mut options = ParquetOptions::default();
+        options.bloom_filter_fpp = Some(f64::EPSILON);
+        assert!(options.into_writer_properties_builder().is_ok());
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24904.

## Rationale for this change

`ParquetOptions::into_writer_properties_builder` handed every value straight to `WriterPropertiesBuilder`, whose setters `assert!` on values they cannot accept. `SET datafusion.execution.parquet.max_row_group_size = 0` or `bloom_filter_fpp = 1.5` made the next `COPY ... TO 'x.parquet'` panic, and `write_batch_size = 0` or `data_page_row_count_limit = 0` made the writer loop forever (which of the two hangs depends on whether the column has definition levels).

## What changes are included in this PR?

Check the values the `parquet` crate asserts on before building the properties and return a `DataFusionError::Configuration` naming the option: `write_batch_size`, `max_row_group_size`, `column_index_truncate_length`, `statistics_truncate_length`, `bloom_filter_fpp` (global and per column), `data_page_row_count_limit` and the content-defined chunking sizes. The docstrings in `config.rs` (and the generated `configs.md`) now state the valid range of each of these options. This matches how an unknown `compression` or `encoding` string is already reported in the same function.

## Are these changes tested?

Yes. `test_invalid_writer_options_are_rejected` covers each rejected value (including `NaN` and the per-column bloom filter fpp) and checks that the defaults and an in-range fpp still build.

## Are there any user-facing changes?

Invalid parquet writer options now fail with a configuration error at write time instead of a panic or a hang.