### PR TITLE
fix: discard parquet bounds when row group statistics are missing

### DIFF
--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -739,9 +739,9 @@ fn summarize_column_statistics(
 ) -> Result<()> {
     let parquet_index = stats_converter.parquet_column_index();
 
-    if let Some(max_acc) = &mut accumulators.max_accs[logical_schema_index] {
+    if accumulators.max_accs[logical_schema_index].is_some() {
         accumulators.is_max_value_exact[logical_schema_index] = summarize_bound(
-            max_acc,
+            &mut accumulators.max_accs[logical_schema_index],
             &stats_converter.row_group_maxes(row_groups_metadata)?,
             parquet_index,
             row_groups_metadata,
@@ -750,9 +750,9 @@ fn summarize_column_statistics(
         )?;
     }
 
-    if let Some(min_acc) = &mut accumulators.min_accs[logical_schema_index] {
+    if accumulators.min_accs[logical_schema_index].is_some() {
         accumulators.is_min_value_exact[logical_schema_index] = summarize_bound(
-            min_acc,
+            &mut accumulators.min_accs[logical_schema_index],
             &stats_converter.row_group_mins(row_groups_metadata)?,
             parquet_index,
             row_groups_metadata,
@@ -785,13 +785,44 @@ fn summarize_column_statistics(
 /// parquet statistics. `row_group_exactness` rebuilds the exactness as a Boolean
 /// array and is only called for the rare case where row groups disagree.
 fn summarize_bound<A: Accumulator>(
-    acc: &mut A,
+    acc: &mut Option<A>,
     values: &ArrayRef,
     parquet_index: Option<usize>,
     row_groups_metadata: &[RowGroupMetaData],
     is_exact: impl Fn(&ParquetStatistics) -> bool,
     row_group_exactness: impl FnOnce() -> Result<BooleanArray>,
 ) -> Result<Option<bool>> {
+    // A NULL converted bound can mean missing statistics, not just all-NULL
+    // data. Ignoring it in MIN/MAX would let another row group's exact endpoint
+    // incorrectly establish an exact bound for the whole file. Drop this bound
+    // unless the row group is empty or is proven to contain only NULLs.
+    if values.null_count() > 0
+        && parquet_index.is_some_and(|column_index| {
+            row_groups_metadata
+                .iter()
+                .enumerate()
+                .any(|(index, group)| {
+                    if values.is_valid(index) || group.num_rows() == 0 {
+                        return false;
+                    }
+                    let column = group.column(column_index);
+                    let all_null = column.num_values() == group.num_rows()
+                        && column
+                            .statistics()
+                            .and_then(|stats| stats.null_count_opt())
+                            .is_some_and(|nulls| {
+                                i64::try_from(nulls).ok() == Some(group.num_rows())
+                            });
+                    !all_null
+                })
+        })
+    {
+        *acc = None;
+        return Ok(None);
+    }
+    let Some(acc) = acc.as_mut() else {
+        return Ok(None);
+    };
     acc.update_batch(&[Arc::clone(values)])?;
 
     Ok(
@@ -1281,7 +1312,7 @@ mod tests {
         );
     }
 
-    mod ndv_tests {
+    mod statistics_tests {
         use super::*;
         use arrow::datatypes::Field;
         use parquet::basic::Type as PhysicalType;
@@ -1676,6 +1707,108 @@ mod tests {
                 result.column_statistics[2].distinct_count,
                 Precision::Exact(100)
             );
+        }
+
+        #[test]
+        fn test_min_max_require_complete_row_group_bounds() {
+            let known =
+                || ParquetStatistics::int32(Some(1), Some(3), None, Some(0), false);
+            let exact = |v| Precision::Exact(ScalarValue::Int32(Some(v)));
+            let cases = [
+                (None, 3, Precision::Absent, Precision::Absent),
+                (
+                    Some(ParquetStatistics::int32(
+                        None,
+                        Some(6),
+                        None,
+                        Some(0),
+                        false,
+                    )),
+                    3,
+                    Precision::Absent,
+                    exact(6),
+                ),
+                (
+                    Some(ParquetStatistics::int32(
+                        Some(4),
+                        None,
+                        None,
+                        Some(0),
+                        false,
+                    )),
+                    3,
+                    exact(1),
+                    Precision::Absent,
+                ),
+                (
+                    Some(ParquetStatistics::int32(None, None, None, None, false)),
+                    3,
+                    Precision::Absent,
+                    Precision::Absent,
+                ),
+                (
+                    Some(ParquetStatistics::int32(None, None, None, Some(2), false)),
+                    3,
+                    Precision::Absent,
+                    Precision::Absent,
+                ),
+                // Empty and proven all-NULL row groups do not contribute extrema.
+                (None, 0, exact(1), exact(3)),
+                (
+                    Some(ParquetStatistics::int32(None, None, None, Some(3), false)),
+                    3,
+                    exact(1),
+                    exact(3),
+                ),
+                (
+                    Some(ParquetStatistics::int32(
+                        Some(4),
+                        Some(6),
+                        None,
+                        Some(0),
+                        false,
+                    )),
+                    3,
+                    exact(1),
+                    exact(6),
+                ),
+            ];
+            for (other, rows, expected_min, expected_max) in cases {
+                for reverse in [false, true] {
+                    let schema_descr = create_schema_descr(1);
+                    let arrow_schema = create_arrow_schema(1);
+                    let mut groups = vec![
+                        create_row_group_with_stats(
+                            &schema_descr,
+                            vec![Some(known())],
+                            3,
+                        ),
+                        create_row_group_with_stats(
+                            &schema_descr,
+                            vec![other.clone()],
+                            rows,
+                        ),
+                    ];
+                    if reverse {
+                        groups.reverse();
+                    }
+                    let metadata = create_parquet_metadata(schema_descr, groups);
+                    let stats = DFParquetMetadata::statistics_from_parquet_metadata(
+                        &metadata,
+                        &arrow_schema,
+                    )
+                    .unwrap();
+                    assert_eq!(
+                        stats.column_statistics[0].min_value, expected_min,
+                        "other={other:?}, rows={rows}, reverse={reverse}"
+                    );
+                    assert_eq!(
+                        stats.column_statistics[0].max_value, expected_max,
+                        "other={other:?}, rows={rows}, reverse={reverse}"
+                    );
+                    assert_eq!(stats.num_rows, Precision::Exact((3 + rows) as usize));
+                }
+            }
         }
 
         #[test]

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -806,10 +806,10 @@ fn summarize_bound<A: Accumulator>(
                         return false;
                     }
                     let column = group.column(column_index);
-let all_null = column
-    .statistics()
-    .and_then(|stats| stats.null_count_opt())
-    .is_some_and(|nulls| nulls == column.num_values() as u64);
+                    let all_null = column
+                        .statistics()
+                        .and_then(|stats| stats.null_count_opt())
+                        .is_some_and(|nulls| nulls == column.num_values() as u64);
                     !all_null
                 })
         })
@@ -817,7 +817,9 @@ let all_null = column
         *acc = None;
         return Ok(None);
     }
-    let Some(acc) = acc.as_mut() else { return Ok(None) };present");
+    let Some(acc) = acc.as_mut() else {
+        return Ok(None);
+    };
     acc.update_batch(&[Arc::clone(values)])?;
 
     Ok(

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -806,13 +806,10 @@ fn summarize_bound<A: Accumulator>(
                         return false;
                     }
                     let column = group.column(column_index);
-                    let all_null = column.num_values() == group.num_rows()
-                        && column
-                            .statistics()
-                            .and_then(|stats| stats.null_count_opt())
-                            .is_some_and(|nulls| {
-                                i64::try_from(nulls).ok() == Some(group.num_rows())
-                            });
+let all_null = column
+    .statistics()
+    .and_then(|stats| stats.null_count_opt())
+    .is_some_and(|nulls| nulls == column.num_values() as u64);
                     !all_null
                 })
         })
@@ -820,7 +817,7 @@ fn summarize_bound<A: Accumulator>(
         *acc = None;
         return Ok(None);
     }
-    let acc = acc.as_mut().expect("caller checked accumulator is present");
+    let Some(acc) = acc.as_mut() else { return Ok(None) };present");
     acc.update_batch(&[Arc::clone(values)])?;
 
     Ok(

--- a/datafusion/datasource-parquet/src/metadata.rs
+++ b/datafusion/datasource-parquet/src/metadata.rs
@@ -820,9 +820,7 @@ fn summarize_bound<A: Accumulator>(
         *acc = None;
         return Ok(None);
     }
-    let Some(acc) = acc.as_mut() else {
-        return Ok(None);
-    };
+    let acc = acc.as_mut().expect("caller checked accumulator is present");
     acc.update_batch(&[Arc::clone(values)])?;
 
     Ok(

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -469,7 +469,7 @@ async fn register_parquet_missing_bounds(test_ctx: &mut TestContext) {
             result.metadata.statistics().is_some(),
             statistics == EnabledStatistics::Chunk
         );
-        drop(buffer);
+        buffer.into_inner().unwrap();
         let mut group = writer.next_row_group().unwrap();
         group
             .append_column(&File::open(&column_path).unwrap(), result)
@@ -477,6 +477,7 @@ async fn register_parquet_missing_bounds(test_ctx: &mut TestContext) {
         group.close().unwrap();
     }
     writer.close().unwrap();
+    std::fs::remove_file(&column_path).unwrap();
     test_ctx
         .ctx
         .register_parquet(

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -418,67 +418,65 @@ pub async fn register_partition_table(test_ctx: &mut TestContext) {
         .unwrap();
 }
 
-/// Generate a real Parquet file whose second row group has no statistics.
+/// Write row groups with different statistics settings using the public writer API.
 async fn register_parquet_missing_bounds(test_ctx: &mut TestContext) {
-    use datafusion::parquet::arrow::ArrowWriter;
-    use datafusion::parquet::file::metadata::{
-        ParquetMetaDataReader, ParquetMetaDataWriter,
-    };
+    use datafusion::parquet::column::writer::ColumnWriterImpl;
+    use datafusion::parquet::data_type::{ByteArray, ByteArrayType};
     use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
-    use datafusion::parquet::file::writer::TrackedWrite;
+    use datafusion::parquet::file::writer::{
+        SerializedFileWriter, SerializedPageWriter, TrackedWrite,
+    };
+    use datafusion::parquet::schema::parser::parse_message_type;
 
     test_ctx.enable_testdir();
     let path = test_ctx.testdir_path().join("missing_bounds.parquet");
-    let batch = RecordBatch::try_from_iter([(
-        "a",
-        Arc::new(Int32Array::from(vec![1, 2, 3, 100, 200, 300])) as ArrayRef,
-    )])
-    .unwrap();
-    let properties = WriterProperties::builder()
-        .set_max_row_group_row_count(Some(3))
-        .set_statistics_enabled(EnabledStatistics::Chunk)
-        .build();
-    let mut writer = ArrowWriter::try_new(
+    let column_path = test_ctx.testdir_path().join("column.pages");
+    let schema = Arc::new(
+        parse_message_type("message schema { REQUIRED BINARY a (UTF8); }").unwrap(),
+    );
+    let mut writer = SerializedFileWriter::new(
         File::create(&path).unwrap(),
-        batch.schema(),
-        Some(properties),
+        schema,
+        Arc::new(WriterProperties::default()),
     )
     .unwrap();
-    writer.write(&batch).unwrap();
+    let long_value = "z".repeat(8192);
+    for (values, statistics) in [
+        (["a", "b"], EnabledStatistics::Chunk),
+        (
+            [long_value.as_str(), long_value.as_str()],
+            EnabledStatistics::None,
+        ),
+    ] {
+        // parquet-rs truncates long extrema rather than omitting them. Disable
+        // statistics for the second chunk to exercise the missing-bound case
+        // produced naturally by writers such as PyArrow, without editing metadata.
+        let properties = Arc::new(
+            WriterProperties::builder()
+                .set_statistics_enabled(statistics)
+                .build(),
+        );
+        let mut buffer = TrackedWrite::new(File::create(&column_path).unwrap());
+        let mut column = ColumnWriterImpl::<ByteArrayType>::new(
+            writer.schema_descr().column(0),
+            properties,
+            Box::new(SerializedPageWriter::new(&mut buffer)),
+        );
+        let values = values.map(ByteArray::from);
+        column.write_batch(&values, None, None).unwrap();
+        let result = column.close().unwrap();
+        assert_eq!(
+            result.metadata.statistics().is_some(),
+            statistics == EnabledStatistics::Chunk
+        );
+        drop(buffer);
+        let mut group = writer.next_row_group().unwrap();
+        group
+            .append_column(&File::open(&column_path).unwrap(), result)
+            .unwrap();
+        group.close().unwrap();
+    }
     writer.close().unwrap();
-
-    let metadata = ParquetMetaDataReader::new()
-        .parse_and_finish(&File::open(&path).unwrap())
-        .unwrap();
-    assert_eq!(metadata.num_row_groups(), 2);
-    let mut groups = metadata.row_groups().to_vec();
-    let column = groups[1]
-        .column(0)
-        .clone()
-        .into_builder()
-        .clear_statistics()
-        .build()
-        .unwrap();
-    groups[1] = groups[1]
-        .clone()
-        .into_builder()
-        .set_column_metadata(vec![column])
-        .build()
-        .unwrap();
-    let metadata = metadata.into_builder().set_row_groups(groups).build();
-
-    // Replace only the footer, preserving the data pages and their offsets.
-    let original = std::fs::read(&path).unwrap();
-    let end = original.len() - 8;
-    let metadata_len = u32::from_le_bytes(original[end..end + 4].try_into().unwrap());
-    let mut tracked = TrackedWrite::new(File::create(&path).unwrap());
-    tracked
-        .write_all(&original[..end - metadata_len as usize])
-        .unwrap();
-    ParquetMetaDataWriter::new_with_tracked(tracked, &metadata)
-        .finish()
-        .unwrap();
-
     test_ctx
         .ctx
         .register_parquet(

--- a/datafusion/sqllogictest/src/test_context.rs
+++ b/datafusion/sqllogictest/src/test_context.rs
@@ -148,6 +148,9 @@ impl TestContext {
 
         let file_name = relative_path.file_name().unwrap().to_str().unwrap();
         match file_name {
+            "parquet_missing_bounds.slt" => {
+                register_parquet_missing_bounds(&mut test_ctx).await;
+            }
             "cte.slt" => {
                 info!("Registering strict schema provider for CTE tests");
                 register_strict_schema_provider(test_ctx.session_ctx());
@@ -410,6 +413,78 @@ pub async fn register_partition_table(test_ctx: &mut TestContext) {
             "test_partition_table",
             test_ctx.testdir_path().to_str().unwrap(),
             CsvReadOptions::new().schema(&schema),
+        )
+        .await
+        .unwrap();
+}
+
+/// Generate a real Parquet file whose second row group has no statistics.
+async fn register_parquet_missing_bounds(test_ctx: &mut TestContext) {
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::parquet::file::metadata::{
+        ParquetMetaDataReader, ParquetMetaDataWriter,
+    };
+    use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+    use datafusion::parquet::file::writer::TrackedWrite;
+
+    test_ctx.enable_testdir();
+    let path = test_ctx.testdir_path().join("missing_bounds.parquet");
+    let batch = RecordBatch::try_from_iter([(
+        "a",
+        Arc::new(Int32Array::from(vec![1, 2, 3, 100, 200, 300])) as ArrayRef,
+    )])
+    .unwrap();
+    let properties = WriterProperties::builder()
+        .set_max_row_group_row_count(Some(3))
+        .set_statistics_enabled(EnabledStatistics::Chunk)
+        .build();
+    let mut writer = ArrowWriter::try_new(
+        File::create(&path).unwrap(),
+        batch.schema(),
+        Some(properties),
+    )
+    .unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    let metadata = ParquetMetaDataReader::new()
+        .parse_and_finish(&File::open(&path).unwrap())
+        .unwrap();
+    assert_eq!(metadata.num_row_groups(), 2);
+    let mut groups = metadata.row_groups().to_vec();
+    let column = groups[1]
+        .column(0)
+        .clone()
+        .into_builder()
+        .clear_statistics()
+        .build()
+        .unwrap();
+    groups[1] = groups[1]
+        .clone()
+        .into_builder()
+        .set_column_metadata(vec![column])
+        .build()
+        .unwrap();
+    let metadata = metadata.into_builder().set_row_groups(groups).build();
+
+    // Replace only the footer, preserving the data pages and their offsets.
+    let original = std::fs::read(&path).unwrap();
+    let end = original.len() - 8;
+    let metadata_len = u32::from_le_bytes(original[end..end + 4].try_into().unwrap());
+    let mut tracked = TrackedWrite::new(File::create(&path).unwrap());
+    tracked
+        .write_all(&original[..end - metadata_len as usize])
+        .unwrap();
+    ParquetMetaDataWriter::new_with_tracked(tracked, &metadata)
+        .finish()
+        .unwrap();
+
+    test_ctx
+        .ctx
+        .register_parquet(
+            "missing_bounds",
+            path.to_str().unwrap(),
+            ParquetReadOptions::default(),
         )
         .await
         .unwrap();

--- a/datafusion/sqllogictest/test_files/parquet_missing_bounds.slt
+++ b/datafusion/sqllogictest/test_files/parquet_missing_bounds.slt
@@ -15,23 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# String extrema do not bound the numeric values after a CAST. These aggregates
-# must not be replaced with casts of the Parquet string min/max statistics.
-# The test context creates two row groups: [1, 2, 3] with statistics,
-# and [100, 200, 300] without statistics. Verify the actual rows as well
-# as the aggregates, which must not use the first group's bounds as
-# exact statistics for the entire file.
+# The test context writes two row groups using the Rust writer API:
+# ["a", "b"] with statistics, and two 8192-character strings without statistics.
+# This models the missing bounds produced by writers that omit oversized extrema.
+
+# Verify that the long values are present in the actual data.
 query I
-SELECT a FROM missing_bounds ORDER BY a;
+SELECT LENGTH(a) FROM missing_bounds ORDER BY a;
 ----
 1
-2
-3
-100
-200
-300
+1
+8192
+8192
 
+# The first group's maximum must not be treated as the entire file's maximum.
 query II
-SELECT MIN(a), MAX(a) FROM missing_bounds;
+SELECT LENGTH(MIN(a)), LENGTH(MAX(a)) FROM missing_bounds;
 ----
-1 300
+1 8192
+
+statement ok
+DROP TABLE missing_bounds;

--- a/datafusion/sqllogictest/test_files/parquet_missing_bounds.slt
+++ b/datafusion/sqllogictest/test_files/parquet_missing_bounds.slt
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# String extrema do not bound the numeric values after a CAST. These aggregates
+# must not be replaced with casts of the Parquet string min/max statistics.
+# The test context creates two row groups: [1, 2, 3] with statistics,
+# and [100, 200, 300] without statistics. Verify the actual rows as well
+# as the aggregates, which must not use the first group's bounds as
+# exact statistics for the entire file.
+query I
+SELECT a FROM missing_bounds ORDER BY a;
+----
+1
+2
+3
+100
+200
+300
+
+query II
+SELECT MIN(a), MAX(a) FROM missing_bounds;
+----
+1 300


### PR DESCRIPTION
## Which issue does this PR close?

Closes #25226.

## Rationale for this change

MIN/MAX queries can return incorrect results when a Parquet file contains a mix of row groups with and without bounds. A missing bound is converted to a NULL in the per-row-group statistics array. Aggregating that array skips the NULL, allowing another group's endpoint to be reported as an exact bound for the entire file. The optimizer can then answer the aggregate from incomplete statistics.

For example, a file contains `["a", "b"]` with statistics and two 8192-character strings starting with `z` without statistics. `SELECT LENGTH(MIN(a)), LENGTH(MAX(a))` previously returned `1, 1`; the correct result is `1, 8192`.

## What changes are included in this PR?

- Invalidate a file-level bound when any row group has no converted bound and may contain non-NULL values. Return `Precision::Absent` so that incomplete statistics cannot establish the file's extrema.
- Handle minimum and maximum independently, preserving a usable bound when only the other endpoint is missing.
- Preserve bounds from other groups when the group with no bound is empty or is proven all NULL. The all-NULL check requires both the column value count and the explicitly recorded NULL count to equal the row count.
- Express the active-accumulator precondition with `expect`: callers already check for `Some`, and the path that clears the accumulator returns immediately. This removes an unreachable fallback return.

## What is the testing strategy for this PR?

`test_min_max_require_complete_row_group_bounds` covers absent statistics, independently missing minimum/maximum values, unknown and partial NULL counts, empty groups, all-NULL groups, and complete bounds. Every case runs in both row-group orders.

`parquet_missing_bounds.slt` verifies both the stored string lengths and the aggregate results. Its fixture is generated at runtime using public Rust Parquet writer APIs, enabling chunk statistics for the first row group and disabling them for the second. Disabling statistics is deliberate: parquet-rs truncates long extrema rather than omitting them. No generated Parquet file is committed and no footer is manually edited.

Local validation:

- All 10 tests in `metadata::tests::statistics_tests` passed.
- `parquet_missing_bounds.slt` passed with the fix. Running the same fixture and SQL test against unmodified main reproduced the incorrect `1, 1` result.
- LLVM coverage confirmed that the removed fallback return had zero executions and that the replacement precondition assertion was exercised 36 times by the statistics tests. The updated Codecov patch percentage remains subject to the next CI run.

## Are there any user-facing changes?

MIN/MAX queries return correct results for Parquet files with incomplete row-group bounds. Valid statistics remain usable for each independently complete endpoint, including when other groups are empty or all NULL. There are no public API changes.
