### PR TITLE
fix: `AT TIME ZONE` on a timezone-aware timestamp returns a naive timestamp

### DIFF
--- a/datafusion/expr/src/planner.rs
+++ b/datafusion/expr/src/planner.rs
@@ -218,6 +218,26 @@ pub trait ExprPlanner: Debug + Send + Sync {
         Ok(PlannerResult::Original(args))
     }
 
+    /// Plan `<expr> AT TIME ZONE '<tz>'` when `<expr>` is **already
+    /// timezone-aware**.
+    ///
+    /// Following PostgreSQL, `<tz-aware timestamp> AT TIME ZONE zone` returns
+    /// the wall clock the instant has in `zone`, as a timezone-*naive*
+    /// timestamp. (The timezone-*naive* case is the plain
+    /// `CAST(<expr> AS Timestamp(unit, Some(tz)))` that the SQL planner
+    /// handles on its own and never reaches this method.)
+    ///
+    /// `args` holds a single expression: the input already cast to
+    /// `Timestamp(unit, Some(tz))`. That cast preserves the instant and only
+    /// relabels the timezone, so all an implementation has to do is drop the
+    /// timezone while keeping the displayed value — exactly what
+    /// `to_local_time` does.
+    ///
+    /// Returns original expression arguments if not possible
+    fn plan_at_time_zone(&self, args: Vec<Expr>) -> Result<PlannerResult<Vec<Expr>>> {
+        Ok(PlannerResult::Original(args))
+    }
+
     /// Plans a struct literal, such as  `{'field1' : expr1, 'field2' : expr2, ...}`
     ///
     /// This function takes a vector of expressions and a boolean flag

--- a/datafusion/functions/src/datetime/planner.rs
+++ b/datafusion/functions/src/datetime/planner.rs
@@ -32,4 +32,20 @@ impl ExprPlanner for DatetimeFunctionPlanner {
             ScalarFunction::new_udf(crate::datetime::date_part(), args),
         )))
     }
+
+    /// `<tz-aware timestamp> AT TIME ZONE 'tz'` returns the wall clock in `tz`
+    /// as a timezone-naive timestamp, matching PostgreSQL.
+    ///
+    /// The SQL planner hands us the input already cast to
+    /// `Timestamp(unit, Some(tz))` — an instant-preserving relabel — so the
+    /// remaining step is to strip the timezone while keeping the displayed
+    /// value, which is `to_local_time`.
+    fn plan_at_time_zone(
+        &self,
+        args: Vec<Expr>,
+    ) -> datafusion_common::Result<PlannerResult<Vec<Expr>>> {
+        Ok(PlannerResult::Planned(Expr::ScalarFunction(
+            ScalarFunction::new_udf(crate::datetime::to_local_time(), args),
+        )))
+    }
 }

--- a/datafusion/functions/src/datetime/to_local_time.rs
+++ b/datafusion/functions/src/datetime/to_local_time.rs
@@ -44,7 +44,11 @@ use datafusion_macros::user_doc;
 /// while keep the display value of the timestamp the same.
 #[user_doc(
     doc_section(label = "Time and Date Functions"),
-    description = "Converts a timestamp with a timezone to a timestamp without a timezone (with no offset or timezone information). This function handles daylight saving time changes.",
+    description = r#"Converts a timestamp with a timezone to a timestamp without a timezone (with no offset or timezone information). This function handles daylight saving time changes.
+
+A timestamp that already has no timezone is returned unchanged.
+
+`AT TIME ZONE` applied to a timezone-*aware* timestamp is defined in terms of this function: it relabels the instant into the target timezone and then applies `to_local_time`. Wrapping such an expression in `to_local_time` is therefore redundant. The examples below instead apply `AT TIME ZONE` to timezone-*naive* values, which is the form that produces a timezone-aware timestamp for `to_local_time` to strip."#,
     syntax_example = "to_local_time(expression)",
     sql_example = r#"```sql
 > SELECT to_local_time('2024-04-01T00:00:20Z'::timestamp);

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::ops::ControlFlow;
+use std::sync::Arc;
 
 use arrow::datatypes::{DataType, TimeUnit};
 use datafusion_expr::planner::{
@@ -659,24 +660,12 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             SQLExpr::AtTimeZone {
                 timestamp,
                 time_zone,
-            } => Ok(Expr::Cast(Cast::new(
-                Box::new(self.sql_expr_to_logical_expr_internal(
-                    *timestamp,
-                    schema,
-                    planner_context,
-                )?),
-                match *time_zone {
-                    SQLExpr::Value(ValueWithSpan {
-                        value: Value::SingleQuotedString(s),
-                        span: _,
-                    }) => DataType::Timestamp(TimeUnit::Nanosecond, Some(s.into())),
-                    _ => {
-                        return not_impl_err!(
-                            "Unsupported ast node in sqltorel: {time_zone:?}"
-                        );
-                    }
-                },
-            ))),
+            } => self.sql_at_time_zone_to_expr(
+                *timestamp,
+                *time_zone,
+                schema,
+                planner_context,
+            ),
             SQLExpr::Dictionary(fields) => {
                 self.try_plan_dictionary_literal(fields, schema, planner_context)
             }
@@ -812,6 +801,86 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 not_impl_err!("Only identifiers and literals are supported in tuples")
             }
         }
