### PR TITLE
fix: apply MemTable DELETE and UPDATE at execution, not planning

### DIFF
--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -24,30 +24,33 @@ use std::sync::Arc;
 
 use crate::TableProvider;
 
-use arrow::array::{
-    Array, ArrayRef, BooleanArray, RecordBatch as ArrowRecordBatch, UInt64Array,
-};
+use arrow::array::{Array, ArrayRef, BooleanArray, UInt64Array};
 use arrow::compute::kernels::zip::zip;
 use arrow::compute::{and, filter_record_batch};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::error::Result;
 use datafusion_common::tree_node::TreeNodeRecursion;
-use datafusion_common::{Constraints, DFSchema, SchemaExt, not_impl_err, plan_err};
+use datafusion_common::{
+    Constraints, DFSchema, SchemaExt, internal_datafusion_err, not_impl_err, plan_err,
+};
 use datafusion_datasource::memory::{MemSink, MemorySourceConfig};
 use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::source::DataSourceExec;
+use datafusion_execution::{SendableRecordBatchStream, TaskContext};
 use datafusion_expr::dml::InsertOp;
 use datafusion_expr::physical_planning_context::PhysicalPlanningContext;
 use datafusion_expr::{Expr, SortExpr, TableType};
 use datafusion_physical_expr::{
-    LexOrdering, create_physical_expr, create_physical_sort_exprs,
+    EquivalenceProperties, LexOrdering, create_physical_expr, create_physical_sort_exprs,
 };
+use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
-    PhysicalExpr, PlanProperties, ReplaceChildrenOptions, collect_partitioned,
+    PhysicalExpr, PlanProperties, ReplaceChildrenOptions, apply_expression_roots,
+    collect_partitioned,
 };
 use datafusion_session::Session;
 
