### PR TITLE
fix: cap the field list in "No field named" errors

### DIFF
--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -269,6 +269,12 @@ fn closest_valid_field<'a>(
     best_match.map(|(_, _, _, valid_field)| valid_field)
 }
 
+/// Maximum number of field names listed in a [`SchemaError::FieldNotFound`]
+/// message. Schemas with hundreds or thousands of columns are ordinary in
+/// analytics workloads, and listing all of them produced error messages
+/// thousands of characters long that pushed the actual error off screen.
+const MAX_LISTED_VALID_FIELDS: usize = 20;
+
 impl Display for SchemaError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -297,15 +303,24 @@ impl Display for SchemaError {
                 }
 
                 if !valid_fields.is_empty() {
-                    write!(
-                        f,
-                        "\nValid fields are {}.",
-                        valid_fields
-                            .iter()
-                            .map(|field| field.quoted_flat_name())
-                            .collect::<Vec<String>>()
-                            .join(", ")
-                    )
+                    // Wide schemas are common, and listing every field turns a
+                    // one-line mistake into a screenful of output. The "Did you
+                    // mean" hint above is the actionable part; the list is just
+                    // context, so cap it.
+                    let listed = valid_fields
+                        .iter()
+                        .take(MAX_LISTED_VALID_FIELDS)
+                        .map(|field| field.quoted_flat_name())
+                        .collect::<Vec<String>>()
+                        .join(", ");
+                    match valid_fields.len().saturating_sub(MAX_LISTED_VALID_FIELDS) {
+                        0 => write!(f, "\nValid fields are {listed}."),
+                        remaining => write!(
+                            f,
+                            "\nValid fields are {listed} and {remaining} other{}.",
+                            if remaining == 1 { "" } else { "s" }
+                        ),
+                    }
                 } else {
                     Ok(())
                 }
