### PR TITLE
chore: test latest sqlparser-rs before 0.63.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2809,7 +2809,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2948,7 +2948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4220,7 +4220,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5381,7 +5381,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5853,7 +5853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5884,8 +5884,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=0821cbdd5cbdc27f9c7205466d357deef632c936#0821cbdd5cbdc27f9c7205466d357deef632c936"
 dependencies = [
  "log",
  "recursive",
@@ -5895,8 +5894,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=0821cbdd5cbdc27f9c7205466d357deef632c936#0821cbdd5cbdc27f9c7205466d357deef632c936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5953,7 +5951,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6133,7 +6131,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7074,7 +7072,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5883,8 +5883,8 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.62.0"
-source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=0821cbdd5cbdc27f9c7205466d357deef632c936#0821cbdd5cbdc27f9c7205466d357deef632c936"
+version = "0.63.0"
+source = "git+https://github.com/alamb/sqlparser-rs?rev=6f9dfd3611449d142208946ba74ffc6687e6c4aa#6f9dfd3611449d142208946ba74ffc6687e6c4aa"
 dependencies = [
  "log",
  "recursive",
@@ -5894,7 +5894,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.5.0"
-source = "git+https://github.com/apache/datafusion-sqlparser-rs?rev=0821cbdd5cbdc27f9c7205466d357deef632c936#0821cbdd5cbdc27f9c7205466d357deef632c936"
+source = "git+https://github.com/alamb/sqlparser-rs?rev=6f9dfd3611449d142208946ba74ffc6687e6c4aa#6f9dfd3611449d142208946ba74ffc6687e6c4aa"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5884,7 +5884,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.63.0"
-source = "git+https://github.com/alamb/sqlparser-rs?rev=6f9dfd3611449d142208946ba74ffc6687e6c4aa#6f9dfd3611449d142208946ba74ffc6687e6c4aa"
+source = "git+https://github.com/alamb/sqlparser-rs?rev=1bff16cd9af5319ee854755e695869246ebcd180#1bff16cd9af5319ee854755e695869246ebcd180"
 dependencies = [
  "log",
  "recursive",
@@ -5893,8 +5893,8 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.5.0"
-source = "git+https://github.com/alamb/sqlparser-rs?rev=6f9dfd3611449d142208946ba74ffc6687e6c4aa#6f9dfd3611449d142208946ba74ffc6687e6c4aa"
+version = "0.6.0"
+source = "git+https://github.com/alamb/sqlparser-rs?rev=1bff16cd9af5319ee854755e695869246ebcd180#1bff16cd9af5319ee854755e695869246ebcd180"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ regex = "1.12"
 rstest = "0.26.1"
 serde_json = "1"
 sha2 = "^0.11.0"
-sqlparser = { version = "0.62.0", default-features = false, features = ["std", "visitor"] }
+sqlparser = { git = "https://github.com/apache/datafusion-sqlparser-rs", rev = "0821cbdd5cbdc27f9c7205466d357deef632c936", default-features = false, features = ["std", "visitor"] }
 stacker = "0.1.24"
 strum = "0.28.0"
 strum_macros = "0.28.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ regex = "1.12"
 rstest = "0.26.1"
 serde_json = "1"
 sha2 = "^0.11.0"
-sqlparser = { git = "https://github.com/alamb/sqlparser-rs", rev = "6f9dfd3611449d142208946ba74ffc6687e6c4aa", default-features = false, features = ["std", "visitor"] }
+sqlparser = { git = "https://github.com/alamb/sqlparser-rs", rev = "1bff16cd9af5319ee854755e695869246ebcd180", default-features = false, features = ["std", "visitor"] }
 stacker = "0.1.24"
 strum = "0.28.0"
 strum_macros = "0.28.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ regex = "1.12"
 rstest = "0.26.1"
 serde_json = "1"
 sha2 = "^0.11.0"
-sqlparser = { git = "https://github.com/apache/datafusion-sqlparser-rs", rev = "0821cbdd5cbdc27f9c7205466d357deef632c936", default-features = false, features = ["std", "visitor"] }
+sqlparser = { git = "https://github.com/alamb/sqlparser-rs", rev = "6f9dfd3611449d142208946ba74ffc6687e6c4aa", default-features = false, features = ["std", "visitor"] }
 stacker = "0.1.24"
 strum = "0.28.0"
 strum_macros = "0.28.0"

--- a/datafusion/sql/src/expr/function.rs
+++ b/datafusion/sql/src/expr/function.rs
@@ -166,6 +166,11 @@ impl FunctionArgs {
                         "Calling {name}: LIMIT not supported in function arguments: {limit}"
                     );
                 }
+                FunctionArgumentClause::Where(predicate) => {
+                    return not_impl_err!(
+                        "Calling {name}: WHERE not supported in function arguments: {predicate}"
+                    );
+                }
                 FunctionArgumentClause::OnOverflow(overflow) => {
                     return not_impl_err!(
                         "Calling {name}: ON OVERFLOW not supported in function arguments: {overflow}"

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -353,16 +353,11 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 planner_context,
             ),
 
-            SQLExpr::Cast { array: true, .. } => {
-                not_impl_err!("`CAST(... AS type ARRAY`) not supported")
-            }
-
             SQLExpr::Cast {
                 kind: CastKind::Cast | CastKind::DoubleColon,
                 expr,
                 data_type,
                 format,
-                array: false,
             } => {
                 self.sql_cast_to_expr(*expr, &data_type, format, schema, planner_context)
             }
@@ -372,7 +367,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 expr,
                 data_type,
                 format,
-                array: false,
             } => {
                 if let Some(format) = format {
                     return not_impl_err!("CAST with format is not supported: {format}");

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -965,7 +965,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         negated: bool,
         expr: SQLExpr,
         pattern: SQLExpr,
-        escape_char: Option<ValueWithSpan>,
+        escape_char: Option<Box<SQLExpr>>,
         schema: &DFSchema,
         planner_context: &mut PlannerContext,
         case_insensitive: bool,
@@ -975,13 +975,14 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             return not_impl_err!("ANY in LIKE expression");
         }
         let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
-        let escape_char = match escape_char.map(|v| v.value) {
-            Some(Value::SingleQuotedString(char)) if char.len() == 1 => {
-                Some(char.chars().next().unwrap())
-            }
-            Some(value) => {
+        let escape_char = match escape_char.map(|e| *e) {
+            Some(SQLExpr::Value(ValueWithSpan {
+                value: Value::SingleQuotedString(char),
+                ..
+            })) if char.len() == 1 => Some(char.chars().next().unwrap()),
+            Some(expr) => {
                 return plan_err!(
-                    "Invalid escape character in LIKE expression. Expected a single character wrapped with single quotes, got {value}"
+                    "Invalid escape character in LIKE expression. Expected a single character wrapped with single quotes, got {expr}"
                 );
             }
             None => None,
@@ -1000,18 +1001,19 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         negated: bool,
         expr: SQLExpr,
         pattern: SQLExpr,
-        escape_char: Option<ValueWithSpan>,
+        escape_char: Option<Box<SQLExpr>>,
         schema: &DFSchema,
         planner_context: &mut PlannerContext,
     ) -> Result<Expr> {
         let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
-        let escape_char = match escape_char.map(|v| v.value) {
-            Some(Value::SingleQuotedString(char)) if char.len() == 1 => {
-                Some(char.chars().next().unwrap())
-            }
-            Some(value) => {
+        let escape_char = match escape_char.map(|e| *e) {
+            Some(SQLExpr::Value(ValueWithSpan {
+                value: Value::SingleQuotedString(char),
+                ..
+            })) if char.len() == 1 => Some(char.chars().next().unwrap()),
+            Some(expr) => {
                 return plan_err!(
-                    "Invalid escape character in SIMILAR TO expression. Expected a single character wrapped with single quotes, got {value}"
+                    "Invalid escape character in SIMILAR TO expression. Expected a single character wrapped with single quotes, got {expr}"
                 );
             }
             None => None,

--- a/datafusion/sql/src/expr/order_by.rs
+++ b/datafusion/sql/src/expr/order_by.rs
@@ -22,7 +22,7 @@ use datafusion_common::{
 use datafusion_expr::expr::Sort;
 use datafusion_expr::{Expr, SortExpr};
 use sqlparser::ast::{
-    Expr as SQLExpr, OrderByExpr, OrderByOptions, Value, ValueWithSpan,
+    Expr as SQLExpr, OrderByExpr, OrderByOptions, OrderBySort, Value, ValueWithSpan,
 };
 
 impl<S: ContextProvider> SqlToRel<'_, S> {
@@ -75,13 +75,22 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         for order_by_expr in order_by_exprs {
             let OrderByExpr {
                 expr,
-                options: OrderByOptions { asc, nulls_first },
+                options: OrderByOptions { sort, nulls_first },
                 with_fill,
             } = order_by_expr;
 
             if let Some(with_fill) = with_fill {
                 return not_impl_err!("ORDER BY WITH FILL is not supported: {with_fill}");
             }
+
+            let asc = match sort {
+                Some(OrderBySort::Asc) => Some(true),
+                Some(OrderBySort::Desc) => Some(false),
+                Some(OrderBySort::Using(op)) => {
+                    return not_impl_err!("ORDER BY USING is not supported: {op}");
+                }
+                None => None,
+            };
 
             let expr = match expr {
                 SQLExpr::Value(ValueWithSpan {

--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -24,7 +24,7 @@ use datafusion_common::DataFusionError;
 use datafusion_common::config::{ConfigNonZeroUsize, SqlParserOptions};
 use datafusion_common::format::{ExplainFormat, ExplainStatementOptions};
 use datafusion_common::{Diagnostic, Span, sql_err};
-use sqlparser::ast::{ExprWithAlias, Ident, OrderByOptions};
+use sqlparser::ast::{ExprWithAlias, Ident, OrderByOptions, OrderBySort};
 use sqlparser::tokenizer::TokenWithSpan;
 use sqlparser::{
     ast::{
@@ -998,10 +998,10 @@ impl<'a> DFParser<'a> {
     pub fn parse_order_by_expr(&mut self) -> Result<OrderByExpr, DataFusionError> {
         let expr = self.parser.parse_expr()?;
 
-        let asc = if self.parser.parse_keyword(Keyword::ASC) {
-            Some(true)
+        let sort = if self.parser.parse_keyword(Keyword::ASC) {
+            Some(OrderBySort::Asc)
         } else if self.parser.parse_keyword(Keyword::DESC) {
-            Some(false)
+            Some(OrderBySort::Desc)
         } else {
             None
         };
@@ -1019,7 +1019,7 @@ impl<'a> DFParser<'a> {
 
         Ok(OrderByExpr {
             expr,
-            options: OrderByOptions { asc, nulls_first },
+            options: OrderByOptions { sort, nulls_first },
             with_fill: None,
         })
     }
@@ -1619,7 +1619,16 @@ mod tests {
                         quote_style: None,
                         span: Span::empty(),
                     }),
-                    options: OrderByOptions { asc, nulls_first },
+                    options: OrderByOptions {
+                        sort: asc.map(|asc| {
+                            if asc {
+                                OrderBySort::Asc
+                            } else {
+                                OrderBySort::Desc
+                            }
+                        }),
+                        nulls_first,
+                    },
                     with_fill: None,
                 }]],
                 ..make_create_external_table("foo.csv")
@@ -1643,7 +1652,7 @@ mod tests {
                         span: Span::empty(),
                     }),
                     options: OrderByOptions {
-                        asc: Some(true),
+                        sort: Some(OrderBySort::Asc),
                         nulls_first: None,
                     },
                     with_fill: None,
@@ -1655,7 +1664,7 @@ mod tests {
                         span: Span::empty(),
                     }),
                     options: OrderByOptions {
-                        asc: Some(false),
+                        sort: Some(OrderBySort::Desc),
                         nulls_first: Some(true),
                     },
                     with_fill: None,
@@ -1688,7 +1697,7 @@ mod tests {
                     })),
                 },
                 options: OrderByOptions {
-                    asc: Some(true),
+                    sort: Some(OrderBySort::Asc),
                     nulls_first: None,
                 },
                 with_fill: None,
@@ -1731,7 +1740,7 @@ mod tests {
                     })),
                 },
                 options: OrderByOptions {
-                    asc: Some(true),
+                    sort: Some(OrderBySort::Asc),
                     nulls_first: None,
                 },
                 with_fill: None,
@@ -1795,7 +1804,7 @@ mod tests {
                     })),
                 },
                 options: OrderByOptions {
-                    asc: Some(true),
+                    sort: Some(OrderBySort::Asc),
                     nulls_first: None,
                 },
                 with_fill: None,

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -838,7 +838,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     .collect::<Result<Vec<_>>>()?;
                 Ok(DataType::Struct(Fields::from(fields)))
             }
-            SQLDataType::Map(key_type, value_type) => {
+            SQLDataType::Map(key_type, value_type, _) => {
                 let key_field = Arc::new(Field::new(
                     "key", self.convert_data_type_to_field(key_type)?.data_type().clone(), false
                 ));

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -27,9 +27,9 @@ use datafusion_expr::{
     CreateMemoryTable, DdlStatement, Distinct, Expr, LogicalPlan, LogicalPlanBuilder,
 };
 use sqlparser::ast::{
-    Expr as SQLExpr, ExprWithAliasAndOrderBy, Ident, LimitClause, Offset, OffsetRows,
-    OrderBy, OrderByExpr, OrderByKind, PipeOperator, Query, SelectInto, SetExpr,
-    SetOperator, SetQuantifier, TableAlias,
+    Expr as SQLExpr, ExprWithAliasAndOrderBy, Ident, LimitClause, ObjectName, Offset,
+    OffsetRows, OrderBy, OrderByExpr, OrderByKind, PipeOperator, Query, SelectInto,
+    SetExpr, SetOperator, SetQuantifier, TableAlias,
 };
 use sqlparser::tokenizer::Span;
 
@@ -362,17 +362,30 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         select_into: Option<SelectInto>,
     ) -> Result<LogicalPlan> {
         match select_into {
-            Some(into) => Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
-                CreateMemoryTable {
-                    name: self.object_name_to_table_reference(into.name)?,
-                    constraints: Constraints::default(),
-                    input: Arc::new(plan),
-                    if_not_exists: false,
-                    or_replace: false,
-                    temporary: false,
-                    column_defaults: vec![],
-                },
-            ))),
+            Some(into) => {
+                let name = match into.targets.as_slice() {
+                    [SQLExpr::Identifier(ident)] => ObjectName::from(vec![ident.clone()]),
+                    [SQLExpr::CompoundIdentifier(idents)] => {
+                        ObjectName::from(idents.clone())
+                    }
+                    _ => {
+                        return not_impl_err!(
+                            "SELECT INTO only supports a single table name target"
+                        );
+                    }
+                };
+                Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
+                    CreateMemoryTable {
+                        name: self.object_name_to_table_reference(name)?,
+                        constraints: Constraints::default(),
+                        input: Arc::new(plan),
+                        if_not_exists: false,
+                        or_replace: false,
+                        temporary: false,
+                        column_defaults: vec![],
+                    },
+                )))
+            }
             _ => Ok(plan),
         }
     }