@@ -251,7 +254,8 @@ impl TableProvider for MemTable {
         'life1: 'async_trait,
         Self: 'async_trait,
     {
-        self.delete_from_boxed(state, filters)
+        // Planning a `DELETE` needs no await, so the future is ready at once.
+        Box::pin(ready(self.delete_from_inner(state, &filters)))
     }
 
     // Hand-written `#[async_trait]` expansion to reduce compile time. See
@@ -267,7 +271,8 @@ impl TableProvider for MemTable {
         'life1: 'async_trait,
         Self: 'async_trait,
     {
-        self.update_boxed(state, assignments, filters)
+        // Planning an `UPDATE` needs no await, so the future is ready at once.
+        Box::pin(ready(self.update_inner(state, &assignments, &filters)))
     }
 }
 
@@ -356,255 +361,110 @@ impl MemTable {
         Ok(Arc::new(DataSinkExec::new(input, Arc::new(sink), None)))
     }
 
-    fn delete_from_boxed<'a>(
-        &'a self,
-        state: &'a dyn Session,
-        filters: Vec<Expr>,
-    ) -> BoxFuture<'a, Result<Arc<dyn ExecutionPlan>>> {
-        Box::pin(self.delete_from_inner(state, filters))
-    }
-
-    async fn delete_from_inner(
+    /// Plan a `DELETE`. The rows change when the returned plan runs, not here,
+    /// so `EXPLAIN DELETE` prints the plan and the table keeps its rows.
+    fn delete_from_inner(
         &self,
         state: &dyn Session,
-        filters: Vec<Expr>,
+        filters: &[Expr],
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Early exit if table has no partitions
-        if self.batches.is_empty() {
-            return Ok(Arc::new(DmlResultExec::new(0)));
-        }
+        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
+        let predicates = create_predicates(filters, &df_schema, state)?;
 
-        *self.sort_order.lock() = vec![];
+        Ok(Arc::new(MemDeleteExec::new(
+            self.batches.clone(),
+            Arc::clone(&self.sort_order),
+            predicates,
+        )))
+    }
 
-        let mut total_deleted: u64 = 0;
+    /// Plan an `UPDATE`. The rows change when the returned plan runs, not here,
+    /// so `EXPLAIN UPDATE` prints the plan and the table keeps its rows.
+    fn update_inner(
+        &self,
+        state: &dyn Session,
+        assignments: &[(String, Expr)],
+        filters: &[Expr],
+    ) -> Result<Arc<dyn ExecutionPlan>> {
         let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
 
-        for partition_data in &self.batches {
-            let mut partition = partition_data.write().await;
-            let mut new_batches = Vec::with_capacity(partition.len());
-
-            for batch in partition.iter() {
-                if batch.num_rows() == 0 {
-                    continue;
-                }
-
-                // Evaluate filters - None means "match all rows"
-                let filter_mask = evaluate_filters_to_mask(
-                    &filters,
-                    batch,
-                    &df_schema,
-                    state.execution_props(),
-                )?;
-
-                let (delete_count, keep_mask) = match filter_mask {
-                    Some(mask) => {
-                        // Count rows where mask is true (will be deleted)
-                        let count = mask.iter().filter(|v| v == &Some(true)).count();
-                        // Keep rows where predicate is false or NULL (SQL three-valued logic)
-                        let keep: BooleanArray =
-                            mask.iter().map(|v| Some(v != Some(true))).collect();
-                        (count, keep)
-                    }
-                    None => {
-                        // No filters = delete all rows
-                        (
-                            batch.num_rows(),
-                            BooleanArray::from(vec![false; batch.num_rows()]),
-                        )
-                    }
-                };
-
-                total_deleted += delete_count as u64;
-
-                let filtered_batch = filter_record_batch(batch, &keep_mask)?;
-                if filtered_batch.num_rows() > 0 {
-                    new_batches.push(filtered_batch);
-                }
-            }
-
-            *partition = new_batches;
-        }
-
-        Ok(Arc::new(DmlResultExec::new(total_deleted)))
-    }
-
-    fn update_boxed<'a>(
-        &'a self,
-        state: &'a dyn Session,
-        assignments: Vec<(String, Expr)>,
-        filters: Vec<Expr>,
-    ) -> BoxFuture<'a, Result<Arc<dyn ExecutionPlan>>> {
-        Box::pin(self.update_inner(state, assignments, filters))
-    }
-
-    async fn update_inner(
-        &self,
-        state: &dyn Session,
-        assignments: Vec<(String, Expr)>,
-        filters: Vec<Expr>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        // Early exit if table has no partitions
-        if self.batches.is_empty() {
-            return Ok(Arc::new(DmlResultExec::new(0)));
-        }
-
-        // Validate column names upfront with clear error messages
-        let available_columns: Vec<&str> = self
-            .schema
-            .fields()
-            .iter()
-            .map(|f| f.name().as_str())
-            .collect();
-        for (column_name, _) in &assignments {
-            if self.schema.field_with_name(column_name).is_err() {
+        // One entry for each field of the table, in field order. A `Some` entry
+        // holds the expression of the `SET` clause for that field.
+        let mut set_exprs: Vec<Option<Arc<dyn PhysicalExpr>>> =
+            vec![None; self.schema.fields().len()];
+        for (column_name, expr) in assignments {
+            let Ok(index) = self.schema.index_of(column_name) else {
+                let available_columns: Vec<&str> = self
+                    .schema
+                    .fields()
+                    .iter()
+                    .map(|f| f.name().as_str())
+                    .collect();
                 return plan_err!(
                     "UPDATE failed: column '{}' does not exist. Available columns: {}",
                     column_name,
                     available_columns.join(", ")
                 );
-            }
+            };
+            set_exprs[index] = Some(create_physical_expr(
+                expr,
+                &df_schema,
+                state.execution_props(),
+                &PhysicalPlanningContext::default(),
+            )?);
         }
 
-        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
+        let predicates = create_predicates(filters, &df_schema, state)?;
 
-        // Create physical expressions for assignments upfront (outside batch loop)
-        let physical_assignments: HashMap<String, Arc<dyn PhysicalExpr>> = assignments
-            .iter()
-            .map(|(name, expr)| {
-                let physical_expr = create_physical_expr(
-                    expr,
-                    &df_schema,
-                    state.execution_props(),
-                    &PhysicalPlanningContext::default(),
-                )?;
-                Ok((name.clone(), physical_expr))
-            })
-            .collect::<Result<_>>()?;
-
-        *self.sort_order.lock() = vec![];
-
-        let mut total_updated: u64 = 0;
-
-        for partition_data in &self.batches {
-            let mut partition = partition_data.write().await;
-            let mut new_batches = Vec::with_capacity(partition.len());
-
-            for batch in partition.iter() {
-                if batch.num_rows() == 0 {
-                    continue;
-                }
-
-                // Evaluate filters - None means "match all rows"
-                let filter_mask = evaluate_filters_to_mask(
-                    &filters,
-                    batch,
-                    &df_schema,
-                    state.execution_props(),
-                )?;
-
-                let (update_count, update_mask) = match filter_mask {
-                    Some(mask) => {
-                        // Count rows where mask is true (will be updated)
-                        let count = mask.iter().filter(|v| v == &Some(true)).count();
-                        // Normalize mask: only true (not NULL) triggers update
-                        let normalized: BooleanArray =
-                            mask.iter().map(|v| Some(v == Some(true))).collect();
-                        (count, normalized)
-                    }
-                    None => {
-                        // No filters = update all rows
-                        (
-                            batch.num_rows(),
-                            BooleanArray::from(vec![true; batch.num_rows()]),
-                        )
-                    }
-                };
-
-                total_updated += update_count as u64;
-
-                if update_count == 0 {
-                    new_batches.push(batch.clone());
-                    continue;
-                }
-
-                let mut new_columns: Vec<ArrayRef> =
-                    Vec::with_capacity(batch.num_columns());
-
-                for field in self.schema.fields() {
-                    let column_name = field.name();
-                    let original_column =
-                        batch.column_by_name(column_name).ok_or_else(|| {
-                            datafusion_common::DataFusionError::Internal(format!(
-                                "Column '{column_name}' not found in batch"
-                            ))
-                        })?;
-
-                    let new_column = if let Some(physical_expr) =
-                        physical_assignments.get(column_name.as_str())
-                    {
-                        // Use evaluate_selection to only evaluate on matching rows.
-                        // This avoids errors (e.g., divide-by-zero) on rows that won't
-                        // be updated. The result is scattered back with nulls for
-                        // non-matching rows, which zip() will replace with originals.
-                        let new_values =
-                            physical_expr.evaluate_selection(batch, &update_mask)?;
-                        let new_array = new_values.into_array(batch.num_rows())?;
-
-                        // Convert to &dyn Array which implements Datum
-                        let new_arr: &dyn Array = new_array.as_ref();
-                        let orig_arr: &dyn Array = original_column.as_ref();
-                        zip(&update_mask, &new_arr, &orig_arr)?
-                    } else {
-                        Arc::clone(original_column)
-                    };
-
-                    new_columns.push(new_column);
-                }
-
-                let updated_batch =
-                    ArrowRecordBatch::try_new(Arc::clone(&self.schema), new_columns)?;
-                new_batches.push(updated_batch);
-            }
-
-            *partition = new_batches;
-        }
-
-        Ok(Arc::new(DmlResultExec::new(total_updated)))
+        Ok(Arc::new(MemUpdateExec::new(
+            self.batches.clone(),
+            Arc::clone(&self.sort_order),
+            Arc::clone(&self.schema),
+            set_exprs,
+            predicates,
+        )))
     }
 }
 
-/// Evaluate filter expressions against a batch and return a combined boolean mask.
-/// Returns None if filters is empty (meaning "match all rows").
-/// The returned mask has true for rows that match the filter predicates.
-fn evaluate_filters_to_mask(
+/// Build one physical predicate for each expression of the `WHERE` clause.
+///
+/// The planner calls this, so a predicate that cannot be planned raises its
+/// error while the plan is built and `EXPLAIN` reports it.
+fn create_predicates(
     filters: &[Expr],
-    batch: &RecordBatch,
     df_schema: &DFSchema,
-    execution_props: &datafusion_expr::execution_props::ExecutionProps,
-) -> Result<Option<BooleanArray>> {
-    if filters.is_empty() {
-        return Ok(None);
-    }
+    state: &dyn Session,
+) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
+    filters
+        .iter()
+        .map(|filter| {
+            create_physical_expr(
+                filter,
+                df_schema,
+                state.execution_props(),
+                &PhysicalPlanningContext::default(),
+            )
+        })
+        .collect()
+}
 
