### PR TITLE
[benchmark only] GroupsAccumulatorAdapter: walk only the groups a batch has rows for

### DIFF
--- a/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator.rs
+++ b/datafusion/functions-aggregate-common/src/aggregate/groups_accumulator.rs
@@ -200,34 +200,34 @@ impl GroupsAccumulatorAdapter {
 
         assert_eq!(values[0].len(), group_indices.len());
 
-        // figure out which input rows correspond to which groups.
-        // Note that self.state.indices starts empty for all groups
-        // (it is cleared out below)
-        for (idx, group_index) in group_indices.iter().enumerate() {
-            self.states[*group_index].indices.push(idx as u32);
-        }
-
-        // groups_with_rows holds a list of group indexes that have
-        // any rows that need to be accumulated, stored in order of
-        // group_index
-
+        // groups_with_rows holds a list of group indexes that have any rows
+        // that need to be accumulated, stored in order of first appearance in
+        // this batch
         let mut groups_with_rows = vec![];
 
+        // figure out which input rows correspond to which groups.
+        // Note that self.state.indices starts empty for all groups (it is
+        // cleared out below), so an empty one is exactly a group that this
+        // batch has not reached yet
+        for (idx, group_index) in group_indices.iter().enumerate() {
+            let state = &mut self.states[*group_index];
+            if state.indices.is_empty() {
+                groups_with_rows.push(*group_index);
+            }
+            state.indices.push(idx as u32);
+        }
+
         // batch_indices holds indices into values, each group is contiguous
-        let mut batch_indices = vec![];
+        let mut batch_indices = Vec::with_capacity(group_indices.len());
 
         // offsets[i] is index into batch_indices where the rows for
-        // group_index i starts
-        let mut offsets = vec![0];
+        // groups_with_rows[i] start
+        let mut offsets = Vec::with_capacity(groups_with_rows.len() + 1);
+        offsets.push(0);
 
         let mut offset_so_far = 0;
-        for (group_index, state) in self.states.iter_mut().enumerate() {
-            let indices = &state.indices;
-            if indices.is_empty() {
-                continue;
-            }
-
-            groups_with_rows.push(group_index);
+        for &group_index in groups_with_rows.iter() {
+            let indices = &self.states[group_index].indices;
             batch_indices.extend_from_slice(indices);
             offset_so_far += indices.len();
             offsets.push(offset_so_far);


### PR DESCRIPTION
**Do not review or merge — this PR exists only so the benchmark bot can reach the ref.**

It measures option 1 of https://github.com/apache/datafusion/issues/25116 (record the groups a batch has rows for, keep the per-group scratch vectors) as the counterfactual for https://github.com/apache/datafusion/pull/25123, which additionally replaces those vectors with a counting sort.

#25123 is a reproducible +19% on `clickbench_extended` Q14 and +6.5% on Q5, but a reproducible −10% on Q2, which groups by a 110-value column with four `COUNT(DISTINCT)` adapters. This branch is the half of that change that has the same sign at every cardinality, and the question is how much of the win it keeps.

Will be closed once the numbers are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
