### PR TITLE
fix: do not panic when partitioning a `COPY` by an out-of-range date

### DIFF
--- a/datafusion/datasource/src/write/demux.rs
+++ b/datafusion/datasource/src/write/demux.rs
@@ -420,30 +420,33 @@ fn compute_partition_keys_by_row<'a>(
             }
             DataType::Date32 => {
                 let array = as_date32_array(col_array)?;
-                // ISO-8601/RFC3339 format - yyyy-mm-dd
-                let format = "%Y-%m-%d";
                 for i in 0..rb.num_rows() {
-                    let date = NaiveDate::from_num_days_from_ce_opt(
-                        EPOCH_DAYS_FROM_CE + array.value(i),
-                    )
-                    .unwrap()
-                    .format(format)
-                    .to_string();
-                    partition_values.push(Cow::from(date));
+                    let value = array.value(i);
+                    let date = EPOCH_DAYS_FROM_CE
+                        .checked_add(value)
+                        .and_then(NaiveDate::from_num_days_from_ce_opt)
+                        .ok_or_else(|| {
+                            exec_datafusion_err!(
+                                "Date32 value {value} is out of range for a partition value"
+                            )
+                        })?;
+                    partition_values.push(Cow::from(format_partition_date(date)));
                 }
             }
             DataType::Date64 => {
                 let array = as_date64_array(col_array)?;
-                // ISO-8601/RFC3339 format - yyyy-mm-dd
-                let format = "%Y-%m-%d";
                 for i in 0..rb.num_rows() {
-                    let date = NaiveDate::from_num_days_from_ce_opt(
-                        EPOCH_DAYS_FROM_CE + (array.value(i) / 86_400_000) as i32,
-                    )
-                    .unwrap()
-                    .format(format)
-                    .to_string();
-                    partition_values.push(Cow::from(date));
+                    let value = array.value(i);
+                    let date = i32::try_from(value.div_euclid(86_400_000))
+                        .ok()
+                        .and_then(|days| EPOCH_DAYS_FROM_CE.checked_add(days))
+                        .and_then(NaiveDate::from_num_days_from_ce_opt)
+                        .ok_or_else(|| {
+                            exec_datafusion_err!(
+                                "Date64 value {value} is out of range for a partition value"
+                            )
+                        })?;
+                    partition_values.push(Cow::from(format_partition_date(date)));
                 }
             }
             DataType::Int8 => {
@@ -538,6 +541,11 @@ fn compute_partition_keys_by_row<'a>(
     }
 
     Ok(all_partition_values)
+}
+
+/// Formats a date as ISO-8601 (`yyyy-mm-dd`) for use in a partition path.
+fn format_partition_date(date: NaiveDate) -> String {
+    date.format("%Y-%m-%d").to_string()
 }
 
 fn compute_take_arrays(

--- a/datafusion/sqllogictest/test_files/copy.slt
+++ b/datafusion/sqllogictest/test_files/copy.slt
@@ -52,6 +52,33 @@ select * from validate_partitioned_parquet_bar order by col1;
 ----
 2
 
+# Partition by a date column: the value is rendered as yyyy-mm-dd in the path
+query I
+COPY (values (1, date '2020-02-29'), (2, date '1969-12-31')) TO 'test_files/scratch/copy/partitioned_by_date/' STORED AS parquet PARTITIONED BY (column2)
+----
+2
+
+statement ok
+CREATE EXTERNAL TABLE partitioned_by_date STORED AS parquet
+LOCATION 'test_files/scratch/copy/partitioned_by_date/' PARTITIONED BY (column2);
+
+query IT
+SELECT * FROM partitioned_by_date ORDER BY column1
+----
+1 2020-02-29
+2 1969-12-31
+
+# Date values that cannot be represented as a calendar date used to panic
+# ("attempt to add with overflow" / unwrap on None) inside the demuxer.
+statement error DataFusion error: Execution error: Date32 value 2147483647 is out of range for a partition value
+COPY (values (arrow_cast(2147483647, 'Date32'))) TO 'test_files/scratch/copy/partitioned_by_date_err1/' STORED AS parquet PARTITIONED BY (column1)
+
+statement error DataFusion error: Execution error: Date32 value -2147483648 is out of range for a partition value
+COPY (values (arrow_cast(-2147483648, 'Date32'))) TO 'test_files/scratch/copy/partitioned_by_date_err2/' STORED AS parquet PARTITIONED BY (column1)
+
+statement error DataFusion error: Execution error: Date64 value 9223372036854775807 is out of range for a partition value
+COPY (values (arrow_cast(9223372036854775807, 'Date64'))) TO 'test_files/scratch/copy/partitioned_by_date_err3/' STORED AS parquet PARTITIONED BY (column1)
+
 # Copy to directory as partitioned files
 query I
 COPY (values (1, 'a', 'x'), (2, 'b', 'y'), (3, 'c', 'z')) TO 'test_files/scratch/copy/partitioned_table2/' STORED AS parquet PARTITIONED BY (column2, column3)


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24907.

## Rationale for this change

`compute_partition_keys_by_row` turned `Date32` / `Date64` partition values into `yyyy-mm-dd` path segments with unchecked arithmetic and an `unwrap`, so a value outside the range of `chrono::NaiveDate` panicked the writer task ("attempt to add with overflow" or "called `Option::unwrap()` on a `None` value").

## What changes are included in this PR?

Use checked conversions and return an execution error naming the value. For `Date64` the milliseconds are converted to days with `div_euclid`, so a value before the epoch lands on the correct calendar day, and the day count is range-checked before it is narrowed to `i32`. The date formatting is shared by both branches.

## Are these changes tested?

Yes. `copy.slt` now partitions by a date column (including a pre-epoch date) and checks the three out-of-range cases return an error; they used to panic.

## Are there any user-facing changes?

An out-of-range date in a `PARTITIONED BY` column produces an execution error instead of a panic. A `Date64` value before the epoch is now placed in the correct day's partition.