+/// Combine the predicates into one mask over the rows of `batch`. The mask is
+/// true for a row that every predicate matches. `None` means there is no
+/// `WHERE` clause, which matches every row.
+fn evaluate_predicates(
+    predicates: &[Arc<dyn PhysicalExpr>],
+    batch: &RecordBatch,
+) -> Result<Option<BooleanArray>> {
     let mut combined_mask: Option<BooleanArray> = None;
 
-    for filter_expr in filters {
-        let physical_expr = create_physical_expr(
-            filter_expr,
-            df_schema,
-            execution_props,
-            &PhysicalPlanningContext::default(),
-        )?;
-
-        let result = physical_expr.evaluate(batch)?;
+    for predicate in predicates {
+        let result = predicate.evaluate(batch)?;
         let array = result.into_array(batch.num_rows())?;
         let bool_array = array
             .as_any()
             .downcast_ref::<BooleanArray>()
             .ok_or_else(|| {
-                datafusion_common::DataFusionError::Internal(
-                    "Filter did not evaluate to boolean".to_string(),
-                )
+                internal_datafusion_err!("Filter did not evaluate to boolean")
             })?
             .clone();
 
@@ -617,38 +477,81 @@ fn evaluate_filters_to_mask(
     Ok(combined_mask)
 }
 
-/// Returns a single row with the count of affected rows.
+/// Schema of the single `count` column that a DML plan emits.
+fn dml_count_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new(
+        "count",
+        DataType::UInt64,
+        false,
+    )]))
+}
+
+/// Properties of a DML plan: one partition, one final batch.
+fn dml_plan_properties(schema: &SchemaRef) -> Arc<PlanProperties> {
+    Arc::new(PlanProperties::new(
+        EquivalenceProperties::new(Arc::clone(schema)),
+        Partitioning::UnknownPartitioning(1),
+        EmissionType::Final,
+        Boundedness::Bounded,
+    ))
+}
+
+/// A single row holding the number of rows the statement changed.
+fn count_batch(schema: &SchemaRef, rows_affected: u64) -> Result<RecordBatch> {
+    let count_array = UInt64Array::from(vec![rows_affected]);
+    Ok(RecordBatch::try_new(
+        Arc::clone(schema),
+        vec![Arc::new(count_array) as ArrayRef],
+    )?)
+}
+
+/// Render the predicates as a comma separated list.
+fn format_predicates(predicates: &[Arc<dyn PhysicalExpr>]) -> String {
+    predicates
+        .iter()
+        .map(|predicate| predicate.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Deletes the matching rows of a [`MemTable`] when it runs, and emits the count.
+///
+/// The provider hook that builds this node changes no row, so `EXPLAIN DELETE`
+/// prints the plan and the table keeps its rows. Each run of the plan applies
+/// the delete once, as [`DataSinkExec`] does for an `INSERT`.
 #[derive(Debug)]
-struct DmlResultExec {
-    rows_affected: u64,
+struct MemDeleteExec {
+    /// Partitions of the target table, shared with the [`MemTable`].
+    partitions: Vec<PartitionData>,
+    /// Declared sort order of the target table. A delete clears it.
+    sort_order: Arc<Mutex<Vec<Vec<SortExpr>>>>,
+    /// Predicates of the `WHERE` clause. An empty list matches every row.
+    predicates: Vec<Arc<dyn PhysicalExpr>>,
+    /// Single `count` column of the output.
     schema: SchemaRef,
     properties: Arc<PlanProperties>,
 }
 
-impl DmlResultExec {
-    fn new(rows_affected: u64) -> Self {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "count",
-            DataType::UInt64,
-            false,
-        )]));
-
-        let properties = PlanProperties::new(
-            datafusion_physical_expr::EquivalenceProperties::new(Arc::clone(&schema)),
-            Partitioning::UnknownPartitioning(1),
-            datafusion_physical_plan::execution_plan::EmissionType::Final,
-            datafusion_physical_plan::execution_plan::Boundedness::Bounded,
-        );
+impl MemDeleteExec {
+    fn new(
+        partitions: Vec<PartitionData>,
+        sort_order: Arc<Mutex<Vec<Vec<SortExpr>>>>,
+        predicates: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Self {
+        let schema = dml_count_schema();
+        let properties = dml_plan_properties(&schema);
 
         Self {
-            rows_affected,
+            partitions,
+            sort_order,
+            predicates,
             schema,
-            properties: Arc::new(properties),
+            properties,
         }
     }
 }
 
-impl DisplayAs for DmlResultExec {
+impl DisplayAs for MemDeleteExec {
     fn fmt_as(
         &self,
         t: DisplayFormatType,
@@ -658,15 +561,19 @@ impl DisplayAs for DmlResultExec {
             DisplayFormatType::Default
             | DisplayFormatType::Verbose
             | DisplayFormatType::TreeRender => {
-                write!(f, "DmlResultExec: rows_affected={}", self.rows_affected)
+                write!(f, "MemDeleteExec")?;
+                if !self.predicates.is_empty() {
+                    write!(f, ": predicate=[{}]", format_predicates(&self.predicates))?;
+                }
+                Ok(())
             }
         }
     }
 }
 
-impl ExecutionPlan for DmlResultExec {
+impl ExecutionPlan for MemDeleteExec {
     fn name(&self) -> &str {
-        "DmlResultExec"
+        "MemDeleteExec"
     }
 
     fn schema(&self) -> SchemaRef {
@@ -702,27 +609,330 @@ impl ExecutionPlan for DmlResultExec {
     fn execute(
         &self,
         _partition: usize,
-        _context: Arc<datafusion_execution::TaskContext>,
-    ) -> Result<datafusion_execution::SendableRecordBatchStream> {
-        // Create a single batch with the count
-        let count_array = UInt64Array::from(vec![self.rows_affected]);
-        let batch = ArrowRecordBatch::try_new(
-            Arc::clone(&self.schema),
-            vec![Arc::new(count_array) as ArrayRef],
-        )?;
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let partitions = self.partitions.clone();
+        let sort_order = Arc::clone(&self.sort_order);
+        let predicates = self.predicates.clone();
+        let schema = Arc::clone(&self.schema);
+        let count_schema = Arc::clone(&self.schema);
 
-        // Create a stream that yields just this one batch
-        let stream = futures::stream::iter(vec![Ok(batch)]);
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&self.schema),
-            stream,
-        )))
+        let stream = futures::stream::once(async move {
+            let rows_affected =
+                delete_rows(&partitions, &sort_order, &predicates).await?;
+            count_batch(&count_schema, rows_affected)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }
 
     fn apply_expressions(
         &self,
-        _f: &mut dyn FnMut(&Arc<dyn PhysicalExpr>) -> Result<TreeNodeRecursion>,
+        f: &mut dyn FnMut(&Arc<dyn PhysicalExpr>) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
-        Ok(TreeNodeRecursion::Continue)
+        apply_expression_roots(&self.predicates, f)
     }
+}
+
+/// Delete the matching rows of every partition and return how many it removed.
+async fn delete_rows(
+    partitions: &[PartitionData],
+    sort_order: &Mutex<Vec<Vec<SortExpr>>>,
+    predicates: &[Arc<dyn PhysicalExpr>],
+) -> Result<u64> {
+    // The surviving rows hold no known order.
+    *sort_order.lock() = vec![];
+
+    let mut total_deleted: u64 = 0;
+
+    for partition_data in partitions {
+        let mut partition = partition_data.write().await;
+        let mut new_batches = Vec::with_capacity(partition.len());
+
+        for batch in partition.iter() {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+
+            let (delete_count, keep_mask) = match evaluate_predicates(predicates, batch)?
+            {
+                Some(mask) => {
+                    // Count the rows the mask selects, which are the rows to delete.
+                    let count = mask.iter().filter(|v| v == &Some(true)).count();
+                    // Keep the rows for which the predicate is false or NULL,
+                    // which follows SQL three-valued logic.
+                    let keep: BooleanArray =
+                        mask.iter().map(|v| Some(v != Some(true))).collect();
+                    (count, keep)
+                }
+                None => {
+                    // No `WHERE` clause deletes every row.
+                    (
+                        batch.num_rows(),
+                        BooleanArray::from(vec![false; batch.num_rows()]),
+                    )
+                }
+            };
+
+            total_deleted += delete_count as u64;
+
+            let filtered_batch = filter_record_batch(batch, &keep_mask)?;
+            if filtered_batch.num_rows() > 0 {
+                new_batches.push(filtered_batch);
+            }
+        }
+
+        *partition = new_batches;
+    }
+
+    Ok(total_deleted)
+}
+
+/// Updates the matching rows of a [`MemTable`] when it runs, and emits the count.
+///
+/// The provider hook that builds this node changes no row, so `EXPLAIN UPDATE`
+/// prints the plan and the table keeps its rows. Each run of the plan applies
+/// the update once, as [`DataSinkExec`] does for an `INSERT`.
+#[derive(Debug)]
+struct MemUpdateExec {
+    /// Partitions of the target table, shared with the [`MemTable`].
+    partitions: Vec<PartitionData>,
+    /// Declared sort order of the target table. An update clears it.
+    sort_order: Arc<Mutex<Vec<Vec<SortExpr>>>>,
+    /// Schema of the target table.
+    table_schema: SchemaRef,
+    /// One entry for each field of the target table, in field order. A `Some`
+    /// entry holds the expression of the `SET` clause for that field.
+    set_exprs: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    /// Predicates of the `WHERE` clause. An empty list matches every row.
+    predicates: Vec<Arc<dyn PhysicalExpr>>,
+    /// Single `count` column of the output.
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+}
+
+impl MemUpdateExec {
+    fn new(
+        partitions: Vec<PartitionData>,
+        sort_order: Arc<Mutex<Vec<Vec<SortExpr>>>>,
+        table_schema: SchemaRef,
+        set_exprs: Vec<Option<Arc<dyn PhysicalExpr>>>,
+        predicates: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Self {
+        let schema = dml_count_schema();
+        let properties = dml_plan_properties(&schema);
+
+        Self {
+            partitions,
+            sort_order,
+            table_schema,
+            set_exprs,
+            predicates,
+            schema,
+            properties,
+        }
+    }
+
+    /// Render the `SET` clauses as `column=expression`, in field order.
+    fn format_set_exprs(&self) -> String {
+        self.table_schema
+            .fields()
+            .iter()
+            .zip(&self.set_exprs)
+            .filter_map(|(field, set_expr)| {
+                set_expr
+                    .as_ref()
+                    .map(|expr| format!("{}={}", field.name(), expr))
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+impl DisplayAs for MemUpdateExec {
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
+                write!(f, "MemUpdateExec: set=[{}]", self.format_set_exprs())?;
+                if !self.predicates.is_empty() {
+                    write!(f, ", predicate=[{}]", format_predicates(&self.predicates))?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for MemUpdateExec {
+    fn name(&self) -> &str {
+        "MemUpdateExec"
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn replace_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+        _: ReplaceChildrenOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let partitions = self.partitions.clone();
+        let sort_order = Arc::clone(&self.sort_order);
+        let table_schema = Arc::clone(&self.table_schema);
+        let set_exprs = self.set_exprs.clone();
+        let predicates = self.predicates.clone();
+        let schema = Arc::clone(&self.schema);
+        let count_schema = Arc::clone(&self.schema);
+
+        let stream = futures::stream::once(async move {
+            let rows_affected = update_rows(
+                &partitions,
+                &sort_order,
+                &table_schema,
+                &set_exprs,
+                &predicates,
+            )
+            .await?;
+            count_batch(&count_schema, rows_affected)
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    fn apply_expressions(
+        &self,
+        f: &mut dyn FnMut(&Arc<dyn PhysicalExpr>) -> Result<TreeNodeRecursion>,
+    ) -> Result<TreeNodeRecursion> {
+        match apply_expression_roots(self.set_exprs.iter().flatten(), f)? {
+            TreeNodeRecursion::Stop => Ok(TreeNodeRecursion::Stop),
+            TreeNodeRecursion::Continue | TreeNodeRecursion::Jump => {
+                apply_expression_roots(&self.predicates, f)
+            }
+        }
+    }
+}
+
+/// Apply the `SET` clauses to the matching rows of every partition and return
+/// how many rows changed.
+async fn update_rows(
+    partitions: &[PartitionData],
+    sort_order: &Mutex<Vec<Vec<SortExpr>>>,
+    table_schema: &SchemaRef,
+    set_exprs: &[Option<Arc<dyn PhysicalExpr>>],
+    predicates: &[Arc<dyn PhysicalExpr>],
+) -> Result<u64> {
+    // The new values hold no known order.
+    *sort_order.lock() = vec![];
+
+    let mut total_updated: u64 = 0;
+
+    for partition_data in partitions {
+        let mut partition = partition_data.write().await;
+        let mut new_batches = Vec::with_capacity(partition.len());
+
+        for batch in partition.iter() {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+
+            let (update_count, update_mask) =
+                match evaluate_predicates(predicates, batch)? {
+                    Some(mask) => {
+                        // Count the rows the mask selects, which are the rows to update.
+                        let count = mask.iter().filter(|v| v == &Some(true)).count();
+                        // Only true, never NULL, selects a row for update.
+                        let normalized: BooleanArray =
+                            mask.iter().map(|v| Some(v == Some(true))).collect();
+                        (count, normalized)
+                    }
+                    None => {
+                        // No `WHERE` clause updates every row.
+                        (
+                            batch.num_rows(),
+                            BooleanArray::from(vec![true; batch.num_rows()]),
+                        )
+                    }
+                };
+
+            total_updated += update_count as u64;
+
+            if update_count == 0 {
+                new_batches.push(batch.clone());
+                continue;
+            }
+
+            let mut new_columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
+
+            for (index, field) in table_schema.fields().iter().enumerate() {
+                let column_name = field.name();
+                let original_column =
+                    batch.column_by_name(column_name).ok_or_else(|| {
+                        internal_datafusion_err!(
+                            "Column '{column_name}' not found in batch"
+                        )
+                    })?;
+
+                let new_column = match set_exprs.get(index).and_then(|e| e.as_ref()) {
+                    Some(set_expr) => {
+                        // `evaluate_selection` evaluates the matching rows only,
+                        // which keeps an error such as a divide by zero away from
+                        // the rows the statement does not touch. It returns NULL
+                        // for the other rows, and `zip` puts the originals back.
+                        let new_values =
+                            set_expr.evaluate_selection(batch, &update_mask)?;
+                        let new_array = new_values.into_array(batch.num_rows())?;
+
+                        // Convert to &dyn Array, which implements Datum
+                        let new_arr: &dyn Array = new_array.as_ref();
+                        let orig_arr: &dyn Array = original_column.as_ref();
+                        zip(&update_mask, &new_arr, &orig_arr)?
+                    }
+                    None => Arc::clone(original_column),
+                };
+
+                new_columns.push(new_column);
+            }
+
+            let updated_batch =
+                RecordBatch::try_new(Arc::clone(table_schema), new_columns)?;
+            new_batches.push(updated_batch);
+        }
+
+        *partition = new_batches;
+    }
+
+    Ok(total_updated)
 }

--- a/datafusion/catalog/src/memory/table.rs
+++ b/datafusion/catalog/src/memory/table.rs
@@ -32,7 +32,8 @@ use arrow::record_batch::RecordBatch;
 use datafusion_common::error::Result;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{
-    Constraints, DFSchema, SchemaExt, internal_datafusion_err, not_impl_err, plan_err,
+    Constraints, DFSchema, SchemaExt, internal_datafusion_err, internal_err,
+    not_impl_err, plan_err,
 };
 use datafusion_datasource::memory::{MemSink, MemorySourceConfig};
 use datafusion_datasource::sink::DataSinkExec;
@@ -608,9 +609,15 @@ impl ExecutionPlan for MemDeleteExec {
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        if partition != 0 {
+            return internal_err!(
+                "MemDeleteExec has one partition, but partition {partition} was requested"
+            );
+        }
+
         let partitions = self.partitions.clone();
         let sort_order = Arc::clone(&self.sort_order);
         let predicates = self.predicates.clone();
@@ -806,9 +813,15 @@ impl ExecutionPlan for MemUpdateExec {
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        if partition != 0 {
+            return internal_err!(
+                "MemUpdateExec has one partition, but partition {partition} was requested"
+            );
+        }
+
         let partitions = self.partitions.clone();
         let sort_order = Arc::clone(&self.sort_order);
         let table_schema = Arc::clone(&self.table_schema);

--- a/datafusion/core/src/datasource/memory_test.rs
+++ b/datafusion/core/src/datasource/memory_test.rs
@@ -20,17 +20,19 @@ mod tests {
 
     use crate::datasource::MemTable;
     use crate::datasource::{DefaultTableSource, provider_as_source};
-    use crate::physical_plan::collect;
+    use crate::physical_plan::{ExecutionPlan, collect};
     use crate::prelude::SessionContext;
     use arrow::array::{AsArray, Int32Array};
-    use arrow::datatypes::{DataType, Field, Schema, UInt64Type};
+    use arrow::datatypes::{DataType, Field, Int32Type, Schema, UInt64Type};
     use arrow::error::ArrowError;
     use arrow::record_batch::RecordBatch;
     use arrow_schema::SchemaRef;
     use datafusion_catalog::TableProvider;
-    use datafusion_common::{Constraint, Constraints, DataFusionError, Result};
-    use datafusion_expr::LogicalPlanBuilder;
+    use datafusion_common::{
+        Constraint, Constraints, DataFusionError, Result, ScalarValue, assert_contains,
+    };
     use datafusion_expr::dml::InsertOp;
+    use datafusion_expr::{Expr, LogicalPlanBuilder, col, lit};
     use futures::StreamExt;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -499,6 +501,361 @@ mod tests {
             "Error during planning: No partitions provided, expected at least one partition",
             experiment_result.strip_backtrace()
         );
+        Ok(())
+    }
+
+    /// A schema of one non-nullable Int32 column called "a".
+    fn one_column_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    /// A batch of the rows 1, 2 and 3 in the column "a".
+    fn one_column_batch(schema: &SchemaRef) -> Result<RecordBatch> {
+        Ok(RecordBatch::try_new(
+            Arc::clone(schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?)
+    }
+
+    /// A `MemTable` of one partition holding the rows 1, 2 and 3.
+    fn one_column_table() -> Result<MemTable> {
+        let schema = one_column_schema();
+        MemTable::try_new(Arc::clone(&schema), vec![vec![one_column_batch(&schema)?]])
+    }
+
+    /// A `MemTable` that holds no partition. `MemTable::try_new` rejects an
+    /// empty partition list, so a caller reaches this state through the public
+    /// `batches` field.
+    fn zero_partition_table(schema: SchemaRef) -> Result<MemTable> {
+        let mut table = MemTable::try_new(schema, vec![vec![]])?;
+        table.batches.clear();
+        Ok(table)
+    }
+
+    /// Run a DELETE or an UPDATE plan and return the count that it emits.
+    async fn run_dml(
+        plan: Arc<dyn ExecutionPlan>,
+        session_ctx: &SessionContext,
+    ) -> Result<u64> {
+        Ok(extract_count(collect(plan, session_ctx.task_ctx()).await?))
+    }
+
+    /// Read one partition of a `MemTable` as a plain vector of batches.
+    async fn read_partition(table: &MemTable, partition: usize) -> Vec<RecordBatch> {
+        table.batches[partition].read().await.clone()
+    }
+
+    /// The values of the first column of `batch`, which must hold no null.
+    fn column_values(batch: &RecordBatch) -> Vec<i32> {
+        batch
+            .column(0)
+            .as_primitive::<Int32Type>()
+            .iter()
+            .map(|value| value.expect("expected non null"))
+            .collect()
+    }
+
+    // A DELETE on a table without a partition affects no row
+    #[tokio::test]
+    async fn test_delete_from_zero_partition() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = zero_partition_table(one_column_schema())?;
+
+        let plan = table.delete_from(&state, vec![col("a").gt(lit(1))]).await?;
+        assert_eq!(run_dml(plan, &session_ctx).await?, 0);
+        Ok(())
+    }
+
+    // An UPDATE on a table without a partition affects no row
+    #[tokio::test]
+    async fn test_update_zero_partition() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = zero_partition_table(one_column_schema())?;
+
+        let plan = table
+            .update(&state, vec![("a".to_string(), lit(7))], vec![])
+            .await?;
+        assert_eq!(run_dml(plan, &session_ctx).await?, 0);
+        Ok(())
+    }
+
+    // A DELETE skips a batch of no row and drops it from the partition
+    #[tokio::test]
+    async fn test_delete_from_empty_batch() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![
+                RecordBatch::new_empty(Arc::clone(&schema)),
+                one_column_batch(&schema)?,
+            ]],
+        )?;
+
+        let plan = table.delete_from(&state, vec![col("a").gt(lit(1))]).await?;
+        assert_eq!(run_dml(plan, &session_ctx).await?, 2);
+
+        // The empty batch is gone and the row 1 remains
+        let partition = read_partition(&table, 0).await;
+        assert_eq!(partition.len(), 1);
+        assert_eq!(column_values(&partition[0]), vec![1]);
+        Ok(())
+    }
+
+    // An UPDATE skips a batch of no row and drops it from the partition
+    #[tokio::test]
+    async fn test_update_empty_batch() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let schema = one_column_schema();
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![
+                RecordBatch::new_empty(Arc::clone(&schema)),
+                one_column_batch(&schema)?,
+            ]],
+        )?;
+
+        let plan = table
+            .update(
+                &state,
+                vec![("a".to_string(), lit(7))],
+                vec![col("a").gt(lit(1))],
+            )
+            .await?;
+        assert_eq!(run_dml(plan, &session_ctx).await?, 2);
+
+        // The empty batch is gone and the rows 2 and 3 now hold 7
+        let partition = read_partition(&table, 0).await;
+        assert_eq!(partition.len(), 1);
+        assert_eq!(column_values(&partition[0]), vec![1, 7, 7]);
+        Ok(())
+    }
+
+    // The DELETE plan has one partition and rejects a request for another
+    #[tokio::test]
+    async fn test_delete_exec_rejects_other_partition() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let plan = table.delete_from(&state, vec![]).await?;
+        let Err(err) = plan.execute(1, session_ctx.task_ctx()) else {
+            panic!("expected an error for partition 1");
+        };
+        assert_contains!(
+            err.strip_backtrace(),
+            "MemDeleteExec has one partition, but partition 1 was requested"
+        );
+
+        // The failed request leaves the rows alone
+        assert_eq!(read_partition(&table, 0).await[0].num_rows(), 3);
+        Ok(())
+    }
+
+    // The UPDATE plan has one partition and rejects a request for another
+    #[tokio::test]
+    async fn test_update_exec_rejects_other_partition() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let plan = table
+            .update(&state, vec![("a".to_string(), lit(7))], vec![])
+            .await?;
+        let Err(err) = plan.execute(1, session_ctx.task_ctx()) else {
+            panic!("expected an error for partition 1");
+        };
+        assert_contains!(
+            err.strip_backtrace(),
+            "MemUpdateExec has one partition, but partition 1 was requested"
+        );
+
+        // The failed request leaves the rows alone
+        assert_eq!(
+            column_values(&read_partition(&table, 0).await[0]),
+            vec![1, 2, 3]
+        );
+        Ok(())
+    }
+
+    // A DELETE whose `WHERE` clause names an unknown column fails while the
+    // plan is built, before any row changes
+    #[tokio::test]
+    async fn test_delete_from_unknown_filter_column() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let err = table
+            .delete_from(&state, vec![col("nonexistent").eq(lit(1))])
+            .await
+            .unwrap_err();
+        assert_contains!(err.strip_backtrace(), "nonexistent");
+        Ok(())
+    }
+
+    // An UPDATE whose `WHERE` clause names an unknown column fails while the
+    // plan is built, before any row changes
+    #[tokio::test]
+    async fn test_update_unknown_filter_column() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let err = table
+            .update(
+                &state,
+                vec![("a".to_string(), lit(7))],
+                vec![col("nonexistent").eq(lit(1))],
+            )
+            .await
+            .unwrap_err();
+        assert_contains!(err.strip_backtrace(), "nonexistent");
+        Ok(())
+    }
+
+    // An UPDATE whose `SET` clause names an unknown column fails while the plan
+    // is built, so `EXPLAIN` reports it
+    #[tokio::test]
+    async fn test_update_unknown_set_column() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let err = table
+            .update(&state, vec![("nonexistent".to_string(), lit(7))], vec![])
+            .await
+            .unwrap_err();
+        assert_contains!(
+            err.strip_backtrace(),
+            "UPDATE failed: column 'nonexistent' does not exist. Available columns: a"
+        );
+        Ok(())
+    }
+
+    // A DELETE whose `WHERE` clause is not a predicate fails when the plan runs
+    #[tokio::test]
+    async fn test_delete_from_non_boolean_filter() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let plan = table.delete_from(&state, vec![lit(1)]).await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "Filter did not evaluate to boolean");
+
+        // The failed run leaves the rows alone
+        assert_eq!(read_partition(&table, 0).await[0].num_rows(), 3);
+        Ok(())
+    }
+
+    // An UPDATE whose `WHERE` clause is not a predicate fails when the plan runs
+    #[tokio::test]
+    async fn test_update_non_boolean_filter() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let plan = table
+            .update(&state, vec![("a".to_string(), lit(7))], vec![lit(1)])
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "Filter did not evaluate to boolean");
+        Ok(())
+    }
+
+    // An UPDATE reports the column that a batch of the table does not hold
+    #[tokio::test]
+    async fn test_update_column_missing_from_batch() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, true),
+        ]));
+        let table = MemTable::try_new(
+            Arc::clone(&table_schema),
+            vec![vec![RecordBatch::try_new(
+                table_schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2, 3])),
+                    Arc::new(Int32Array::from(vec![4, 5, 6])),
+                ],
+            )?]],
+        )?;
+        // `try_new` rejects a batch that misses a column of the table, so the
+        // test writes one straight into the partition. The UPDATE reports the
+        // missing column instead of a panic.
+        let batch = one_column_batch(&one_column_schema())?;
+        *table.batches[0].write().await = vec![batch];
+
+        let plan = table
+            .update(&state, vec![("a".to_string(), lit(7))], vec![])
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "Column 'b' not found in batch");
+        Ok(())
+    }
+
+    // An UPDATE reports the failure of an assignment expression
+    #[tokio::test]
+    async fn test_update_assignment_evaluation_error() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let plan = table
+            .update(
+                &state,
+                vec![("a".to_string(), col("a") / lit(0))],
+                vec![col("a").gt(lit(1))],
+            )
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "Divide by zero");
+        Ok(())
+    }
+
+    // An UPDATE reports an assignment of a value of the wrong type
+    #[tokio::test]
+    async fn test_update_assignment_type_mismatch() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let assignment: (String, Expr) = ("a".to_string(), lit("seven"));
+        let plan = table
+            .update(&state, vec![assignment], vec![col("a").gt(lit(1))])
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(
+            err.strip_backtrace(),
+            "arguments need to have the same data type"
+        );
+        Ok(())
+    }
+
+    // An UPDATE rejects a null value for a column that the table declares NOT NULL
+    #[tokio::test]
+    async fn test_update_null_into_non_nullable_column() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let state = session_ctx.state();
+        let table = one_column_table()?;
+
+        let null = lit(ScalarValue::Int32(None));
+        let plan = table
+            .update(
+                &state,
+                vec![("a".to_string(), null)],
+                vec![col("a").gt(lit(1))],
+            )
+            .await?;
+        let err = run_dml(plan, &session_ctx).await.unwrap_err();
+        assert_contains!(err.strip_backtrace(), "non-nullable but contains null");
         Ok(())
     }
 }