@@ -409,7 +422,7 @@ pub(crate) fn to_order_by_exprs_with_select(
                             quote_style: None,
                             span: Span::empty(),
                         }),
-                        options: order_by_options,
+                        options: order_by_options.clone(),
                         with_fill: None,
                     }),
                     // TODO: Support other types of expressions

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -118,6 +118,7 @@ fn calc_inline_constraints_from_columns(columns: &[ColumnDef]) -> Vec<TableConst
                     index_type_display: _index_type_display,
                     index_type: _index_type,
                     columns: _column,
+                    include: _include,
                     index_options: _index_options,
                     nulls_distinct: _nulls_distinct,
                 }) => constraints.push(TableConstraint::Unique(UniqueConstraint {
@@ -129,13 +130,14 @@ fn calc_inline_constraints_from_columns(columns: &[ColumnDef]) -> Vec<TableConst
                         column: OrderByExpr {
                             expr: SQLExpr::Identifier(column.name.clone()),
                             options: OrderByOptions {
-                                asc: None,
+                                sort: None,
                                 nulls_first: None,
                             },
                             with_fill: None,
                         },
                         operator_class: None,
                     }],
+                    include: vec![],
                     index_options: vec![],
                     characteristics: *characteristics,
                     nulls_distinct: NullsDistinctOption::None,
@@ -146,6 +148,7 @@ fn calc_inline_constraints_from_columns(columns: &[ColumnDef]) -> Vec<TableConst
                     index_name: _index_name,
                     index_type: _index_type,
                     columns: _columns,
+                    include: _include,
                     index_options: _index_options,
                 }) => {
                     constraints.push(TableConstraint::PrimaryKey(PrimaryKeyConstraint {
@@ -156,13 +159,14 @@ fn calc_inline_constraints_from_columns(columns: &[ColumnDef]) -> Vec<TableConst
                             column: OrderByExpr {
                                 expr: SQLExpr::Identifier(column.name.clone()),
                                 options: OrderByOptions {
-                                    asc: None,
+                                    sort: None,
                                     nulls_first: None,
                                 },
                                 with_fill: None,
                             },
                             operator_class: None,
                         }],
+                        include: vec![],
                         index_options: vec![],
                         characteristics: *characteristics,
                     }))