+    }
+
+    /// Plan `<timestamp> AT TIME ZONE '<tz>'`.
+    ///
+    /// The meaning of `AT TIME ZONE` depends on whether its input carries a
+    /// timezone, and it always returns the *other* kind of timestamp. This
+    /// follows PostgreSQL (and DuckDB):
+    ///
+    /// * a timezone-**naive** input is read as a wall clock in `tz`, and the
+    ///   result is the corresponding timezone-**aware** instant. That is a
+    ///   plain `CAST(expr AS Timestamp(unit, Some(tz)))`, because arrow's
+    ///   `Timestamp(_, None) -> Timestamp(_, Some(tz))` cast interprets the
+    ///   naive value as local time in `tz`.
+    /// * a timezone-**aware** input is an instant, and the result is the wall
+    ///   clock that instant has in `tz`, as a timezone-**naive** timestamp.
+    ///   The same cast is still the first half of that (casting between two
+    ///   aware types preserves the instant and only relabels the zone); the
+    ///   second half — dropping the zone while keeping the displayed value —
+    ///   is delegated to [`ExprPlanner::plan_at_time_zone`], which
+    ///   `datafusion-functions` implements with `to_local_time`.
+    ///
+    /// Anything that is not a timestamp (a string literal, for instance) takes
+    /// the naive path, since a `CAST` to a timezone-aware timestamp is the
+    /// natural reading of `AT TIME ZONE` for it.
+    ///
+    /// [`ExprPlanner::plan_at_time_zone`]: datafusion_expr::planner::ExprPlanner::plan_at_time_zone
+    fn sql_at_time_zone_to_expr(
+        &self,
+        timestamp: SQLExpr,
+        time_zone: SQLExpr,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let tz: Arc<str> = match time_zone {
+            SQLExpr::Value(ValueWithSpan {
+                value: Value::SingleQuotedString(s),
+                span: _,
+            }) => s.into(),
+            _ => {
+                return not_impl_err!("Unsupported ast node in sqltorel: {time_zone:?}");
+            }
+        };
+
+        let expr =
+            self.sql_expr_to_logical_expr_internal(timestamp, schema, planner_context)?;
+
+        // `AT TIME ZONE` does not change the precision of its input, so keep
+        // the input's `TimeUnit` when it has one.
+        let (unit, input_is_tz_aware) = match expr.get_type(schema)? {
+            DataType::Timestamp(unit, tz) => (unit, tz.is_some()),
+            _ => (TimeUnit::Nanosecond, false),
+        };
+
+        // Instant-preserving relabel into `tz` for an aware input; local-time
+        // interpretation for a naive one.
+        let relabeled = Expr::Cast(Cast::new(
+            Box::new(expr),
+            DataType::Timestamp(unit, Some(tz)),
+        ));
+
+        if !input_is_tz_aware {
+            return Ok(relabeled);
+        }
+
+        let mut args = vec![relabeled];
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_at_time_zone(args)? {
+                PlannerResult::Planned(expr) => return Ok(expr),
+                PlannerResult::Original(original) => {
+                    args = original;
+                }
+            }
+        }
+
+        plan_err!(
+            "AT TIME ZONE on a timezone-aware timestamp is not supported by any \
+             ExprPlanner. It needs the `to_local_time` function; register \
+             `datafusion_functions::datetime` (or its `DatetimeFunctionPlanner`) \
+             with the session"
+        )
     }
 
     fn sql_position_to_expr(

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -3805,6 +3805,39 @@ fn plan_merge_into_rejects_invalid_actions_and_structure(
     );
 }
 
+/// A timezone-naive input is read as a wall clock in the target timezone, so it
+/// lowers to a plain `CAST` and preserves the input's `TimeUnit`.
+#[test]
+fn plan_at_time_zone_on_naive_timestamp() {
+    let plan =
+        logical_plan("SELECT birth_date AT TIME ZONE 'America/Denver' FROM person")
+            .unwrap();
+    assert_snapshot!(
+        plan,
+        @r#"
+    Projection: CAST(person.birth_date AS Timestamp(ns, "America/Denver"))
+      TableScan: person
+    "#
+    );
+}
+
+/// A timezone-aware input needs `to_local_time`, which is provided by
+/// `datafusion-functions`' `DatetimeFunctionPlanner`. The mock context provider
+/// used by these tests does not register it, so planning must fail with a clear
+/// message rather than silently falling back to the naive lowering.
+#[test]
+fn plan_at_time_zone_on_tz_aware_timestamp_without_planner() {
+    let err = logical_plan(
+        "SELECT (birth_date AT TIME ZONE 'UTC') AT TIME ZONE 'America/Denver' FROM person",
+    )
+    .unwrap_err();
+    assert!(
+        err.strip_backtrace()
+            .contains("AT TIME ZONE on a timezone-aware timestamp"),
+        "unexpected error: {err}"
+    );
+}
+
 fn logical_plan(sql: &str) -> Result<LogicalPlan> {
     logical_plan_with_options(sql, ParserOptions::default())
 }

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -5643,3 +5643,41 @@ query P
 SELECT date_bin(NULL, TIMESTAMP '2023-01-01 12:30:00', TIMESTAMP '2023-01-01 12:00:00')
 ----
 NULL
+
+# KNOWN LIMITATION: `AT TIME ZONE` chooses its behaviour from the type that
+# `Expr::get_type` reports in the SQL planner, which runs BEFORE the type
+# coercion analyzer. For a `CASE` expression, `get_type` reports the type of the
+# first non-null `THEN` arm and ignores coercion. So the two queries below have
+# the same coerced input type, `Timestamp(ns, "UTC")`, but give different
+# results: the first still takes the timezone-naive path and keeps the old
+# aware-in aware-out shape.
+#
+# PostgreSQL gives `2024-01-01 05:00:00` as a naive timestamp for both.
+# A correct fix has to dispatch after coercion. Tracked here so the behaviour is
+# visible rather than silent.
+statement ok
+CREATE TABLE at_tz_case AS
+SELECT arrow_cast('2024-01-01T12:00:00Z', 'Timestamp(Nanosecond, Some("UTC"))') AS aware,
+       arrow_cast('2024-01-01T12:00:00', 'Timestamp(Nanosecond, None)') AS naive,
+       true AS b
+
+# both CASE expressions have the same type
+query TT
+SELECT arrow_typeof(CASE WHEN b THEN naive ELSE aware END),
+       arrow_typeof(CASE WHEN b THEN aware ELSE naive END)
+FROM at_tz_case
+----
+Timestamp(ns, "UTC") Timestamp(ns, "UTC")
+
+# but AT TIME ZONE does not agree on them
+query TPTP
+SELECT arrow_typeof((CASE WHEN b THEN naive ELSE aware END) AT TIME ZONE 'America/Denver'),
+       (CASE WHEN b THEN naive ELSE aware END) AT TIME ZONE 'America/Denver',
+       arrow_typeof((CASE WHEN b THEN aware ELSE naive END) AT TIME ZONE 'America/Denver'),
+       (CASE WHEN b THEN aware ELSE naive END) AT TIME ZONE 'America/Denver'
+FROM at_tz_case
+----
+Timestamp(ns, "America/Denver") 2024-01-01T05:00:00-07:00 Timestamp(ns) 2024-01-01T05:00:00
+
+statement ok
+DROP TABLE at_tz_case

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -4049,6 +4049,123 @@ SELECT '2000-12-01 04:04:12' AT TIME ZONE 'America/New York';
 statement error
 SELECT '2023-03-12 02:00:00' AT TIME ZONE 'EDT';
 
