### PR TITLE
fix(substrait): Allow lossless numeric widening in read schemas

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer/utils.rs
+++ b/datafusion/substrait/src/logical_plan/consumer/utils.rs
@@ -329,6 +329,9 @@ fn ensure_field_compatibility(
     if !DFSchema::datatype_is_logically_equal(
         datafusion_field.data_type(),
         substrait_field.data_type(),
+    ) && !is_safe_widening(
+        datafusion_field.data_type(),
+        substrait_field.data_type(),
     ) {
         return substrait_err!(
             "Field '{}' in Substrait schema has a different type ({}) than the corresponding field in the table schema ({}).",
@@ -372,6 +375,41 @@ fn ensure_nested_nullability_compatibility(
         }
     }
     Ok(())
+}
+
+/// Returns true if the DataFusion type can be promoted to the Substrait type without loss of
+/// precision. Struct fields are matched recursively by name and position.
+fn is_safe_widening(datafusion_type: &DataType, substrait_type: &DataType) -> bool {
+    match (datafusion_type, substrait_type) {
+        // Signed integer widening
+        (DataType::Int8, DataType::Int16 | DataType::Int32 | DataType::Int64)
+        | (DataType::Int16, DataType::Int32 | DataType::Int64)
+        | (DataType::Int32, DataType::Int64)
+        // Unsigned integer widening
+        | (DataType::UInt8, DataType::UInt16 | DataType::UInt32 | DataType::UInt64)
+        | (DataType::UInt16, DataType::UInt32 | DataType::UInt64)
+        | (DataType::UInt32, DataType::UInt64)
+        // Float widening
+        | (DataType::Float16, DataType::Float32 | DataType::Float64)
+        | (DataType::Float32, DataType::Float64) => true,
+        (DataType::Struct(df_fields), DataType::Struct(substrait_fields)) => {
+            df_fields.len() == substrait_fields.len()
+                && df_fields
+                    .iter()
+                    .zip(substrait_fields.iter())
+                    .all(|(df_field, substrait_field)| {
+                        df_field.name() == substrait_field.name()
+                            && (DFSchema::datatype_is_logically_equal(
+                                df_field.data_type(),
+                                substrait_field.data_type(),
+                            ) || is_safe_widening(
+                                df_field.data_type(),
+                                substrait_field.data_type(),
+                            ))
+                    })
+        }
+        _ => false,
+    }
 }
 
 fn check_nested_field(
@@ -861,6 +899,59 @@ pub(crate) mod tests {
         let inner = Field::new("inner", DataType::Int32, inner_nullable);
         let outer = Field::new("s", DataType::Struct(Fields::from(vec![inner])), false);
         DFSchema::try_from(Schema::new(vec![outer])).unwrap()
+    }
+
+    #[test]
+    fn compatibility_accepts_safe_numeric_widening() -> Result<()> {
+        let df = DFSchema::try_from(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]))?;
+        let sub = DFSchema::try_from(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int64,
+            false,
+        )]))?;
+        ensure_schema_compatibility(&df, sub)
+    }
+
+    #[test]
+    fn nested_compatibility_accepts_safe_numeric_widening() -> Result<()> {
+        fn schema(value_type: DataType) -> DFSchema {
+            let period = Field::new(
+                "period",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("period_unit", DataType::Utf8, true),
+                    Field::new("period_value", value_type, true),
+                ])),
+                true,
+            );
+            DFSchema::try_from(Schema::new(vec![period])).unwrap()
+        }
+
+        let df = schema(DataType::Int32);
+        let sub = schema(DataType::Int64);
+        ensure_schema_compatibility(&df, sub)
+    }
+
+    #[test]
+    fn nested_compatibility_rejects_numeric_narrowing() {
+        fn schema(value_type: DataType) -> DFSchema {
+            let period = Field::new(
+                "period",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("period_unit", DataType::Utf8, true),
+                    Field::new("period_value", value_type, true),
+                ])),
+                true,
+            );
+            DFSchema::try_from(Schema::new(vec![period])).unwrap()
+        }
+
+        let df = schema(DataType::Int64);
+        let sub = schema(DataType::Int32);
+        assert!(ensure_schema_compatibility(&df, sub).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

- Follow-up to #20646. This is a draft for design discussion; no issue has been filed yet.

## Rationale for this change

The Substrait consumer currently rejects a `ReadRel` when a table provider reports a narrower numeric type than the logical type declared by the Substrait `base_schema`, even when promoting the provider type is lossless.

A concrete case is a table field with type:

```text
Struct("period_unit": Utf8, "period_value": Int32)
```

and a Substrait read schema with type:

```text
Struct("period_unit": Utf8, "period_value": Int64)
```

The read projection already casts fields to the Substrait schema, but the compatibility check rejects the plan before that projection can be built. This occurs with producers that normalize integer widths in their logical type system while table providers retain narrower storage types.

#20646 proposed allowing top-level numeric widening. This draft revisits that proposal with the concrete nested-struct case and recursive validation. I am opening it as a draft because the earlier discussion questioned whether such plans should instead be rejected or fixed by producers.

## What changes are included in this PR?

- Accept lossless signed-integer, unsigned-integer, and floating-point widening when validating read schemas.
- Apply the same compatibility rule recursively to `Struct` children.
- Continue requiring struct arity, field order, and field names to match.
- Continue rejecting numeric narrowing and unrelated type changes.

## What is the testing strategy for this PR?

Added unit coverage for:

- top-level `Int32` to `Int64` widening;
- nested-struct `Int32` to `Int64` widening;
- rejection of nested `Int64` to `Int32` narrowing.

Validation run:

```text
cargo fmt --all
cargo clippy --all-targets --all-features -- -D warnings
RUST_BACKTRACE=1 cargo test --profile ci \
  --exclude datafusion-examples --exclude datafusion-benchmarks --exclude datafusion-cli \
  --workspace --lib --tests --bins \
  --features avro,json,backtrace,extended_tests,recursive_protection,parquet_encryption
```

## Are there any user-facing changes?

Substrait `ReadRel` plans may resolve tables whose numeric fields are narrower than the corresponding declared Substrait fields when promotion is lossless, including fields nested inside structs. The resulting projection retains the types declared by the Substrait plan.