--- a/datafusion/sqllogictest/test_files/delete.slt
+++ b/datafusion/sqllogictest/test_files/delete.slt
@@ -36,7 +36,7 @@ logical_plan
 02)--TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDeleteExec
 
 
 # Filtered by existing columns
@@ -49,7 +49,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDeleteExec: predicate=[CAST(a@0 AS Int64) = 1, CAST(b@1 AS Int64) = 2, c@2 > CAST(3 AS Float64), CAST(d@3 AS Int64) != 4]
 
 
 # Filtered by existing columns, using qualified and unqualified names
@@ -62,7 +62,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDeleteExec: predicate=[CAST(a@0 AS Int64) = 1, CAST(b@1 AS Int64) = 2, c@2 > CAST(3 AS Float64), CAST(d@3 AS Int64) != 4]
 
 
 # Filtered by a mix of columns and literal predicates
@@ -75,7 +75,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDeleteExec: predicate=[CAST(a@0 AS Int64) = 1, 1 = 1, true]
 
 
 # Deleting by columns that do not exist returns an error
@@ -126,7 +126,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDeleteExec
 
 
 query TT
@@ -139,7 +139,7 @@ logical_plan
 04)------TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemDeleteExec: predicate=[CAST(a@0 AS Int64) = 1, b@1 = CAST(2 AS Utf8View)]
 
 # Config reset
 statement ok

