### PR TITLE
ci: cache dependencies for feature checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Rust Dependency Cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
-          shared-key: "amd-ci-check" # this job uses it's own cache becase check has a separate cache and we need it to be fast as it blocks other jobs
+          shared-key: "amd-ci-check" # Keep cargo check artifacts separate from test builds.
           save-if: ${{ github.ref_name == 'main' }}
       - name: Prepare cargo build
         # `--locked` asserts that Cargo.lock is up to date with the manifest.
@@ -95,6 +95,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: false # The workspace and functions checks save this cache on main.
+          shared-key: "amd-ci-check"
       - name: Check datafusion-common (default features)
         run: cargo xtask ci step check datafusion-common default
       #
@@ -158,6 +163,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: false # The workspace and functions checks save this cache on main.
+          shared-key: "amd-ci-check"
       - name: Check datafusion-proto (default features)
         run: cargo xtask ci step check datafusion-proto default
       #
@@ -189,6 +199,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: false # The workspace and functions checks save this cache on main.
+          shared-key: "amd-ci-check"
       - name: Check datafusion-ffi (no-default-features)
         run: cargo xtask ci step check datafusion-ffi no-default
 
@@ -275,6 +290,12 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          # Warm GitHub's cache when linux-build-lib saves to Runs-On.
+          save-if: ${{ github.ref_name == 'main' }}
+          shared-key: "amd-ci-check"
       - name: Check datafusion-functions (default features)
         run: cargo xtask ci step check datafusion-functions default
       #
@@ -314,6 +335,11 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          save-if: false # The workspace and functions checks save this cache on main.
+          shared-key: "amd-ci-check"
       - name: Check datafusion-spark (default features)
         run: cargo check --profile ci --all-targets -p datafusion-spark
       #


### PR DESCRIPTION
## Which issue does this PR close?

Part of #25148.

## Rationale for this change

Five feature-check jobs currently run without a Rust dependency cache. Reusing compatible compilation artifacts should reduce repeated dependency compilation and CI runner usage while preserving the existing feature checks and parallel jobs.

## What changes are included in this PR?

- Add dependency caching to the `datafusion-common`, `datafusion-proto`, `datafusion-ffi`, `datafusion-functions`, and `datafusion-spark` feature-check jobs using the existing `amd-ci-check` key.
- Let the functions check save the cache on `main` to populate GitHub's cache backend. The workspace check already saves to the separate Runs-On cache backend. The other four jobs only restore caches.
- Clarify the cache comments. Job names, runner choices, feature-check commands, and required checks remain unchanged.

## What is the testing strategy for this PR?

- Compared the parsed workflows before and after the change: removing the five new cache steps produces the original configuration, including all 26 jobs and their commands.
- `python3 ci/scripts/check_asf_yaml_status_checks.py` passed for all 35 required checks.
- `ci/scripts/check_no_cargo_install_in_workflows.sh`, targeted spelling checks, and `git diff --check` passed.
- Actionlint passed for the complete cache producer and consumer job definitions. Full-workflow actionlint still reports existing `parallel` blocks and a numeric service-port lookup outside the changed jobs.

This changes workflow configuration only. Cache hit rates and elapsed-time savings need measurement in hosted CI with populated caches. A cache miss still compiles dependencies and runs the existing checks.

## Are there any user-facing changes?

No.