@@ -193,10 +197,12 @@ fn calc_inline_constraints_from_columns(columns: &[ColumnDef]) -> Vec<TableConst
                 ast::ColumnOption::Check(CheckConstraint {
                     name,
                     expr,
+                    no_inherit: _no_inherit,
                     enforced: _enforced,
                 }) => constraints.push(TableConstraint::Check(CheckConstraint {
                     name: name.clone(),
                     expr: expr.clone(),
+                    no_inherit: false,
                     enforced: None,
                 })),
                 ast::ColumnOption::Default(_)
@@ -360,6 +366,11 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 distkey,
                 sortkey,
                 backup,
+                unlogged,
+                with_connection,
+                multiset,
+                fallback,
+                with_data,
             }) => {
                 if temporary {
                     return not_impl_err!("Temporary tables not supported");
@@ -530,6 +541,21 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
                 if backup.is_some() {
                     return not_impl_err!("BACKUP not supported");
+                }
+                if unlogged {
+                    return not_impl_err!("UNLOGGED tables not supported");
+                }
+                if with_connection.is_some() {
+                    return not_impl_err!("WITH CONNECTION not supported");
+                }
+                if multiset.is_some() {
+                    return not_impl_err!("MULTISET tables not supported");
+                }
+                if fallback.is_some() {
+                    return not_impl_err!("FALLBACK not supported");
+                }
+                if with_data.is_some() {
+                    return not_impl_err!("WITH [NO] DATA not supported");
                 }
                 // Merge inline constraints and existing constraints
                 let mut all_constraints = constraints;
@@ -1763,7 +1789,15 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                                 schema,
                                 planner_context,
                             )?;
-                            let asc = order_by_expr.options.asc.unwrap_or(true);
+                            let asc = match &order_by_expr.options.sort {
+                                Some(ast::OrderBySort::Asc) | None => true,
+                                Some(ast::OrderBySort::Desc) => false,
+                                Some(ast::OrderBySort::Using(op)) => {
+                                    return not_impl_err!(
+                                        "ORDER BY USING is not supported: {op}"
+                                    );
+                                }
+                            };
                             let nulls_first =
                                 order_by_expr.options.nulls_first.unwrap_or_else(|| {
                                     self.options.default_null_ordering.nulls_first(asc)
@@ -1930,6 +1964,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     index_type_display: _,
                     index_type: _,
                     columns,
+                    include: _,
                     index_options: _,
                     characteristics: _,
                     nulls_distinct: _,
@@ -1951,6 +1986,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     index_name: _,
                     index_type: _,
                     columns,
+                    include: _,
                     index_options: _,
                     characteristics: _,
                 }) => {
@@ -1964,6 +2000,9 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
                 TableConstraint::ForeignKey { .. } => {
                     _plan_err!("Foreign key constraints are not currently supported")
+                }
+                TableConstraint::Exclude(_) => {
+                    _plan_err!("Exclude constraints are not currently supported")
                 }
                 TableConstraint::Check { .. } => {
                     _plan_err!("Check constraints are not currently supported")
@@ -2721,8 +2760,13 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                         "MERGE UPDATE DELETE WHERE predicates are not supported"
                     );
                 }
-                let assignments = update_expr
-                    .assignments
+                let sql_assignments = match update_expr.kind {
+                    ast::MergeUpdateKind::Set(assignments) => assignments,
+                    ast::MergeUpdateKind::Wildcard => {
+                        return not_impl_err!("MERGE UPDATE SET * is not supported");
+                    }
+                };
+                let assignments = sql_assignments
                     .into_iter()
                     .map(|assign| {
                         let col_name = match &assign.target {
@@ -2799,6 +2843,9 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     }
                     ast::MergeInsertKind::Row => {
                         return not_impl_err!("MERGE INSERT ROW is not supported");
+                    }
+                    ast::MergeInsertKind::Wildcard => {
+                        return not_impl_err!("MERGE INSERT * is not supported");
                     }
                 };
 

--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -2852,6 +2852,9 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 MergeIntoAction::Insert { columns, values }
             }
             ast::MergeAction::Delete { .. } => MergeIntoAction::Delete,
+            ast::MergeAction::DoNothing { .. } => {
+                return not_impl_err!("MERGE DO NOTHING is not supported");
+            }
         };
 
         Ok(MergeIntoClause {

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -465,7 +465,6 @@ impl PostgreSqlDialect {
                     kind: ast::CastKind::Cast,
                     expr: Box::new(expr.clone()),
                     data_type: ast::DataType::Numeric(ast::ExactNumberInfo::None),
-                    array: false,
                     format: None,
                 };
             }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -560,7 +560,6 @@ impl Unparser<'_> {
                     kind: ast::CastKind::TryCast,
                     expr: Box::new(inner_expr),
                     data_type: self.arrow_dtype_to_ast_dtype(field)?,
-                    array: false,
                     format: None,
                 })
             }