--- a/datafusion/sqllogictest/test_files/dml_delete.slt
+++ b/datafusion/sqllogictest/test_files/dml_delete.slt
@@ -200,3 +200,31 @@ SELECT * FROM test_delete_in;
 
 statement ok
 DROP TABLE test_delete_in;
+
+# Test that EXPLAIN DELETE prints the plan and deletes nothing.
+# Regression test for https://github.com/apache/datafusion/issues/24656:
+# the delete used to run while the physical plan was built.
+statement ok
+CREATE TABLE test_delete_explain AS VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+statement ok
+EXPLAIN DELETE FROM test_delete_explain WHERE column1 > 1;
+
+query IT rowsort
+SELECT * FROM test_delete_explain;
+----
+1 a
+2 b
+3 c
+
+# EXPLAIN ANALYZE runs the plan, so it does delete, and it deletes once.
+statement ok
+EXPLAIN ANALYZE DELETE FROM test_delete_explain WHERE column1 > 1;
+
+query IT rowsort
+SELECT * FROM test_delete_explain;
+----
+1 a
+
+statement ok
+DROP TABLE test_delete_explain;

--- a/datafusion/sqllogictest/test_files/dml_update.slt
+++ b/datafusion/sqllogictest/test_files/dml_update.slt
@@ -284,3 +284,34 @@ SELECT * FROM test_update_div;
 
 statement ok
 DROP TABLE test_update_div;
