### PR TITLE
fix: correct the copy-pasted docs for covar_pop and bool_or

### DIFF
--- a/datafusion/functions-aggregate/src/bool_and_or.rs
+++ b/datafusion/functions-aggregate/src/bool_and_or.rs
@@ -221,12 +221,12 @@ impl Accumulator for BoolAndAccumulator {
 
 #[user_doc(
     doc_section(label = "General Functions"),
-    description = "Returns true if all non-null input values are true, otherwise false.",
-    syntax_example = "bool_and(expression)",
+    description = "Returns true if any non-null input value is true, otherwise false.",
+    syntax_example = "bool_or(expression)",
     sql_example = r#"```sql
-> SELECT bool_and(column_name) FROM table_name;
+> SELECT bool_or(column_name) FROM table_name;
 +----------------------------+
-| bool_and(column_name)      |
+| bool_or(column_name)       |
 +----------------------------+
 | true                       |
 +----------------------------+

--- a/datafusion/functions-aggregate/src/covariance.rs
+++ b/datafusion/functions-aggregate/src/covariance.rs
@@ -132,14 +132,14 @@ impl AggregateUDFImpl for CovarianceSample {
 
 #[user_doc(
     doc_section(label = "Statistical Functions"),
-    description = "Returns the sample covariance of a set of number pairs.",
-    syntax_example = "covar_samp(expression1, expression2)",
+    description = "Returns the population covariance of a set of number pairs.",
+    syntax_example = "covar_pop(expression1, expression2)",
     sql_example = r#"```sql
-> SELECT covar_samp(column1, column2) FROM table_name;
+> SELECT covar_pop(column1, column2) FROM table_name;
 +-----------------------------------+
-| covar_samp(column1, column2)      |
+| covar_pop(column1, column2)       |
 +-----------------------------------+
-| 8.25                              |
+| 7.63333333333                     |
 +-----------------------------------+
 ```"#,
     standard_argument(name = "expression1", prefix = "First"),

--- a/docs/source/user-guide/sql/aggregate_functions.md
+++ b/docs/source/user-guide/sql/aggregate_functions.md
@@ -247,10 +247,10 @@ bool_and(expression)
 
 ### `bool_or`
 
-Returns true if all non-null input values are true, otherwise false.
+Returns true if any non-null input value is true, otherwise false.
 
 ```sql
-bool_and(expression)
+bool_or(expression)
 ```
 
 #### Arguments
@@ -260,9 +260,9 @@ bool_and(expression)
 #### Example
 
 ```sql
-> SELECT bool_and(column_name) FROM table_name;
+> SELECT bool_or(column_name) FROM table_name;
 +----------------------------+
-| bool_and(column_name)      |
+| bool_or(column_name)       |
 +----------------------------+
 | true                       |
 +----------------------------+
@@ -644,10 +644,10 @@ _Alias of [covar_samp](#covar_samp)._
 
 ### `covar_pop`
 
-Returns the sample covariance of a set of number pairs.
+Returns the population covariance of a set of number pairs.
 
 ```sql
-covar_samp(expression1, expression2)
+covar_pop(expression1, expression2)
 ```
 
 #### Arguments
@@ -658,11 +658,11 @@ covar_samp(expression1, expression2)
 #### Example
 
 ```sql
-> SELECT covar_samp(column1, column2) FROM table_name;
+> SELECT covar_pop(column1, column2) FROM table_name;
 +-----------------------------------+
-| covar_samp(column1, column2)      |
+| covar_pop(column1, column2)       |
 +-----------------------------------+
-| 8.25                              |
+| 7.63333333333                     |
 +-----------------------------------+
 ```
 


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## Rationale for this change

The `user_doc` blocks for `covar_pop` and `bool_or` are verbatim copies of `covar_samp` and `bool_and`, so the SQL reference documents the wrong function. `covar_pop` is described as sample covariance, and `bool_or` as "true if all non-null input values are true" — the inverse of what it does.

Existing tests already show the behaviour differs: `aggregate.slt` gives `covar_samp = 1` vs `covar_pop = 0.666666666667` on the same data, and `bool_and = false` vs `bool_or = true` on the same column.

## What changes are included in this PR?

Corrects the description, `syntax_example` and `sql_example` of both, and regenerates `aggregate_functions.md`.

## What is the testing strategy for this PR?

Docs only; the behaviour is unchanged and already covered by the `aggregate.slt` cases cited above.

## Are there any user-facing changes?

The SQL reference for `covar_pop` and `bool_or` is now correct. No API change.
