### PR TITLE
Fix outdated Python DataFrame API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Here are links to important resources:
 - [Rust DataFrame API](https://datafusion.apache.org/user-guide/dataframe.html)
 - [Rust API docs](https://docs.rs/datafusion/latest/datafusion)
 - [Rust Examples](https://github.com/apache/datafusion/tree/main/datafusion-examples)
-- [Python DataFrame API](https://arrow.apache.org/datafusion-python/)
+- [Python DataFrame API](https://datafusion.apache.org/python/)
 - [Architecture](https://docs.rs/datafusion/latest/datafusion/index.html#architecture)
 
 ## What can you do with this crate?


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  

Please explain the problem you are trying to solve in terms of the user-visible
behavior, rather than the implementation.

For example, "The code in `foo.rs` doesn't handle nulls" is a symptom of the
implementation. "COUNT(DISTINCT) returns wrong results when the column contains
nulls" is the user-visible problem.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## What is the testing strategy for this PR?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

Briefly describe how this PR is tested, and point to the specific tests you added. For example: 'This new feature is covered by the `sqllogictest` cases added in `foo.slt`'.

If this PR does not add tests, explain why. For example, if the change is already covered by existing tests, please mention it.

You should also check the `codecov` bot reply on this PR to confirm the changed code is exercised.
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please add the `api change` label.
-->

The Python DataFrame API link in the README points to an outdated URL.

This change updates the link to the current Apache DataFusion Python documentation page, making the README navigation accurate for users looking for the Python DataFrame API.