+
+# Test that EXPLAIN UPDATE prints the plan and updates nothing.
+# Regression test for https://github.com/apache/datafusion/issues/24656:
+# the update used to run while the physical plan was built.
+statement ok
+CREATE TABLE test_update_explain AS VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+statement ok
+EXPLAIN UPDATE test_update_explain SET column1 = column1 + 10 WHERE column1 > 1;
+
+query IT rowsort
+SELECT * FROM test_update_explain;
+----
+1 a
+2 b
+3 c
+
+# EXPLAIN ANALYZE runs the plan, so it does update. Each matching value goes
+# up by ten once, so a second run of the plan would show 22 and 23.
+statement ok
+EXPLAIN ANALYZE UPDATE test_update_explain SET column1 = column1 + 10 WHERE column1 > 1;
+
+query IT rowsort
+SELECT * FROM test_update_explain;
+----
+1 a
+12 b
+13 c
+
+statement ok
+DROP TABLE test_update_explain;

--- a/datafusion/sqllogictest/test_files/update.slt
+++ b/datafusion/sqllogictest/test_files/update.slt
@@ -35,7 +35,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemUpdateExec: set=[a=CAST(1 AS Int32), b=CAST(2 AS Utf8View), c=3, d=CAST(NULL AS Int32)]
 
 query TT
 explain update t1 set a=c+1, b=a, c=c+1.0, d=b;
