### PR TITLE
fix: report nested `unnest` of a struct as a planning error

### DIFF
--- a/datafusion/sql/src/utils.rs
+++ b/datafusion/sql/src/utils.rs
@@ -26,8 +26,8 @@ use datafusion_common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion, TreeNodeRewriter,
 };
 use datafusion_common::{
-    Column, DFSchemaRef, Diagnostic, HashMap, Result, ScalarValue,
-    assert_or_internal_err, exec_datafusion_err, exec_err, internal_err, plan_err,
+    Column, DFSchemaRef, Diagnostic, HashMap, Result, ScalarValue, exec_datafusion_err,
+    exec_err, internal_err, plan_err,
 };
 use datafusion_expr::builder::get_struct_unnested_columns;
 use datafusion_expr::expr::{
@@ -489,10 +489,14 @@ impl RecursiveUnnestRewriter<'_> {
 
         match data_type {
             DataType::Struct(inner_fields) => {
-                assert_or_internal_err!(
-                    struct_allowed,
-                    "unnest on struct can only be applied at the root level of select expression"
-                );
+                // Reachable from user input, e.g. `unnest(unnest(struct_col))`
+                // or `unnest(struct_col)['field']`, so this is a planning
+                // error rather than an internal invariant.
+                if !struct_allowed {
+                    return plan_err!(
+                        "unnest on struct can only be applied at the root level of select expression"
+                    );
+                }
                 push_projection_dedupl(
                     self.inner_projection_exprs,
                     expr_in_unnest.clone().alias(placeholder_name.clone()),

--- a/datafusion/sqllogictest/test_files/unnest.slt
+++ b/datafusion/sqllogictest/test_files/unnest.slt
@@ -525,8 +525,16 @@ x y [30, 40, 50]
 query error DataFusion error: type_coercion\ncaused by\nThis feature is not implemented: Unnest should be rewritten to LogicalPlan::Unnest before type coercion
 select sum(unnest(generate_series(1,10)));
 
-query error DataFusion error: Internal error: Assertion failed: struct_allowed: unnest on struct can only be applied at the root level of select expression
+# unnest on a struct is only supported as the top level select expression;
+# nesting it in another expression is a planning error, not an internal one
+query error DataFusion error: Error during planning: unnest on struct can only be applied at the root level of select expression
 select arrow_typeof(unnest(column5)) from unnest_table;
+
+query error DataFusion error: Error during planning: unnest on struct can only be applied at the root level of select expression
+select unnest(struct(1))['c0'];
+
+query error DataFusion error: Error during planning: unnest on struct can only be applied at the root level of select expression
+select unnest(unnest(struct([1])));
 
 query T
 select arrow_typeof(unnest(column1)) from unnest_table;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24911.

## Rationale for this change

`unnest` on a struct is only supported as the top-level select expression. Using it anywhere else (`unnest(unnest(struct([1])))`, `unnest(struct(1))['c0']`) tripped `assert_or_internal_err!(struct_allowed, ...)` and produced an internal error asking the user to file a bug. `struct_allowed` is derived from the shape of the user's expression, so this is a planning error, not a broken invariant.

## What changes are included in this PR?

Return `plan_err!` with the same message instead of the internal-error assertion. The now-unused `assert_or_internal_err` import is dropped.

## Are these changes tested?

Yes. The existing `unnest.slt` case that had captured the internal-error text now expects the planning error, and two more cases (`unnest(struct(1))['c0']`, `unnest(unnest(struct([1])))`) are added.

## Are there any user-facing changes?

The error for a nested `unnest` of a struct is now `Error during planning: unnest on struct can only be applied at the root level of select expression`, without the "likely caused by a bug in DataFusion" boilerplate.
