### PR TITLE
fix: preserve nulls in array_has_any/all empty-needle path

### DIFF
--- a/datafusion/functions-nested/src/array_has.rs
+++ b/datafusion/functions-nested/src/array_has.rs
@@ -756,7 +756,8 @@ fn array_has_all_and_any_dispatch<'a>(
             ComparisonType::All => BooleanBuffer::new_set(haystack.len()),
             ComparisonType::Any => BooleanBuffer::new_unset(haystack.len()),
         };
-        Ok(Arc::new(BooleanArray::from(buffer)))
+        let nulls = NullBuffer::union(haystack.nulls(), needle.nulls());
+        Ok(Arc::new(BooleanArray::new(buffer, nulls)))
     } else {
         match needle.value_type() {
             DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {

--- a/datafusion/sqllogictest/test_files/array/array_has.slt
+++ b/datafusion/sqllogictest/test_files/array/array_has.slt
@@ -51,6 +51,23 @@ query error array_has does not support type 'Null'
 select array_has_all([], null),
        array_has_all([1, 2, 3], null);
 
+# Preserve NULL rows when all needles are NULL or empty
+query BB
+WITH t(id, haystack, needle) AS (
+  VALUES
+    (1, [1, 2], arrow_cast(NULL, 'List(Int64)')),
+    (2, arrow_cast(NULL, 'List(Int64)'), arrow_cast([], 'List(Int64)')),
+    (3, [3, 4], arrow_cast([], 'List(Int64)'))
+)
+SELECT array_has_any(haystack, needle),
+       array_has_all(haystack, needle)
+FROM t
+ORDER BY id;
+----
+NULL NULL
+NULL NULL
+false true
+
 query BBBBBBBBBBBB
 select array_has(make_array(1,2), 1),
        array_has(make_array(1,2,NULL), 1),


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24985.

## Rationale for this change

When every needle array in a batch is NULL or empty, `array_has_any` and
`array_has_all` use an empty-needle fast path.

That path currently drops the input null masks, so a row can return a different
result depending on the contents of another row in the batch.

## What changes are included in this PR?

Preserves the combined null mask from the haystack and needle when constructing
the fast-path result.

Non-NULL empty needles will keep the existing behavior:

- `array_has_any(array, [])` returns `false`
- `array_has_all(array, [])` returns `true`

## What is the testing strategy for this PR?

Added a SQLLogicTest covering this edge case

## Are there any user-facing changes?

Yes. NULL input rows now return NULL consistently in the empty-needle path.
There is no API change.