### PR TITLE
Add special case in validate_struct_compatibility for empty structs

### DIFF
--- a/datafusion/common/src/nested_struct.rs
+++ b/datafusion/common/src/nested_struct.rs
@@ -116,8 +116,12 @@ fn cast_struct_column(
             }
         }
 
-        let struct_array =
-            StructArray::try_new(fields.into(), arrays, source_struct.nulls().cloned())?;
+        let struct_array = StructArray::try_new_with_length(
+            fields.into(),
+            arrays,
+            source_struct.nulls().cloned(),
+            source_struct.len(),
+        )?;
         Ok(Arc::new(struct_array))
     } else {
         // Return error if source is not a struct type
@@ -1155,6 +1159,8 @@ mod tests {
         buffer::{NullBuffer, OffsetBuffer, ScalarBuffer},
         datatypes::{DataType, Field, FieldRef, Int32Type},
     };
+    use arrow_schema::Fields;
+
     /// Macro to extract and downcast a column from a StructArray
     macro_rules! get_column_as {
         ($struct_array:expr, $column_name:expr, $array_type:ty) => {
@@ -1289,6 +1295,65 @@ mod tests {
         assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("Cannot cast struct field 'a'"));
+    }
+
+    #[test]
+    fn test_cast_struct_empty_source_and_target() {
+        // Source and target struct: {} (no fields)
+        let source =
+            StructArray::try_new_with_length(Fields::empty(), vec![], None, 1024)
+                .unwrap();
+        let source = Arc::new(source) as ArrayRef;
+
+        // Target struct: {}
+        let target_field = struct_field("s", vec![]);
+
+        // This should succeed - an empty struct is compatible with itself
+        let result =
+            cast_column(&source, target_field.data_type(), &DEFAULT_CAST_OPTIONS)
+                .unwrap();
+        let result = result.as_any().downcast_ref::<StructArray>().unwrap();
+
+        assert_eq!(result.len(), source.len());
+        assert_eq!(result.data_type(), target_field.data_type());
+    }
+
+    #[test]
+    fn test_cast_struct_compatibility_empty_source_nullable_target() {
+        // Source and target struct: {} (no fields)
+        let source =
+            StructArray::try_new_with_length(Fields::empty(), vec![], None, 1024)
+                .unwrap();
+        let source = Arc::new(source) as ArrayRef;
+
+        // Target struct: {a: Int32}
+        let target_field = struct_field("s", vec![field("a", DataType::Int32)]);
+
+        // This should succeed - all target fields are nullable
+        let result =
+            cast_column(&source, target_field.data_type(), &DEFAULT_CAST_OPTIONS)
+                .unwrap();
+        let result = result.as_any().downcast_ref::<StructArray>().unwrap();
+
+        assert_eq!(result.len(), source.len());
+        assert_eq!(result.data_type(), target_field.data_type());
+    }
+
+    #[test]
+    fn test_cast_struct_compatibility_empty_source_non_nullable_target() {
+        // Source and target struct: {} (no fields)
+        let source =
+            StructArray::try_new_with_length(Fields::empty(), vec![], None, 1024)
+                .unwrap();
+        let source = Arc::new(source) as ArrayRef;
+
+        // Target struct: {a: Int32}
+        let target_field = struct_field("s", vec![non_null_field("a", DataType::Int32)]);
+
+        // This should succeed - all target fields are nullable
+        let result =
+            cast_column(&source, target_field.data_type(), &DEFAULT_CAST_OPTIONS);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/datafusion/common/src/nested_struct.rs
+++ b/datafusion/common/src/nested_struct.rs
@@ -36,13 +36,13 @@ use std::{
 
 /// Cast a struct column to match target struct fields, handling nested structs recursively.
 ///
-/// This function implements struct-to-struct casting with the assumption that **structs should
-/// always be allowed to cast to other structs**. However, the source column must already be
-/// a struct type - non-struct sources will result in an error.
+/// Structs can be cast to other structs as long as they share at least one field. The source column
+/// must already be a struct type - non-struct sources will result in an error.
 ///
 /// ## Field Matching Strategy
 /// - **By Name**: Source struct fields are matched to target fields by name (case-sensitive)
-/// - **No Positional Mapping**: Structs with no overlapping field names are rejected
+/// - **At Least One Mapped Field**: The source and target struct must share at least one field by name
+///   (unless the source struct has no fields at all)
 /// - **Type Adaptation**: When a matching field is found, it is recursively cast to the target field's type
 /// - **Missing Fields**: Target fields not present in the source are filled with null values
 /// - **Extra Fields**: Source fields not present in the target are ignored
@@ -75,7 +75,13 @@ fn cast_struct_column(
 
     if let Some(source_struct) = source_col.as_any().downcast_ref::<StructArray>() {
         let source_fields = source_struct.fields();
-        validate_struct_compatibility(source_fields, target_fields)?;
+        let mut mapped_source_fields: Vec<Option<usize>> =
+            Vec::with_capacity(target_fields.len());
+        map_struct_fields(
+            source_fields,
+            target_fields,
+            Some(&mut mapped_source_fields),
+        )?;
 
         if !source_col.is_empty() && source_col.null_count() == source_col.len() {
             return Ok(new_null_array(
@@ -89,14 +95,15 @@ fn cast_struct_column(
         let num_rows = source_col.len();
 
         // Iterate target fields and pick source child by name when present.
-        for target_child_field in target_fields.iter() {
+        for (source_child_opt, target_child_field) in
+            mapped_source_fields.iter().zip(target_fields.iter())
+        {
             fields.push(Arc::clone(target_child_field));
 
-            let source_child_opt =
-                source_struct.column_by_name(target_child_field.name());
-
             match source_child_opt {
-                Some(source_child_col) => {
+                Some(source_child_col_idx) => {
+                    let source_child_col = source_struct.column(*source_child_col_idx);
+
                     let adapted_child = cast_column(
                         source_child_col,
                         target_child_field.data_type(),
@@ -111,6 +118,8 @@ fn cast_struct_column(
                     arrays.push(adapted_child);
                 }
                 None => {
+                    // No need to check if `target_child_field` is nullable here
+                    // The call to `map_struct_fields` will have done that for us
                     arrays.push(new_null_array(target_child_field.data_type(), num_rows));
                 }
             }
@@ -674,6 +683,8 @@ fn cast_dictionary_column(
 /// - **Field Matching**: Fields are matched by name (case-sensitive)
 /// - **Missing Target Fields**: Allowed - will be filled with null values during casting
 /// - **Extra Source Fields**: Allowed - will be ignored during casting
+/// - **At Least One Mapped Field**: source and target must share at least one field by name
+///   (unless source is empty)
 /// - **Type Compatibility**: Each matching field must be castable using Arrow's type system
 /// - **Nested Structs**: Recursively validates nested struct compatibility
 ///
@@ -702,6 +713,25 @@ pub fn validate_struct_compatibility(
     source_fields: &[FieldRef],
     target_fields: &[FieldRef],
 ) -> Result<()> {
+    map_struct_fields(source_fields, target_fields, None)
+}
+
+/// Performs the mapping of struct fields, checking compatibility and handling missing or extra fields.
+///
+/// # Arguments
+/// * `source_fields` - Fields from the source struct type
+/// * `target_fields` - Fields from the target struct type
+/// * `mapped_source_fields` - An optional `Vec` into which the indexes of the matching source fields
+///   are written in the order of the target fields
+///
+/// # Returns
+/// * `Ok(())` if the structs are compatible for casting
+/// * `Err(DataFusionError)` with detailed error message if incompatible
+fn map_struct_fields(
+    source_fields: &[FieldRef],
+    target_fields: &[FieldRef],
+    mut mapped_source_fields: Option<&mut Vec<Option<usize>>>,
+) -> Result<()> {
     if !source_fields.is_empty() {
         let has_overlap = has_one_of_more_common_fields(source_fields, target_fields);
         if !has_overlap {
@@ -716,11 +746,16 @@ pub fn validate_struct_compatibility(
     // Check compatibility for each target field
     for target_field in target_fields {
         // Look for matching field in source by name
-        if let Some(source_field) = source_fields
+        let source_field_opt = source_fields
             .iter()
-            .find(|f| f.name() == target_field.name())
+            .enumerate()
+            .find(|(_, f)| f.name() == target_field.name());
+        let source_field_idx = if let Some((source_field_idx, source_field)) =
+            source_field_opt
         {
             validate_field_compatibility(source_field, target_field)?;
+
+            Some(source_field_idx)
         } else {
             // Target field is missing from source
             // If it's non-nullable, we cannot fill it with NULL
@@ -731,6 +766,12 @@ pub fn validate_struct_compatibility(
                     target_field.name()
                 );
             }
+
+            None
+        };
+
+        if let Some(mapped_fields) = mapped_source_fields.as_mut() {
+            mapped_fields.push(source_field_idx);
         }
     }
 

--- a/datafusion/common/src/nested_struct.rs
+++ b/datafusion/common/src/nested_struct.rs
@@ -698,13 +698,15 @@ pub fn validate_struct_compatibility(
     source_fields: &[FieldRef],
     target_fields: &[FieldRef],
 ) -> Result<()> {
-    let has_overlap = has_one_of_more_common_fields(source_fields, target_fields);
-    if !has_overlap {
-        return _plan_err!(
-            "Cannot cast struct with {} fields to {} fields because there is no field name overlap",
-            source_fields.len(),
-            target_fields.len()
-        );
+    if !source_fields.is_empty() {
+        let has_overlap = has_one_of_more_common_fields(source_fields, target_fields);
+        if !has_overlap {
+            return _plan_err!(
+                "Cannot cast struct with {} fields to {} fields because there is no field name overlap",
+                source_fields.len(),
+                target_fields.len()
+            );
+        }
     }
 
     // Check compatibility for each target field
@@ -1549,6 +1551,46 @@ mod tests {
         // and missing field 'b' is nullable
         let result = validate_struct_compatibility(&source_fields, &target_fields);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_struct_compatibility_empty_source_and_target() {
+        // Source and target struct: {} (no fields)
+        let source_fields = vec![];
+        let target_fields = vec![];
+
+        // This should succeed - an empty struct is compatible with itself
+        let result = validate_struct_compatibility(&source_fields, &target_fields);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_struct_compatibility_empty_source_nullable_target() {
+        // Source and target struct: {} (no fields)
+        let source_fields = vec![];
+
+        // Target struct: {a: Int32}
+        let target_fields = vec![arc_field("a", DataType::Int32)];
+
+        // This should succeed - all target fields are nullable
+        let result = validate_struct_compatibility(&source_fields, &target_fields);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_struct_compatibility_empty_source_non_nullable_target() {
+        // Source and target struct: {} (no fields)
+        let source_fields = vec![];
+
+        // Target struct: {a: Int32 NOT NULL}
+        let target_fields = vec![
+            arc_field("a", DataType::Int32),
+            Arc::new(non_null_field("b", DataType::Utf8)),
+        ];
+
+        // This should fail - not all target fields are nullable
+        let result = validate_struct_compatibility(&source_fields, &target_fields);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #25022.

## Rationale for this change

`nested_struct::validate_struct_compatibility` checks for at least one common field between the source and target field sets. This does not take into account that the source field set might be empty. This can cause issue during query planning. 

For instance, when querying an Iceberg table's manifest with no partitioning information the following error is produced:

```
Execution error: Cannot cast column 'data_file' from 'Struct("content": non-null Int32, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null Struct(), metadata: {"avro.name": "r102"}, "record_count": non-null Int64, "file_size_in_bytes": non-null Int64, "column_sizes": List(non-null Struct("key": non-null Int32, "value": non-null Int64), metadata: {"avro.name": "k117_v118"}), "value_counts": List(non-null Struct("key": non-null Int32, "value": non-null Int64), metadata: {"avro.name": "k119_v120"}), "null_value_counts": List(non-null Struct("key": non-null Int32, "value": non-null Int64), metadata: {"avro.name": "k121_v122"}), "nan_value_counts": List(non-null Struct("key": non-null Int32, "value": non-null Int64), metadata: {"avro.name": "k138_v139"}), "lower_bounds": List(non-null Struct("key": non-null Int32, "value": non-null Binary), metadata: {"avro.name": "k126_v127"}), "upper_bounds": List(non-null Struct("key": non-null Int32, "value": non-null Binary), metadata: {"avro.name": "k129_v130"}), "key_metadata": Binary, "split_offsets": List(non-null Int64), metadata: {"element-id": "133"}, "equality_ids": List(non-null Int32), metadata: {"element-id": "136"}, "sort_order_id": Int32, "referenced_data_file": Utf8)' (physical data type) to 'Struct("content": non-null Int32, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null Struct(), "record_count": non-null Int64, "file_size_in_bytes": non-null Int64, "column_sizes": List(non-null Struct("key": non-null Int32, "value": non-null Int64)), "value_counts": List(non-null Struct("key": non-null Int32, "value": non-null Int64)), "null_value_counts": List(non-null Struct("key": non-null Int32, "value": non-null Int64)), "nan_value_counts": List(non-null Struct("key": non-null Int32, "value": non-null Int64)), "lower_bounds": List(non-null Struct("key": non-null Int32, "value": non-null Binary)), "upper_bounds": List(non-null Struct("key": non-null Int32, "value": non-null Binary)), "key_metadata": Binary, "split_offsets": List(non-null Int64), "equality_ids": List(non-null Int32), "sort_order_id": Int32, "referenced_data_file": Utf8)' (logical data type): Error during planning: Cannot cast struct with 0 fields to 0 fields because there is no field name overlap
```

## What changes are included in this PR?

- Skip the field overlap check when `source_fields.is_empty()`

## What is the testing strategy for this PR?

- Added unit tests
- Verified SLTs still pass

## Are there any user-facing changes?

No