### PR TITLE
fix: wrong log and power results for invalid bases and inputs

### DIFF
--- a/datafusion/core/tests/expr_api/simplification.rs
+++ b/datafusion/core/tests/expr_api/simplification.rs
@@ -606,24 +606,35 @@ fn test_simplify_with_cycle_count(
 
 #[test]
 fn test_simplify_log() {
-    // Log(c3, 1) ===> 0
+    // These identities hold only for a base in (0, 1) union (1, inf), so they
+    // apply to a literal base whose value proves it, not to a column.
+    // Log(2, 1) ===> 0
     {
-        let expr = log(col("c3_non_null"), lit(1));
+        let expr = log(lit(2i64), lit(1));
         test_simplify(expr, lit(0i64));
     }
-    // Log(c3, c3) ===> 1
+    // Log(2, 2) ===> 1
     {
-        let expr = log(col("c3_non_null"), col("c3_non_null"));
+        let expr = log(lit(2i64), lit(2i64));
         let expected = lit(1i64);
         test_simplify(expr, expected);
     }
-    // Log(c3, Power(c3, c4)) ===> c4
+    // Log(2, Power(2, c4)) ===> c4
     {
-        let expr = log(
-            col("c3_non_null"),
-            power(col("c3_non_null"), col("c4_non_null")),
-        );
+        let expr = log(lit(2i64), power(lit(2i64), col("c4_non_null")));
         let expected = col("c4_non_null");
+        test_simplify(expr, expected);
+    }
+    // Log(c3, 1) ===> Log(c3, 1), since c3 may be 1, 0 or negative
+    {
+        let expr = log(col("c3_non_null"), lit(1));
+        let expected = log(col("c3_non_null"), lit(1));
+        test_simplify(expr, expected);
+    }
+    // Log(c3, c3) ===> Log(c3, c3)
+    {
+        let expr = log(col("c3_non_null"), col("c3_non_null"));
+        let expected = log(col("c3_non_null"), col("c3_non_null"));
         test_simplify(expr, expected);
     }
     // Log(c3, c4) ===> Log(c3, c4)
@@ -649,17 +660,26 @@ fn test_simplify_power() {
             Expr::Cast(Cast::new(Box::new(col("c3_non_null")), DataType::Float64));
         test_simplify(expr, expected)
     }
-    // Power(c3, Log(c3, c4)) ===> cast(c4 AS Float64)
+    // Power(c3, Log(c3, c4)) is left alone, since c3 may be 1, 0 or negative.
+    {
+        let expr = power(
+            col("c3_non_null"),
+            log(col("c3_non_null"), col("c4_non_null")),
+        );
+        let expected = power(
+            col("c3_non_null"),
+            log(col("c3_non_null"), col("c4_non_null")),
+        );
+        test_simplify(expr, expected)
+    }
+    // Power(2, Log(2, c4)) ===> cast(c4 AS Float64)
     // The simplifier rewrites `power(b, log(b, x))` to `x`, but the
     // rewritten expression must keep the same type as the original
     // `power` call. `power` returns Float64, so the UInt32 c4 has to be cast
     // to Float64 to preserve the output schema the optimizer already
     // committed to.
     {
-        let expr = power(
-            col("c3_non_null"),
-            log(col("c3_non_null"), col("c4_non_null")),
-        );
+        let expr = power(lit(2i64), log(lit(2i64), col("c4_non_null")));
         let expected =
             Expr::Cast(Cast::new(Box::new(col("c4_non_null")), DataType::Float64));
         test_simplify(expr, expected)

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -812,7 +812,13 @@ mod tests {
 
         // log(base, 1) => 0, log(base, base) => 1 and log(base, power(base, b)) => b
         // hold only for a base in (0, 1) union (1, inf).
-        for base in [lit(1.0), lit(0.0), lit(-2.0), lit(f64::NAN), lit(f64::INFINITY)] {
+        for base in [
+            lit(1.0),
+            lit(0.0),
+            lit(-2.0),
+            lit(f64::NAN),
+            lit(f64::INFINITY),
+        ] {
             let result = LogFunc::new()
                 .simplify(vec![base.clone(), lit(1.0)], &context)
                 .unwrap();

--- a/datafusion/functions/src/math/log.rs
+++ b/datafusion/functions/src/math/log.rs
@@ -362,11 +362,11 @@ impl ScalarUDFImpl for LogFunc {
         } else {
             lit(ScalarValue::new_ten(&number_datatype)?)
         };
-        let base_nullable = info.nullable(&base)?;
 
         match number {
             Expr::Literal(value, _)
-                if value == ScalarValue::new_one(&number_datatype)? && !base_nullable =>
+                if value == ScalarValue::new_one(&number_datatype)?
+                    && is_valid_log_base(&base) =>
             {
                 Ok(ExprSimplifyResult::Simplified(lit(ScalarValue::new_zero(
                     &info.get_data_type(&base)?,
@@ -376,13 +376,13 @@ impl ScalarUDFImpl for LogFunc {
                 if is_pow(&func)
                     && args.len() == 2
                     && base == args[0]
-                    && !base_nullable =>
+                    && is_valid_log_base(&base) =>
             {
                 let b = args.pop().unwrap(); // length checked above
                 Ok(ExprSimplifyResult::Simplified(b))
             }
             number => {
-                if number == base && !base_nullable {
+                if number == base && is_valid_log_base(&base) {
                     Ok(ExprSimplifyResult::Simplified(lit(ScalarValue::new_one(
                         &number_datatype,
                     )?)))
@@ -406,6 +406,24 @@ impl ScalarUDFImpl for LogFunc {
 /// Returns true if the function is `PowerFunc`
 fn is_pow(func: &ScalarUDF) -> bool {
     func.inner().is::<PowerFunc>()
+}
+
+/// Returns true when `base` is a literal that is a valid logarithm base.
+///
+/// The `log`/`power` identities hold only for a base in `(0, 1) ∪ (1, ∞)`.
+/// A base of 1 makes `log(base, x)` infinite, a base of 0 or a negative number
+/// makes it undefined, and an infinite base collapses the result to zero, so the
+/// rewrites are unsound for all of them. Only a literal proves the value, so a
+/// non-literal base keeps the original expression.
+pub(super) fn is_valid_log_base(base: &Expr) -> bool {
+    let Expr::Literal(value, _) = base else {
+        return false;
+    };
+
+    matches!(
+        value.cast_to(&DataType::Float64),
+        Ok(ScalarValue::Float64(Some(value))) if value.is_finite() && value > 0.0 && value != 1.0
+    )
 }
 
 #[cfg(test)]
@@ -786,6 +804,58 @@ mod tests {
         assert_eq!(args.len(), 2);
         assert_eq!(args[0], lit(2));
         assert_eq!(args[1], lit(3));
+    }
+
+    #[test]
+    fn test_log_simplify_rejects_degenerate_base() {
+        let context = SimplifyContext::default();
+
+        // log(base, 1) => 0, log(base, base) => 1 and log(base, power(base, b)) => b
+        // hold only for a base in (0, 1) union (1, inf).
+        for base in [lit(1.0), lit(0.0), lit(-2.0), lit(f64::NAN), lit(f64::INFINITY)] {
+            let result = LogFunc::new()
+                .simplify(vec![base.clone(), lit(1.0)], &context)
+                .unwrap();
+            assert!(
+                matches!(result, ExprSimplifyResult::Original(_)),
+                "log({base:?}, 1) must not simplify"
+            );
+
+            let result = LogFunc::new()
+                .simplify(vec![base.clone(), base.clone()], &context)
+                .unwrap();
+            assert!(
+                matches!(result, ExprSimplifyResult::Original(_)),
+                "log({base:?}, {base:?}) must not simplify"
+            );
+
+            let power = Expr::ScalarFunction(ScalarFunction::new_udf(
+                Arc::new(ScalarUDF::from(PowerFunc::new())),
+                vec![base.clone(), lit(2.0)],
+            ));
+            let result = LogFunc::new()
+                .simplify(vec![base.clone(), power], &context)
+                .unwrap();
+            assert!(
+                matches!(result, ExprSimplifyResult::Original(_)),
+                "log({base:?}, power({base:?}, 2)) must not simplify"
+            );
+        }
+    }
+
+    #[test]
+    fn test_log_simplify_accepts_valid_base() {
+        let context = SimplifyContext::default();
+
+        let result = LogFunc::new()
+            .simplify(vec![lit(2.0), lit(1.0)], &context)
+            .unwrap();
+        assert!(matches!(result, ExprSimplifyResult::Simplified(_)));
+
+        let result = LogFunc::new()
+            .simplify(vec![lit(2.0), lit(2.0)], &context)
+            .unwrap();
+        assert!(matches!(result, ExprSimplifyResult::Simplified(_)));
     }
 
     #[test]

--- a/datafusion/functions/src/math/power.rs
+++ b/datafusion/functions/src/math/power.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 //! Math function: `power()`.
-use super::log::LogFunc;
+use super::log::{LogFunc, is_valid_log_base};
 
 use crate::utils::calculate_binary_math;
 use arrow::array::{Array, ArrayRef};
@@ -183,7 +183,7 @@ impl ScalarUDFImpl for PowerFunc {
                 if is_log(&func)
                     && args.len() == 2
                     && base == args[0]
-                    && !base_nullable =>
+                    && is_valid_log_base(&base) =>
             {
                 let b = args.pop().unwrap(); // length checked above
                 let b_type = info.get_data_type(&b)?;

--- a/datafusion/sqllogictest/test_files/math.slt
+++ b/datafusion/sqllogictest/test_files/math.slt
@@ -1213,7 +1213,9 @@ physical_plan
 01)ProjectionExec: expr=[log(column1@0, 1) as l1, log(column1@0, column1@0) as la, power(column1@0, 0) as p0, power(column1@0, log(column1@0, column2@1)) as pl]
 02)--DataSourceExec: partitions=1, partition_sizes=[1]
 
-# Non-nullable bases still use the existing simplifications
+# A column base is left alone even when it is not nullable, because its value is
+# not known to be outside {0, 1, negative}. power(a, 0) does not depend on the
+# base value, so it still folds.
 query TT
 EXPLAIN SELECT
   log(a, 1) AS l1,
@@ -1223,12 +1225,12 @@ EXPLAIN SELECT
 FROM (VALUES (2.0::double, 3.0::double)) AS t(a, b);
 ----
 logical_plan
-01)Projection: Float64(0) AS l1, Float64(1) AS la, Float64(1) AS p0, t.b AS pl
+01)Projection: log(t.a, Float64(1)) AS l1, log(t.a, t.a) AS la, Float64(1) AS p0, power(t.a, log(t.a, t.b)) AS pl
 02)--SubqueryAlias: t
-03)----Projection: column2 AS b
+03)----Projection: column1 AS a, column2 AS b
 04)------Values: (Float64(2), Float64(3))
 physical_plan
-01)ProjectionExec: expr=[0 as l1, 1 as la, 1 as p0, column2@1 as pl]
+01)ProjectionExec: expr=[log(column1@0, 1) as l1, log(column1@0, column1@0) as la, 1 as p0, power(column1@0, log(column1@0, column2@1)) as pl]
 02)--DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Float 16/32/64 for log


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion/issues/25137.

## Rationale for this change

For a column containing -3.0, `power(2.0, log(2.0, a))` returned -3.0 instead of NaN. Equality filters could include that row. Logarithm rewrites also gave wrong results for bases of 1, 0, negative numbers, NaN and infinity.

## What changes are included in this PR?

The logarithm rewrites require a literal, finite, positive base other than 1. Power/log cancellation is removed because the simplification context cannot prove a column argument is positive. The zero- and one-exponent power rules remain.

## What is the testing strategy for this PR?

The same queries ran through DataFusion CLI [before](https://github.com/apache/datafusion/commit/75d26e482d57e9ba50e9d040191c82e255bb3996) and [after](https://github.com/apache/datafusion/commit/0efbdb82e78de223e14fd8cb0c687bea4793f8d3). The projection changed from -3.0 to NaN; the filter count changed from 1 to 0. SQL regressions also cover positive and NULL inputs.

```sql
SELECT power(2.0, log(2.0, a)) FROM (VALUES (-3.0::double)) t(a);
SELECT count(*) AS matched_rows FROM (VALUES (-3.0::double)) t(a)
WHERE power(2.0, log(2.0, a)) = -3.0;
```

<details><summary>Raw logs</summary>

Before:

```text
+---------------------------------------+
| power(Float64(2),log(Float64(2),t.a)) |
+---------------------------------------+
| -3.0                                  |
+---------------------------------------+
1 row(s) fetched. 
Elapsed 0.014 seconds.
```

```text
+--------------+
| matched_rows |
+--------------+
| 1            |
+--------------+
1 row(s) fetched. 
Elapsed 0.008 seconds.
```

After:

```text
+---------------------------------------+
| power(Float64(2),log(Float64(2),t.a)) |
+---------------------------------------+
| NaN                                   |
+---------------------------------------+
1 row(s) fetched. 
Elapsed 0.016 seconds.
```

```text
+--------------+
| matched_rows |
+--------------+
| 0            |
+--------------+
1 row(s) fetched. 
Elapsed 0.008 seconds.
```

</details>

## Are there any user-facing changes?

These expressions preserve their evaluated math results. The negative-input predicate no longer matches. No API change.
