### PR TITLE
chore: Fix duplicated word typos in comments and docs

### DIFF
--- a/datafusion-examples/examples/query_planning/expr_api.rs
+++ b/datafusion-examples/examples/query_planning/expr_api.rs
@@ -63,7 +63,7 @@ pub fn expr_api() -> Result<()> {
     // "fluent"-style API:
     let expr = col("a") + lit(5);
 
-    // The same same expression can be created directly, with much more code:
+    // The same expression can be created directly, with much more code:
     let expr2 = Expr::BinaryExpr(BinaryExpr::new(
         Box::new(col("a")),
         Operator::Plus,

--- a/datafusion/core/src/datasource/file_format/options.rs
+++ b/datafusion/core/src/datasource/file_format/options.rs
@@ -50,7 +50,7 @@ use futures::future::BoxFuture;
 /// Options that control the reading of CSV files.
 ///
 /// Note this structure is supplied when a datasource is created and
-/// can not not vary from statement to statement. For settings that
+/// can not vary from statement to statement. For settings that
 /// can vary statement to statement see
 /// [`ConfigOptions`](crate::config::ConfigOptions).
 #[derive(Clone)]
@@ -246,7 +246,7 @@ impl<'a> CsvReadOptions<'a> {
 /// Options that control the reading of Parquet files.
 ///
 /// Note this structure is supplied when a datasource is created and
-/// can not not vary from statement to statement. For settings that
+/// can not vary from statement to statement. For settings that
 /// can vary statement to statement see
 /// [`ConfigOptions`](crate::config::ConfigOptions).
 #[derive(Clone)]
@@ -357,7 +357,7 @@ impl<'a> ParquetReadOptions<'a> {
 /// Options that control the reading of ARROW files.
 ///
 /// Note this structure is supplied when a datasource is created and
-/// can not not vary from statement to statement. For settings that
+/// can not vary from statement to statement. For settings that
 /// can vary statement to statement see
 /// [`ConfigOptions`](crate::config::ConfigOptions).
 #[derive(Clone)]
@@ -403,7 +403,7 @@ impl<'a> ArrowReadOptions<'a> {
 /// Options that control the reading of AVRO files.
 ///
 /// Note this structure is supplied when a datasource is created and
-/// can not not vary from statement to statement. For settings that
+/// can not vary from statement to statement. For settings that
 /// can vary statement to statement see
 /// [`ConfigOptions`](crate::config::ConfigOptions).
 #[derive(Clone)]

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1787,7 +1787,7 @@ impl LogicalPlan {
     /// updated according to the new parameters.
     ///
     /// Unlike `recompute_schema()`, this method rebuilds VALUES plans entirely to properly infer
-    /// types types from literal values after placeholder substitution.
+    /// types from literal values after placeholder substitution.
     fn update_schema_data_type(self) -> Result<LogicalPlan> {
         match self {
             // Build `LogicalPlan::Values` from the values for type inference.

--- a/datafusion/expr/src/window_frame.rs
+++ b/datafusion/expr/src/window_frame.rs
@@ -475,7 +475,7 @@ pub enum WindowFrameUnits {
     Range,
     /// The GROUPS frame type means that the starting and ending boundaries are determine
     /// by counting "groups" relative to the current group. A "group" is a set of rows that all have
-    /// equivalent values for all all terms of the window ORDER BY clause.
+    /// equivalent values for all terms of the window ORDER BY clause.
     Groups,
 }
 

--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -104,25 +104,25 @@ impl PhysicalSortExpr {
         result
     }
 
-    /// Set the sort sort options to ASC
+    /// Set the sort options to ASC
     pub fn asc(mut self) -> Self {
         self.options.descending = false;
         self
     }
 
-    /// Set the sort sort options to DESC
+    /// Set the sort options to DESC
     pub fn desc(mut self) -> Self {
         self.options.descending = true;
         self
     }
 
-    /// Set the sort sort options to NULLS FIRST
+    /// Set the sort options to NULLS FIRST
     pub fn nulls_first(mut self) -> Self {
         self.options.nulls_first = true;
         self
     }
 
-    /// Set the sort sort options to NULLS LAST
+    /// Set the sort options to NULLS LAST
     pub fn nulls_last(mut self) -> Self {
         self.options.nulls_first = false;
         self

--- a/datafusion/physical-plan/src/repartition/distributor_channels.rs
+++ b/datafusion/physical-plan/src/repartition/distributor_channels.rs
@@ -161,7 +161,7 @@ impl<T> Drop for DistributionSender<T> {
             // During the shutdown of a empty channel, both the sender and the receiver side will be dropped. However we
             // only want to decrement the "empty channels" counter once.
             //
-            // We are within a critical section here, so we we can safely assume that either the last sender or the
+            // We are within a critical section here, so we can safely assume that either the last sender or the
             // receiver (there's only one) will be dropped first.
             //
             // If the last sender is dropped first, `state.data` will still exists and the sender side decrements the

--- a/docs/source/contributor-guide/testing.md
+++ b/docs/source/contributor-guide/testing.md
@@ -164,7 +164,7 @@ contributions. Kudos to [@2010YOUY01] for the initial implementation.
 ## Documentation Examples
 
 We use Rust [doctest] to verify examples from the documentation are correct and
-up-to-date. These tests are run as part of our CI and you can run them them
+up-to-date. These tests are run as part of our CI and you can run them
 locally with the following command:
 
 ```shell


### PR DESCRIPTION
## Which issue does this PR close?

No issue. This follows the precedent of prior comment-typo cleanups, which were merged without a linked issue:

- #23662 `chore: Fix duplicated word typos in comments` (10 files, +14/-14)
- #21495 ``chore: Fix `typo` problems`` (10 files, +14/-14)
- #22625 `chore: Fix typos in comments` (2 files, +2/-2)
- #22524 `chore: fix two comment typos` (2 files, +4/-4)
- #20157 `chore: Fix typos in comments` (1 file, +2/-2)

## Rationale for this change

Several comments and doc comments contain accidentally doubled words — `the sort sort options`, `can not not vary`, `types types from`. Four of them are rustdoc on public methods, so they render on docs.rs.

These survive automated checking because the CI typo checker (`ci/scripts/typos_check.sh`, the `typos` crate) matches misspelled *words* and does not detect a correctly spelled word repeated twice in a row. Searching the tree for `\b(\w+)\s+\1\b` restricted to comment and prose lines finds the cases below; the remaining matches are ASCII-art plan diagrams and pasted `parquet-tools` output, which are left alone.

## What changes are included in this PR?

Removes 7 doubled words across 6 Rust files and 1 documentation file (13 lines). Comment and prose text only — no code changes.

| File | Fix |
| --- | --- |
| `datafusion/physical-expr-common/src/sort_expr.rs` (x4) | `Set the sort sort options` on the public `asc` / `desc` / `nulls_first` / `nulls_last` builders |
| `datafusion/core/src/datasource/file_format/options.rs` (x4) | `can not not vary from statement to statement` on the CSV / Parquet / Arrow / Avro read options |
| `datafusion/expr/src/window_frame.rs` | `equivalent values for all all terms` |
| `datafusion/expr/src/logical_plan/plan.rs` | `properly infer types types from literal values` |
| `datafusion/physical-plan/src/repartition/distributor_channels.rs` | `so we we can safely assume` |
| `datafusion-examples/examples/query_planning/expr_api.rs` | `The same same expression` |
| `docs/source/contributor-guide/testing.md` | `you can run them them locally` |

## What is the testing strategy for this PR?

No new tests. The change is confined to comments and prose, so there is no behaviour to cover.

Checks run locally on Linux x86_64 with the pinned 1.97.0 toolchain:

- `cargo fmt --all --check` — pass
- `cargo clippy --all-targets --all-features -- -D warnings` — pass, no warnings (full workspace, 22m)
- `./ci/scripts/doc_prettier_check.sh` — pass
- `cargo test --doc -p datafusion-physical-expr-common -p datafusion-expr -p datafusion` — pass, 254 tests (186 + 60 + 8), 0 failed

I did not run the full extended test suite. No edited comment contains a doctest code fence, and the workspace compiles cleanly under `--all-features`, so the change cannot affect compiled or tested behaviour.

## Are there any user-facing changes?

No API or behaviour changes. The rendered rustdoc for four public `PhysicalSortExpr` builder methods and for the four `*ReadOptions` structs is corrected.

---

## AI disclosure

This contribution was AI-assisted. Claude Code (Claude Opus 5) performed the tree-wide doubled-word search, made the 13 line edits, and ran every check listed above on Linux x86_64 with the pinned 1.97.0 toolchain. The contributor reviewed the diff and the check output before this PR was opened; the check commands themselves were executed by the AI and were not independently re-run by hand.

The two `datafusion/core/src/lib.rs` doctests initially failed for a missing `parquet-testing` submodule (`PARQUET_TEST_DATA` undefined) rather than for any change in this PR; they pass once the submodule is initialised. That file is not touched by this PR.