@@ -46,7 +46,7 @@ logical_plan
 03)----TableScan: t1
 physical_plan
 01)CooperativeExec
-02)--DmlResultExec: rows_affected=0
+02)--MemUpdateExec: set=[a=CAST(c@2 + CAST(1 AS Float64) AS Int32), b=CAST(a@0 AS Utf8View), c=c@2 + 1, d=CAST(b@1 AS Int32)]
 
 statement ok
 create table t2(a int, b varchar, c double, d int);


### PR DESCRIPTION

## Which issue does this PR close?

- Closes #24656.
- Supersedes https://github.com/apache/datafusion/pull/24655

## Rationale for this change

`EXPLAIN DELETE` and `EXPLAIN UPDATE` changed the rows of an in-memory table. The plan was printed, and the statement had also run:

```sql
> create table t as values (1), (2), (3);

> explain delete from t where column1 > 1;
+---------------+----------------------------------+
| plan_type     | plan                             |
+---------------+----------------------------------+
| logical_plan  | Dml: op=[Delete] table=[t]       |
|               |   Filter: t.column1 > Int64(1)   |
|               |     TableScan: t                 |
| physical_plan | CooperativeExec                  |
|               |   DmlResultExec: rows_affected=2 |
+---------------+----------------------------------+

> select * from t;
+---------+
| column1 |
+---------+
| 1       |
+---------+
```

