### PR TITLE
Feat: allow fine tuning output record batch size for repartionionExec

### DIFF
--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -2234,12 +2234,17 @@ impl RepartitionExec {
 
     /// Override the target batch size used by the output coalescer.
     ///
-    /// By default the coalescer targets [`SessionConfig::batch_size`]. Use
+    /// By default the coalescer targets the session batch size. Use
     /// this method when you need a different batch size for a specific
     /// `RepartitionExec` node without changing the global session config.
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+    ///
+    /// Returns an error if `batch_size` is zero.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Result<Self> {
+        if batch_size == 0 {
+            return internal_err!("batch_size must be greater than zero");
+        }
         self.batch_size = Some(batch_size);
-        self
+        Ok(self)
     }
 
     /// Return the sort expressions that are used to merge
@@ -3767,7 +3772,7 @@ mod tests {
             Arc::new(TaskContext::default().with_session_config(session_config));
 
         let exec = TestMemoryExec::try_new_exec(&partitions, Arc::clone(&schema), None)?;
-        let exec = RepartitionExec::try_new(exec, partitioning)?.with_batch_size(100);
+        let exec = RepartitionExec::try_new(exec, partitioning)?.with_batch_size(100)?;
 
         let mut stream = exec.execute(0, Arc::clone(&task_ctx))?;
         while let Some(result) = stream.next().await {

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -445,6 +445,7 @@ impl RepartitionExecState {
         name: &str,
         context: &Arc<TaskContext>,
         spill_manager: SpillManager,
+        coalescer_batch_size: usize,
     ) -> Result<&mut ConsumingInputStreamsState> {
         let streams_and_metrics = match self {
             RepartitionExecState::NotInitialized => {
@@ -544,7 +545,7 @@ impl RepartitionExecState {
             let shared_coalescer = coalesce_batches.then(|| {
                 SharedCoalescer::new(
                     input.schema(),
-                    context.session_config().batch_size(),
+                    coalescer_batch_size,
                     num_input_partitions,
                 )
             });
@@ -1522,6 +1523,9 @@ pub struct RepartitionExec {
     preserve_order: bool,
     /// Cache holding plan properties like equivalences, output partitioning etc.
     cache: Arc<PlanProperties>,
+    /// Optional override for the batch size used by the output coalescer.
+    /// When `None`, falls back to `SessionConfig::batch_size`.
+    batch_size: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -1741,6 +1745,9 @@ impl ExecutionPlan for RepartitionExec {
         let name = self.name().to_owned();
         let schema = self.schema();
         let schema_captured = Arc::clone(&schema);
+        let coalescer_batch_size = self
+            .batch_size
+            .unwrap_or_else(|| context.session_config().batch_size());
 
         let spill_manager = SpillManager::new(
             Arc::clone(&context.runtime_env()),
@@ -1776,6 +1783,7 @@ impl ExecutionPlan for RepartitionExec {
                     &name,
                     &context,
                     spill_manager.clone(),
+                    coalescer_batch_size,
                 )?;
 
                 // now return stream for the specified *output* partition which will
@@ -2050,6 +2058,7 @@ impl ExecutionPlan for RepartitionExec {
             metrics: self.metrics.clone(),
             preserve_order: self.preserve_order,
             cache: new_properties.into(),
+            batch_size: self.batch_size,
         })))
     }
 
@@ -2072,6 +2081,8 @@ impl ExecutionPlan for RepartitionExec {
             // the plan's own `partitioning`) and *is* serialized below; the rest
             // is recomputed on decode.
             cache,
+            // User-configurable output batch size, recomputed on decode from session config.
+            batch_size: _,
         } = self;
 
         let input = ctx.encode_child(input)?;
@@ -2156,6 +2167,7 @@ impl RepartitionExec {
             metrics: ExecutionPlanMetricsSet::new(),
             preserve_order,
             cache: Arc::new(cache),
+            batch_size: None,
         })
     }
 
@@ -2217,6 +2229,16 @@ impl RepartitionExec {
                 self.input.output_partitioning().partition_count() > 1;
         let eq_properties = Self::eq_properties_helper(&self.input, self.preserve_order);
         Arc::make_mut(&mut self.cache).set_eq_properties(eq_properties);
+        self
+    }
+
+    /// Override the target batch size used by the output coalescer.
+    ///
+    /// By default the coalescer targets [`SessionConfig::batch_size`]. Use
+    /// this method when you need a different batch size for a specific
+    /// `RepartitionExec` node without changing the global session config.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = Some(batch_size);
         self
     }
 
@@ -3727,6 +3749,30 @@ mod tests {
                 let batch = result?;
                 assert_eq!(200, batch.num_rows());
             }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_with_batch_size_overrides_session_config() -> Result<()> {
+        let schema = test_schema(false);
+        // 2 partitions × 50 batches of 8 rows each = 800 rows total funnelled into 1 output partition.
+        let partition = create_vec_batches(50);
+        let partitions = vec![partition.clone(), partition.clone()];
+        let partitioning = Partitioning::RoundRobinBatch(1);
+
+        // Session config says batch_size = 200, but with_batch_size overrides to 100.
+        let session_config = SessionConfig::new().with_batch_size(200);
+        let task_ctx =
+            Arc::new(TaskContext::default().with_session_config(session_config));
+
+        let exec = TestMemoryExec::try_new_exec(&partitions, Arc::clone(&schema), None)?;
+        let exec = RepartitionExec::try_new(exec, partitioning)?.with_batch_size(100);
+
+        let mut stream = exec.execute(0, Arc::clone(&task_ctx))?;
+        while let Some(result) = stream.next().await {
+            let batch = result?;
+            assert_eq!(100, batch.num_rows());
         }
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #25174.

## Rationale for this change
`RepartitionExec` coalesces output batches to `SessionConfig::batch_size` (typically 8192). Some callers need a different target size for a single repartition node without altering the global session config. This PR adds a builder method that makes that possible.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?
- Added optional batch_size: Option<usize> field to RepartitionExec
- Added public builder method with_batch_size(usize) -> Self with a doc comment
- The override is propagated through consume_input_streams and used when constructing the SharedCoalescer; falls back to session config when None
- Field is preserved in repartition_target_partitions
<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## What is the testing strategy for this PR?
added 1 test to assert that SharedCoalescer produces the correctly fine-tuned target batch size
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

Briefly describe how this PR is tested, and point to the specific tests you added. For example: 'This new feature is covered by the `sqllogictest` cases added in `foo.slt`'.

If this PR does not add tests, explain why. For example, if the change is already covered by existing tests, please mention it.

You should also check the `codecov` bot reply on this PR to confirm the changed code is exercised.
-->

## Are there any user-facing changes?
yes, user can now change the output batch size for repartionExec streams
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
