### PR TITLE
chore: remove deprecated Parquet APIs past the API health policy

### DIFF
--- a/datafusion/datasource-parquet/src/file_format.rs
+++ b/datafusion/datasource-parquet/src/file_format.rs
@@ -67,14 +67,12 @@ use crate::source::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion_datasource::source::DataSourceExec;
-use datafusion_execution::cache::cache_manager::FileMetadataCache;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 use parquet::arrow::async_reader::MetadataFetch;
 use parquet::errors::ParquetError;
-use parquet::file::metadata::ParquetMetaData;
 
 #[derive(Default)]
 /// Factory struct used to create [ParquetFormat]
@@ -637,68 +635,6 @@ impl MetadataFetch for ObjectStoreFetch<'_> {
         }
         .boxed()
     }
-}
-
-/// Fetches parquet metadata from ObjectStore for given object
-///
-/// This component is a subject to **change** in near future and is exposed for low level integrations
-/// through [`ParquetFileReaderFactory`].
-///
-/// [`ParquetFileReaderFactory`]: crate::ParquetFileReaderFactory
-#[deprecated(
-    since = "50.0.0",
-    note = "Use `DFParquetMetadata::fetch_metadata` instead"
-)]
-pub async fn fetch_parquet_metadata(
-    store: &dyn ObjectStore,
-    object_meta: &ObjectMeta,
-    size_hint: Option<usize>,
-    decryption_properties: Option<&FileDecryptionProperties>,
-    file_metadata_cache: Option<Arc<FileMetadataCache>>,
-) -> Result<Arc<ParquetMetaData>> {
-    let decryption_properties = decryption_properties.cloned().map(Arc::new);
-    DFParquetMetadata::new(store, object_meta)
-        .with_metadata_size_hint(size_hint)
-        .with_decryption_properties(decryption_properties)
-        .with_file_metadata_cache(file_metadata_cache)
-        .fetch_metadata()
-        .await
-}
-
-/// Read and parse the statistics of the Parquet file at location `path`
-///
-/// See [`statistics_from_parquet_meta_calc`] for more details
-#[deprecated(
-    since = "50.0.0",
-    note = "Use `DFParquetMetadata::fetch_statistics` instead"
-)]
-pub async fn fetch_statistics(
-    store: &dyn ObjectStore,
-    table_schema: SchemaRef,
-    file: &ObjectMeta,
-    metadata_size_hint: Option<usize>,
-    decryption_properties: Option<&FileDecryptionProperties>,
-    file_metadata_cache: Option<Arc<FileMetadataCache>>,
-) -> Result<Statistics> {
-    let decryption_properties = decryption_properties.cloned().map(Arc::new);
-    DFParquetMetadata::new(store, file)
-        .with_metadata_size_hint(metadata_size_hint)
-        .with_decryption_properties(decryption_properties)
-        .with_file_metadata_cache(file_metadata_cache)
-        .fetch_statistics(&table_schema)
-        .await
-}
-
-#[deprecated(
-    since = "50.0.0",
-    note = "Use `DFParquetMetadata::statistics_from_parquet_metadata` instead"
-)]
-#[expect(clippy::needless_pass_by_value)]
-pub fn statistics_from_parquet_meta_calc(
-    metadata: &ParquetMetaData,
-    table_schema: SchemaRef,
-) -> Result<Statistics> {
-    DFParquetMetadata::statistics_from_parquet_metadata(metadata, &table_schema)
 }
 
 #[cfg(feature = "proto")]

--- a/datafusion/datasource-parquet/src/source.rs
+++ b/datafusion/datasource-parquet/src/source.rs
@@ -394,12 +394,6 @@ impl ParquetSource {
         &self.table_parquet_options
     }
 
-    /// Optional predicate.
-    #[deprecated(since = "50.2.0", note = "use `filter` instead")]
-    pub fn predicate(&self) -> Option<&Arc<dyn PhysicalExpr>> {
-        self.predicate.as_ref()
-    }
-
     /// return the optional file reader factory
     pub fn parquet_file_reader_factory(
         &self,
@@ -1298,17 +1292,6 @@ mod tests {
     use super::*;
     use arrow::datatypes::Schema;
     use datafusion_physical_expr::expressions::lit;
-
-    #[test]
-    #[expect(deprecated)]
-    fn test_parquet_source_predicate_same_as_filter() {
-        let predicate = lit(true);
-
-        let parquet_source =
-            ParquetSource::new(Arc::new(Schema::empty())).with_predicate(predicate);
-        // same value. but filter() call Arc::clone internally
-        assert_eq!(parquet_source.predicate(), parquet_source.filter().as_ref());
-    }
 
     #[test]
     fn test_reverse_scan_default_value() {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #24540 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->
The deprecated Parquet APIs have passed the API health policy.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Remove the deprecated `fetch_parquet_metadata`, `fetch_statistics`, and `statistics_from_parquet_meta_calc` functions.
- Remove the deprecated `ParquetSource::predicate` method.
- Remove the associated unused imports and test.

## What is the testing strategy for this PR?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

Briefly describe how this PR is tested, and point to the specific tests you added. For example: 'This new feature is covered by the `sqllogictest` cases added in `foo.slt`'.

If this PR does not add tests, explain why. For example, if the change is already covered by existing tests, please mention it.

You should also check the `codecov` bot reply on this PR to confirm the changed code is exercised.
-->
No new tests are added because this only removes deprecated apis.

Tested by:

```bash
./dev/rust_lint.sh
```

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->
Yes. It's a breaking Rust API change because public deprecated APIs are removed.