### PR TITLE
fix(proto): preserve CSV sink writer options

### DIFF
--- a/datafusion/datasource-csv/src/file_format.rs
+++ b/datafusion/datasource-csv/src/file_format.rs
@@ -848,6 +848,13 @@ impl DataSink for CsvSink {
         use datafusion_proto_models::protobuf;
         use protobuf::physical_plan_node::PhysicalPlanType;
 
+        // Keep an exhaustive guard in the active hook while centralizing the
+        // field mapping in the exhaustive `TryFrom<&CsvSink>` below.
+        let Self {
+            config: _,
+            writer_options: _,
+        } = self;
+
         let input = ctx.encode_child(exec.input())?;
         let sort_order = exec.encode_sort_order(ctx)?;
         let sink = protobuf::CsvSink::try_from(self)?;
@@ -868,9 +875,13 @@ impl TryFrom<&CsvSink> for datafusion_proto_models::protobuf::CsvSink {
     type Error = DataFusionError;
 
     fn try_from(value: &CsvSink) -> Result<Self> {
+        let CsvSink {
+            config,
+            writer_options,
+        } = value;
         Ok(Self {
-            config: Some(value.config().try_into()?),
-            writer_options: Some(value.writer_options().try_into()?),
+            config: Some(config.try_into()?),
+            writer_options: Some(writer_options.try_into()?),
         })
     }
 }
@@ -880,14 +891,16 @@ impl TryFrom<&datafusion_proto_models::protobuf::CsvSink> for CsvSink {
     type Error = DataFusionError;
 
     fn try_from(value: &datafusion_proto_models::protobuf::CsvSink) -> Result<Self> {
-        let config =
-            FileSinkConfig::try_from(value.config.as_ref().ok_or_else(|| {
-                datafusion_common::internal_datafusion_err!(
-                    "CsvSink is missing required field 'config'"
-                )
-            })?)?;
-        let writer_options = value
-            .writer_options
+        let datafusion_proto_models::protobuf::CsvSink {
+            config,
+            writer_options,
+        } = value;
+        let config = FileSinkConfig::try_from(config.as_ref().ok_or_else(|| {
+            datafusion_common::internal_datafusion_err!(
+                "CsvSink is missing required field 'config'"
+            )
+        })?)?;
+        let writer_options = writer_options
             .as_ref()
             .ok_or_else(|| {
                 datafusion_common::internal_datafusion_err!(
@@ -914,19 +927,24 @@ impl CsvSink {
             protobuf::physical_plan_node::PhysicalPlanType::CsvSink,
             "CsvSink",
         );
-        let input = ctx.decode_required_child(
-            sink_node.input.as_deref(),
-            "CsvSinkExecNode",
-            "input",
-        )?;
-        let proto_sink = sink_node.sink.as_ref().ok_or_else(|| {
+        let protobuf::CsvSinkExecNode {
+            input,
+            sink,
+            // The output schema is recomputed by `DataSinkExec::new`.
+            sink_schema: _,
+            sort_order,
+        } = sink_node.as_ref();
+
+        let input =
+            ctx.decode_required_child(input.as_deref(), "CsvSinkExecNode", "input")?;
+        let proto_sink = sink.as_ref().ok_or_else(|| {
             datafusion_common::internal_datafusion_err!(
                 "CsvSinkExecNode is missing required field 'sink'"
             )
         })?;
         let data_sink = CsvSink::try_from(proto_sink)?;
         let sort_order = DataSinkExec::decode_sort_order(
-            sink_node.sort_order.as_ref(),
+            sort_order.as_ref(),
             ctx,
             input.schema().as_ref(),
         )?;

--- a/datafusion/proto-common/proto/datafusion_common.proto
+++ b/datafusion/proto-common/proto/datafusion_common.proto
@@ -471,6 +471,12 @@ message CsvWriterOptions {
   bool ignore_leading_whitespace = 13;
   // Whether to ignore trailing whitespace in string values
   bool ignore_trailing_whitespace = 14;
+  // Optional compression level
+  optional uint32 compression_level = 15;
+  // Optional timestamp format for timestamp with timezone arrays
+  string timestamp_tz_format = 16;
+  // Optional line terminator. Empty defaults to LF; valid values are one byte or CRLF
+  bytes terminator = 17;
 }
 
 // Options controlling CSV format

--- a/datafusion/proto-common/src/from_proto/mod.rs
+++ b/datafusion/proto-common/src/from_proto/mod.rs
@@ -22,6 +22,7 @@ use crate::common::proto_error;
 use crate::protobuf_common as protobuf;
 use arrow::array::{ArrayRef, AsArray};
 use arrow::buffer::Buffer;
+use arrow::csv::writer::Terminator;
 use arrow::csv::{QuoteStyle, WriterBuilder};
 use arrow::datatypes::{
     DataType, Field, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit, Schema,
@@ -985,9 +986,112 @@ impl TryFrom<&protobuf::CsvWriterOptions> for CsvWriterOptions {
     fn try_from(
         opts: &protobuf::CsvWriterOptions,
     ) -> datafusion_common::Result<Self, Self::Error> {
-        let write_options = csv_writer_options_from_proto(opts)?;
-        let compression: CompressionTypeVariant = opts.compression().into();
-        Ok(CsvWriterOptions::new(write_options, compression))
+        let protobuf::CsvWriterOptions {
+            compression,
+            delimiter,
+            has_header,
+            date_format,
+            datetime_format,
+            timestamp_format,
+            time_format,
+            null_value,
+            quote,
+            escape,
+            double_quote,
+            quote_style,
+            ignore_leading_whitespace,
+            ignore_trailing_whitespace,
+            compression_level,
+            timestamp_tz_format,
+            terminator,
+        } = opts;
+
+        let mut writer_options = WriterBuilder::new();
+        if !delimiter.is_empty() {
+            if let Some(delimiter) = delimiter.chars().next() {
+                if delimiter.is_ascii() {
+                    writer_options = writer_options.with_delimiter(delimiter as u8);
+                } else {
+                    return Err(proto_error("CSV Delimiter is not ASCII"));
+                }
+            } else {
+                return Err(proto_error("Error parsing CSV Delimiter"));
+            }
+        }
+        if !quote.is_empty() {
+            if let Some(quote) = quote.chars().next() {
+                if quote.is_ascii() {
+                    writer_options = writer_options.with_quote(quote as u8);
+                } else {
+                    return Err(proto_error("CSV Quote is not ASCII"));
+                }
+            } else {
+                return Err(proto_error("Error parsing CSV Quote"));
+            }
+        }
+        if !escape.is_empty() {
+            if let Some(escape) = escape.chars().next() {
+                if escape.is_ascii() {
+                    writer_options = writer_options.with_escape(escape as u8);
+                } else {
+                    return Err(proto_error("CSV Escape is not ASCII"));
+                }
+            } else {
+                return Err(proto_error("Error parsing CSV Escape"));
+            }
+        }
+        let quote_style = match protobuf::CsvQuoteStyle::try_from(*quote_style) {
+            Ok(protobuf::CsvQuoteStyle::Always) => QuoteStyle::Always,
+            Ok(protobuf::CsvQuoteStyle::NonNumeric) => QuoteStyle::NonNumeric,
+            Ok(protobuf::CsvQuoteStyle::Never) => QuoteStyle::Never,
+            Ok(protobuf::CsvQuoteStyle::Necessary) => QuoteStyle::Necessary,
+            _ => {
+                return Err(proto_error(
+                    "Unknown quote style, must be one of: 'Always', 'NonNumeric', 'Never', 'Necessary'",
+                ));
+            }
+        };
+        writer_options = writer_options
+            .with_header(*has_header)
+            .with_null(null_value.clone())
+            .with_double_quote(*double_quote)
+            .with_quote_style(quote_style)
+            .with_ignore_leading_whitespace(*ignore_leading_whitespace)
+            .with_ignore_trailing_whitespace(*ignore_trailing_whitespace);
+        if !date_format.is_empty() {
+            writer_options = writer_options.with_date_format(date_format.clone());
+        }
+        if !datetime_format.is_empty() {
+            writer_options = writer_options.with_datetime_format(datetime_format.clone());
+        }
+        if !timestamp_format.is_empty() {
+            writer_options =
+                writer_options.with_timestamp_format(timestamp_format.clone());
+        }
+        if !timestamp_tz_format.is_empty() {
+            writer_options =
+                writer_options.with_timestamp_tz_format(timestamp_tz_format.clone());
+        }
+        if !time_format.is_empty() {
+            writer_options = writer_options.with_time_format(time_format.clone());
+        }
+        writer_options = match terminator.as_slice() {
+            [] => writer_options,
+            [byte] => writer_options.with_line_terminator(Terminator::Any(*byte)),
+            [b'\r', b'\n'] => writer_options.with_line_terminator(Terminator::CRLF),
+            _ => {
+                return Err(proto_error("CSV line terminator must be one byte or CRLF"));
+            }
+        };
+
+        let compression = protobuf::CompressionTypeVariant::try_from(*compression)
+            .unwrap_or_default()
+            .into();
+        Ok(CsvWriterOptions {
+            writer_options,
+            compression,
+            compression_level: *compression_level,
+        })
     }
 }
 
@@ -1322,66 +1426,6 @@ where
         .into_iter()
         .map(Field::try_from)
         .collect::<datafusion_common::Result<_, _>>()
-}
-
-pub(crate) fn csv_writer_options_from_proto(
-    writer_options: &protobuf::CsvWriterOptions,
-) -> datafusion_common::Result<WriterBuilder> {
-    let mut builder = WriterBuilder::new();
-    if !writer_options.delimiter.is_empty() {
-        if let Some(delimiter) = writer_options.delimiter.chars().next() {
-            if delimiter.is_ascii() {
-                builder = builder.with_delimiter(delimiter as u8);
-            } else {
-                return Err(proto_error("CSV Delimiter is not ASCII"));
-            }
-        } else {
-            return Err(proto_error("Error parsing CSV Delimiter"));
-        }
-    }
-    if !writer_options.quote.is_empty() {
-        if let Some(quote) = writer_options.quote.chars().next() {
-            if quote.is_ascii() {
-                builder = builder.with_quote(quote as u8);
-            } else {
-                return Err(proto_error("CSV Quote is not ASCII"));
-            }
-        } else {
-            return Err(proto_error("Error parsing CSV Quote"));
-        }
-    }
-    if !writer_options.escape.is_empty() {
-        if let Some(escape) = writer_options.escape.chars().next() {
-            if escape.is_ascii() {
-                builder = builder.with_escape(escape as u8);
-            } else {
-                return Err(proto_error("CSV Escape is not ASCII"));
-            }
-        } else {
-            return Err(proto_error("Error parsing CSV Escape"));
-        }
-    }
-    let quote_style = match protobuf::CsvQuoteStyle::try_from(writer_options.quote_style)
-    {
-        Ok(protobuf::CsvQuoteStyle::Always) => QuoteStyle::Always,
-        Ok(protobuf::CsvQuoteStyle::NonNumeric) => QuoteStyle::NonNumeric,
-        Ok(protobuf::CsvQuoteStyle::Never) => QuoteStyle::Never,
-        Ok(protobuf::CsvQuoteStyle::Necessary) => QuoteStyle::Necessary,
-        _ => Err(proto_error(
-            "Unknown quote style, must be one of: 'Always', 'NonNumeric', 'Never', 'Necessary'",
-        ))?,
-    };
-    Ok(builder
-        .with_header(writer_options.has_header)
-        .with_date_format(writer_options.date_format.clone())
-        .with_datetime_format(writer_options.datetime_format.clone())
-        .with_timestamp_format(writer_options.timestamp_format.clone())
-        .with_time_format(writer_options.time_format.clone())
-        .with_null(writer_options.null_value.clone())
-        .with_double_quote(writer_options.double_quote)
-        .with_quote_style(quote_style)
-        .with_ignore_leading_whitespace(writer_options.ignore_leading_whitespace)
-        .with_ignore_trailing_whitespace(writer_options.ignore_trailing_whitespace))
 }
 
 #[cfg(test)]

--- a/datafusion/proto-common/src/generated/pbjson.rs
+++ b/datafusion/proto-common/src/generated/pbjson.rs
@@ -2309,6 +2309,15 @@ impl serde::Serialize for CsvWriterOptions {
         if self.ignore_trailing_whitespace {
             len += 1;
         }
+        if self.compression_level.is_some() {
+            len += 1;
+        }
+        if !self.timestamp_tz_format.is_empty() {
+            len += 1;
+        }
+        if !self.terminator.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion_common.CsvWriterOptions", len)?;
         if self.compression != 0 {
             let v = CompressionTypeVariant::try_from(self.compression)
@@ -2356,6 +2365,17 @@ impl serde::Serialize for CsvWriterOptions {
         if self.ignore_trailing_whitespace {
             struct_ser.serialize_field("ignoreTrailingWhitespace", &self.ignore_trailing_whitespace)?;
         }
+        if let Some(v) = self.compression_level.as_ref() {
+            struct_ser.serialize_field("compressionLevel", v)?;
+        }
+        if !self.timestamp_tz_format.is_empty() {
+            struct_ser.serialize_field("timestampTzFormat", &self.timestamp_tz_format)?;
+        }
+        if !self.terminator.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("terminator", pbjson::private::base64::encode(&self.terminator).as_str())?;
+        }
         struct_ser.end()
     }
 }
@@ -2390,6 +2410,11 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
             "ignoreLeadingWhitespace",
             "ignore_trailing_whitespace",
             "ignoreTrailingWhitespace",
+            "compression_level",
+            "compressionLevel",
+            "timestamp_tz_format",
+            "timestampTzFormat",
+            "terminator",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -2408,6 +2433,9 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
             QuoteStyle,
             IgnoreLeadingWhitespace,
             IgnoreTrailingWhitespace,
+            CompressionLevel,
+            TimestampTzFormat,
+            Terminator,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2443,6 +2471,9 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
                             "quoteStyle" | "quote_style" => Ok(GeneratedField::QuoteStyle),
                             "ignoreLeadingWhitespace" | "ignore_leading_whitespace" => Ok(GeneratedField::IgnoreLeadingWhitespace),
                             "ignoreTrailingWhitespace" | "ignore_trailing_whitespace" => Ok(GeneratedField::IgnoreTrailingWhitespace),
+                            "compressionLevel" | "compression_level" => Ok(GeneratedField::CompressionLevel),
+                            "timestampTzFormat" | "timestamp_tz_format" => Ok(GeneratedField::TimestampTzFormat),
+                            "terminator" => Ok(GeneratedField::Terminator),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -2476,6 +2507,9 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
                 let mut quote_style__ = None;
                 let mut ignore_leading_whitespace__ = None;
                 let mut ignore_trailing_whitespace__ = None;
+                let mut compression_level__ = None;
+                let mut timestamp_tz_format__ = None;
+                let mut terminator__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Compression => {
@@ -2562,6 +2596,28 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
                             }
                             ignore_trailing_whitespace__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::CompressionLevel => {
+                            if compression_level__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("compressionLevel"));
+                            }
+                            compression_level__ =
+                                map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| x.0)
+                            ;
+                        }
+                        GeneratedField::TimestampTzFormat => {
+                            if timestamp_tz_format__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timestampTzFormat"));
+                            }
+                            timestamp_tz_format__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Terminator => {
+                            if terminator__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("terminator"));
+                            }
+                            terminator__ =
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(CsvWriterOptions {
@@ -2579,6 +2635,9 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
                     quote_style: quote_style__.unwrap_or_default(),
                     ignore_leading_whitespace: ignore_leading_whitespace__.unwrap_or_default(),
                     ignore_trailing_whitespace: ignore_trailing_whitespace__.unwrap_or_default(),
+                    compression_level: compression_level__,
+                    timestamp_tz_format: timestamp_tz_format__.unwrap_or_default(),
+                    terminator: terminator__.unwrap_or_default(),
                 })
             }
         }

--- a/datafusion/proto-common/src/generated/prost.rs
+++ b/datafusion/proto-common/src/generated/prost.rs
@@ -630,6 +630,15 @@ pub struct CsvWriterOptions {
     /// Whether to ignore trailing whitespace in string values
     #[prost(bool, tag = "14")]
     pub ignore_trailing_whitespace: bool,
+    /// Optional compression level
+    #[prost(uint32, optional, tag = "15")]
+    pub compression_level: ::core::option::Option<u32>,
+    /// Optional timestamp format for timestamp with timezone arrays
+    #[prost(string, tag = "16")]
+    pub timestamp_tz_format: ::prost::alloc::string::String,
+    /// Optional line terminator. Empty defaults to LF; valid values are one byte or CRLF
+    #[prost(bytes = "vec", tag = "17")]
+    pub terminator: ::prost::alloc::vec::Vec<u8>,
 }
 /// Options controlling CSV format
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -23,7 +23,8 @@ use crate::protobuf_common::{
     EmptyMessage, arrow_type::ArrowTypeEnum, scalar_value::Value,
 };
 use arrow::array::{ArrayRef, RecordBatch};
-use arrow::csv::{QuoteStyle, WriterBuilder};
+use arrow::csv::QuoteStyle;
+use arrow::csv::writer::Terminator;
 use arrow::datatypes::{
     DataType, Field, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit, Schema,
     SchemaRef, TimeUnit, UnionMode,
@@ -872,10 +873,46 @@ impl TryFrom<&CsvWriterOptions> for protobuf::CsvWriterOptions {
     type Error = DataFusionError;
 
     fn try_from(opts: &CsvWriterOptions) -> datafusion_common::Result<Self, Self::Error> {
-        Ok(csv_writer_options_to_proto(
-            &opts.writer_options,
-            &opts.compression,
-        ))
+        let CsvWriterOptions {
+            writer_options,
+            compression,
+            compression_level,
+        } = opts;
+        let compression: protobuf::CompressionTypeVariant = compression.into();
+        let quote_style: protobuf::CsvQuoteStyle = writer_options.quote_style().into();
+        let terminator = match writer_options.line_terminator() {
+            Terminator::CRLF => b"\r\n".to_vec(),
+            Terminator::Any(byte) => vec![*byte],
+        };
+
+        Ok(protobuf::CsvWriterOptions {
+            compression: compression.into(),
+            delimiter: (writer_options.delimiter() as char).to_string(),
+            has_header: writer_options.header(),
+            date_format: writer_options.date_format().unwrap_or_default().to_owned(),
+            datetime_format: writer_options
+                .datetime_format()
+                .unwrap_or_default()
+                .to_owned(),
+            timestamp_format: writer_options
+                .timestamp_format()
+                .unwrap_or_default()
+                .to_owned(),
+            time_format: writer_options.time_format().unwrap_or_default().to_owned(),
+            null_value: writer_options.null().to_owned(),
+            quote: (writer_options.quote() as char).to_string(),
+            escape: (writer_options.escape() as char).to_string(),
+            double_quote: writer_options.double_quote(),
+            quote_style: quote_style.into(),
+            ignore_leading_whitespace: writer_options.ignore_leading_whitespace(),
+            ignore_trailing_whitespace: writer_options.ignore_trailing_whitespace(),
+            compression_level: *compression_level,
+            timestamp_tz_format: writer_options
+                .timestamp_tz_format()
+                .unwrap_or_default()
+                .to_owned(),
+            terminator,
+        })
     }
 }
 
@@ -1174,28 +1211,4 @@ where
         .into_iter()
         .map(|field| field.as_ref().try_into())
         .collect::<Result<Vec<_>, Error>>()
-}
-
-pub(crate) fn csv_writer_options_to_proto(
-    csv_options: &WriterBuilder,
-    compression: &CompressionTypeVariant,
-) -> protobuf::CsvWriterOptions {
-    let compression: protobuf::CompressionTypeVariant = compression.into();
-    let quote_style: protobuf::CsvQuoteStyle = csv_options.quote_style().into();
-    protobuf::CsvWriterOptions {
-        compression: compression.into(),
-        delimiter: (csv_options.delimiter() as char).to_string(),
-        has_header: csv_options.header(),
-        date_format: csv_options.date_format().unwrap_or("").to_owned(),
-        datetime_format: csv_options.datetime_format().unwrap_or("").to_owned(),
-        timestamp_format: csv_options.timestamp_format().unwrap_or("").to_owned(),
-        time_format: csv_options.time_format().unwrap_or("").to_owned(),
-        null_value: csv_options.null().to_owned(),
-        quote: (csv_options.quote() as char).to_string(),
-        escape: (csv_options.escape() as char).to_string(),
-        double_quote: csv_options.double_quote(),
-        quote_style: quote_style.into(),
-        ignore_leading_whitespace: csv_options.ignore_leading_whitespace(),
-        ignore_trailing_whitespace: csv_options.ignore_trailing_whitespace(),
-    }
 }

--- a/datafusion/proto-models/src/generated/datafusion_proto_common.rs
+++ b/datafusion/proto-models/src/generated/datafusion_proto_common.rs
@@ -630,6 +630,15 @@ pub struct CsvWriterOptions {
     /// Whether to ignore trailing whitespace in string values
     #[prost(bool, tag = "14")]
     pub ignore_trailing_whitespace: bool,
+    /// Optional compression level
+    #[prost(uint32, optional, tag = "15")]
+    pub compression_level: ::core::option::Option<u32>,
+    /// Optional timestamp format for timestamp with timezone arrays
+    #[prost(string, tag = "16")]
+    pub timestamp_tz_format: ::prost::alloc::string::String,
+    /// Optional line terminator. Empty defaults to LF; valid values are one byte or CRLF
+    #[prost(bytes = "vec", tag = "17")]
+    pub terminator: ::prost::alloc::vec::Vec<u8>,
 }
 /// Options controlling CSV format
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/datafusion/proto/tests/cases/plans/sinks.rs
+++ b/datafusion/proto/tests/cases/plans/sinks.rs
@@ -18,7 +18,8 @@
 //! Data sinks and their file sink configurations.
 
 use super::{roundtrip_test, roundtrip_test_and_return};
-use arrow::csv::WriterBuilder;
+use arrow::csv::writer::Terminator;
+use arrow::csv::{QuoteStyle, WriterBuilder};
 use async_trait::async_trait;
 use datafusion::arrow::compute::kernels::sort::SortOptions;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -51,6 +52,7 @@ use datafusion_proto::physical_plan::{
 };
 use datafusion_proto::protobuf;
 use datafusion_proto::protobuf::PhysicalPlanNode;
+use datafusion_proto_common::protobuf_common::CsvWriterOptions as ProtoCsvWriterOptions;
 use std::fmt::Formatter;
 use std::sync::Arc;
 use std::vec;
@@ -291,11 +293,27 @@ fn roundtrip_csv_sink() -> Result<()> {
         file_extension: "csv".into(),
         file_output_mode: FileOutputMode::Directory,
     };
+    let writer_options = WriterBuilder::default()
+        .with_delimiter(b'|')
+        .with_header(false)
+        .with_quote(b'\'')
+        .with_escape(b'!')
+        .with_double_quote(false)
+        .with_date_format("%Y/%m/%d".into())
+        .with_datetime_format("%Y/%m/%d %H:%M:%S".into())
+        .with_timestamp_format("%s".into())
+        .with_timestamp_tz_format("%Y-%m-%dT%H:%M:%S%:z".into())
+        .with_time_format("%H-%M-%S".into())
+        .with_null("NULL".into())
+        .with_quote_style(QuoteStyle::Always)
+        .with_ignore_leading_whitespace(true)
+        .with_ignore_trailing_whitespace(true)
+        .with_line_terminator(Terminator::CRLF);
     let data_sink = Arc::new(CsvSink::new(
         file_sink_config,
-        CsvWriterOptions::new(WriterBuilder::default(), CompressionTypeVariant::ZSTD),
+        CsvWriterOptions::new_with_level(writer_options, CompressionTypeVariant::ZSTD, 7),
     ));
-    let sort_order = [PhysicalSortRequirement::new(
+    let sort_order: LexRequirement = [PhysicalSortRequirement::new(
         Arc::new(Column::new("plan_type", 0)),
         Some(SortOptions {
             descending: true,
@@ -309,18 +327,77 @@ fn roundtrip_csv_sink() -> Result<()> {
     let proto_converter = DefaultPhysicalProtoConverter {};
 
     let roundtrip_plan = roundtrip_test_and_return(
-        Arc::new(DataSinkExec::new(input, data_sink, Some(sort_order))),
+        Arc::new(DataSinkExec::new(
+            input,
+            data_sink,
+            Some(sort_order.clone()),
+        )),
         &ctx,
         &codec,
         &proto_converter,
     )?;
 
-    let roundtrip_plan = roundtrip_plan.downcast_ref::<DataSinkExec>().unwrap();
-    let csv_sink = roundtrip_plan.sink().downcast_ref::<CsvSink>().unwrap();
+    let roundtrip_plan =
+        roundtrip_plan
+            .downcast_ref::<DataSinkExec>()
+            .ok_or_else(|| {
+                datafusion_common::internal_datafusion_err!("Expected DataSinkExec")
+            })?;
+    let csv_sink = roundtrip_plan
+        .sink()
+        .downcast_ref::<CsvSink>()
+        .ok_or_else(|| datafusion_common::internal_datafusion_err!("Expected CsvSink"))?;
+    assert_eq!(csv_sink.config().insert_op, InsertOp::Overwrite);
+    assert!(csv_sink.config().keep_partition_by_columns);
     assert_eq!(
-        CompressionTypeVariant::ZSTD,
-        csv_sink.writer_options().compression
+        csv_sink.config().file_output_mode,
+        FileOutputMode::Directory
     );
+
+    let options = csv_sink.writer_options();
+    assert_eq!(options.compression, CompressionTypeVariant::ZSTD);
+    assert_eq!(options.compression_level, Some(7));
+    let writer = &options.writer_options;
+    assert_eq!(writer.delimiter(), b'|');
+    assert!(!writer.header());
+    assert_eq!(writer.quote(), b'\'');
+    assert_eq!(writer.escape(), b'!');
+    assert!(!writer.double_quote());
+    assert_eq!(writer.date_format(), Some("%Y/%m/%d"));
+    assert_eq!(writer.datetime_format(), Some("%Y/%m/%d %H:%M:%S"));
+    assert_eq!(writer.timestamp_format(), Some("%s"));
+    assert_eq!(writer.timestamp_tz_format(), Some("%Y-%m-%dT%H:%M:%S%:z"));
+    assert_eq!(writer.time_format(), Some("%H-%M-%S"));
+    assert_eq!(writer.null(), "NULL");
+    assert!(matches!(writer.quote_style(), QuoteStyle::Always));
+    assert!(writer.ignore_leading_whitespace());
+    assert!(writer.ignore_trailing_whitespace());
+    assert!(matches!(writer.line_terminator(), Terminator::CRLF));
+    assert_eq!(roundtrip_plan.sort_order(), &Some(sort_order));
+
+    let unset = CsvWriterOptions::new(
+        WriterBuilder::default(),
+        CompressionTypeVariant::UNCOMPRESSED,
+    );
+    let unset = CsvWriterOptions::try_from(&ProtoCsvWriterOptions::try_from(&unset)?)?;
+    assert_eq!(unset.writer_options.date_format(), None);
+    assert_eq!(unset.writer_options.datetime_format(), None);
+    assert_eq!(unset.writer_options.timestamp_format(), None);
+    assert_eq!(unset.writer_options.timestamp_tz_format(), None);
+    assert_eq!(unset.writer_options.time_format(), None);
+
+    let defaults = CsvWriterOptions::try_from(&ProtoCsvWriterOptions::default())?;
+    assert_eq!(defaults.compression_level, None);
+    assert!(matches!(
+        defaults.writer_options.line_terminator(),
+        Terminator::Any(b'\n')
+    ));
+
+    let malformed = ProtoCsvWriterOptions {
+        terminator: b"\r\r".to_vec(),
+        ..Default::default()
+    };
+    assert!(CsvWriterOptions::try_from(&malformed).is_err());
 
     Ok(())
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #24623.

## Rationale for this change

The CSV sink protobuf hooks accessed state indirectly, allowing new fields to be omitted silently. Auditing the writer options found that compression level, timezone-aware timestamp format, and line terminator were not represented on the wire, so those settings changed after a physical-plan round trip.

## What changes are included in this PR?

- Exhaustively destructure `CsvSink`, `CsvSinkExecNode`, and the nested CSV sink/writer option messages.
- Add protobuf fields for compression level, timezone-aware timestamp format, and line terminator.
- Make all five optional date/time formats presence-aware so `None` and `Some("")` remain distinct.
- Add a DataFusion 56.0 upgrade guide for the generated `CsvWriterOptions` API changes.
- Regenerate the protobuf models.

The protobuf wire format remains backward compatible. The generated Rust API changes are documented in the upgrade guide.

## What is the testing strategy for this PR?

Expanded the CSV sink round-trip test to cover every writer option, optional defaults, explicitly empty formats, and malformed line terminators.

Validated with:

- `cargo test -p datafusion-proto --test proto_integration roundtrip_csv_sink`
- `cargo clippy -p datafusion-datasource-csv -p datafusion-proto-common -p datafusion-proto --all-features --tests -- -D warnings`
- `cargo fmt --all --check`

## Are there any user-facing changes?

CSV sinks now retain compression level, timezone-aware timestamp formatting, line terminators, and explicitly empty date/time formats across protobuf plan round trips. Invalid wire terminators return an error.

The generated public `CsvWriterOptions` gains three fields, and its existing date/time format fields change from `String` to `Option<String>`. Migration is documented in the DataFusion 56.0 upgrade guide. The protobuf wire format remains backward compatible.
