### PR TITLE
fix: reject groups accumulator for bit_xor(DISTINCT)

### DIFF
--- a/datafusion/functions-aggregate/src/bit_and_or_xor.rs
+++ b/datafusion/functions-aggregate/src/bit_and_or_xor.rs
@@ -290,8 +290,8 @@ impl AggregateUDFImpl for BitwiseOperation {
         }
     }
 
-    fn groups_accumulator_supported(&self, _args: AccumulatorArgs) -> bool {
-        true
+    fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
+        !args.is_distinct
     }
 
     fn create_groups_accumulator(

--- a/datafusion/functions-aggregate/src/bit_and_or_xor.rs
+++ b/datafusion/functions-aggregate/src/bit_and_or_xor.rs
@@ -291,7 +291,8 @@ impl AggregateUDFImpl for BitwiseOperation {
     }
 
     fn groups_accumulator_supported(&self, args: AccumulatorArgs) -> bool {
-        !args.is_distinct
+        // DISTINCT only changes the result of XOR; AND and OR are idempotent
+        !(args.is_distinct && self.operation == BitwiseOperationType::Xor)
     }
 
     fn create_groups_accumulator(

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -5123,6 +5123,28 @@ ORDER BY tag
 33 11 NULL 33 11 NULL 33 11 NULL B
 
 
+# bit_xor(DISTINCT) with GROUP BY must not use the non-distinct groups
+# accumulator: for tag A, 5 ^ 5 ^ 9 = 9 but 5 ^ 9 = 12.
+statement ok
+create table bit_distinct (c SMALLINT, tag varchar) as values
+  (5, 'A'), (5, 'A'), (9, 'A'), (33, 'B'), (33, 'B');
+
+query IIT
+SELECT bit_xor(DISTINCT c), count(c), tag FROM bit_distinct GROUP BY tag ORDER BY tag;
+----
+12 3 A
+33 2 B
+
+query IT
+SELECT bit_xor(DISTINCT c) FILTER (WHERE c > 4), tag FROM bit_distinct GROUP BY tag ORDER BY tag;
+----
+12 A
+33 B
+
+statement ok
+drop table bit_distinct;
+
+
 # bit_and_i32
 statement ok
 create table t (c int) as values (4), (7), (15);

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -5124,7 +5124,8 @@ ORDER BY tag
 
 
 # bit_xor(DISTINCT) with GROUP BY must not use the non-distinct groups
-# accumulator: for tag A, 5 ^ 5 ^ 9 = 9 but 5 ^ 9 = 12.
+# accumulator: for tag A, 5 ^ 5 ^ 9 = 9 but 5 ^ 9 = 12. AND and OR are
+# idempotent, so they keep the groups accumulator.
 statement ok
 create table bit_distinct (c SMALLINT, tag varchar) as values
   (5, 'A'), (5, 'A'), (9, 'A'), (33, 'B'), (33, 'B');
@@ -5140,6 +5141,12 @@ SELECT bit_xor(DISTINCT c) FILTER (WHERE c > 4), tag FROM bit_distinct GROUP BY 
 ----
 12 A
 33 B
+
+query IIIT
+SELECT bit_and(DISTINCT c), bit_or(DISTINCT c), count(c), tag FROM bit_distinct GROUP BY tag ORDER BY tag;
+----
+1 13 3 A
+33 33 2 B
 
 statement ok
 drop table bit_distinct;


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## Rationale for this change

`bit_xor(DISTINCT c)` with `GROUP BY` fails with `column types must match schema types, expected List(Int16) but found Int16`: `groups_accumulator_supported` ignored `is_distinct`, so the plan got the non-distinct groups accumulator while `state_fields` declared the `List` state.

## What changes are included in this PR?

`groups_accumulator_supported` now returns false only for `bit_xor(DISTINCT)`, matching `accumulator` and `state_fields`. `bit_and` and `bit_or` are idempotent, so they keep the vectorized path.

## What is the testing strategy for this PR?

Three `aggregate.slt` queries: the two shapes `SingleDistinctToGroupBy` does not rewrite (a non-distinct aggregate alongside, a `FILTER`) fail on `main`; a `bit_and`/`bit_or` `DISTINCT` row pins the narrower predicate.

## Are there any user-facing changes?

`bit_xor(DISTINCT)` with `GROUP BY` now works. No API change.