+##########
+## AT TIME ZONE applied to a timezone-*aware* timestamp
+##
+## https://github.com/apache/datafusion/issues/12218
+##
+## PostgreSQL (and DuckDB) semantics are asymmetric:
+##
+##   * `<tz-naive timestamp> AT TIME ZONE zone` reads the value as a wall clock
+##     in `zone` and returns the matching tz-*aware* instant, and
+##   * `<tz-aware timestamp> AT TIME ZONE zone` returns the wall clock that the
+##     instant has in `zone`, as a tz-*naive* timestamp.
+##
+## The expectations below record DataFusion's behaviour *before* the fix for
+## #12218: the tz-aware case wrongly stays tz-aware, which only relabels the
+## display zone. The following commit flips them to the PostgreSQL results.
+##########
+
+statement ok
+SET datafusion.execution.time_zone = 'UTC';
+
+statement ok
+CREATE TABLE at_tz_t AS
+SELECT
+  '2024-01-01T12:00:00Z'::timestamptz AS tstz,
+  '2024-01-01 12:00:00'::timestamp AS tsn;
+
+# The tz-naive column is unaffected by this issue: noon-in-Denver is the same
+# instant PostgreSQL reports (`2024-01-01 19:00:00+00`).
+query TP
+SELECT arrow_typeof(tsn AT TIME ZONE 'America/Denver'), tsn AT TIME ZONE 'America/Denver' FROM at_tz_t;
+----
+Timestamp(ns, "America/Denver") 2024-01-01T12:00:00-07:00
+
+# The tz-aware column: PostgreSQL returns `timestamp` (naive) `2024-01-01 05:00:00`.
+query TP
+SELECT arrow_typeof(tstz AT TIME ZONE 'America/Denver'), tstz AT TIME ZONE 'America/Denver' FROM at_tz_t;
+----
+Timestamp(ns, "America/Denver") 2024-01-01T05:00:00-07:00
+
+# The exact reproducer from #12218. PostgreSQL returns `2024-01-01 05:00:00`.
+query P
+SELECT (tstz AT TIME ZONE 'America/Denver')::timestamp FROM at_tz_t;
+----
+2024-01-01T12:00:00
+
+# Chained. PostgreSQL: `timestamptz` `2024-01-01 04:00:00+00`, i.e. the Denver
+# wall clock (05:00) re-read as a Brussels wall clock.
+query TP
+SELECT
+  arrow_typeof(tstz AT TIME ZONE 'America/Denver' AT TIME ZONE 'Europe/Brussels'),
+  tstz AT TIME ZONE 'America/Denver' AT TIME ZONE 'Europe/Brussels'
+FROM at_tz_t;
+----
+Timestamp(ns, "Europe/Brussels") 2024-01-01T13:00:00+01:00
+
+# Fixed offset. Note DataFusion follows the arrow/ISO-8601 sign convention here
+# (`+05:30` is 5h30m *east* of UTC), while PostgreSQL applies the POSIX
+# convention to offsets spelled as strings. That difference is pre-existing and
+# is not what #12218 is about; only the result *type* changes below.
+query TP
+SELECT arrow_typeof(tstz AT TIME ZONE '+05:30'), tstz AT TIME ZONE '+05:30' FROM at_tz_t;
+----
+Timestamp(ns, "+05:30") 2024-01-01T17:30:00+05:30
+
+# `AT TIME ZONE` currently forces Nanosecond precision regardless of the input.
+query T
+SELECT arrow_typeof(arrow_cast('2024-01-01T12:00:00Z', 'Timestamp(Microsecond, Some("UTC"))') AT TIME ZONE 'America/Denver');
+----
+Timestamp(ns, "America/Denver")
+
+query T
+SELECT arrow_typeof(arrow_cast('2024-01-01T12:00:00', 'Timestamp(Microsecond, None)') AT TIME ZONE 'America/Denver');
+----
+Timestamp(ns, "America/Denver")
+
+# A real (multi-row) tz-aware column, spanning both DST transitions in
+# America/Denver. The wall clocks below all agree with PostgreSQL; it is only
+# the type that is wrong today.
+statement ok
+CREATE TABLE at_tz_dst(ts timestamptz) AS VALUES
+  (arrow_cast('2024-01-01T12:00:00Z', 'Timestamp(Nanosecond, Some("UTC"))')),
+  (arrow_cast('2024-03-10T08:59:00Z', 'Timestamp(Nanosecond, Some("UTC"))')),
+  (arrow_cast('2024-03-10T09:00:00Z', 'Timestamp(Nanosecond, Some("UTC"))')),
+  (arrow_cast('2024-07-01T12:00:00Z', 'Timestamp(Nanosecond, Some("UTC"))')),
+  (arrow_cast('2024-11-03T07:59:00Z', 'Timestamp(Nanosecond, Some("UTC"))')),
+  (arrow_cast('2024-11-03T08:00:00Z', 'Timestamp(Nanosecond, Some("UTC"))'));
+
+query PPT
+SELECT
+  ts,
+  ts AT TIME ZONE 'America/Denver' AS denver,
+  arrow_typeof(ts AT TIME ZONE 'America/Denver') AS denver_type
+FROM at_tz_dst ORDER BY ts;
+----
+2024-01-01T12:00:00Z 2024-01-01T05:00:00-07:00 Timestamp(ns, "America/Denver")
+2024-03-10T08:59:00Z 2024-03-10T01:59:00-07:00 Timestamp(ns, "America/Denver")
+2024-03-10T09:00:00Z 2024-03-10T03:00:00-06:00 Timestamp(ns, "America/Denver")
+2024-07-01T12:00:00Z 2024-07-01T06:00:00-06:00 Timestamp(ns, "America/Denver")
+2024-11-03T07:59:00Z 2024-11-03T01:59:00-06:00 Timestamp(ns, "America/Denver")
+2024-11-03T08:00:00Z 2024-11-03T01:00:00-07:00 Timestamp(ns, "America/Denver")
+
+# `now()` is tz-aware whenever `datafusion.execution.time_zone` is set.
+query T
+SELECT arrow_typeof(now() AT TIME ZONE 'America/Denver');
+----
+Timestamp(ns, "America/Denver")
+
+statement ok
+DROP TABLE at_tz_dst;
+
+statement ok
+DROP TABLE at_tz_t;
+
+statement ok
+RESET datafusion.execution.time_zone;
+
+
 # Test current_time without parentheses
 query B
 select current_time = current_time;

