### PR TITLE
chore: mark partial reduce stream as can handle back pressure (spillable)

### DIFF
--- a/datafusion/physical-plan/src/aggregates/hash_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/hash_stream.rs
@@ -425,6 +425,9 @@ impl PartialHashAggregateStream {
 
         let reservation =
             MemoryConsumer::new(format!("PartialHashAggregateStream[{partition}]"))
+                // We interpret 'can spill' as 'can handle memory back pressure'.
+                // This value needs to be set to true for the default memory pool implementations
+                // to ensure fair application of back pressure amongst the memory consumers.
                 .with_can_spill(true)
                 .register(context.memory_pool());
 

--- a/datafusion/physical-plan/src/aggregates/partial_reduce_stream.rs
+++ b/datafusion/physical-plan/src/aggregates/partial_reduce_stream.rs
@@ -203,6 +203,10 @@ impl PartialReduceHashAggregateStream {
 
         let reservation =
             MemoryConsumer::new(format!("PartialReduceHashAggregateStream[{partition}]"))
+                // We interpret 'can spill' as 'can handle memory back pressure'.
+                // This value needs to be set to true for the default memory pool implementations
+                // to ensure fair application of back pressure amongst the memory consumers.
+                .with_can_spill(true)
                 .register(context.memory_pool());
 
         Ok(Self {


### PR DESCRIPTION
## Which issue does this PR close?
N/A

## Rationale for this change
While adding fuzz tests for aggregate streams I encounter OOMs that partial reduce takes up all the memory and leave nothing to partial

Same as:
https://github.com/apache/datafusion/blob/a5c809f98dedcf4b22f5d317ea8efe0720834925/datafusion/physical-plan/src/aggregates/grouped_hash_stream.rs#L544-L546

## What changes are included in this PR?

mark reduce hash aggregate stream as spillable

## What is the testing strategy for this PR?

This was found as part of:
- #24881

## Are there any user-facing changes?
No
