### PR TITLE
fix: compare nested list scalars with a dynamic comparator

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -856,9 +856,9 @@ fn partial_cmp_list(arr1: &dyn Array, arr2: &dyn Array) -> Option<Ordering> {
     .ok()?;
 
     for j in 0..min_length {
-        match cmp(j, j) {
-            Ordering::Equal => continue,
-            ordering => return Some(ordering),
+        let ordering = cmp(j, j);
+        if ordering != Ordering::Equal {
+            return Some(ordering);
         }
     }
 

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -59,6 +59,7 @@ use crate::scalar::consts::{
 };
 use crate::utils::SingleRowListArrayBuilder;
 use crate::{_internal_datafusion_err, arrow_datafusion_err};
+use arrow::array::make_comparator;
 use arrow::array::{
     Array, ArrayData, ArrayDataBuilder, ArrayRef, ArrowNativeTypeOp, ArrowPrimitiveType,
     AsArray, BinaryArray, BinaryViewArray, BinaryViewBuilder, BooleanArray, Date32Array,
@@ -77,6 +78,7 @@ use arrow::array::{
     downcast_run_array, new_empty_array, new_null_array,
 };
 use arrow::buffer::{BooleanBuffer, ScalarBuffer};
+use arrow::compute::SortOptions;
 use arrow::compute::kernels::cast::{CastOptions, cast_with_options};
 use arrow::compute::kernels::numeric::{
     add, add_wrapping, div, mul, mul_wrapping, rem, sub, sub_wrapping,
@@ -835,29 +837,28 @@ fn partial_cmp_list(arr1: &dyn Array, arr2: &dyn Array) -> Option<Ordering> {
     let arr1_trimmed = arr1.slice(0, min_length);
     let arr2_trimmed = arr2.slice(0, min_length);
 
-    let lt_res = arrow::compute::kernels::cmp::lt(&arr1_trimmed, &arr2_trimmed).ok()?;
-    let eq_res = arrow::compute::kernels::cmp::eq(&arr1_trimmed, &arr2_trimmed).ok()?;
+    // Compare the elements with a dynamic comparator rather than the `lt` /
+    // `eq` kernels: it covers nested lists, structs and the other nested
+    // element types the kernels reject, and `nulls_first: false` gives the
+    // Postgres semantics kept here, where a NULL element is greater than a
+    // non-NULL one:
+    //
+    // $ SELECT ARRAY[NULL]::integer[] > ARRAY[1]
+    // true
+    let cmp = make_comparator(
+        &arr1_trimmed,
+        &arr2_trimmed,
+        SortOptions {
+            descending: false,
+            nulls_first: false,
+        },
+    )
+    .ok()?;
 
-    for j in 0..lt_res.len() {
-        // In Postgres, NULL values in lists are always considered to be greater than non-NULL values:
-        //
-        // $ SELECT ARRAY[NULL]::integer[] > ARRAY[1]
-        // true
-        //
-        // These next two if statements are introduced for replicating Postgres behavior, as
-        // arrow::compute does not account for this.
-        if arr1_trimmed.is_null(j) && !arr2_trimmed.is_null(j) {
-            return Some(Ordering::Greater);
-        }
-        if !arr1_trimmed.is_null(j) && arr2_trimmed.is_null(j) {
-            return Some(Ordering::Less);
-        }
-
-        if lt_res.is_valid(j) && lt_res.value(j) {
-            return Some(Ordering::Less);
-        }
-        if eq_res.is_valid(j) && !eq_res.value(j) {
-            return Some(Ordering::Greater);
+    for j in 0..min_length {
+        match cmp(j, j) {
+            Ordering::Equal => continue,
+            ordering => return Some(ordering),
         }
     }
 
@@ -7227,6 +7228,68 @@ mod tests {
         assert_eq!(
             ScalarValue::new_negative_one(&DataType::Decimal128(5, 2)).unwrap(),
             ScalarValue::Decimal128(Some(-100), 5, 2)
+        );
+    }
+
+    #[test]
+    fn test_nested_list_partial_cmp() {
+        // Lists whose elements are lists or structs used to be uncomparable
+        // because the element comparison went through the `lt` / `eq`
+        // kernels, which reject nested types.
+        fn nested(values: Vec<Vec<i64>>) -> ScalarValue {
+            let inner: ArrayRef =
+                Arc::new(ListArray::from_iter_primitive::<Int64Type, _, _>(
+                    values
+                        .into_iter()
+                        .map(|v| Some(v.into_iter().map(Some).collect::<Vec<_>>())),
+                ));
+            ScalarValue::List(Arc::new(
+                SingleRowListArrayBuilder::new(inner).build_list_array(),
+            ))
+        }
+
+        assert_eq!(
+            nested(vec![vec![1, 2]]).partial_cmp(&nested(vec![vec![1, 2]])),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            nested(vec![vec![1, 2]]).partial_cmp(&nested(vec![vec![1, 3]])),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            nested(vec![vec![2]]).partial_cmp(&nested(vec![vec![1, 9]])),
+            Some(Ordering::Greater)
+        );
+        // a shorter prefix sorts first, at both levels
+        assert_eq!(
+            nested(vec![vec![1]]).partial_cmp(&nested(vec![vec![1, 2]])),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            nested(vec![vec![1, 2]]).partial_cmp(&nested(vec![vec![1, 2], vec![0]])),
+            Some(Ordering::Less)
+        );
+
+        let a = ScalarValue::Struct(Arc::new(StructArray::from(vec![(
+            Arc::new(Field::new("a", DataType::Int64, true)),
+            Arc::new(Int64Array::from(vec![1])) as ArrayRef,
+        )])));
+        let b = ScalarValue::Struct(Arc::new(StructArray::from(vec![(
+            Arc::new(Field::new("a", DataType::Int64, true)),
+            Arc::new(Int64Array::from(vec![2])) as ArrayRef,
+        )])));
+        let list_of_structs = |s: &ScalarValue| {
+            ScalarValue::List(Arc::new(
+                SingleRowListArrayBuilder::new(s.to_array().unwrap()).build_list_array(),
+            ))
+        };
+        assert_eq!(
+            list_of_structs(&a).partial_cmp(&list_of_structs(&b)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            list_of_structs(&b).partial_cmp(&list_of_structs(&a)),
+            Some(Ordering::Greater)
         );
     }
 

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -3044,6 +3044,18 @@ select min(t), max(t) from  (select '00:00:00' as t union select '00:00:01' unio
 ----
 00:00:00 00:00:02
 
+# min/max over lists whose elements are lists or structs used to fail with
+# "Internal error: Uncomparable values"
+query ??
+select min(column1), max(column1) from values ([[1, 2]]), ([[1, 3]]), ([[0, 9], [5]]), ([[1]]);
+----
+[[0, 9], [5]] [[1, 3]]
+
+query ??
+select min(column1), max(column1) from values ([struct(2, 'b')]), ([struct(1, 'z')]), ([struct(1, 'a'), struct(0, 'x')]);
+----
+[{c0: 1, c1: a}, {c0: 0, c1: x}] [{c0: 2, c1: b}]
+
 # aggregate Interval(MonthDayNano) min/max
 query T??
 select


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24937.

## Rationale for this change

`ScalarValue::partial_cmp` for lists compared the elements with the `lt` / `eq` kernels, which reject nested element types, so `min` / `max` over a list of lists or a list of structs failed with `Internal error: Uncomparable values`.

## What changes are included in this PR?

`partial_cmp_list` now compares the elements with `arrow::array::make_comparator`, which supports the nested types. `nulls_first: false` keeps the existing Postgres semantics where a NULL element is greater than a non-NULL one (this replaces the hand-written null checks), and the prefix / length rule is unchanged.

## Are these changes tested?

Yes. `test_nested_list_partial_cmp` covers lists of lists (equal, less, greater, shorter prefix at both levels) and lists of structs; the existing `test_list_partial_cmp` and the rest of the `scalar` tests pass unchanged. `aggregate.slt` gains `min` / `max` over a list of lists and a list of structs.

## Are there any user-facing changes?

`min` / `max` (and other list scalar comparisons) work for lists of nested values instead of returning an internal error.
