### PR TITLE
benchmarks: introduce RepartitionExec benchmarks

### DIFF
--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -165,3 +165,8 @@ name = "window_filter"
 [[bench]]
 harness = false
 name = "range_repartition"
+
+[[bench]]
+harness = false
+name = "repartition"
+required-features = ["test_utils"]

--- a/datafusion/physical-plan/benches/repartition.rs
+++ b/datafusion/physical-plan/benches/repartition.rs
@@ -1,0 +1,568 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Benchmarks for [`RepartitionExec`] and [`BatchPartitioner`].
+//!
+//! # Microbenchmarks (`BatchPartitioner`)
+//!
+//! These isolate the CPU cost of routing a batch to output partitions, with no
+//! channel or async overhead:
+//!
+//! - `hash_partitioner/partition_count`: hash routing across a mix of power-of-two
+//!   and non-power-of-two partition counts. The hot path uses [`StrengthReducedU64`]
+//!   (bit-mask for powers-of-two, reciprocal multiply otherwise), so both branches
+//!   are exercised.
+//!
+//! - `hash_partitioner/key_type`: hash cost per key type — `Int32`, `Int64`, `Utf8View`.
+//!
+//! - `hash_partitioner/key_count`: composite hash cost for 1, 2, and 3 key columns.
+//!   Each additional key column adds a separate hash pass.
+//!
+//! - `round_robin_partitioner/partition_count`: trivial round-robin routing (no
+//!   hashing). Establishes the baseline overhead of the `partition()` interface.
+//!
+//! # End-to-end benchmarks (`RepartitionExec`)
+//!
+//! These exercise the full async operator, including channel sends/receives,
+//! batch coalescing, and memory reservation:
+//!
+//! - `repartition_exec/hash_1_to_n`: 1 input partition fanned out to N output
+//!   partitions with hash partitioning.
+//!
+//! - `repartition_exec/round_robin_1_to_n`: same topology with round-robin
+//!   partitioning — compare against hash to isolate routing overhead.
+//!
+//! - `repartition_exec/hash_n_to_n`: N input partitions → N output partitions.
+//!   The N concurrent producer tasks are the realistic multi-threaded scenario.
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo bench -p datafusion-physical-plan --bench repartition
+//! ```
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Int32Array, Int64Array, RecordBatch, StringViewArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use datafusion_execution::TaskContext;
+use datafusion_physical_expr::expressions::col;
+use datafusion_physical_expr::PhysicalExpr;
+use datafusion_physical_plan::metrics::Time;
+use datafusion_physical_plan::repartition::{BatchPartitioner, RepartitionExec};
+use datafusion_physical_plan::test::TestMemoryExec;
+use datafusion_physical_plan::{Partitioning, collect};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use tokio::runtime::Runtime;
+
+const BATCH_SIZE: usize = 8192;
+const SEED: u64 = 42;
+
+// Intentionally mixes powers-of-two (8, 16, 32, 64, 128) and non-powers-of-two
+// (10, 100) so both StrengthReducedU64 branches (bit-mask and reciprocal) are
+// exercised in every benchmark run.
+const PARTITION_COUNTS: &[usize] = &[8, 10, 16, 32, 64, 100, 128];
+
+fn make_i64_batch(schema: &SchemaRef, num_rows: usize) -> RecordBatch {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let keys: Vec<i64> = (0..num_rows)
+        .map(|_| rng.random_range(0..1_000_000i64))
+        .collect();
+    let vals: Vec<i64> = (0..num_rows as i64).collect();
+    RecordBatch::try_new(
+        Arc::clone(schema),
+        vec![
+            Arc::new(Int64Array::from(keys)) as ArrayRef,
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )
+    .unwrap()
+}
+
+fn make_i32_batch(schema: &SchemaRef, num_rows: usize) -> RecordBatch {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let keys: Vec<i32> = (0..num_rows)
+        .map(|_| rng.random_range(0..1_000_000i32))
+        .collect();
+    let vals: Vec<i64> = (0..num_rows as i64).collect();
+    RecordBatch::try_new(
+        Arc::clone(schema),
+        vec![
+            Arc::new(Int32Array::from(keys)) as ArrayRef,
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )
+    .unwrap()
+}
+
+fn make_utf8view_batch(schema: &SchemaRef, num_rows: usize) -> RecordBatch {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let keys: Vec<String> = (0..num_rows)
+        .map(|_| format!("key_{:08}", rng.random_range(0..1_000_000usize)))
+        .collect();
+    let vals: Vec<i64> = (0..num_rows as i64).collect();
+    RecordBatch::try_new(
+        Arc::clone(schema),
+        vec![
+            Arc::new(StringViewArray::from_iter_values(
+                keys.iter().map(String::as_str),
+            )) as ArrayRef,
+            Arc::new(Int64Array::from(vals)),
+        ],
+    )
+    .unwrap()
+}
+
+fn make_multi_key_batch(schema: &SchemaRef, num_keys: usize, num_rows: usize) -> RecordBatch {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let mut columns: Vec<ArrayRef> = (0..num_keys)
+        .map(|_| {
+            let v: Vec<i64> = (0..num_rows)
+                .map(|_| rng.random_range(0..1_000_000i64))
+                .collect();
+            Arc::new(Int64Array::from(v)) as ArrayRef
+        })
+        .collect();
+    let vals: Vec<i64> = (0..num_rows as i64).collect();
+    columns.push(Arc::new(Int64Array::from(vals)) as ArrayRef);
+    RecordBatch::try_new(Arc::clone(schema), columns).unwrap()
+}
+
+/// Build `num_partitions` input partition slots, each holding `rows_per_partition / batch_size`
+/// batches of random Int64 data.
+fn make_partitioned_input(
+    num_partitions: usize,
+    rows_per_partition: usize,
+) -> (Vec<Vec<RecordBatch>>, SchemaRef) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Int64, false),
+        Field::new("val", DataType::Int64, false),
+    ]));
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let num_batches = (rows_per_partition + BATCH_SIZE - 1) / BATCH_SIZE;
+    let partitions = (0..num_partitions)
+        .map(|_| {
+            (0..num_batches)
+                .map(|_| {
+                    let keys: Vec<i64> = (0..BATCH_SIZE)
+                        .map(|_| rng.random_range(0..1_000_000i64))
+                        .collect();
+                    let vals: Vec<i64> = (0..BATCH_SIZE as i64).collect();
+                    RecordBatch::try_new(
+                        Arc::clone(&schema),
+                        vec![
+                            Arc::new(Int64Array::from(keys)) as ArrayRef,
+                            Arc::new(Int64Array::from(vals)),
+                        ],
+                    )
+                    .unwrap()
+                })
+                .collect()
+        })
+        .collect();
+    (partitions, schema)
+}
+
+/// Hash routing at varying partition counts.
+///
+/// Power-of-two counts (8, 16, 32 …) use a bitmask inside `StrengthReducedU64`;
+/// non-powers (10, 100 …) use a reciprocal multiply. Both paths are included so
+/// the difference in routing cost is visible.
+fn bench_hash_partitioner_partition_count(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_partitioner/partition_count");
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Int64, false),
+        Field::new("val", DataType::Int64, false),
+    ]));
+    let batch = make_i64_batch(&schema, BATCH_SIZE);
+    let key_expr = col("key", &schema).unwrap();
+
+    for &n in PARTITION_COUNTS {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            let mut partitioner = BatchPartitioner::new_hash_partitioner(
+                vec![Arc::clone(&key_expr)],
+                n,
+                Time::default(),
+            )
+            .unwrap();
+            b.iter(|| {
+                partitioner
+                    .partition(batch.clone(), |p, b| {
+                        black_box((p, b));
+                        Ok(())
+                    })
+                    .unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Hash routing cost per key column type at a fixed 32 output partitions.
+fn bench_hash_partitioner_key_types(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_partitioner/key_type");
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+    const N: usize = 32;
+
+    // Int32
+    {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("val", DataType::Int64, false),
+        ]));
+        let batch = make_i32_batch(&schema, BATCH_SIZE);
+        let key_expr = col("key", &schema).unwrap();
+        group.bench_function("int32", |b| {
+            let mut p = BatchPartitioner::new_hash_partitioner(
+                vec![Arc::clone(&key_expr)],
+                N,
+                Time::default(),
+            )
+            .unwrap();
+            b.iter(|| {
+                p.partition(batch.clone(), |p, b| {
+                    black_box((p, b));
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    // Int64
+    {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int64, false),
+            Field::new("val", DataType::Int64, false),
+        ]));
+        let batch = make_i64_batch(&schema, BATCH_SIZE);
+        let key_expr = col("key", &schema).unwrap();
+        group.bench_function("int64", |b| {
+            let mut p = BatchPartitioner::new_hash_partitioner(
+                vec![Arc::clone(&key_expr)],
+                N,
+                Time::default(),
+            )
+            .unwrap();
+            b.iter(|| {
+                p.partition(batch.clone(), |p, b| {
+                    black_box((p, b));
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    // Utf8View
+    {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Utf8View, false),
+            Field::new("val", DataType::Int64, false),
+        ]));
+        let batch = make_utf8view_batch(&schema, BATCH_SIZE);
+        let key_expr = col("key", &schema).unwrap();
+        group.bench_function("utf8", |b| {
+            let mut p = BatchPartitioner::new_hash_partitioner(
+                vec![Arc::clone(&key_expr)],
+                N,
+                Time::default(),
+            )
+            .unwrap();
+            b.iter(|| {
+                p.partition(batch.clone(), |p, b| {
+                    black_box((p, b));
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Composite hash cost for 1, 2, and 3 key columns.
+///
+/// Each extra key column adds an independent hash pass over all rows, so this
+/// shows how multi-column GROUP BY / JOIN keys scale the routing cost.
+fn bench_hash_partitioner_key_count(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_partitioner/key_count");
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+    const N: usize = 32;
+
+    for num_keys in [1usize, 2, 3] {
+        let fields: Vec<Field> = (0..num_keys)
+            .map(|i| Field::new(format!("k{i}"), DataType::Int64, false))
+            .chain(std::iter::once(Field::new("val", DataType::Int64, false)))
+            .collect();
+        let schema = Arc::new(Schema::new(fields));
+        let batch = make_multi_key_batch(&schema, num_keys, BATCH_SIZE);
+        let key_exprs: Vec<Arc<dyn PhysicalExpr>> = (0..num_keys)
+            .map(|i| col(&format!("k{i}"), &schema).unwrap())
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_keys),
+            &num_keys,
+            |b, _| {
+                let mut p = BatchPartitioner::new_hash_partitioner(
+                    key_exprs.clone(),
+                    N,
+                    Time::default(),
+                )
+                .unwrap();
+                b.iter(|| {
+                    p.partition(batch.clone(), |p, b| {
+                        black_box((p, b));
+                        Ok(())
+                    })
+                    .unwrap();
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Round-robin routing at varying partition counts.
+///
+/// Round-robin does no hashing — it simply increments a counter. This is the
+/// baseline for the `partition()` interface overhead. Compare against
+/// `hash_partitioner/partition_count` to isolate pure hashing cost.
+fn bench_round_robin_partitioner(c: &mut Criterion) {
+    let mut group = c.benchmark_group("round_robin_partitioner/partition_count");
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Int64, false),
+        Field::new("val", DataType::Int64, false),
+    ]));
+    let batch = make_i64_batch(&schema, BATCH_SIZE);
+
+    for &n in PARTITION_COUNTS {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            let mut partitioner =
+                BatchPartitioner::new_round_robin_partitioner(n, Time::default(), 0, 1);
+            b.iter(|| {
+                partitioner
+                    .partition(batch.clone(), |p, b| {
+                        black_box((p, b));
+                        Ok(())
+                    })
+                    .unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+const E2E_ROWS: usize = 5_000_000;
+
+/// Hash repartition: 1 input partition → N output partitions.
+///
+/// Measures the full operator path: batch partitioning, channel sends,
+/// coalescing, memory reservation, and downstream collection.
+fn bench_repartition_exec_hash_1_to_n(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let task_ctx = Arc::new(TaskContext::default());
+    let mut group = c.benchmark_group("repartition_exec/hash_1_to_n");
+    group.throughput(Throughput::Elements(E2E_ROWS as u64));
+
+    let (partitions, schema) = make_partitioned_input(1, E2E_ROWS);
+    let key_expr = col("key", &schema).unwrap();
+
+    for &n in &[4usize, 8, 16, 32] {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let input =
+                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None).unwrap();
+                    Arc::new(
+                        RepartitionExec::try_new(
+                            input,
+                            Partitioning::Hash(vec![Arc::clone(&key_expr)], n),
+                        )
+                        .unwrap(),
+                    )
+                },
+                |plan| {
+                    rt.block_on(async {
+                        collect(plan, task_ctx.clone()).await.unwrap();
+                    });
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+/// Round-robin repartition: 1 input partition → N output partitions.
+///
+/// Compare against `hash_1_to_n` to isolate the cost of hash computation
+/// versus channel/coalescing overhead that both modes share.
+fn bench_repartition_exec_round_robin_1_to_n(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let task_ctx = Arc::new(TaskContext::default());
+    let mut group = c.benchmark_group("repartition_exec/round_robin_1_to_n");
+    group.throughput(Throughput::Elements(E2E_ROWS as u64));
+
+    let (partitions, schema) = make_partitioned_input(1, E2E_ROWS);
+
+    for &n in &[4usize, 8, 16, 32] {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let input =
+                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None).unwrap();
+                    Arc::new(
+                        RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(n))
+                            .unwrap(),
+                    )
+                },
+                |plan| {
+                    rt.block_on(async {
+                        collect(plan, task_ctx.clone()).await.unwrap();
+                    });
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+/// Hash repartition: N input partitions → N output partitions.
+///
+/// Models the typical distributed query scenario where N concurrent producer
+/// tasks each hash-route their share of rows to N output channels. The
+/// contention on shared channels and coalescer locks shows up here but not
+/// in the 1→N benchmarks.
+fn bench_repartition_exec_hash_n_to_n(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let task_ctx = Arc::new(TaskContext::default());
+    let mut group = c.benchmark_group("repartition_exec/hash_n_to_n");
+    group.throughput(Throughput::Elements(E2E_ROWS as u64));
+
+    for &n in &[4usize, 8, 16] {
+        let rows_per_partition = E2E_ROWS / n;
+        let (partitions, schema) = make_partitioned_input(n, rows_per_partition);
+        let key_expr = col("key", &schema).unwrap();
+
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let input =
+                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None).unwrap();
+                    Arc::new(
+                        RepartitionExec::try_new(
+                            input,
+                            Partitioning::Hash(vec![Arc::clone(&key_expr)], n),
+                        )
+                        .unwrap(),
+                    )
+                },
+                |plan| {
+                    rt.block_on(async {
+                        collect(plan, task_ctx.clone()).await.unwrap();
+                    });
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+/// Hash repartition across asymmetric M→N topologies.
+///
+/// Covers two directions:
+/// - M > N (consolidation): many input partitions funnel into fewer outputs.
+///   More producers contend on fewer channels.
+/// - M < N (fan-out): few input partitions scatter to many outputs.
+///   Each producer writes to more channels per batch.
+fn bench_repartition_exec_hash_m_to_n(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let task_ctx = Arc::new(TaskContext::default());
+    let mut group = c.benchmark_group("repartition_exec/hash_m_to_n");
+    group.throughput(Throughput::Elements(E2E_ROWS as u64));
+
+    // (input_partitions, output_partitions)
+    let cases: &[(usize, usize)] = &[
+        // M > N: consolidation
+        (16, 4),
+        (16, 8),
+        (32, 8),
+        // M < N: fan-out
+        (4, 16),
+        (8, 16),
+        (8, 32),
+    ];
+
+    for &(m, n) in cases {
+        let rows_per_partition = E2E_ROWS / m;
+        let (partitions, schema) = make_partitioned_input(m, rows_per_partition);
+        let key_expr = col("key", &schema).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("m_to_n", format!("{m}_{n}")),
+            &(m, n),
+            |b, &(_, n)| {
+                b.iter_batched(
+                    || {
+                        let input =
+                            TestMemoryExec::try_new_exec(&partitions, schema.clone(), None)
+                                .unwrap();
+                        Arc::new(
+                            RepartitionExec::try_new(
+                                input,
+                                Partitioning::Hash(vec![Arc::clone(&key_expr)], n),
+                            )
+                            .unwrap(),
+                        )
+                    },
+                    |plan| {
+                        rt.block_on(async {
+                            collect(plan, task_ctx.clone()).await.unwrap();
+                        });
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_hash_partitioner_partition_count,
+    bench_hash_partitioner_key_types,
+    bench_hash_partitioner_key_count,
+    bench_round_robin_partitioner,
+    bench_repartition_exec_hash_1_to_n,
+    bench_repartition_exec_round_robin_1_to_n,
+    bench_repartition_exec_hash_n_to_n,
+    bench_repartition_exec_hash_m_to_n,
+);
+criterion_main!(benches);

--- a/datafusion/physical-plan/benches/repartition.rs
+++ b/datafusion/physical-plan/benches/repartition.rs
@@ -15,46 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Benchmarks for [`RepartitionExec`] and [`BatchPartitioner`].
-//!
-//! # Microbenchmarks (`BatchPartitioner`)
-//!
-//! These isolate the CPU cost of routing a batch to output partitions, with no
-//! channel or async overhead:
-//!
-//! - `hash_partitioner/partition_count`: hash routing across a mix of power-of-two
-//!   and non-power-of-two partition counts. The hot path uses [`StrengthReducedU64`]
-//!   (bit-mask for powers-of-two, reciprocal multiply otherwise), so both branches
-//!   are exercised.
-//!
-//! - `hash_partitioner/key_type`: hash cost per key type — `Int32`, `Int64`, `Utf8View`.
-//!
-//! - `hash_partitioner/key_count`: composite hash cost for 1, 2, and 3 key columns.
-//!   Each additional key column adds a separate hash pass.
-//!
-//! - `round_robin_partitioner/partition_count`: trivial round-robin routing (no
-//!   hashing). Establishes the baseline overhead of the `partition()` interface.
-//!
-//! # End-to-end benchmarks (`RepartitionExec`)
-//!
-//! These exercise the full async operator, including channel sends/receives,
-//! batch coalescing, and memory reservation:
-//!
-//! - `repartition_exec/hash_1_to_n`: 1 input partition fanned out to N output
-//!   partitions with hash partitioning.
-//!
-//! - `repartition_exec/round_robin_1_to_n`: same topology with round-robin
-//!   partitioning — compare against hash to isolate routing overhead.
-//!
-//! - `repartition_exec/hash_n_to_n`: N input partitions → N output partitions.
-//!   The N concurrent producer tasks are the realistic multi-threaded scenario.
-//!
-//! # Usage
-//!
-//! ```sh
-//! cargo bench -p datafusion-physical-plan --bench repartition
-//! ```
-
 use std::hint::black_box;
 use std::sync::Arc;
 
@@ -352,7 +312,7 @@ fn bench_hash_partitioner_key_count(c: &mut Criterion) {
 
 /// Round-robin routing at varying partition counts.
 ///
-/// Round-robin does no hashing — it simply increments a counter. This is the
+/// Round-robin does no hashing, it simply increments a counter. This is the
 /// baseline for the `partition()` interface overhead. Compare against
 /// `hash_partitioner/partition_count` to isolate pure hashing cost.
 fn bench_round_robin_partitioner(c: &mut Criterion) {

--- a/datafusion/physical-plan/benches/repartition.rs
+++ b/datafusion/physical-plan/benches/repartition.rs
@@ -112,7 +112,7 @@ fn make_multi_key_batch(
 }
 
 /// Build `num_partitions` input partition slots, each holding `rows_per_partition / batch_size`
-/// batches of random Int64 data.
+/// batches of mixed-type data: an Int64 key, an Int64 value, and a Utf8View tag column.
 fn make_partitioned_input(
     num_partitions: usize,
     rows_per_partition: usize,
@@ -120,9 +120,10 @@ fn make_partitioned_input(
     let schema = Arc::new(Schema::new(vec![
         Field::new("key", DataType::Int64, false),
         Field::new("val", DataType::Int64, false),
+        Field::new("tag", DataType::Utf8View, false),
     ]));
     let mut rng = StdRng::seed_from_u64(SEED);
-    let num_batches = (rows_per_partition + BATCH_SIZE - 1) / BATCH_SIZE;
+    let num_batches = rows_per_partition.div_ceil(BATCH_SIZE);
     let partitions = (0..num_partitions)
         .map(|_| {
             (0..num_batches)
@@ -131,11 +132,19 @@ fn make_partitioned_input(
                         .map(|_| rng.random_range(0..1_000_000i64))
                         .collect();
                     let vals: Vec<i64> = (0..BATCH_SIZE as i64).collect();
+                    let tag_vals: Vec<String> = (0..BATCH_SIZE)
+                        .map(|_| {
+                            format!("tag_{:08}", rng.random_range(0..1_000_000usize))
+                        })
+                        .collect();
                     RecordBatch::try_new(
                         Arc::clone(&schema),
                         vec![
                             Arc::new(Int64Array::from(keys)) as ArrayRef,
                             Arc::new(Int64Array::from(vals)),
+                            Arc::new(StringViewArray::from_iter_values(
+                                tag_vals.iter().map(String::as_str),
+                            )),
                         ],
                     )
                     .unwrap()
@@ -146,11 +155,6 @@ fn make_partitioned_input(
     (partitions, schema)
 }
 
-/// Hash routing at varying partition counts.
-///
-/// Power-of-two counts (8, 16, 32 …) use a bitmask inside `StrengthReducedU64`;
-/// non-powers (10, 100 …) use a reciprocal multiply. Both paths are included so
-/// the difference in routing cost is visible.
 fn bench_hash_partitioner_partition_count(c: &mut Criterion) {
     let mut group = c.benchmark_group("hash_partitioner/partition_count");
     group.throughput(Throughput::Elements(BATCH_SIZE as u64));
@@ -189,7 +193,6 @@ fn bench_hash_partitioner_key_types(c: &mut Criterion) {
     group.throughput(Throughput::Elements(BATCH_SIZE as u64));
     const N: usize = 32;
 
-    // Int32
     {
         let schema = Arc::new(Schema::new(vec![
             Field::new("key", DataType::Int32, false),
@@ -214,7 +217,6 @@ fn bench_hash_partitioner_key_types(c: &mut Criterion) {
         });
     }
 
-    // Int64
     {
         let schema = Arc::new(Schema::new(vec![
             Field::new("key", DataType::Int64, false),
@@ -239,7 +241,6 @@ fn bench_hash_partitioner_key_types(c: &mut Criterion) {
         });
     }
 
-    // Utf8View
     {
         let schema = Arc::new(Schema::new(vec![
             Field::new("key", DataType::Utf8View, false),
@@ -247,7 +248,7 @@ fn bench_hash_partitioner_key_types(c: &mut Criterion) {
         ]));
         let batch = make_utf8view_batch(&schema, BATCH_SIZE);
         let key_expr = col("key", &schema).unwrap();
-        group.bench_function("utf8", |b| {
+        group.bench_function("utf8_view", |b| {
             let mut p = BatchPartitioner::new_hash_partitioner(
                 vec![Arc::clone(&key_expr)],
                 N,
@@ -344,21 +345,18 @@ fn bench_round_robin_partitioner(c: &mut Criterion) {
 
 const E2E_ROWS: usize = 5_000_000;
 
-/// Hash repartition: 1 input partition → N output partitions.
-///
-/// Measures the full operator path: batch partitioning, channel sends,
-/// coalescing, memory reservation, and downstream collection.
-fn bench_repartition_exec_hash_1_to_n(c: &mut Criterion) {
+/// End-to-end repartition: 1 input partition → N output partitions, hash and round-robin.
+fn bench_repartition_exec_1_to_n(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let task_ctx = Arc::new(TaskContext::default());
-    let mut group = c.benchmark_group("repartition_exec/hash_1_to_n");
+    let mut group = c.benchmark_group("repartition_exec/1_to_n");
     group.throughput(Throughput::Elements(E2E_ROWS as u64));
 
     let (partitions, schema) = make_partitioned_input(1, E2E_ROWS);
     let key_expr = col("key", &schema).unwrap();
 
     for &n in &[4usize, 8, 16, 32] {
-        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+        group.bench_with_input(BenchmarkId::new("hash", n), &n, |b, &n| {
             b.iter_batched(
                 || {
                     let input =
@@ -380,24 +378,8 @@ fn bench_repartition_exec_hash_1_to_n(c: &mut Criterion) {
                 BatchSize::LargeInput,
             );
         });
-    }
-    group.finish();
-}
 
-/// Round-robin repartition: 1 input partition → N output partitions.
-///
-/// Compare against `hash_1_to_n` to isolate the cost of hash computation
-/// versus channel/coalescing overhead that both modes share.
-fn bench_repartition_exec_round_robin_1_to_n(c: &mut Criterion) {
-    let rt = Runtime::new().unwrap();
-    let task_ctx = Arc::new(TaskContext::default());
-    let mut group = c.benchmark_group("repartition_exec/round_robin_1_to_n");
-    group.throughput(Throughput::Elements(E2E_ROWS as u64));
-
-    let (partitions, schema) = make_partitioned_input(1, E2E_ROWS);
-
-    for &n in &[4usize, 8, 16, 32] {
-        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+        group.bench_with_input(BenchmarkId::new("round_robin", n), &n, |b, &n| {
             b.iter_batched(
                 || {
                     let input =
@@ -420,16 +402,11 @@ fn bench_repartition_exec_round_robin_1_to_n(c: &mut Criterion) {
     group.finish();
 }
 
-/// Hash repartition: N input partitions → N output partitions.
-///
-/// Models the typical distributed query scenario where N concurrent producer
-/// tasks each hash-route their share of rows to N output channels. The
-/// contention on shared channels and coalescer locks shows up here but not
-/// in the 1→N benchmarks.
-fn bench_repartition_exec_hash_n_to_n(c: &mut Criterion) {
+/// End-to-end repartition: N input partitions → N output partitions, hash and round-robin.
+fn bench_repartition_exec_n_to_n(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let task_ctx = Arc::new(TaskContext::default());
-    let mut group = c.benchmark_group("repartition_exec/hash_n_to_n");
+    let mut group = c.benchmark_group("repartition_exec/n_to_n");
     group.throughput(Throughput::Elements(E2E_ROWS as u64));
 
     for &n in &[4usize, 8, 16] {
@@ -437,7 +414,7 @@ fn bench_repartition_exec_hash_n_to_n(c: &mut Criterion) {
         let (partitions, schema) = make_partitioned_input(n, rows_per_partition);
         let key_expr = col("key", &schema).unwrap();
 
-        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+        group.bench_with_input(BenchmarkId::new("hash", n), &n, |b, &n| {
             b.iter_batched(
                 || {
                     let input =
@@ -449,6 +426,26 @@ fn bench_repartition_exec_hash_n_to_n(c: &mut Criterion) {
                             Partitioning::Hash(vec![Arc::clone(&key_expr)], n),
                         )
                         .unwrap(),
+                    )
+                },
+                |plan| {
+                    rt.block_on(async {
+                        collect(plan, task_ctx.clone()).await.unwrap();
+                    });
+                },
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("round_robin", n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let input =
+                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None)
+                            .unwrap();
+                    Arc::new(
+                        RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(n))
+                            .unwrap(),
                     )
                 },
                 |plan| {
@@ -532,9 +529,8 @@ criterion_group!(
     bench_hash_partitioner_key_types,
     bench_hash_partitioner_key_count,
     bench_round_robin_partitioner,
-    bench_repartition_exec_hash_1_to_n,
-    bench_repartition_exec_round_robin_1_to_n,
-    bench_repartition_exec_hash_n_to_n,
+    bench_repartition_exec_1_to_n,
+    bench_repartition_exec_n_to_n,
     bench_repartition_exec_hash_m_to_n,
 );
 criterion_main!(benches);

--- a/datafusion/physical-plan/benches/repartition.rs
+++ b/datafusion/physical-plan/benches/repartition.rs
@@ -60,10 +60,12 @@ use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Int32Array, Int64Array, RecordBatch, StringViewArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
 use datafusion_execution::TaskContext;
-use datafusion_physical_expr::expressions::col;
 use datafusion_physical_expr::PhysicalExpr;
+use datafusion_physical_expr::expressions::col;
 use datafusion_physical_plan::metrics::Time;
 use datafusion_physical_plan::repartition::{BatchPartitioner, RepartitionExec};
 use datafusion_physical_plan::test::TestMemoryExec;
@@ -130,7 +132,11 @@ fn make_utf8view_batch(schema: &SchemaRef, num_rows: usize) -> RecordBatch {
     .unwrap()
 }
 
-fn make_multi_key_batch(schema: &SchemaRef, num_keys: usize, num_rows: usize) -> RecordBatch {
+fn make_multi_key_batch(
+    schema: &SchemaRef,
+    num_keys: usize,
+    num_rows: usize,
+) -> RecordBatch {
     let mut rng = StdRng::seed_from_u64(SEED);
     let mut columns: Vec<ArrayRef> = (0..num_keys)
         .map(|_| {
@@ -396,7 +402,8 @@ fn bench_repartition_exec_hash_1_to_n(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let input =
-                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None).unwrap();
+                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None)
+                            .unwrap();
                     Arc::new(
                         RepartitionExec::try_new(
                             input,
@@ -434,7 +441,8 @@ fn bench_repartition_exec_round_robin_1_to_n(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let input =
-                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None).unwrap();
+                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None)
+                            .unwrap();
                     Arc::new(
                         RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(n))
                             .unwrap(),
@@ -473,7 +481,8 @@ fn bench_repartition_exec_hash_n_to_n(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let input =
-                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None).unwrap();
+                        TestMemoryExec::try_new_exec(&partitions, schema.clone(), None)
+                            .unwrap();
                     Arc::new(
                         RepartitionExec::try_new(
                             input,
@@ -530,9 +539,12 @@ fn bench_repartition_exec_hash_m_to_n(c: &mut Criterion) {
             |b, &(_, n)| {
                 b.iter_batched(
                     || {
-                        let input =
-                            TestMemoryExec::try_new_exec(&partitions, schema.clone(), None)
-                                .unwrap();
+                        let input = TestMemoryExec::try_new_exec(
+                            &partitions,
+                            schema.clone(),
+                            None,
+                        )
+                        .unwrap();
                         Arc::new(
                             RepartitionExec::try_new(
                                 input,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #25127.

## Rationale for this change
RepartitionExec is one of the most frequently executed operators in DataFusion, every parallel query goes through it, but there were no dedicated benchmarks for it. 
also see #25127

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?

Adds `datafusion/physical-plan/benches/repartition.rs` with two categories of benchmarks:

BatchPartitioner microbenchmarks (no async, pure CPU routing cost):
- `hash_partitioner/partition_count` — sweeps power-of-two and non-power-of-two counts (8, 10, 16, 32, 64, 100, 128), exercising both branches of StrengthReducedU64 (bitmask vs. reciprocal multiply)
- `hash_partitioner/key_type` — compares Int32, Int64, and Utf8View hashing cost at 32 partitions
- `hash_partitioner/key_count` — 1, 2, and 3 composite key columns at 32 partitions, showing per-key overhead
- `round_robin_partitioner/partition_count` — trivial routing baseline for isolating channel overhead from hash cost

End-to-end RepartitionExec benchmarks (full async path, 5M rows):
- `repartition_exec/hash_1_to_n` — 1 input → N outputs (4, 8, 16, 32) with hash partitioning
- `repartition_exec/round_robin_1_to_n` — same topology with round-robin, for direct comparison against hash
- `repartition_exec/hash_n_to_n` — N inputs → N outputs (4, 8, 16), the typical concurrent-producer scenario
- `repartition_exec/hash_m_to_n` — asymmetric topologies: consolidation (16→4, 16→8, 32→8) and fan-out (4→16, 8→16, 8→32)

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## What is the testing strategy for this PR?
n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

Briefly describe how this PR is tested, and point to the specific tests you added. For example: 'This new feature is covered by the `sqllogictest` cases added in `foo.slt`'.

If this PR does not add tests, explain why. For example, if the change is already covered by existing tests, please mention it.

You should also check the `codecov` bot reply on this PR to confirm the changed code is exercised.
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