--- a/datafusion/sqllogictest/test_files/datetime/timestamps.slt
+++ b/datafusion/sqllogictest/test_files/datetime/timestamps.slt
@@ -4061,9 +4061,7 @@ SELECT '2023-03-12 02:00:00' AT TIME ZONE 'EDT';
 ##   * `<tz-aware timestamp> AT TIME ZONE zone` returns the wall clock that the
 ##     instant has in `zone`, as a tz-*naive* timestamp.
 ##
-## The expectations below record DataFusion's behaviour *before* the fix for
-## #12218: the tz-aware case wrongly stays tz-aware, which only relabels the
-## display zone. The following commit flips them to the PostgreSQL results.
+## Every result below was checked against PostgreSQL 17.
 ##########
 
 statement ok
@@ -4086,13 +4084,13 @@ Timestamp(ns, "America/Denver") 2024-01-01T12:00:00-07:00
 query TP
 SELECT arrow_typeof(tstz AT TIME ZONE 'America/Denver'), tstz AT TIME ZONE 'America/Denver' FROM at_tz_t;
 ----
-Timestamp(ns, "America/Denver") 2024-01-01T05:00:00-07:00
+Timestamp(ns) 2024-01-01T05:00:00
 
 # The exact reproducer from #12218. PostgreSQL returns `2024-01-01 05:00:00`.
 query P
 SELECT (tstz AT TIME ZONE 'America/Denver')::timestamp FROM at_tz_t;
 ----
-2024-01-01T12:00:00
+2024-01-01T05:00:00
 
 # Chained. PostgreSQL: `timestamptz` `2024-01-01 04:00:00+00`, i.e. the Denver
 # wall clock (05:00) re-read as a Brussels wall clock.
@@ -4102,7 +4100,7 @@ SELECT
   tstz AT TIME ZONE 'America/Denver' AT TIME ZONE 'Europe/Brussels'
 FROM at_tz_t;
 ----
-Timestamp(ns, "Europe/Brussels") 2024-01-01T13:00:00+01:00
+Timestamp(ns, "Europe/Brussels") 2024-01-01T05:00:00+01:00
 
 # Fixed offset. Note DataFusion follows the arrow/ISO-8601 sign convention here
 # (`+05:30` is 5h30m *east* of UTC), while PostgreSQL applies the POSIX
@@ -4111,22 +4109,21 @@ Timestamp(ns, "Europe/Brussels") 2024-01-01T13:00:00+01:00
 query TP
 SELECT arrow_typeof(tstz AT TIME ZONE '+05:30'), tstz AT TIME ZONE '+05:30' FROM at_tz_t;
 ----
-Timestamp(ns, "+05:30") 2024-01-01T17:30:00+05:30
+Timestamp(ns) 2024-01-01T17:30:00
 
-# `AT TIME ZONE` currently forces Nanosecond precision regardless of the input.
+# `AT TIME ZONE` preserves the precision of its input.
 query T
 SELECT arrow_typeof(arrow_cast('2024-01-01T12:00:00Z', 'Timestamp(Microsecond, Some("UTC"))') AT TIME ZONE 'America/Denver');
 ----
-Timestamp(ns, "America/Denver")
+Timestamp(µs)
 
 query T
 SELECT arrow_typeof(arrow_cast('2024-01-01T12:00:00', 'Timestamp(Microsecond, None)') AT TIME ZONE 'America/Denver');
 ----
-Timestamp(ns, "America/Denver")
+Timestamp(µs, "America/Denver")
 
 # A real (multi-row) tz-aware column, spanning both DST transitions in
-# America/Denver. The wall clocks below all agree with PostgreSQL; it is only
-# the type that is wrong today.
+# America/Denver.
 statement ok
 CREATE TABLE at_tz_dst(ts timestamptz) AS VALUES
   (arrow_cast('2024-01-01T12:00:00Z', 'Timestamp(Nanosecond, Some("UTC"))')),
@@ -4143,18 +4140,18 @@ SELECT
   arrow_typeof(ts AT TIME ZONE 'America/Denver') AS denver_type
 FROM at_tz_dst ORDER BY ts;
 ----
