### PR TITLE
fix: sort pushed below `GlobalLimitExec` ignores `skip`, returning too few rows

### DIFF
--- a/datafusion/core/tests/physical_optimizer/ensure_requirements.rs
+++ b/datafusion/core/tests/physical_optimizer/ensure_requirements.rs
@@ -1531,3 +1531,32 @@ fn test_collect_left_join_keeps_hash_partitioned_build_side_coalesce() -> Result
 
     Ok(())
 }
+
+// ========================================================================
+// Limits with a `skip`
+// ========================================================================
+
+/// A sort pushed below `GlobalLimitExec` with a non-zero `skip` must ask its
+/// input for `skip + fetch` rows; asking for only `fetch` rows used to leave
+/// `LIMIT 10 OFFSET 5` with 5 result rows.
+///
+/// This checks a single pass only: the sort is inserted by `pushdown_sorts`,
+/// which runs after `parallelize_sorts`, so a second pass would additionally
+/// parallelize it into `SortPreservingMergeExec` + partitioned `SortExec`.
+#[test]
+fn test_sort_pushed_below_limit_with_skip_keeps_skip_rows() -> Result<()> {
+    let source = Arc::new(MockMultiPartitionExec::new(4));
+    let coalesce = Arc::new(CoalescePartitionsExec::new(source));
+    let limit = Arc::new(GlobalLimitExec::new(coalesce, 5, Some(10)));
+    let sort: Arc<dyn ExecutionPlan> =
+        Arc::new(SortExec::new(sort_expr_on("a", 0, true, true), limit));
+
+    let optimized = optimize_and_sanity_check(sort)?;
+    assert_snapshot!(plan_string(&optimized), @r"
+    GlobalLimitExec: skip=5, fetch=10
+      SortExec: TopK(fetch=15), expr=[a@0 DESC], preserve_partitioning=[false]
+        CoalescePartitionsExec
+          MockMultiPartitionExec
+    ");
+    Ok(())
+}

--- a/datafusion/physical-optimizer/src/ensure_requirements/enforce_sorting/sort_pushdown.rs
+++ b/datafusion/physical-optimizer/src/ensure_requirements/enforce_sorting/sort_pushdown.rs
@@ -80,21 +80,31 @@ impl Default for ParentRequirements {
 pub type SortPushDown = PlanContext<ParentRequirements>;
 
 /// Number of input rows `plan` needs from its children in order to produce
-/// its own `fetch` rows. This is `plan.fetch()` for every operator except
-/// [`GlobalLimitExec`], which discards `skip` rows first and therefore needs
-/// `skip + fetch` input rows. Using the bare `fetch` there would turn
-/// `LIMIT 10 OFFSET 5` into `TopK(10)` below the limit, i.e. 5 result rows.
+/// the rows its parent will consume.
 ///
-/// Note this is distinct from the fetch a parent imposes on `plan`'s *output*
-/// (`ParentRequirements::fetch`), for which `plan.fetch()` is the right bound.
+/// `parent_fetch` is the fetch a parent imposes on `plan`'s *output*
+/// (`ParentRequirements::fetch`). It bounds `plan.fetch()` directly because
+/// both count output rows, so the effective output fetch is
+/// `min(plan.fetch(), parent_fetch)`.
+///
+/// The input fetch is that output fetch for every operator except
+/// [`GlobalLimitExec`], which discards `skip` rows first and therefore needs
+/// `skip` more input rows. `skip` must be added *after* taking the minimum:
+/// `min(fetch + skip, parent_fetch)` would be too small whenever the parent
+/// fetch is the tighter bound. Using the bare `fetch` would be wrong too, as
+/// it would turn `LIMIT 10 OFFSET 5` into `TopK(10)` below the limit, i.e. 5
+/// result rows.
 ///
 /// `skip` and `fetch` are independent `usize`s, so their sum can overflow. Like
 /// [`combine_limit`], we saturate: `usize::MAX` input rows is never a smaller
 /// bound than the real one, so the pushed-down fetch stays correct.
 ///
 /// [`combine_limit`]: datafusion_common::utils::combine_limit
-fn input_fetch(plan: &Arc<dyn ExecutionPlan>) -> Option<usize> {
-    let fetch = plan.fetch()?;
+fn input_fetch(
+    plan: &Arc<dyn ExecutionPlan>,
+    parent_fetch: Option<usize>,
+) -> Option<usize> {
+    let fetch = min_fetch(plan.fetch(), parent_fetch)?;
     let skip = plan
         .downcast_ref::<GlobalLimitExec>()
         .map_or(0, |limit| limit.skip());
@@ -386,7 +396,7 @@ fn pushdown_sorts_helper(
         // For operators that can take a sort pushdown, continue with updated
         // requirements. If this node already outputs single partition (e.g. SPM),
         // don't push SinglePartition to children.
-        let current_fetch = input_fetch(&sort_push_down.plan);
+        let current_fetch = input_fetch(&sort_push_down.plan, parent_fetch);
         let dists = sort_push_down
             .plan
             .input_distribution_requirements()
@@ -401,7 +411,7 @@ fn pushdown_sorts_helper(
             sort_push_down.children.iter_mut().zip(adjusted).enumerate()
         {
             child.data.ordering_requirement = order;
-            child.data.fetch = min_fetch(current_fetch, parent_fetch);
+            child.data.fetch = current_fetch;
             child.data.distribution_requirement = stronger_distribution(
                 &effective_dist,
                 dists
@@ -1243,7 +1253,32 @@ mod tests {
         let limit: Arc<dyn ExecutionPlan> =
             Arc::new(GlobalLimitExec::new(input, 5, Some(10)));
 
-        assert_eq!(input_fetch(&limit), Some(15));
+        assert_eq!(input_fetch(&limit, None), Some(15));
+    }
+
+    /// A parent fetch bounds the limit's *output*, so it is applied before
+    /// `skip` is added: `min(10, 3) + 5 = 8`, not `min(10 + 5, 3) = 3`.
+    #[test]
+    fn input_fetch_applies_parent_fetch_before_adding_skip() {
+        let input = Arc::new(EmptyExec::new(child_schema()));
+        let limit: Arc<dyn ExecutionPlan> =
+            Arc::new(GlobalLimitExec::new(input, 5, Some(10)));
+
+        assert_eq!(input_fetch(&limit, Some(3)), Some(8));
+        // A looser parent fetch changes nothing.
+        assert_eq!(input_fetch(&limit, Some(20)), Some(15));
+    }
+
+    /// `OFFSET` without `LIMIT` has no fetch of its own, but a parent fetch
+    /// still needs `skip` extra input rows.
+    #[test]
+    fn input_fetch_adds_skip_to_parent_fetch_without_own_fetch() {
+        let input = Arc::new(EmptyExec::new(child_schema()));
+        let limit: Arc<dyn ExecutionPlan> =
+            Arc::new(GlobalLimitExec::new(input, 5, None));
+
+        assert_eq!(input_fetch(&limit, None), None);
+        assert_eq!(input_fetch(&limit, Some(3)), Some(8));
     }
 
     /// `skip` and `fetch` are unrelated `usize`s, so `skip + fetch` can exceed
@@ -1256,7 +1291,7 @@ mod tests {
         let limit: Arc<dyn ExecutionPlan> =
             Arc::new(GlobalLimitExec::new(input, usize::MAX, Some(1)));
 
-        assert_eq!(input_fetch(&limit), Some(usize::MAX));
+        assert_eq!(input_fetch(&limit, None), Some(usize::MAX));
     }
 
     /// Child (input) schema fed to the projections under test: `[a, b, c]`.

--- a/datafusion/physical-optimizer/src/ensure_requirements/enforce_sorting/sort_pushdown.rs
+++ b/datafusion/physical-optimizer/src/ensure_requirements/enforce_sorting/sort_pushdown.rs
@@ -87,12 +87,18 @@ pub type SortPushDown = PlanContext<ParentRequirements>;
 ///
 /// Note this is distinct from the fetch a parent imposes on `plan`'s *output*
 /// (`ParentRequirements::fetch`), for which `plan.fetch()` is the right bound.
+///
+/// `skip` and `fetch` are independent `usize`s, so their sum can overflow. Like
+/// [`combine_limit`], we saturate: `usize::MAX` input rows is never a smaller
+/// bound than the real one, so the pushed-down fetch stays correct.
+///
+/// [`combine_limit`]: datafusion_common::utils::combine_limit
 fn input_fetch(plan: &Arc<dyn ExecutionPlan>) -> Option<usize> {
     let fetch = plan.fetch()?;
     let skip = plan
         .downcast_ref::<GlobalLimitExec>()
         .map_or(0, |limit| limit.skip());
-    Some(fetch + skip)
+    Some(fetch.saturating_add(skip))
 }
 
 /// Assigns the ordering requirement of the root node to the its children.
@@ -1220,6 +1226,7 @@ mod tests {
     use datafusion_physical_expr::PhysicalExpr;
     use datafusion_physical_expr::expressions::{BinaryExpr, col};
     use datafusion_physical_plan::empty::EmptyExec;
+    use datafusion_physical_plan::limit::GlobalLimitExec;
 
     const DESC: SortOptions = SortOptions {
         descending: true,
@@ -1229,6 +1236,28 @@ mod tests {
         descending: false,
         nulls_first: true,
     };
+
+    #[test]
+    fn input_fetch_adds_skip_for_global_limit() {
+        let input = Arc::new(EmptyExec::new(child_schema()));
+        let limit: Arc<dyn ExecutionPlan> =
+            Arc::new(GlobalLimitExec::new(input, 5, Some(10)));
+
+        assert_eq!(input_fetch(&limit), Some(15));
+    }
+
+    /// `skip` and `fetch` are unrelated `usize`s, so `skip + fetch` can exceed
+    /// `usize::MAX`. Saturating keeps this at an (unreachable) upper bound
+    /// instead of panicking in debug builds or wrapping to a too-small fetch --
+    /// wrapping to 0 would push down a `TopK(fetch=0)` and drop every row.
+    #[test]
+    fn input_fetch_saturates_instead_of_overflowing() {
+        let input = Arc::new(EmptyExec::new(child_schema()));
+        let limit: Arc<dyn ExecutionPlan> =
+            Arc::new(GlobalLimitExec::new(input, usize::MAX, Some(1)));
+
+        assert_eq!(input_fetch(&limit), Some(usize::MAX));
+    }
 
     /// Child (input) schema fed to the projections under test: `[a, b, c]`.
     fn child_schema() -> Arc<Schema> {

--- a/datafusion/physical-optimizer/src/ensure_requirements/enforce_sorting/sort_pushdown.rs
+++ b/datafusion/physical-optimizer/src/ensure_requirements/enforce_sorting/sort_pushdown.rs
@@ -79,6 +79,22 @@ impl Default for ParentRequirements {
 
 pub type SortPushDown = PlanContext<ParentRequirements>;
 
+/// Number of input rows `plan` needs from its children in order to produce
+/// its own `fetch` rows. This is `plan.fetch()` for every operator except
+/// [`GlobalLimitExec`], which discards `skip` rows first and therefore needs
+/// `skip + fetch` input rows. Using the bare `fetch` there would turn
+/// `LIMIT 10 OFFSET 5` into `TopK(10)` below the limit, i.e. 5 result rows.
+///
+/// Note this is distinct from the fetch a parent imposes on `plan`'s *output*
+/// (`ParentRequirements::fetch`), for which `plan.fetch()` is the right bound.
+fn input_fetch(plan: &Arc<dyn ExecutionPlan>) -> Option<usize> {
+    let fetch = plan.fetch()?;
+    let skip = plan
+        .downcast_ref::<GlobalLimitExec>()
+        .map_or(0, |limit| limit.skip());
+    Some(fetch + skip)
+}
+
 /// Assigns the ordering requirement of the root node to the its children.
 pub fn assign_initial_requirements(sort_push_down: &mut SortPushDown) {
     let reqs = sort_push_down.plan.required_input_ordering();
@@ -364,7 +380,7 @@ fn pushdown_sorts_helper(
         // For operators that can take a sort pushdown, continue with updated
         // requirements. If this node already outputs single partition (e.g. SPM),
         // don't push SinglePartition to children.
-        let current_fetch = sort_push_down.plan.fetch();
+        let current_fetch = input_fetch(&sort_push_down.plan);
         let dists = sort_push_down
             .plan
             .input_distribution_requirements()

--- a/datafusion/sqllogictest/test_files/limit.slt
+++ b/datafusion/sqllogictest/test_files/limit.slt
@@ -339,6 +339,29 @@ SELECT COUNT(*) FROM (SELECT a FROM t1 LIMIT 3 OFFSET 8);
 ----
 2
 
+# A sort above LIMIT ... OFFSET is pushed below the limit as a TopK. The TopK
+# has to keep `skip + fetch` rows (3 + 4 = 7) so that the limit can still skip
+# 3 rows and return 4; keeping only `fetch` rows returned a single row.
+query TT
+EXPLAIN SELECT * FROM (SELECT a FROM t1 LIMIT 4 OFFSET 3) ORDER BY a;
+----
+logical_plan
+01)Sort: t1.a ASC NULLS LAST
+02)--Limit: skip=3, fetch=4
+03)----TableScan: t1 projection=[a], fetch=7
+physical_plan
+01)GlobalLimitExec: skip=3, fetch=4
+02)--SortExec: TopK(fetch=7), expr=[a@0 ASC NULLS LAST], preserve_partitioning=[false]
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
+
+query I
+SELECT * FROM (SELECT a FROM t1 LIMIT 4 OFFSET 3) ORDER BY a;
+----
+4
+5
+6
+7
+
 # The aggregate does not need to be computed because the input statistics are exact and
 # an OFFSET, but no LIMIT, is specified.
 query TT


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #.

## Rationale for this change

`ORDER BY` applied on top of a `LIMIT ... OFFSET` subquery returns too few rows.

```sql
SELECT * FROM (SELECT a FROM t1 LIMIT 4 OFFSET 3) ORDER BY a;
```

`EnforceSorting` pushes the sort below the `GlobalLimitExec` and converts it into a
TopK. The TopK's fetch was seeded from `GlobalLimitExec::fetch()`, which is the
limit's *output* row count and ignores `skip`. So the TopK kept only 4 rows, the
limit then skipped 3 of them, and the query returned a single row instead of 4.

The same seeding happens in two places in `sort_pushdown.rs`: when a root's direct
child is a `GlobalLimitExec` (`assign_initial_requirements`) and when the pushdown
descends through one (`pushdown_sorts_helper`). Both had the bug.

## What changes are included in this PR?

- Add an `input_fetch` helper in `sort_pushdown.rs` that returns `skip + fetch` for
  `GlobalLimitExec` and plain `fetch()` for every other operator.
- Use it at both sites where the pushed-down fetch is derived from the plan node, so
  the TopK below a `GlobalLimitExec` retains enough rows for the limit to skip and
  still return `fetch` rows.

## What is the testing strategy for this PR?

- `limit.slt`: new `EXPLAIN` + result test for `LIMIT 4 OFFSET 3` under `ORDER BY`,
  showing `TopK(fetch=7)` below `GlobalLimitExec: skip=3, fetch=4` and the correct
  4 rows.
- `ensure_requirements.rs`: two unit tests, one per code path
  (`test_sort_pushed_below_limit_with_skip_keeps_skip_rows` and
  `test_parent_ordering_over_limit_with_skip_keeps_skip_rows`), asserting the
  pushed sort has `fetch=15` for `skip=5, fetch=10`.

## Are there any user-facing changes?

Queries with a sort above `LIMIT ... OFFSET` now return the correct number of rows.
No API changes.
