### PR TITLE
fix(smj): handle floating-point keys across batch boundaries

### DIFF
--- a/datafusion/physical-plan/src/joins/sort_merge_join/bitwise_stream.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/bitwise_stream.rs
@@ -1193,6 +1193,21 @@ fn keys_match(
     null_equality: NullEquality,
 ) -> Result<bool> {
     debug_assert!(left_arrays.iter().all(|a| a.len() == 1));
+    if left_arrays
+        .iter()
+        .any(|array| array.data_type().is_floating())
+    {
+        // The scalar comparator's partial_cmp panics on NaN. Match the merge
+        // scan's floating-point equality, including its signed-zero handling.
+        let right_keys = slice_keys(right_arrays, 0);
+        return Ok(JoinKeyComparator::new(
+            left_arrays,
+            &right_keys,
+            sort_options,
+            null_equality,
+        )?
+        .is_equal(0, 0));
+    }
     let cmp = compare_join_arrays(
         left_arrays,
         0,

--- a/datafusion/physical-plan/src/joins/sort_merge_join/tests.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/tests.rs
@@ -4353,6 +4353,120 @@ fn columns(schema: &Schema) -> Vec<String> {
     schema.fields().iter().map(|f| f.name().clone()).collect()
 }
 
+// Floating-point key groups must compare consistently within and across batches.
+#[rstest::rstest]
+#[tokio::test]
+async fn join_float_key_batch_boundaries(
+    #[values(DataType::Float16, DataType::Float32, DataType::Float64)] key_type: DataType,
+    #[values(LeftMark, RightMark, LeftSemi, RightSemi, LeftAnti, RightAnti)]
+    join_type: JoinType,
+    #[values(NullEquality::NullEqualsNothing, NullEquality::NullEqualsNull)]
+    null_equality: NullEquality,
+    #[values(false, true)] descending: bool,
+    #[values(1, 2)] input_batch_size: usize,
+) -> Result<()> {
+    let input = |unmatched_key| -> Result<Arc<dyn ExecutionPlan>> {
+        let mut keys = vec![
+            None,
+            Some(f64::NEG_INFINITY),
+            Some(-0.0),
+            Some(0.0),
+            Some(unmatched_key),
+            Some(f64::INFINITY),
+            Some(f64::NAN),
+            Some(f64::NAN),
+            Some(f64::NAN),
+        ];
+        let mut ids: Vec<i32> = (0..keys.len() as i32).collect();
+        if descending {
+            keys.reverse();
+            ids.reverse();
+        }
+        let batch = RecordBatch::try_from_iter(vec![
+            (
+                "id",
+                Arc::new(Int32Array::from(ids)) as arrow::array::ArrayRef,
+            ),
+            (
+                "key",
+                arrow::compute::cast(&arrow::array::Float64Array::from(keys), &key_type)?,
+            ),
+        ])?;
+        Ok(build_table_from_batches(
+            (0..batch.num_rows())
+                .step_by(input_batch_size)
+                .map(|offset| {
+                    batch.slice(offset, input_batch_size.min(batch.num_rows() - offset))
+                })
+                .collect(),
+        ))
+    };
+    let on: JoinOn = vec![(
+        Arc::new(Column::new("key", 1)),
+        Arc::new(Column::new("key", 1)),
+    )];
+    let (_, output) = join_collect_with_options(
+        input(1.0)?,
+        input(2.0)?,
+        on,
+        join_type,
+        vec![SortOptions {
+            descending,
+            nulls_first: !descending,
+        }],
+        null_equality,
+    )
+    .await?;
+
+    let is_mark = matches!(join_type, LeftMark | RightMark);
+    let is_anti = matches!(join_type, LeftAnti | RightAnti);
+    let mut expected: Vec<_> = (0..9)
+        .map(|id| {
+            let matched =
+                id != 4 && (id != 0 || null_equality == NullEquality::NullEqualsNull);
+            (id, matched)
+        })
+        .filter(|(_, matched)| is_mark || *matched != is_anti)
+        .collect();
+    if descending {
+        expected.reverse();
+    }
+    let mut ids = vec![];
+    let mut marks = vec![];
+    for batch in output {
+        assert_eq!(batch.schema().field(1).data_type(), &key_type);
+        ids.extend_from_slice(
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values(),
+        );
+        if is_mark {
+            marks.extend(
+                batch
+                    .column(2)
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .unwrap()
+                    .iter(),
+            );
+        }
+    }
+    assert_eq!(ids, expected.iter().map(|(id, _)| *id).collect::<Vec<_>>());
+    if is_mark {
+        assert_eq!(
+            marks,
+            expected
+                .iter()
+                .map(|(_, matched)| Some(*matched))
+                .collect::<Vec<_>>()
+        );
+    }
+    Ok(())
+}
+
 // ==================== BitwiseSortMergeJoinStream direct tests ====================
 //
 // These tests construct a BitwiseSortMergeJoinStream directly (bypassing exec)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #25133.

## Rationale for this change

Sort-merge mark, semi, and anti joins can fail when floating-point key groups cross input batches. Float32/Float64 keys containing NaN can panic, and Float16 keys can return an unsupported-type error, even though the main merge scan supports these keys.

## What changes are included in this PR?

Use the existing `JoinKeyComparator` for batch-boundary comparisons involving floating-point keys, matching the main merge scan's equality semantics. Slice the right-hand keys to one row before constructing the comparator; the left-hand keys are already single-row slices. This bounds signed-zero normalization to the rows being compared.

Integer-only comparisons keep the existing scalar path. There are no memory-accounting, buffering, configuration, dependency, or public-API changes.

## What is the testing strategy for this PR?

`join_float_key_batch_boundaries` in `datafusion/physical-plan/src/joins/sort_merge_join/tests.rs` exercises actual one- and two-row input batches. Its 144 cases cover Float16/32/64, left/right mark/semi/anti joins, both null-equality modes, and ascending/descending order. Inputs include nulls, infinities, signed zero, unmatched keys, and NaN groups spanning batches. Assertions check exact output row IDs/order, key types, and mark values.

A physical-plan test is used because the reproducer needs precise input batch boundaries, independent of SQL optimizer choices.

On unpatched Apache main (`40488988ad596c9b093ad60e1453430d803ce33c`) plus only the new tests, all 144 cases fail: 96 NaN panics and 48 Float16 unsupported-type errors.

Local validation of `9ea2dea17b53b8ed2f8ea877df3d95604b87f450`:

- Physical-plan library: **2,096 passed**, including all 144 new regression cases.
- Full extended workspace command below: **11,454 Rust tests passed, 0 failed, 8 ignored**; the SQL logic harness also completed **513/513 files** successfully.
- CLI: **107 reported passed, 0 failed**. Six environment-gated cases did not exercise external storage.
- `cargo fmt --all -- --check`, `git diff --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, and the complete `./dev/rust_lint.sh` suite, including documentation: **passed**. The lint suite used the CI-pinned Hawkeye 7.0.0.

```sh
ulimit -n 4096
RUST_BACKTRACE=1 cargo test --locked --profile ci --no-fail-fast \
  --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-cli \
  --workspace --lib --tests --bins \
  --features avro,json,backtrace,extended_tests,recursive_protection,parquet_encryption
cargo test --locked --profile ci -p datafusion-cli
```

The initial workspace attempt failed four sort-only RSS runners (`sort_no_mem_limit_runner` and `sort_with_mem_limit_{1,2,3}_runner`) with a zero baseline RSS. All four passed an isolated serial rerun, and the subsequent full workspace rerun passed without source/test changes. The cause of the initial intermittent failures has not been established.

Supplemental standalone validation, not committed to this PR: an independent row-by-row oracle passed 2,592 cases covering asymmetric/empty input batches, filters, composite keys, both null placements and the float/join options above. An allocation probe confirmed the single-row slicing bounds comparator allocation independently of the full input batch size (32 through 1,048,576 rows). These checks supplement, rather than replace, the committed regression tests.

The existing eight-case `sort_merge_join` release benchmark completed on the exact upstream base and PR, with an identical harness, compiler and lockfile. Runs were ordered base→PR and PR→base, using 30 samples, one-second warmup and a three-second requested measurement time. Short-run differences were mixed; the left-semi delta reversed from +3.5% to -2.6%. Inner 1-to-1 was initially slower (+9.9% and +3.7%), so it was repeated in three longer, alternating-order pairs (50 samples, eight-second requested measurement time). The PR/base point-estimate differences were -0.17%, +0.26% and -0.84%; Criterion reported change within its noise threshold or no change. The initial slowdown did not reproduce. These are integer-key control workloads on a development machine, not a floating-point speedup benchmark; no speedup or general performance-neutrality claim is made.

Upstream test workflows currently require maintainer approval (`action_required`); local results above are not a claim that GitHub CI or coverage checks have passed.

## Are there any user-facing changes?

Affected sort-merge joins can complete instead of failing at floating-point batch boundaries. No public API changes.

AI-assisted contribution (OpenAI Codex).