-2024-01-01T12:00:00Z 2024-01-01T05:00:00-07:00 Timestamp(ns, "America/Denver")
-2024-03-10T08:59:00Z 2024-03-10T01:59:00-07:00 Timestamp(ns, "America/Denver")
-2024-03-10T09:00:00Z 2024-03-10T03:00:00-06:00 Timestamp(ns, "America/Denver")
-2024-07-01T12:00:00Z 2024-07-01T06:00:00-06:00 Timestamp(ns, "America/Denver")
-2024-11-03T07:59:00Z 2024-11-03T01:59:00-06:00 Timestamp(ns, "America/Denver")
-2024-11-03T08:00:00Z 2024-11-03T01:00:00-07:00 Timestamp(ns, "America/Denver")
+2024-01-01T12:00:00Z 2024-01-01T05:00:00 Timestamp(ns)
+2024-03-10T08:59:00Z 2024-03-10T01:59:00 Timestamp(ns)
+2024-03-10T09:00:00Z 2024-03-10T03:00:00 Timestamp(ns)
+2024-07-01T12:00:00Z 2024-07-01T06:00:00 Timestamp(ns)
+2024-11-03T07:59:00Z 2024-11-03T01:59:00 Timestamp(ns)
+2024-11-03T08:00:00Z 2024-11-03T01:00:00 Timestamp(ns)
 
 # `now()` is tz-aware whenever `datafusion.execution.time_zone` is set.
 query T
 SELECT arrow_typeof(now() AT TIME ZONE 'America/Denver');
 ----
-Timestamp(ns, "America/Denver")
+Timestamp(ns)
 
 statement ok
 DROP TABLE at_tz_dst;

