### PR TITLE
fix: `make_array` over NULL-typed columns returns one list per row

### DIFF
--- a/datafusion/functions-nested/src/make_array.rs
+++ b/datafusion/functions-nested/src/make_array.rs
@@ -28,7 +28,6 @@ use arrow::array::{
 use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::DataType;
 use arrow::datatypes::{DataType::Null, Field};
-use datafusion_common::utils::SingleRowListArrayBuilder;
 use datafusion_common::{Result, plan_err};
 use datafusion_expr::binary::{
     try_type_union_resolution_with_struct, type_union_resolution,
@@ -137,15 +136,34 @@ pub(crate) fn make_array_inner(arrays: &[ArrayRef]) -> Result<ArrayRef> {
 
     let data_type = data_type.unwrap_or(&Null);
     if data_type.is_null() {
-        // Either an empty array or all nulls:
-        let length = arrays.iter().map(|a| a.len()).sum();
-        let array = new_null_array(&Null, length);
-        Ok(Arc::new(
-            SingleRowListArrayBuilder::new(array).build_list_array(),
-        ))
+        Ok(Arc::new(null_list_array(
+            arrays,
+            Field::LIST_FIELD_DEFAULT_NAME,
+        )))
     } else {
         array_array::<i32>(arrays, data_type.clone(), Field::LIST_FIELD_DEFAULT_NAME)
     }
+}
+
+/// Builds the result of `make_array` when there are no arguments or every
+/// argument is `NULL`-typed: a `List(Null)` array with one row per input row,
+/// each holding one null per argument. With no arguments there is a single
+/// row holding an empty list.
+///
+/// The arguments have already been expanded to a common length, so the row
+/// count is taken from the first one. Summing the argument lengths instead
+/// produced a single row for column inputs, see
+/// <https://github.com/apache/datafusion/issues/21841>.
+pub fn null_list_array(arrays: &[ArrayRef], field_name: &str) -> GenericListArray<i32> {
+    let num_rows = arrays.first().map_or(1, |array| array.len());
+    let values = new_null_array(&Null, num_rows * arrays.len());
+    let offsets = OffsetBuffer::from_lengths(std::iter::repeat_n(arrays.len(), num_rows));
+    GenericListArray::new(
+        Arc::new(Field::new(field_name, Null, true)),
+        offsets,
+        values,
+        None,
+    )
 }
 
 /// Convert one or more [`ArrayRef`] of the same type into a

--- a/datafusion/spark/src/function/array/spark_array.rs
+++ b/datafusion/spark/src/function/array/spark_array.rs
@@ -17,15 +17,16 @@
 
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, new_null_array};
+use arrow::array::{Array, ArrayRef};
 use arrow::datatypes::{DataType, Field, FieldRef};
-use datafusion_common::utils::SingleRowListArrayBuilder;
 use datafusion_common::{Result, internal_err};
 use datafusion_expr::{
     ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     Volatility,
 };
-use datafusion_functions_nested::make_array::{array_array, coerce_types_inner};
+use datafusion_functions_nested::make_array::{
+    array_array, coerce_types_inner, null_list_array,
+};
 
 use crate::function::functions_nested_utils::make_scalar_function;
 
@@ -121,17 +122,7 @@ pub fn make_array_inner(arrays: &[ArrayRef]) -> Result<ArrayRef> {
 
     match data_type {
         // Either an empty array or all nulls:
-        DataType::Null => {
-            let length = arrays.iter().map(|a| a.len()).sum();
-            // By default Int32
-            let array = new_null_array(&DataType::Null, length);
-            Ok(Arc::new(
-                SingleRowListArrayBuilder::new(array)
-                    .with_nullable(true)
-                    .with_field_name(Some(ARRAY_FIELD_DEFAULT_NAME.to_string()))
-                    .build_list_array(),
-            ))
-        }
+        DataType::Null => Ok(Arc::new(null_list_array(arrays, ARRAY_FIELD_DEFAULT_NAME))),
         _ => array_array::<i32>(arrays, data_type, ARRAY_FIELD_DEFAULT_NAME),
     }
 }

--- a/datafusion/sqllogictest/test_files/array/make_array.slt
+++ b/datafusion/sqllogictest/test_files/array/make_array.slt
@@ -88,6 +88,33 @@ select make_array(NULL), make_array(NULL, NULL, NULL), make_array(make_array(NUL
 ----
 [NULL] [NULL, NULL, NULL] [[NULL, NULL], [NULL, NULL]]
 
+# make_array over NULL-typed columns builds one list per row, not a single
+# list of all the nulls (https://github.com/apache/datafusion/issues/21841)
+query ?
+select make_array(n) from (values (NULL), (NULL), (NULL)) as t(n);
+----
+[NULL]
+[NULL]
+[NULL]
+
+query ?T
+select [n, n], arrow_typeof([n, n]) from (values (NULL), (NULL)) as t(n);
+----
+[NULL, NULL] List(Field { name: "item", data_type: Null, nullable: true })
+[NULL, NULL] List(Field { name: "item", data_type: Null, nullable: true })
+
+query I
+select count(*) from (select unnest([n, n]) from (values (NULL), (NULL), (NULL)) as t(n));
+----
+6
+
+# the NULL-typed path of array_append goes through make_array as well
+query ?
+select array_append(n, n) from (values (NULL), (NULL)) as t(n);
+----
+[NULL]
+[NULL]
+
 # make_array with 1 columns
 query ???
 select make_array(a), make_array(d), make_array(e) from values;

--- a/datafusion/sqllogictest/test_files/array/make_array.slt
+++ b/datafusion/sqllogictest/test_files/array/make_array.slt
@@ -100,8 +100,8 @@ select make_array(n) from (values (NULL), (NULL), (NULL)) as t(n);
 query ?T
 select [n, n], arrow_typeof([n, n]) from (values (NULL), (NULL)) as t(n);
 ----
-[NULL, NULL] List(Field { name: "item", data_type: Null, nullable: true })
-[NULL, NULL] List(Field { name: "item", data_type: Null, nullable: true })
+[NULL, NULL] List(Null)
+[NULL, NULL] List(Null)
 
 query I
 select count(*) from (select unnest([n, n]) from (values (NULL), (NULL), (NULL)) as t(n));

--- a/datafusion/sqllogictest/test_files/spark/array/array.slt
+++ b/datafusion/sqllogictest/test_files/spark/array/array.slt
@@ -85,3 +85,10 @@ query ?
 SELECT array(arrow_cast(array(1,2), 'LargeList(Int64)'), array(3));
 ----
 [[1, 2], [3]]
+
+# NULL-typed columns build one list per row
+query ?
+SELECT array(n) FROM (VALUES (NULL), (NULL)) AS t(n);
+----
+[NULL]
+[NULL]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #21841.

## Rationale for this change

`make_array_inner` handled arguments that are all `NULL`-typed by summing their lengths and wrapping the nulls in a single-row list. That is right for literals, whose arrays have one row, but a `Null`-typed column has one row per input row, so `SELECT make_array(n) FROM (VALUES (NULL), (NULL), (NULL)) AS t(n)` failed with an internal error ("returned a different number of rows than expected. Expected: 3, Got: 1"). `[n, n]`, `array_append(n, n)` and `map([n::varchar], [n])` reach the same code.

Picks up where #21842 (closed as stale) left off, with the logic kept inside `make_array_inner` so the `array_append` and `map` callers are covered too.

## What changes are included in this PR?

A `null_list_array` helper builds a `List(Null)` array with one row per input row, each holding one null per argument (a single row with an empty list when there are no arguments, as before). The Spark `array` function had its own copy of the old logic and now uses the helper.

## Are these changes tested?

Yes. `make_array.slt` covers `make_array(n)`, `[n, n]` (with its type), `unnest([n, n])` and `array_append(n, n)` over a NULL-typed column; `spark/array/array.slt` covers the Spark `array` function. The existing literal cases (`make_array(NULL)`, `make_array(NULL, NULL, NULL)`, `make_array()`) are unchanged.

## Are there any user-facing changes?

`make_array` (and the functions built on it) over a `Null`-typed column returns one list per row instead of an internal error.
