### PR TITLE
fix: reject invalid strftime strings in `datafusion.format.*` options

### DIFF
--- a/datafusion/common/src/config.rs
+++ b/datafusion/common/src/config.rs
@@ -1997,9 +1997,39 @@ config_namespace! {
     }
 }
 
+/// Checks that `format` is a valid `strftime` specification.
+///
+/// The arrow formatter only discovers an invalid specification while it is
+/// rendering a value, where the failure surfaces as a `fmt::Error` that most
+/// callers (`format!`, `to_string`) turn into a panic. Rejecting it up front
+/// gives a configuration error that names the option instead.
+fn validate_strftime_format(option: &str, format: Option<&str>) -> Result<()> {
+    if let Some(format) = format {
+        chrono::format::StrftimeItems::new(format)
+            .parse()
+            .map_err(|e| {
+                DataFusionError::Configuration(format!(
+                    "Invalid strftime format {format:?} for datafusion.format.{option}: {e}"
+                ))
+            })?;
+    }
+    Ok(())
+}
+
 impl<'a> TryFrom<&'a FormatOptions> for arrow::util::display::FormatOptions<'a> {
     type Error = DataFusionError;
     fn try_from(options: &'a FormatOptions) -> Result<Self> {
+        validate_strftime_format("date_format", options.date_format.as_deref())?;
+        validate_strftime_format("datetime_format", options.datetime_format.as_deref())?;
+        validate_strftime_format(
+            "timestamp_format",
+            options.timestamp_format.as_deref(),
+        )?;
+        validate_strftime_format(
+            "timestamp_tz_format",
+            options.timestamp_tz_format.as_deref(),
+        )?;
+        validate_strftime_format("time_format", options.time_format.as_deref())?;
         Ok(Self::new()
             .with_display_error(options.safe)
             .with_null(&options.null)
@@ -4544,6 +4574,78 @@ mod tests {
         let parsed_metadata = table_config.parquet.key_value_metadata;
         assert_eq!(parsed_metadata.get("key_dupe"), Some(&Some("B".into())));
     }
+    #[test]
+    fn test_invalid_strftime_format_is_rejected() {
+        use crate::config::FormatOptions;
+
+        fn err(options: FormatOptions) -> String {
+            arrow::util::display::FormatOptions::try_from(&options)
+                .expect_err("expected a configuration error")
+                .to_string()
+        }
+
+        // A trailing `%` is not a valid strftime specification. The arrow
+        // formatter used to hit this only while rendering a value, where the
+        // failure surfaced as a panic in callers using `to_string`.
+        for (name, options) in [
+            (
+                "date_format",
+                FormatOptions {
+                    date_format: Some("%".into()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "datetime_format",
+                FormatOptions {
+                    datetime_format: Some("%".into()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "timestamp_format",
+                FormatOptions {
+                    timestamp_format: Some("%".into()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "timestamp_tz_format",
+                FormatOptions {
+                    timestamp_tz_format: Some("%".into()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "time_format",
+                FormatOptions {
+                    time_format: Some("%".into()),
+                    ..Default::default()
+                },
+            ),
+        ] {
+            let message = err(options);
+            assert!(message.contains(name), "{message}");
+            assert!(message.contains("Invalid strftime format"), "{message}");
+        }
+
+        // The defaults and unset formats are accepted.
+        assert!(
+            arrow::util::display::FormatOptions::try_from(&FormatOptions::default())
+                .is_ok()
+        );
+        assert!(
+            arrow::util::display::FormatOptions::try_from(&FormatOptions {
+                date_format: None,
+                datetime_format: None,
+                timestamp_format: None,
+                time_format: None,
+                ..Default::default()
+            })
+            .is_ok()
+        );
+    }
+
     #[cfg(feature = "parquet")]
     #[test]
     fn test_parquet_writer_version_validation() {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24909.

## Rationale for this change

The `datafusion.format.*_format` options were handed to the arrow formatter unchecked. An invalid `strftime` specification only failed while a value was being rendered, where the arrow `Display` impl returns `fmt::Error` and callers such as `format!` turn that into a panic (`SET datafusion.format.time_format = '%'; SELECT time '12:00:00';` panicked in `datafusion-cli`).

## What changes are included in this PR?

When `FormatOptions` is converted to `arrow::util::display::FormatOptions`, parse each of the five format strings with `chrono::format::StrftimeItems` and return a `DataFusionError::Configuration` naming the option if it is invalid. Unset formats and the defaults are unaffected.

## Are these changes tested?

Yes. `test_invalid_strftime_format_is_rejected` checks that each of the five options rejects a trailing `%` with a message naming the option, and that the defaults and unset formats still convert.

## Are there any user-facing changes?

An invalid format string now produces a configuration error when the results are about to be formatted, instead of a panic.
