### PR TITLE
TEST: ungrouped_utf8_view_accumulator_is_never_worse_than_a_pre_allocated_set

### DIFF
--- a/datafusion/functions-aggregate-common/src/aggregate/count_distinct/bytes.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/count_distinct/bytes.rs
@@ -179,7 +179,7 @@ mod tests {
 
     /// Distinct value counts spanning both sides of the warm up capacity, up to
     /// ones where the two constructors have converged.
-    const CARDINALITIES: [usize; 7] = [0, 1, 100, 1_000, 10_000, 100_000, 500_000];
+    const CARDINALITIES: [usize; 7] = [0, 1, 100, 1_000, 10_000, 100_000, 500_001];
 
     /// Cardinalities small enough that the warm up dominates what the set
     /// holds. This is the per group population, where `GroupsAccumulatorAdapter`

--- a/datafusion/sql/src/lib.rs
+++ b/datafusion/sql/src/lib.rs
@@ -42,6 +42,7 @@
 //! [`LogicalPlan`]: datafusion_expr::logical_plan::LogicalPlan
 //! [`Expr`]: datafusion_expr::expr::Expr
 
+// SQL parsing and logical-plan construction modules.
 mod cte;
 mod expr;
 pub mod parser;


### PR DESCRIPTION
investigate why
test ungrouped_utf8_view_accumulator_is_never_worse_than_a_pre_allocated_set
takes a long time 
in 
https://github.com/apache/datafusion/actions/runs/34089015519/job/101638557066?pr=24757