@@ -864,7 +863,11 @@ impl Unparser<'_> {
         Ok(ast::OrderByExpr {
             expr: sql_parser_expr,
             options: OrderByOptions {
-                asc: Some(*asc),
+                sort: Some(if *asc {
+                    ast::OrderBySort::Asc
+                } else {
+                    ast::OrderBySort::Desc
+                }),
                 nulls_first,
             },
             with_fill: None,
@@ -1245,7 +1248,6 @@ impl Unparser<'_> {
             kind: ast::CastKind::Cast,
             expr: Box::new(ast::Expr::value(SingleQuotedString(ts))),
             data_type: self.dialect.timestamp_cast_dtype(&time_unit, &None),
-            array: false,
             format: None,
         })
     }
@@ -1268,7 +1270,6 @@ impl Unparser<'_> {
             kind: ast::CastKind::Cast,
             expr: Box::new(ast::Expr::value(SingleQuotedString(time))),
             data_type: ast::DataType::Time(None, TimezoneInfo::None),
-            array: false,
             format: None,
         })
     }
@@ -1289,7 +1290,6 @@ impl Unparser<'_> {
                     kind: ast::CastKind::Cast,
                     expr: Box::new(inner_expr),
                     data_type: self.arrow_dtype_to_ast_dtype(field)?,
