### PR TITLE
fix: preserve scalar UDF strictness across FFI

### DIFF
--- a/datafusion/ffi/src/tests/udf_udaf_udwf.rs
+++ b/datafusion/ffi/src/tests/udf_udaf_udwf.rs
@@ -150,6 +150,10 @@ impl ScalarUDFImpl for PlacementUDF {
         datafusion_common::internal_err!("placement_udf is not meant to be invoked")
     }
 
+    fn is_strict(&self) -> bool {
+        true
+    }
+
     fn placement(&self, args: &[ExpressionPlacement]) -> ExpressionPlacement {
         // Push to the leaves only for a (Column, Literal) pairing, so the
         // test catches dropped, reordered, or truncated arguments.

--- a/datafusion/ffi/src/udf/mod.rs
+++ b/datafusion/ffi/src/udf/mod.rs
@@ -130,6 +130,9 @@ pub struct FFI_ScalarUDF {
             udf: &Self,
             config: FFI_ConfigOptions,
         ) -> FFI_Result<FFI_Option<FFI_ScalarUDF>>,
+
+    /// FFI equivalent to [`ScalarUDFImpl::is_strict`].
+    pub is_strict: unsafe extern "C" fn(udf: &Self) -> bool,
 }
 
 unsafe impl Send for FFI_ScalarUDF {}
@@ -191,6 +194,10 @@ unsafe extern "C" fn placement_fn_wrapper(
         .collect::<Vec<_>>();
 
     udf.inner().placement(&args).into()
+}
+
+unsafe extern "C" fn is_strict_fn_wrapper(udf: &FFI_ScalarUDF) -> bool {
+    udf.inner().is_strict()
 }
 
 unsafe extern "C" fn preserves_lex_ordering_fn_wrapper(
@@ -321,6 +328,7 @@ impl From<Arc<ScalarUDF>> for FFI_ScalarUDF {
             library_marker_id: crate::get_library_marker_id,
             preserves_lex_ordering: preserves_lex_ordering_fn_wrapper,
             with_updated_config: with_updated_config_fn_wrapper,
+            is_strict: is_strict_fn_wrapper,
         }
     }
 }
@@ -502,6 +510,10 @@ impl ScalarUDFImpl for ForeignScalarUDF {
         self.udf.short_circuits
     }
 
+    fn is_strict(&self) -> bool {
+        unsafe { (self.udf.is_strict)(&self.udf) }
+    }
+
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
         unsafe {
             let arg_types = vec_datatype_to_rvec_wrapped(arg_types)?;
@@ -574,6 +586,10 @@ mod tests {
 
         fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
             internal_err!("placement_udf is not meant to be invoked")
+        }
+
+        fn is_strict(&self) -> bool {
+            true
         }
 
         fn placement(&self, args: &[ExpressionPlacement]) -> ExpressionPlacement {
@@ -663,6 +679,7 @@ mod tests {
         ffi_udf.library_marker_id = crate::mock_foreign_marker_id;
         let foreign_udf: Arc<dyn ScalarUDFImpl> = (&ffi_udf).into();
         assert!(foreign_udf.is::<ForeignScalarUDF>());
+        assert!(foreign_udf.is_strict());
 
         // Without the plumbing the override is dropped and every call is
         // KeepInPlace. The three cases also check the arguments survive the

--- a/datafusion/ffi/tests/ffi_udf.rs
+++ b/datafusion/ffi/tests/ffi_udf.rs
@@ -100,6 +100,8 @@ mod tests {
         let ffi_placement_func = (module.create_placement_udf)();
         let foreign_func: Arc<dyn ScalarUDFImpl> = (&ffi_placement_func).into();
 
+        assert!(foreign_func.is_strict());
+
         // The override pushes to the leaves only for (Column, Literal), so these
         // also check the arguments cross the boundary in order.
         assert_eq!(


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #22330.

## Rationale for this change

Foreign scalar UDFs currently lose their `is_strict()` value across the FFI boundary. The consumer therefore reports `false`, preventing optimizer rules from using the provider's nullability metadata.

## What changes are included in this PR?

- Add an `is_strict` callback to `FFI_ScalarUDF`.
- Forward the provider's value through `ForeignScalarUDF`.
- Test forced-foreign and dynamic-library round trips.

## What is the testing strategy for this PR?

- `cargo test -p datafusion-ffi --features integration-tests`
- `cargo fmt --all -- --check`

The FFI test suite passes with 122 unit tests plus the integration targets.

## Are there any user-facing changes?

Yes. Foreign scalar UDFs now preserve strictness metadata. The `FFI_ScalarUDF` layout changes, so this PR requires the `api change` label.
