### PR TITLE
bench: add a ClickBench extended query for a grouped COUNT(DISTINCT) over a string

### DIFF
--- a/benchmarks/queries/clickbench/README.md
+++ b/benchmarks/queries/clickbench/README.md
@@ -261,6 +261,44 @@ WHERE "URL" < 'zzzz';
 ```
 
 
+### Q14: Grouped `COUNT(DISTINCT <string>)` beside a non-distinct `COUNT(*)`
+
+**Question**: "For the top 10 search phrases by hit count, how many distinct
+mobile phone models were used?"
+
+**Important Query Properties**: A single `COUNT(DISTINCT)` over a high
+cardinality string, next to a non-distinct `COUNT(*)`, grouped by a high
+cardinality string.
+
+`COUNT(DISTINCT)` has a specialized `GroupsAccumulator` for the integer types
+and for no other type. Every other type falls back to
+`GroupsAccumulatorAdapter`, which holds one boxed `Accumulator`, and therefore
+one hash table, for each group. The cost of that fallback is per group, so it is
+the group cardinality that decides how much it costs.
+
+Extended Q2 above is the only other query that puts a `COUNT(DISTINCT)` on a
+non-integer column, and it groups by `BrowserCountry`. This query groups by
+`SearchPhrase` instead, which has far more distinct values, so it exercises the
+adapter where its cost actually scales.
+
+The shape is also the one `SingleDistinctToGroupBy` reasons about. That rule
+rewrites a lone distinct aggregate into a two phase group by, which is what
+keeps it off the adapter. Standard Q8, Q10, Q11 and Q13 are already rewritten
+because their distinct aggregate stands alone, and Q9 is not because it carries
+an `AVG`. Q22 is the only standard query that pairs a lone distinct aggregate
+with a non-distinct count, and its distinct argument is an `Int64`, which has a
+specialized accumulator and never reaches the adapter. So no query in either
+suite covers a lone `COUNT(DISTINCT <string>)` next to a non-distinct count.
+
+```sql
+SELECT "SearchPhrase", COUNT(*) AS c, COUNT(DISTINCT "MobilePhoneModel") AS models
+FROM hits
+WHERE "SearchPhrase" <> ''
+GROUP BY "SearchPhrase"
+ORDER BY c DESC
+LIMIT 10;
+```
+
 
 
 ## Data Notes

--- a/benchmarks/queries/clickbench/extended/q14.sql
+++ b/benchmarks/queries/clickbench/extended/q14.sql
@@ -1,0 +1,9 @@
+-- Must set for ClickBench hits_partitioned dataset. See https://github.com/apache/datafusion/issues/16591
+-- set datafusion.execution.parquet.binary_as_string = true
+
+-- A grouped COUNT(DISTINCT <string>) beside a non-distinct COUNT(*). No query in
+-- the standard suite has this shape: q22 is the only one that pairs a lone
+-- distinct aggregate with a non-distinct count, and its distinct argument is an
+-- Int64, which has a specialized GroupsAccumulator. A string argument has none,
+-- so one boxed Accumulator, and one hash table, is built for every group.
+SELECT "SearchPhrase", COUNT(*) AS c, COUNT(DISTINCT "MobilePhoneModel") AS models FROM hits WHERE "SearchPhrase" <> '' GROUP BY "SearchPhrase" ORDER BY c DESC LIMIT 10;

--- a/benchmarks/sql_benchmarks/clickbench_extended/benchmarks/q14.benchmark
+++ b/benchmarks/sql_benchmarks/clickbench_extended/benchmarks/q14.benchmark
@@ -1,0 +1,22 @@
+name Q14
+group clickbench_extended
+subgroup ${CLICKBENCH_TYPE:-single}
+
+init sql_benchmarks/clickbench/init/set_config.sql
+
+load sql_benchmarks/clickbench/init/load-${CLICKBENCH_TYPE:-single}.sql
+
+assert I
+SELECT COUNT(*) > 0 from hits;
+----
+true
+
+run
+SELECT "SearchPhrase", COUNT(*) AS c, COUNT(DISTINCT "MobilePhoneModel") AS models
+FROM hits
+WHERE "SearchPhrase" <> ''
+GROUP BY "SearchPhrase"
+ORDER BY c DESC
+LIMIT 10;
+
+result sql_benchmarks/clickbench_extended/results/q14.csv

--- a/datafusion/sqllogictest/test_files/clickbench_extended.slt
+++ b/datafusion/sqllogictest/test_files/clickbench_extended.slt
@@ -61,6 +61,76 @@ SELECT COUNT(*) AS ShareCount FROM hits WHERE "IsMobile" = 1 AND "MobilePhoneMod
 ----
 0
 
+query IIII
+SELECT "WatchID", MIN("ResolutionWidth") as wmin, MAX("ResolutionWidth") as wmax, SUM("IsRefresh") as srefresh FROM hits GROUP BY "WatchID" ORDER BY "WatchID" DESC LIMIT 10;
+----
+9110818468285196899 0 0 0
+8924809397503602651 0 0 0
+8740403056911509777 0 0 0
+8156744413230856864 0 0 0
+8120543446287442873 0 0 0
+6864353419233967042 0 0 0
+6635790769678439148 0 0 0
+6308646140879811077 0 0 0
+5206346422301499756 0 0 0
+4894690465724379622 0 0 0
+
+query III??
+SELECT "RegionID", "UserAgent", "OS", AVG(to_timestamp("ResponseEndTiming")-to_timestamp("ResponseStartTiming")) as avg_response_time, AVG(to_timestamp("ResponseEndTiming")-to_timestamp("ConnectTiming")) as avg_latency FROM hits GROUP BY "RegionID", "UserAgent", "OS" ORDER BY avg_latency DESC limit 10;
+----
+229 3 44 0 days 0 hours 0 mins 0.000000000 secs 0 days 0 hours 0 mins 0.000000000 secs
+197 7 39 0 days 0 hours 0 mins 0.000000000 secs 0 days 0 hours 0 mins 0.000000000 secs
+839 3 2 0 days 0 hours 0 mins 0.000000000 secs 0 days 0 hours 0 mins 0.000000000 secs
+839 0 0 0 days 0 hours 0 mins 0.000000000 secs 0 days 0 hours 0 mins 0.000000000 secs
+39 7 2 0 days 0 hours 0 mins 0.000000000 secs 0 days 0 hours 0 mins 0.000000000 secs
+
+query I
+SELECT MAX(len) FROM (
+    SELECT LENGTH(FIRST_VALUE("URL" ORDER BY "EventTime")) as len
+    FROM hits
+    GROUP BY "UserID"
+);
+----
+72
+
+query I
+SELECT MAX(len) FROM (
+    SELECT LENGTH(FIRST_VALUE("URL" ORDER BY "EventTime")) as len
+    FROM hits
+    GROUP BY "OS"
+);
+----
+57
+
+query I
+SELECT MAX(fv) FROM (
+    SELECT FIRST_VALUE("WatchID" ORDER BY "EventTime") as fv
+    FROM hits
+    GROUP BY "UserID"
+);
+----
+9110818468285196899
+
+query I
+SELECT MAX(fv) FROM (
+    SELECT FIRST_VALUE("WatchID" ORDER BY "EventTime") as fv
+    FROM hits
+    GROUP BY "OS"
+);
+----
+9110818468285196899
+
+query I
+SELECT SUM("CounterID") AS counter_id_sum
+FROM hits
+WHERE "URL" < 'zzzz';
+----
+173
+
+query TII
+SELECT "SearchPhrase", COUNT(*) AS c, COUNT(DISTINCT "MobilePhoneModel") AS models FROM hits WHERE "SearchPhrase" <> '' GROUP BY "SearchPhrase" ORDER BY c DESC LIMIT 10;
+----
+
 
 statement ok
 drop table hits;


### PR DESCRIPTION
## Which issue does this PR close?

No existing issue. This is benchmark coverage carved out of #24859 so that it can land first: a benchmark query added in the same PR that needs it cannot appear in an A/B run, because the bot compares against the merge base and the merge base does not have the query.

## Rationale for this change

`COUNT(DISTINCT)` has a specialized `GroupsAccumulator` for the integer types and for no other type. Every other type falls back to `GroupsAccumulatorAdapter`, which holds one boxed `Accumulator`, and therefore one hash table, for each group. The cost of that fallback is per group, so the group cardinality is what decides how much it costs.

Nothing in either suite measures that:

- Extended Q2 is the only query that puts a `COUNT(DISTINCT)` on a non-integer column at all. It groups by `BrowserCountry`, so it exercises the adapter at a low group cardinality, which is where the adapter is cheapest.
- Standard Q8, Q10, Q11 and Q13 hold a distinct aggregate that stands alone, so `SingleDistinctToGroupBy` already rewrites them and they never reach the adapter.
- Standard Q9 carries an `AVG`, which that rule has never accepted.
- Standard Q22 is the one query that pairs a lone distinct aggregate with a non-distinct count, and it counts distinct `UserID`, an `Int64`, which has a specialized accumulator.

So a lone `COUNT(DISTINCT <string>)` grouped by a high cardinality key, next to a non-distinct `COUNT(*)`, is uncovered. That is an ordinary analytics shape, it is the shape #24857 changed the memory profile of, and it is the shape #24859 proposes to rewrite. Neither of those could show its effect on any benchmark in this repository.

## What changes are included in this PR?

The query:

```sql
SELECT "SearchPhrase", COUNT(*) AS c, COUNT(DISTINCT "MobilePhoneModel") AS models
FROM hits
WHERE "SearchPhrase" <> ''
GROUP BY "SearchPhrase"
ORDER BY c DESC
LIMIT 10;
```

The extended ClickBench queries live in three places, and a query added to only one of them is invisible to the others. This PR adds it to all three:

- `benchmarks/queries/clickbench/extended/q14.sql`, which feeds `dfbench clickbench --queries-path`. Queries are discovered from the directory, so the runner needs no change.
- `benchmarks/sql_benchmarks/clickbench_extended/benchmarks/q14.benchmark`, which feeds `benchmark_runner clickbench_extended`. Structurally identical to `q13.benchmark` apart from the query. Suite files are also discovered from the directory; `benchmark_runner clickbench_extended --list` now reports 15 queries.
- `datafusion/sqllogictest/test_files/clickbench_extended.slt`, which runs the extended queries against the committed ten row `clickbench_hits_10.parquet` fixture.

That last file had only ever mirrored q0 through q6. q7 through q13 were added to the queries directory without a matching sqllogictest entry, and q14 would have widened that gap, so this backfills q7 through q14 together. That is why the diff is larger than one query.

Having to add one query in three places is itself the problem, and the copies have already drifted: extended q6 carries a cast in its `sql_benchmarks` copy that the other two do not have. I filed #25031 for that; it is out of scope here.

There is one pre-existing staleness this PR does not fix. `datafusion/core/benches/sql_planner.rs` builds its ClickBench planning set from a hardcoded `(0..=7)` over the extended directory, so extended Q8 through Q13 were already outside it before this PR and Q14 joins them. That is a separate cleanup.

## What is the testing strategy for this PR?

The sqllogictest entries are the test. `clickbench_extended.slt` runs every extended query against the committed ten row fixture and asserts its output, so q7 through q14 are now executed on every CI run rather than only by whoever runs the benchmark suite by hand. `cargo test -p datafusion-sqllogictest --test sqllogictests -- clickbench` passes, 2 of 2 files.

`cargo test -p datafusion-benchmarks` passes, 192 tests, and `benchmark_runner clickbench_extended --list` reports the suite at 15 queries, confirming the new `.benchmark` file parses and is discovered.

I do not have a `hits.parquet` to hand, so I have not run the query against the full dataset. The plan shape, which is the whole value of the query, was checked separately: on an equivalent local table with the same filter, grouping, `COUNT(*)` and string `COUNT(DISTINCT)`, the aggregate keeps `aggr=[[count(Int64(1)), count(DISTINCT ...)]]`, which is the `GroupsAccumulatorAdapter` path this query exists to measure, and it is not rewritten away.

What I have not established is the effect size on the real dataset, since that depends on how many distinct `SearchPhrase` values survive the filter. If a reviewer with the data runs it, that number is worth having on this PR.

`ci/scripts/doc_prettier_check.sh` passes on the README change.

## Are there any user-facing changes?

No. This adds a benchmark query and documentation only.
