### PR TITLE
Fix Postgres decimal formatter clippy

### DIFF
--- a/datafusion/sqllogictest/src/engines/conversion.rs
+++ b/datafusion/sqllogictest/src/engines/conversion.rs
@@ -96,7 +96,7 @@ pub(crate) fn arrow_decimal_to_str<T: DecimalType>(
 }
 
 #[cfg(feature = "postgres")]
-pub(crate) fn decimal_to_str(value: BigDecimal) -> String {
+pub(crate) fn decimal_to_str(value: &BigDecimal) -> String {
     value.to_plain_string()
 }
 
@@ -161,5 +161,12 @@ mod tests {
             ),
             "0.12345678901234567890123456789012345678"
         );
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn test_decimal_to_str() {
+        let value = BigDecimal::from_str("1.2300").unwrap();
+        assert_eq!(decimal_to_str(&value), "1.2300");
     }
 }

--- a/datafusion/sqllogictest/src/engines/postgres_engine/mod.rs
+++ b/datafusion/sqllogictest/src/engines/postgres_engine/mod.rs
@@ -377,7 +377,7 @@ fn cell_to_string(row: &SimpleQueryRow, column_type: &Type, idx: usize) -> Strin
         (&Type::INT4, Some(value)) => value.parse::<i32>().unwrap().to_string(),
         (&Type::INT8, Some(value)) => value.parse::<i64>().unwrap().to_string(),
         (&Type::NUMERIC, Some(value)) => {
-            decimal_to_str(BigDecimal::from_str(value).unwrap())
+            decimal_to_str(&BigDecimal::from_str(value).unwrap())
         }
         // Parse date/time strings explicitly to avoid locale-specific formatting.
         (&Type::DATE, Some(value)) => NaiveDate::parse_from_str(value, "%Y-%m-%d")


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24974.

## Rationale for this change

The required `cargo clippy --all-targets --all-features -- -D warnings` command fails because the PostgreSQL result formatter takes a `BigDecimal` by value but only reads it.

## What changes are included in this PR?

- Accept `&BigDecimal` in `decimal_to_str`.
- Borrow the parsed PostgreSQL decimal at the call site.
- Add a direct formatting regression test under the `postgres` feature.

## What is the testing strategy for this PR?

- `cargo test -p datafusion-sqllogictest --lib --features postgres engines::conversion`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

## Are there any user-facing changes?

No. The formatted PostgreSQL decimal output is unchanged.