Two causes combined. `handle_explain()` builds the physical plan in order to print the `physical_plan` section, and the planner awaits `TableProvider::delete_from()` and `TableProvider::update()` while it builds. `MemTable` did the whole row change inside those hooks: it took a write lock on each partition, overwrote it, cleared the declared sort order, and returned a constant `DmlResultExec` carrying a count it had already computed. The row count baked into the plan text was the tell.

`EXPLAIN ANALYZE DELETE` is expected to change the rows, because it runs the plan by design. It must apply the statement exactly once.

## What changes are included in this PR?

Each hook is split into a planning half and an execution half.

| Stays in the hook (planning) | Moves to `execute()` |
|---|---|
| Clone the `batches` and `sort_order` handles | Take the write lock on each partition |
| Build the physical predicates of the `WHERE` clause | Evaluate the mask per batch |
| Validate the `SET` column names, build the physical assignments | Rewrite or filter the batches |
| | Clear the declared sort order |
| | Count the affected rows and emit the `count` batch |

`delete_from()` now returns `MemDeleteExec` and `update()` returns `MemUpdateExec`. Each node holds the shared partition handles plus the expressions the hook built, and applies the change on the first poll of the stream that `execute()` returns. `DmlResultExec` is removed, since the count is not known while the plan is built. Each run of the plan applies the statement once, as `DataSinkExec` does for an `INSERT`.

The row logic itself moved unchanged into `delete_rows()` and `update_rows()`, including the SQL three-valued logic for a NULL predicate and the `evaluate_selection` call that keeps an error such as a divide by zero away from the rows the statement does not touch.

Planning errors stay in the hooks, so `EXPLAIN` still reports an unknown `SET` column and a predicate that cannot be planned. `apply_expressions()` now visits the expressions the nodes hold; the constant node it replaces had none.

Both nodes are private to `datafusion-catalog`, so there is no public API change.


## What is the testing strategy for this PR?

New sqllogictest cases in `dml_delete.slt` and `dml_update.slt` assert that `EXPLAIN` leaves the three rows alone and that `EXPLAIN ANALYZE` changes them. Against the unfixed provider both fail. The update case adds ten to each matching value rather than deleting, so a plan that ran twice would print `22` and `23` instead of `12` and `13`; that is what pins the once-only guarantee, and it is what the old code produced.

The eight physical plan expectations in `delete.slt` and `update.slt` are regenerated. They can no longer carry `rows_affected`, and the new text names the predicates and the assignments instead:

```
02)--MemDeleteExec: predicate=[CAST(a@0 AS Int64) = 1, c@2 > CAST(3 AS Float64)]
02)--MemUpdateExec: set=[a=CAST(c@2 + CAST(1 AS Float64) AS Int32), b=CAST(a@0 AS Utf8View)]
```

`cargo test --test sqllogictests`, `cargo test -p datafusion --lib`, and `cargo test -p datafusion --test core_integration` show identical results before and after the change. Clippy passes with `-D warnings` on `datafusion-catalog`, `datafusion`, and `datafusion-sqllogictest`.

## Are there any user-facing changes?

Yes, and all three are the point of the fix or follow from it.

`EXPLAIN DELETE` and `EXPLAIN UPDATE` on a `MemTable` no longer change data, and they no longer clear the table's declared sort order.

The physical plan text of a `DELETE` or an `UPDATE` on a `MemTable` changed. `DmlResultExec: rows_affected=N` becomes `MemDeleteExec` or `MemUpdateExec`, which name the predicates and the assignments in place of the count.

One behaviour change beyond the fix, noted for completeness: the early return for a `MemTable` with no partitions is gone, so an `UPDATE` naming an unknown column now raises its plan error rather than reporting zero rows. `MemTable::try_new` rejects an empty partition list, so this is unreachable through normal construction.

`EXPLAIN INSERT` still clears the declared sort order, because `insert_into()` does that inside the hook. That is a smaller instance of the same shape and is left for a follow-up.
