### PR TITLE
fix: reject unsupported DELETE LIMIT

### DIFF
--- a/datafusion/sql/src/statement.rs
+++ b/datafusion/sql/src/statement.rs
@@ -1208,6 +1208,10 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     plan_err!("Delete-order-by clause not yet supported")?;
                 }
 
+                if limit.is_some() {
+                    return not_impl_err!("Delete-limit clause not supported");
+                }
+
                 if !optimizer_hints.is_empty() {
                     plan_err!("Optimizer hints not supported")?;
                 }
@@ -1216,7 +1220,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 }
 
                 let table_name = self.get_delete_target(from)?;
-                self.delete_to_plan(&table_name, selection, limit)
+                self.delete_to_plan(&table_name, selection)
             }
 
             Statement::Merge(merge) => self.merge_to_plan(merge),
@@ -2254,7 +2258,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
         &self,
         table_name: &ObjectName,
         predicate_expr: Option<SQLExpr>,
-        limit: Option<SQLExpr>,
     ) -> Result<LogicalPlan> {
         // Do a table lookup to verify the table exists
         let table_ref = self.object_name_to_table_reference(table_name.clone())?;
@@ -2268,7 +2271,7 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 .build()?;
         let mut planner_context = PlannerContext::new();
 
-        let mut source = match predicate_expr {
+        let source = match predicate_expr {
             None => scan,
             Some(predicate_expr) => {
                 let filter_expr =
@@ -2284,14 +2287,6 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 LogicalPlan::Filter(Filter::try_new(filter_expr, Arc::new(scan))?)
             }
         };
-
-        if let Some(limit) = limit {
-            let empty_schema = DFSchema::empty();
-            let limit = self.sql_to_expr(limit, &empty_schema, &mut planner_context)?;
-            source = LogicalPlanBuilder::from(source)
-                .limit_by_expr(None, Some(limit))?
-                .build()?
-        }
 
         let plan = LogicalPlan::Dml(DmlStatement::new(
             table_ref,

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -792,6 +792,17 @@ fn plan_delete() {
     );
 }
 
+#[rstest]
+#[case("delete from person limit 1")]
+#[case("delete from person where id = 1 limit 1")]
+fn plan_delete_rejects_limit(#[case] sql: &str) {
+    let err = logical_plan(sql).expect_err("DELETE LIMIT should be rejected");
+    assert_eq!(
+        err.strip_backtrace(),
+        "This feature is not implemented: Delete-limit clause not supported"
+    );
+}
+
 #[test]
 fn plan_delete_quoted_identifier_case_sensitive() {
     let sql =

--- a/datafusion/sqllogictest/test_files/delete.slt
+++ b/datafusion/sqllogictest/test_files/delete.slt
@@ -117,29 +117,11 @@ physical_plan_error This feature is not implemented: Physical plan does not supp
 
 # Delete with limit
 
-query TT
-explain delete from t1 limit 10
-----
-logical_plan
-01)Dml: op=[Delete] table=[t1]
-02)--Limit: skip=0, fetch=10
-03)----TableScan: t1
-physical_plan
-01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+statement error This feature is not implemented: Delete-limit clause not supported
+delete from t1 limit 10;
 
-
-query TT
-explain delete from t1 where a = 1 and b = '2' limit 10
-----
-logical_plan
-01)Dml: op=[Delete] table=[t1]
-02)--Limit: skip=0, fetch=10
-03)----Filter: CAST(t1.a AS Int64) = Int64(1) AND t1.b = CAST(Utf8("2") AS Utf8View)
-04)------TableScan: t1
-physical_plan
-01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+statement error This feature is not implemented: Delete-limit clause not supported
+delete from t1 where a = 1 and b = '2' limit 10;
 
 # Config reset
 statement ok


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #24998; this PR adds a safe rejection until bounded DELETE is implemented.

## Rationale for this change

DELETE with LIMIT currently appears to plan successfully, but the table provider receives only the filters and deletes every matching row. Rejecting the unsupported clause prevents a bounded delete from silently becoming an unbounded one and matches the existing UPDATE LIMIT behavior.

## What changes are included in this PR?

- reject DELETE LIMIT during SQL planning
- remove the unreachable limit construction from delete_to_plan
- replace the misleading EXPLAIN snapshots with error regressions, both with and without WHERE
- directly cover both planner rejection branches in the SQL integration suite

## What is the testing strategy for this PR?

- cargo test -p datafusion-sqllogictest --test sqllogictests -- delete
- cargo test -p datafusion-sql --lib (88 passed)
- cargo test -p datafusion-sql --test sql_integration plan_delete_rejects_limit (2 passed)
- cargo clippy -p datafusion-sql --all-targets -- -D warnings
- cargo fmt --all -- --check

## Are there any user-facing changes?

Yes. DELETE statements containing LIMIT now return a not-implemented planning error instead of accepting the limit and potentially deleting every matching row. There is no public Rust API change.

Implementation and validation were completed with AI coding assistance under the account owner’s direction.