-                    array: false,
                     format: None,
                 }),
             },
@@ -1297,7 +1297,6 @@ impl Unparser<'_> {
                 kind: ast::CastKind::Cast,
                 expr: Box::new(inner_expr),
                 data_type: self.arrow_dtype_to_ast_dtype(field)?,
-                array: false,
                 format: None,
             }),
         }
@@ -1448,7 +1447,6 @@ impl Unparser<'_> {
                         date.to_string(),
                     ))),
                     data_type: ast::DataType::Date,
-                    array: false,
                     format: None,
                 })
             }
@@ -1472,7 +1470,6 @@ impl Unparser<'_> {
                         datetime.to_string(),
                     ))),
                     data_type: self.ast_type_for_date64_in_cast(),
-                    array: false,
                     format: None,
                 })
             }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -360,8 +360,9 @@ impl Unparser<'_> {
                 negated: *negated,
                 expr: Box::new(self.expr_to_sql_inner(expr)?),
                 pattern: Box::new(self.expr_to_sql_inner(pattern)?),
-                escape_char: escape_char
-                    .map(|c| SingleQuotedString(c.to_string()).into()),
+                escape_char: escape_char.map(|c| {
+                    Box::new(ast::Expr::Value(SingleQuotedString(c.to_string()).into()))
+                }),
                 any: false,
             }),
             Expr::Like(Like {
@@ -376,8 +377,11 @@ impl Unparser<'_> {
                         negated: *negated,
                         expr: Box::new(self.expr_to_sql_inner(expr)?),
                         pattern: Box::new(self.expr_to_sql_inner(pattern)?),
-                        escape_char: escape_char
-                            .map(|c| SingleQuotedString(c.to_string()).into()),
+                        escape_char: escape_char.map(|c| {
+                            Box::new(ast::Expr::Value(
+                                SingleQuotedString(c.to_string()).into(),
+                            ))
+                        }),
                         any: false,
                     })
                 } else {
@@ -385,8 +389,11 @@ impl Unparser<'_> {
                         negated: *negated,
                         expr: Box::new(self.expr_to_sql_inner(expr)?),
                         pattern: Box::new(self.expr_to_sql_inner(pattern)?),
-                        escape_char: escape_char
-                            .map(|c| SingleQuotedString(c.to_string()).into()),
+                        escape_char: escape_char.map(|c| {
+                            Box::new(ast::Expr::Value(
+                                SingleQuotedString(c.to_string()).into(),
+                            ))
+                        }),
                         any: false,
                     })
                 }