@@ -1195,6 +1210,59 @@ pub fn add_possible_columns_to_diag(
 
 #[cfg(test)]
 mod test {
+    use crate::error::{Column, MAX_LISTED_VALID_FIELDS, SchemaError};
+
+    fn field_not_found_message(num_fields: usize) -> String {
+        let valid_fields = (0..num_fields)
+            .map(|i| Column::new_unqualified(format!("col_{i}")))
+            .collect::<Vec<_>>();
+        SchemaError::FieldNotFound {
+            field: Box::new(Column::new_unqualified("nope")),
+            valid_fields,
+        }
+        .to_string()
+    }
+
+    #[test]
+    fn field_not_found_lists_every_field_for_a_narrow_schema() {
+        let message = field_not_found_message(3);
+        assert!(
+            message.contains("Valid fields are col_0, col_1, col_2."),
+            "{message}"
+        );
+        assert!(!message.contains("other"), "{message}");
+    }
+
+    #[test]
+    fn field_not_found_lists_every_field_at_the_cap() {
+        let message = field_not_found_message(MAX_LISTED_VALID_FIELDS);
+        assert!(
+            message.contains(&format!("col_{}.", MAX_LISTED_VALID_FIELDS - 1)),
+            "{message}"
+        );
+        assert!(!message.contains("other"), "{message}");
+    }
+
+    #[test]
+    fn field_not_found_truncates_a_wide_schema() {
+        let message = field_not_found_message(200);
+        // The remaining fields are summarised rather than listed.
+        assert!(message.contains("and 180 others."), "{message}");
+        assert!(message.contains("col_0"), "{message}");
+        assert!(
+            !message.contains(&format!("col_{MAX_LISTED_VALID_FIELDS}")),
+            "{message}"
+        );
+        // A 200 column schema used to produce roughly 2.8k characters.
+        assert!(message.len() < 500, "message was {} chars", message.len());
+    }
+
+    #[test]
+    fn field_not_found_uses_singular_for_one_extra_field() {
+        let message = field_not_found_message(MAX_LISTED_VALID_FIELDS + 1);
+        assert!(message.contains("and 1 other."), "{message}");
+    }
+
     use super::*;
 
     use std::mem::size_of;

--- a/datafusion/common/src/error.rs
+++ b/datafusion/common/src/error.rs
@@ -1210,7 +1210,13 @@ pub fn add_possible_columns_to_diag(
 
 #[cfg(test)]
 mod test {
-    use crate::error::{Column, MAX_LISTED_VALID_FIELDS, SchemaError};
+    use super::*;
+
+    use std::mem::size_of;
+    use std::sync::Arc;
+
+    use arrow::error::ArrowError;
+    use insta::assert_snapshot;
 
     fn field_not_found_message(num_fields: usize) -> String {
         let valid_fields = (0..num_fields)
@@ -1225,50 +1231,36 @@ mod test {
 
     #[test]
     fn field_not_found_lists_every_field_for_a_narrow_schema() {
-        let message = field_not_found_message(3);
-        assert!(
-            message.contains("Valid fields are col_0, col_1, col_2."),
-            "{message}"
-        );
-        assert!(!message.contains("other"), "{message}");
+        assert_snapshot!(field_not_found_message(3), @r"
+        No field named nope.
+        Valid fields are col_0, col_1, col_2.
+        ");
     }
 
     #[test]
     fn field_not_found_lists_every_field_at_the_cap() {
-        let message = field_not_found_message(MAX_LISTED_VALID_FIELDS);
-        assert!(
-            message.contains(&format!("col_{}.", MAX_LISTED_VALID_FIELDS - 1)),
-            "{message}"
-        );
-        assert!(!message.contains("other"), "{message}");
-    }
-
-    #[test]
-    fn field_not_found_truncates_a_wide_schema() {
-        let message = field_not_found_message(200);
-        // The remaining fields are summarised rather than listed.
-        assert!(message.contains("and 180 others."), "{message}");
-        assert!(message.contains("col_0"), "{message}");
-        assert!(
-            !message.contains(&format!("col_{MAX_LISTED_VALID_FIELDS}")),
-            "{message}"
-        );
-        // A 200 column schema used to produce roughly 2.8k characters.
-        assert!(message.len() < 500, "message was {} chars", message.len());
+        assert_snapshot!(field_not_found_message(MAX_LISTED_VALID_FIELDS), @r"
+        No field named nope.
+        Valid fields are col_0, col_1, col_2, col_3, col_4, col_5, col_6, col_7, col_8, col_9, col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, col_18, col_19.
+        ");
     }
 
     #[test]
     fn field_not_found_uses_singular_for_one_extra_field() {
-        let message = field_not_found_message(MAX_LISTED_VALID_FIELDS + 1);
-        assert!(message.contains("and 1 other."), "{message}");
+        assert_snapshot!(field_not_found_message(MAX_LISTED_VALID_FIELDS + 1), @r"
+        No field named nope.
+        Valid fields are col_0, col_1, col_2, col_3, col_4, col_5, col_6, col_7, col_8, col_9, col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, col_18, col_19 and 1 other.
+        ");
     }
 
-    use super::*;
-
-    use std::mem::size_of;
-    use std::sync::Arc;
-
-    use arrow::error::ArrowError;
+    /// A 200 column schema used to produce roughly 2.8k characters.
+    #[test]
+    fn field_not_found_truncates_a_wide_schema() {
+        assert_snapshot!(field_not_found_message(200), @r"
+        No field named nope.
+        Valid fields are col_0, col_1, col_2, col_3, col_4, col_5, col_6, col_7, col_8, col_9, col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, col_18, col_19 and 180 others.
+        ");
+    }
 
     fn ok_result() -> Result<()> {
         Ok(())


### PR DESCRIPTION

## Which issue does this PR close?

Closes #5332.

## Rationale for this change

Selecting a column that doesn't exist lists every field in the schema. On a 200 column table that's about 2.8k characters, and the useful part of the message - the name that wasn't found and the "Did you mean" suggestion - ends up scrolled off the top.

```
> SELECT not_a_column FROM wide;
Error: Schema error: No field named not_a_column.
Valid fields are wide.col_0, wide.col_1, ... wide.col_199.
```

Filed in 2023, still reproduces.

## What changes are included in this PR?

Cap the list at 20 fields and summarise the rest:

```
Valid fields are wide.col_0, ... wide.col_19 and 180 others.
```

2.8k characters down to 356. Schemas at or under 20 fields print the same as before, so the existing message assertions in dfschema.rs, column.rs, expr_rewriter and the dataframe tests are untouched - they're all well under that.

The issue suggested either dropping the list like Postgres does or truncating it. I kept it and bounded it, since the list is useful on narrow schemas and closest_valid_field already handles the common typo. Happy to switch to the Postgres behaviour instead if you'd rather.

## Are these changes tested?

Four unit tests in datafusion/common/src/error.rs: a narrow schema, exactly 20 fields, 21 fields (checks it says "1 other" not "1 others"), and 200 fields.

cargo test -p datafusion-common: 608 passed. datafusion-expr --lib: 258 passed. cargo fmt clean.

Two things in my checkout that aren't from this change and reproduce on unmodified main: the arrow_test_data doctest fails because the testing/ submodule isn't initialised, and clippy reports an unused import of crate::config::TableParquetOptions.

## Are there any user-facing changes?

The wording of SchemaError::FieldNotFound when a schema has more than 20 fields. No API change.