--- a/docs/source/user-guide/sql/operators.md
+++ b/docs/source/user-guide/sql/operators.md
@@ -507,6 +507,7 @@ Bitwise Shift Left
 - [|| (string concatenation)](#op_str_cat)
 - [@> (array contains)](#op_arr_contains)
 - [<@ (array is contained by)](#op_arr_contained_by)
+- [AT TIME ZONE](#op_at_time_zone)
 
 (op_str_cat)=
 
@@ -552,6 +553,67 @@ Array Is Contained By
 | true                                                                    |
 +-------------------------------------------------------------------------+
 ```
+
+(op_at_time_zone)=
+
+### `AT TIME ZONE`
+
+Converts between timezone-naive and timezone-aware timestamps, following
+PostgreSQL. `AT TIME ZONE` always returns the _other_ kind of timestamp from
+the one it is given:
+
+| Input type                               | Result type                              | Meaning                                                             |
+| ---------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------- |
+| `Timestamp(unit, None)` (timezone-naive) | `Timestamp(unit, Some(tz))` (tz-aware)   | Read the value as a wall clock in `tz`; the result is that instant. |
+| `Timestamp(unit, Some(_))` (tz-aware)    | `Timestamp(unit, None)` (timezone-naive) | Return the wall clock that instant has in `tz`.                     |
+
+A timezone-naive timestamp is a wall clock with no instant attached, so
+`AT TIME ZONE` pins it to one:
+
+```sql
+> SET datafusion.execution.time_zone = 'UTC';
+> SELECT
+  '2024-01-01 12:00:00'::timestamp AT TIME ZONE 'America/Denver' AS instant,
+  arrow_typeof('2024-01-01 12:00:00'::timestamp AT TIME ZONE 'America/Denver') AS type;
++---------------------------+---------------------------------+
+| instant                   | type                            |
++---------------------------+---------------------------------+
+| 2024-01-01T12:00:00-07:00 | Timestamp(ns, "America/Denver") |
++---------------------------+---------------------------------+
+```
+
+A timezone-aware timestamp already is an instant, so `AT TIME ZONE` reads off
+its wall clock in `tz` and drops the timezone. Daylight saving time is taken
+into account:
+
+```sql
+> SELECT
+  '2024-01-01T12:00:00Z'::timestamptz AT TIME ZONE 'America/Denver' AS wall_clock,
+  arrow_typeof('2024-01-01T12:00:00Z'::timestamptz AT TIME ZONE 'America/Denver') AS type;
++---------------------+---------------+
+| wall_clock          | type          |
++---------------------+---------------+
+| 2024-01-01T05:00:00 | Timestamp(ns) |
++---------------------+---------------+
+```
+
+The second form is equivalent to [`to_local_time`] applied to the timestamp
+after it has been relabelled into `tz`, and requires `to_local_time` to be
+registered with the session.
+
+Because the two forms return different types, applying `AT TIME ZONE` twice
+returns a timezone-aware timestamp again: the wall clock produced by the first
+application is re-read as a local time in the second timezone.
+
+`AT TIME ZONE` never changes the precision (`TimeUnit`) of its input. Inputs
+that are not timestamps at all (a string literal, for example) are cast to
+`Timestamp(Nanosecond, Some(tz))`.
+
+Note that a timezone written as a fixed offset string follows the ISO 8601
+convention, so `'+05:30'` is 5 hours 30 minutes _east_ of UTC. PostgreSQL
+applies the opposite (POSIX) convention to offsets spelled this way.
+
+[`to_local_time`]: scalar_functions.md#to_local_time
 
 ## Literals
 

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -2855,6 +2855,10 @@ Additional examples can be found [here](https://github.com/apache/datafusion/blo
 
 Converts a timestamp with a timezone to a timestamp without a timezone (with no offset or timezone information). This function handles daylight saving time changes.
 
+A timestamp that already has no timezone is returned unchanged.
+
+`AT TIME ZONE` applied to a timezone-_aware_ timestamp is defined in terms of this function: it relabels the instant into the target timezone and then applies `to_local_time`. Wrapping such an expression in `to_local_time` is therefore redundant. The examples below instead apply `AT TIME ZONE` to timezone-_naive_ values, which is the form that produces a timezone-aware timestamp for `to_local_time` to strip.
+
 ```sql
 to_local_time(expression)
 ```


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/12218

> [!WARNING]
> **Known limitation, found in review of this PR: the fix does not reach every expression.**
>
> The type branch calls `Expr::get_type` in the SQL planner, and the planner runs before the type
> coercion analyzer. For a `CASE`, `get_type` reports the first non-null `THEN` arm and ignores
> coercion. So the two queries below have the **same** coerced input type, `Timestamp(ns, "UTC")`,
> and give different answers:
>
> ```sql
> CASE WHEN b THEN naive ELSE aware END AT TIME ZONE 'America/Denver'
> -- Timestamp(ns, "America/Denver")   2024-01-01T05:00:00-07:00   <- old shape, not fixed
> CASE WHEN b THEN aware ELSE naive END AT TIME ZONE 'America/Denver'
> -- Timestamp(ns)                     2024-01-01T05:00:00         <- fixed
> ```
>
> PostgreSQL 17 gives the naive `2024-01-01 05:00:00` for both. `coalesce` is not affected, because
> `verify_function_arguments` coerces before the planner reads the type.
>
> A correct fix must dispatch after coercion, which is a larger change than this PR. The behaviour is
> pinned in `datetime/timestamps.slt` so it is visible rather than silent. **Maintainers: please say
> whether you want that fixed here before merge, or tracked separately.**

## Rationale for this change

### Start here: what a user gets today

Two terms run through this description:

- an **aware timestamp** carries a timezone, so it names an instant. Arrow spells it `Timestamp(unit, Some(tz))`. SQL spells it `timestamptz`.
- a **naive timestamp** carries no timezone, so it names only a wall clock. Arrow spells it `Timestamp(unit, None)`. SQL spells it `timestamp`.

This is the case from the issue. Noon UTC is 05:00 in Denver.

```sql
SET datafusion.execution.time_zone = 'UTC';

SELECT ('2024-01-01T12:00:00Z'::timestamptz AT TIME ZONE 'America/Denver')::timestamp;
```

| Engine | Result |
| --- | --- |
| DataFusion, today | `2024-01-01T12:00:00` |
| DataFusion, this PR | `2024-01-01T05:00:00` |
| PostgreSQL 17.11 | `2024-01-01 05:00:00` |
| DuckDB 1.5.2 | `2024-01-01 05:00:00` |

DataFusion returns the UTC wall clock, so it drops the timezone the user asks for. Drop the final cast and the cause appears:

```sql
SELECT
  '2024-01-01T12:00:00Z'::timestamptz AT TIME ZONE 'America/Denver' AS value,
  arrow_typeof('2024-01-01T12:00:00Z'::timestamptz AT TIME ZONE 'America/Denver') AS type;
```

| Engine | Value | Type |
| --- | --- | --- |
| DataFusion, today | `2024-01-01T05:00:00-07:00` | `Timestamp(ns, "America/Denver")` |
| DataFusion, this PR | `2024-01-01T05:00:00` | `Timestamp(ns)` |
| PostgreSQL 17.11 | `2024-01-01 05:00:00` | `timestamp without time zone` |
| DuckDB 1.5.2 | `2024-01-01 05:00:00` | `TIMESTAMP` |

The displayed value looks right today, but the type is wrong. The result stays aware, so the next operation on it reads the UTC wall clock again.

### Overview

**This is a breaking semantic change.** It changes the result type of `AT TIME ZONE`, and so the result value of anything downstream, when the input is an aware timestamp.

`AT TIME ZONE` is asymmetric in PostgreSQL. It always returns the other kind of timestamp:

- a **naive** input becomes an **aware** timestamp. The engine reads the value as a wall clock in the target timezone and returns that instant.
- an **aware** input becomes a **naive** timestamp. The engine reads off the wall clock that the instant has in the target timezone.

DataFusion implements the first half only. This PR adds the second half. The first half does not change.

### Why the current lowering is wrong

DataFusion lowers both halves to `CAST(expr AS Timestamp(Nanosecond, Some(tz)))`.

- For a naive input that cast is correct. Arrow reads the naive value as local time in `tz`.
- For an aware input that cast only relabels the display timezone. It keeps the instant, so the result stays aware.

## What changes are included in this PR?

`SqlToRel` now types the input of `AT TIME ZONE` and branches on it. The new function is `sql_at_time_zone_to_expr` in `datafusion/sql/src/expr/mod.rs`.

- `Timestamp(unit, None)`, or any type that is not a timestamp: no change. The planner emits `CAST(expr AS Timestamp(unit, Some(tz)))`.
- `Timestamp(unit, Some(_))`: the planner emits the same cast, then wraps it in a step that drops the timezone and keeps the wall clock. That step is `to_local_time`.

### The planner hook

`datafusion-sql` must not depend on `datafusion-functions`, so the second step goes through a new trait method:

- `ExprPlanner::plan_at_time_zone` in `datafusion/expr/src/planner.rs`,
- implemented by `DatetimeFunctionPlanner` in `datafusion/functions/src/datetime/planner.rs`,
- with a default `PlannerResult::Original` body, so out-of-tree implementations still compile.

`plan_extract` lowers `EXTRACT` to `date_part` through the same seam, so this follows an established pattern. The alternative was a name lookup through `ContextProvider::get_function_meta("to_local_time")`. The hook keeps the function name out of the SQL planner.

The type branch stays in `datafusion-sql`, because `Expr::get_type` needs the schema and an `ExprPlanner` does not have one. The hook receives the expression after the cast, and the trait doc states that contract.

A session that registers no such planner now gets a plan error, where before it got a wrong plan.

### The `TimeUnit` change

`AT TIME ZONE` no longer forces `Nanosecond`. It keeps the input's `TimeUnit` when the input is a timestamp.

| Input | Type today | Type with this PR |
| --- | --- | --- |
| `Timestamp(µs, "UTC")` | `Timestamp(ns, "America/Denver")` | `Timestamp(µs)` |
| `Timestamp(µs, None)` | `Timestamp(ns, "America/Denver")` | `Timestamp(µs, "America/Denver")` |
| `Timestamp(s, "UTC")` | `Timestamp(ns, "America/Denver")` | `Timestamp(s)` |
| `Utf8`, `Date32`, and other non-timestamps | `Timestamp(ns, "America/Denver")` | `Timestamp(ns, "America/Denver")` |

PostgreSQL keeps the precision of its input too. `timestamptz '2024-01-01 12:00:00.123456Z' AT TIME ZONE 'America/Denver'` returns `2024-01-01 05:00:00.123456`.

### Not changed

- **Spark.** `SparkFunctionPlanner` implements `plan_extract` and `plan_substring` only, and `with_spark_features` inserts it at index 0 of the list that `with_default_features` builds. So `plan_at_time_zone` falls through to `DatetimeFunctionPlanner`, and no Spark-specific function or planner behaviour changes. A Spark-flavoured session that uses DataFusion's SQL planner does get the new `AT TIME ZONE` semantics, but Spark SQL has no `AT TIME ZONE` syntax. It uses `from_utc_timestamp` and `to_utc_timestamp`. Nothing under `datafusion/spark/` implements, tests or documents the operator.
- **`AT LOCAL`.** PostgreSQL 17 supports it. sqlparser 0.62.0 has no `AtLocal` AST node and rejects the syntax, so there is nothing to route.
- **Fixed-offset strings.** See the field research below. Only the result type changes for these.
- **String-literal inputs.** `'2000-12-01T04:04:12-05:00' AT TIME ZONE 'x'` still takes the naive path, because `Utf8` is not a timestamp type. That keeps today's behaviour: DataFusion honours the offset inside the string. PostgreSQL resolves the unknown-typed literal to `timestamp` and drops the offset. This gap is older than this PR and is separate from #12218.

## What is the testing strategy for this PR?

### Field research

I measured two reference engines rather than trust the documentation:

- PostgreSQL 17.11, `docker run --rm -e POSTGRES_PASSWORD=pw -p 55452:5432 postgres:17`, with `SET TimeZone='UTC'`,
- DuckDB 1.5.2 CLI, with `SET TimeZone='UTC'`.

The DataFusion columns come from a `datafusion-cli` build of `main` and of this branch, with `SET datafusion.execution.time_zone = 'UTC'`.

#### The four core cases

| Case | DataFusion, today | DataFusion, this PR | PostgreSQL 17.11 | DuckDB 1.5.2 |
| --- | --- | --- | --- | --- |
| naive input:<br>`'2024-01-01 12:00:00'::timestamp AT TIME ZONE 'America/Denver'` | `2024-01-01T12:00:00-07:00`<br>`Timestamp(ns, "America/Denver")` | same as today | `2024-01-01 19:00:00+00`<br>`timestamp with time zone` | `2024-01-01 19:00:00+00`<br>`TIMESTAMP WITH TIME ZONE` |
| aware input:<br>`'2024-01-01T12:00:00Z'::timestamptz AT TIME ZONE 'America/Denver'` | `2024-01-01T05:00:00-07:00`<br>`Timestamp(ns, "America/Denver")` | `2024-01-01T05:00:00`<br>`Timestamp(ns)` | `2024-01-01 05:00:00`<br>`timestamp without time zone` | `2024-01-01 05:00:00`<br>`TIMESTAMP` |
| the issue reproducer:<br>`(<aware> AT TIME ZONE 'America/Denver')::timestamp` | `2024-01-01T12:00:00` | `2024-01-01T05:00:00` | `2024-01-01 05:00:00` | `2024-01-01 05:00:00` |
| chained:<br>`<aware> AT TIME ZONE 'America/Denver' AT TIME ZONE 'Europe/Brussels'` | `2024-01-01T13:00:00+01:00`<br>= 12:00 UTC | `2024-01-01T05:00:00+01:00`<br>= 04:00 UTC | `2024-01-01 04:00:00+00` | `2024-01-01 04:00:00+00` |

The naive row agrees across all four columns. `12:00` in Denver is `19:00` UTC. Only the display convention differs.

The chained row is the one that changes value, not just type. Today DataFusion relabels twice and the instant never moves. With this PR the Denver wall clock (05:00) becomes a Brussels wall clock, which is 04:00 UTC. PostgreSQL and DuckDB both return 04:00 UTC.

#### Both 2024 DST transitions in `America/Denver`, aware input

| UTC instant | DataFusion, today | DataFusion, this PR | PostgreSQL 17.11 | DuckDB 1.5.2 |
| --- | --- | --- | --- | --- |
| `2024-01-01T12:00:00Z` | `2024-01-01T05:00:00-07:00` | `2024-01-01T05:00:00` | `2024-01-01 05:00:00` | `2024-01-01 05:00:00` |
| `2024-03-10T08:59:00Z` | `2024-03-10T01:59:00-07:00` | `2024-03-10T01:59:00` | `2024-03-10 01:59:00` | `2024-03-10 01:59:00` |
| `2024-03-10T09:00:00Z` | `2024-03-10T03:00:00-06:00` | `2024-03-10T03:00:00` | `2024-03-10 03:00:00` | `2024-03-10 03:00:00` |
| `2024-07-01T12:00:00Z` | `2024-07-01T06:00:00-06:00` | `2024-07-01T06:00:00` | `2024-07-01 06:00:00` | `2024-07-01 06:00:00` |
| `2024-11-03T07:59:00Z` | `2024-11-03T01:59:00-06:00` | `2024-11-03T01:59:00` | `2024-11-03 01:59:00` | `2024-11-03 01:59:00` |
| `2024-11-03T08:00:00Z` | `2024-11-03T01:00:00-07:00` | `2024-11-03T01:00:00` | `2024-11-03 01:00:00` | `2024-11-03 01:00:00` |

The rows cover the spring-forward gap (`01:59` jumps to `03:00`) and the fall-back overlap (`01:59` MDT, then `01:00` MST). All four columns agree on the wall clock. Only the DataFusion type changes.

#### The DST gap and overlap from the other side, naive input

This is the branch that this PR does not touch. It is here so the table stays honest.

| Case | DataFusion, today and with this PR | PostgreSQL 17.11 | DuckDB 1.5.2 |
| --- | --- | --- | --- |
| gap: `'2024-03-10 02:30:00'::timestamp AT TIME ZONE 'America/Denver'` | `Arrow error: Cast error: Cannot cast timezone to different timezone` | `2024-03-10 09:30:00+00` | `2024-03-10 09:30:00+00` |
| overlap: `'2024-11-03 01:30:00'::timestamp AT TIME ZONE 'America/Denver'` | same error | `2024-11-03 08:30:00+00` | `2024-11-03 08:30:00+00` |

A bare `arrow_cast` to `Timestamp(Nanosecond, Some("America/Denver"))` reproduces the error, so it comes from the arrow cast and not from the SQL planner. This PR does not change it.

#### The case the two engines cannot arbitrate: a fixed-offset string

| Case | DataFusion, today | DataFusion, this PR | PostgreSQL 17.11 | DuckDB 1.5.2 |
| --- | --- | --- | --- | --- |
| `<aware> AT TIME ZONE '+05:30'` | `2024-01-01T17:30:00+05:30`<br>`Timestamp(ns, "+05:30")` | `2024-01-01T17:30:00`<br>`Timestamp(ns)` | `2024-01-01 06:30:00`<br>`timestamp without time zone` | `Not implemented Error: Unknown TimeZone '+05:30'!` |

DataFusion follows arrow and ISO 8601, where `+05:30` is east of UTC. PostgreSQL applies the POSIX convention to an offset spelled as a string and reads `+05:30` as west of UTC. DuckDB rejects the string and accepts IANA names only. So DataFusion's reading matches neither engine.

PostgreSQL does agree with DataFusion when the offset carries a type:

```sql
postgres=# SELECT timestamptz '2024-01-01 12:00:00Z' AT TIME ZONE interval '+05:30';
 2024-01-01 17:30:00
```

This divergence already exists on main. It is separate from #12218 and out of scope here. It is tracked in https://github.com/apache/datafusion/issues/25170. This PR changes only the result type for this case, not the value.

### Tests

New `sqllogictest` coverage in `datafusion/sqllogictest/test_files/datetime/timestamps.slt`. The first commit adds it as a characterization of today's behaviour. The second commit flips it, so the diff shows exactly what changes. Every case asserts `arrow_typeof` next to the value, and I checked every expected value against PostgreSQL 17 by hand. I did not regenerate them with `--complete`. The cases are:

- a naive column and an aware column,
- the exact `::timestamp` reproducer from #12218,
- two chained `AT TIME ZONE` applications,
- a fixed-offset zone,
- microsecond precision in both directions,
- `now()`,
- a multi-row aware column that spans both 2024 DST transitions in `America/Denver`.

Two planner tests in `datafusion/sql/tests/sql_integration.rs`: the plan shape of the naive lowering, and the error when no `ExprPlanner` provides `to_local_time`.

Green locally:

- the full `sqllogictest` suite, with zero changed expectations in the files that main already has,
- `cargo test -p datafusion-sql`,
- `cargo test -p datafusion-functions to_local_time`,
- `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings`,
- the repo's extended workspace suite (`--features avro,json,backtrace,extended_tests,recursive_protection,parquet_encryption`).

One caveat on the zero-change result. `AT TIME ZONE` appears in exactly one test file on main, and every use there has a `Utf8` or naive inner expression. So the corpus had no coverage of the broken case at all, which is why the bug survived from #9647 in DataFusion 37. "Zero changed expectations" is a weak safety signal here, not a strong one. The field research above carries the argument instead.

## Are there any user-facing changes?

**Yes. This is a breaking change to `AT TIME ZONE` semantics.** The `api change` label is applied.

The changes, in order of impact:

1. An **aware** input now returns a **naive** timestamp, per the tables above. Any expression downstream of it changes value.
2. `AT TIME ZONE` keeps the input's `TimeUnit` instead of a forced `Nanosecond`.
3. An unaliased projection changes its column name for the aware case. `SELECT aware AT TIME ZONE 'America/Denver' FROM t` now names the column `to_local_time(t.aware)`.
4. A session that does not register the datetime planner from `datafusion-functions` now gets a plan error for `AT TIME ZONE` on an aware input, where before it got a wrong plan.
5. `ExprPlanner` gains a `plan_at_time_zone` method. It has a default body, so out-of-tree implementations still compile.
6. New `AT TIME ZONE` section in `docs/source/user-guide/sql/operators.md`. The `to_local_time` description says how the two relate.

A **naive** input does not change. Its value and its timezone label stay the same.

**Maintainer input wanted:** does this land as a straight behaviour fix, or behind a config flag with a deprecation period? I deliberately added no flag. The current behaviour has no defensible justification, and a flag means two timestamp typings through the planner for a long time. But this changes results for anyone who relies on the old shape, so I would rather you decide than assume.

**Merge order:** https://github.com/apache/datafusion/pull/25175 adds a timezone characterization suite (`test_files/datetime/timestamps_timezone.slt`) whose SECTION 5b pins the exact behaviour this PR changes, both the `arrow_typeof` and the value. Whichever of the two merges second must update the other, and CI on it stays red until that happens. After this PR lands, the two queries in SECTION 5b become:

```
SELECT arrow_typeof(column1 AT TIME ZONE 'Europe/Brussels'), column1 AT TIME ZONE 'Europe/Brussels' FROM c_utc
  Timestamp(ns, "Europe/Brussels") 2024-01-15T13:00:00+01:00  ->  Timestamp(ns) 2024-01-15T13:00:00
  Timestamp(ns, "Europe/Brussels") 2024-07-01T14:00:00+02:00  ->  Timestamp(ns) 2024-07-01T14:00:00

SELECT arrow_typeof(column1 AT TIME ZONE 'America/Denver'), column1 AT TIME ZONE 'America/Denver' FROM c_denver
  Timestamp(ns, "America/Denver") 2024-01-15T12:00:00-07:00  ->  Timestamp(ns) 2024-01-15T12:00:00
  Timestamp(ns, "America/Denver") 2024-07-01T12:00:00-06:00  ->  Timestamp(ns) 2024-07-01T12:00:00
```

The `DIVERGES FROM POSTGRESQL (type, not instant)` comment above them can go, because this PR removes that divergence. Nothing else in that file conflicts. Its other `AT TIME ZONE` cases all apply the operator to a naive input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

