### PR TITLE
Support dotted field access on struct lambda parameters in SQL exprs

### DIFF
--- a/datafusion/sql/src/expr/identifier.rs
+++ b/datafusion/sql/src/expr/identifier.rs
@@ -18,12 +18,12 @@
 use arrow::datatypes::FieldRef;
 use datafusion_common::datatype::DataTypeExt;
 use datafusion_common::{
-    Column, DFSchema, Result, Span, TableReference, assert_or_internal_err,
+    Column, DFSchema, Result, ScalarValue, Span, TableReference, assert_or_internal_err,
     exec_datafusion_err, internal_err, not_impl_err, plan_datafusion_err, plan_err,
 };
 use datafusion_expr::expr::LambdaVariable;
-use datafusion_expr::planner::PlannerResult;
-use datafusion_expr::{Case, Expr};
+use datafusion_expr::planner::{PlannerResult, RawFieldAccessExpr};
+use datafusion_expr::{Case, Expr, GetFieldAccess};
 use sqlparser::ast::{CaseWhen, Expr as SQLExpr, Ident};
 use std::sync::Arc;
 
@@ -144,6 +144,33 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 })?;
             Ok(Expr::ScalarVariable(field, var_names))
         } else {
+            let root_name = self.ident_normalizer.normalize(ids[0].clone());
+            if planner_context.lambda_parameters().contains_key(&root_name) {
+                let mut expr =
+                    self.sql_identifier_to_expr(ids[0].clone(), schema, planner_context)?;
+                'fields: for id in ids.into_iter().skip(1) {
+                    let field_access = GetFieldAccess::NamedStructField {
+                        name: ScalarValue::from(self.ident_normalizer.normalize(id)),
+                    };
+                    let mut field_access_expr = RawFieldAccessExpr { expr, field_access };
+                    for planner in self.context_provider.get_expr_planners() {
+                        match planner.plan_field_access(field_access_expr, schema)? {
+                            PlannerResult::Planned(planned) => {
+                                expr = planned;
+                                continue 'fields;
+                            }
+                            PlannerResult::Original(original) => {
+                                field_access_expr = original;
+                            }
+                        }
+                    }
+                    return not_impl_err!(
+                        "GetFieldAccess not supported by ExprPlanner: {field_access_expr:?}"
+                    );
+                }
+                return Ok(expr);
+            }
+
             let ids = ids
                 .into_iter()
                 .map(|id| self.ident_normalizer.normalize(id))

--- a/datafusion/sqllogictest/test_files/array/array_transform.slt
+++ b/datafusion/sqllogictest/test_files/array/array_transform.slt
@@ -133,6 +133,33 @@ SELECT array_transform([[10, 20]], v -> v[1]);
 ----
 [10]
 
+# dotted field access on a struct-valued lambda parameter
+query ?
+SELECT array_transform(
+  make_array(named_struct('rule_number', 1, 'rule_action', 'allow')),
+  e -> e.rule_action
+);
+----
+[allow]
+
+# dotted field access followed by a list subscript
+query ?
+SELECT array_transform(
+  make_array(named_struct('items', make_array(10, 20))),
+  e -> e.items[1]
+);
+----
+[10]
+
+# chained dotted field access on nested structs
+query ?
+SELECT array_transform(
+  make_array(named_struct('metadata', named_struct('rule_action', 'deny'))),
+  e -> e.metadata.rule_action
+);
+----
+[deny]
+
 
 # expr simplifier inside lambda body
 query TT


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change
Struct-valued lambda parameters cannot currently be accessed using dotted field syntax. For example, the following query fails because `record.rule_action` is resolved as a table-qualified column instead of field access on the lambda parameter:

```sql
SELECT array_transform(
  records,
  record -> record.rule_action
);
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?
When a compound identifier begins with an active lambda parameter, resolve the root as a lambda variable and plan each remaining identifier as named struct-field access.
This supports expressions such as:
```
record.rule_action
record.metadata.rule_action
record.items[1]
```
Field access is planned through the configured expression planners, consistent with existing field-access handling.
<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## What is the testing strategy for this PR?
Added sqllogictest coverage in array/array_transform.slt for:
* Direct field access on a struct-valued lambda parameter.
* Field access followed by list indexing.
* Chained field access through nested structs.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

Briefly describe how this PR is tested, and point to the specific tests you added. For example: 'This new feature is covered by the `sqllogictest` cases added in `foo.slt`'.

If this PR does not add tests, explain why. For example, if the change is already covered by existing tests, please mention it.

You should also check the `codecov` bot reply on this PR to confirm the changed code is exercised.
-->

## Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