--- a/datafusion/sql/tests/cases/params.rs
+++ b/datafusion/sql/tests/cases/params.rs
@@ -171,7 +171,7 @@ fn test_non_prepare_statement_should_infer_types() {
 
 #[test]
 #[should_panic(
-    expected = "Expected: [NOT] NULL | TRUE | FALSE | DISTINCT | [form] NORMALIZED FROM after IS, found: $1"
+    expected = "Expected: [NOT] NULL | TRUE | FALSE | DISTINCT | [NOT] JSON [VALUE | SCALAR | ARRAY | OBJECT] [WITH | WITHOUT UNIQUE [KEYS]] | [form] NORMALIZED FROM after IS, found: $1"
 )]
 fn test_prepare_statement_to_plan_panic_is_param() {
     let sql = "PREPARE my_plan(INT) AS SELECT id, age  FROM person WHERE age is $1";


### PR DESCRIPTION
## Which issue does this PR close?

- Part of https://github.com/apache/datafusion-sqlparser-rs/issues/2453

Note: this PR is for testing only and is not intended to be merged as-is. Once `sqlparser` 0.63.0 is released, the pin will be updated to the released version.

## Rationale for this change

Test DataFusion against the head of [apache/datafusion-sqlparser-rs](https://github.com/apache/datafusion-sqlparser-rs) ahead of the 0.63.0 release, to find regressions before the release is cut (the same exercise as #21960 for 0.62.0). 

In particular, it is important that all queries that DataFusion accepts with the current sqlparser release must continue to be accepted.

## What changes are included in this PR?

1. Pin `sqlparser` to git rev `0821cbdd5cbdc27f9c7205466d357deef632c936` (current head)
2. Update DataFusion for upstream AST changes

## What is the testing strategy for this PR?

Existing CI (including sqllogictests) run against the new sqlparser version.

## Are there any user-facing changes?

Updated sqlparser version