### PR TITLE
fix: preserve scheduling and evaluation properties across FFI

### DIFF
--- a/datafusion/ffi/src/execution_plan.rs
+++ b/datafusion/ffi/src/execution_plan.rs
@@ -595,6 +595,22 @@ pub mod tests {
             self
         }
 
+        pub fn with_scheduling_type(
+            mut self,
+            scheduling_type: datafusion_physical_plan::execution_plan::SchedulingType,
+        ) -> Self {
+            Arc::make_mut(&mut self.props).scheduling_type = scheduling_type;
+            self
+        }
+
+        pub fn with_evaluation_type(
+            mut self,
+            evaluation_type: datafusion_physical_plan::execution_plan::EvaluationType,
+        ) -> Self {
+            Arc::make_mut(&mut self.props).evaluation_type = evaluation_type;
+            self
+        }
+
         pub fn with_statistics(mut self, statistics: Statistics) -> Self {
             self.statistics = Some(statistics);
             self

--- a/datafusion/ffi/src/plan_properties.rs
+++ b/datafusion/ffi/src/plan_properties.rs
@@ -23,7 +23,9 @@ use datafusion_common::error::{DataFusionError, Result};
 use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
 use datafusion_physical_plan::PlanProperties;
-use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion_physical_plan::execution_plan::{
+    Boundedness, EmissionType, EvaluationType, SchedulingType,
+};
 
 use stabby::vec::Vec as SVec;
 
@@ -44,6 +46,12 @@ pub struct FFI_PlanProperties {
 
     /// Indicate boundedness of the plan and its memory requirements.
     pub boundedness: unsafe extern "C" fn(plan: &Self) -> FFI_Boundedness,
+
+    /// Return the scheduling type of the plan.
+    pub scheduling_type: unsafe extern "C" fn(plan: &Self) -> FFI_SchedulingType,
+
+    /// Return the evaluation type of the plan.
+    pub evaluation_type: unsafe extern "C" fn(plan: &Self) -> FFI_EvaluationType,
 
     /// The output ordering of the plan.
     pub output_ordering:
@@ -94,6 +102,18 @@ unsafe extern "C" fn boundedness_fn_wrapper(
     properties.inner().boundedness.into()
 }
 
+unsafe extern "C" fn scheduling_type_fn_wrapper(
+    properties: &FFI_PlanProperties,
+) -> FFI_SchedulingType {
+    properties.inner().scheduling_type.into()
+}
+
+unsafe extern "C" fn evaluation_type_fn_wrapper(
+    properties: &FFI_PlanProperties,
+) -> FFI_EvaluationType {
+    properties.inner().evaluation_type.into()
+}
+
 unsafe extern "C" fn output_ordering_fn_wrapper(
     properties: &FFI_PlanProperties,
 ) -> FFI_Option<SVec<FFI_PhysicalSortExpr>> {
@@ -140,6 +160,8 @@ impl From<&PlanProperties> for FFI_PlanProperties {
             output_partitioning: output_partitioning_fn_wrapper,
             emission_type: emission_type_fn_wrapper,
             boundedness: boundedness_fn_wrapper,
+            scheduling_type: scheduling_type_fn_wrapper,
+            evaluation_type: evaluation_type_fn_wrapper,
             output_ordering: output_ordering_fn_wrapper,
             schema: schema_fn_wrapper,
             release: release_fn_wrapper,
@@ -186,12 +208,14 @@ impl TryFrom<FFI_PlanProperties> for PlanProperties {
         let boundedness: Boundedness =
             unsafe { (ffi_props.boundedness)(&ffi_props).into() };
 
-        Ok(PlanProperties::new(
-            eq_properties,
-            partitioning,
-            emission_type,
-            boundedness,
-        ))
+        let scheduling_type = unsafe { (ffi_props.scheduling_type)(&ffi_props).into() };
+        let evaluation_type = unsafe { (ffi_props.evaluation_type)(&ffi_props).into() };
+
+        Ok(
+            PlanProperties::new(eq_properties, partitioning, emission_type, boundedness)
+                .with_scheduling_type(scheduling_type)
+                .with_evaluation_type(evaluation_type),
+        )
     }
 }
 
@@ -259,6 +283,60 @@ impl From<FFI_EmissionType> for EmissionType {
     }
 }
 
+/// FFI safe version of [`SchedulingType`].
+#[expect(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Clone)]
+pub enum FFI_SchedulingType {
+    NonCooperative,
+    Cooperative,
+}
+
+impl From<SchedulingType> for FFI_SchedulingType {
+    fn from(value: SchedulingType) -> Self {
+        match value {
+            SchedulingType::NonCooperative => Self::NonCooperative,
+            SchedulingType::Cooperative => Self::Cooperative,
+        }
+    }
+}
+
+impl From<FFI_SchedulingType> for SchedulingType {
+    fn from(value: FFI_SchedulingType) -> Self {
+        match value {
+            FFI_SchedulingType::NonCooperative => Self::NonCooperative,
+            FFI_SchedulingType::Cooperative => Self::Cooperative,
+        }
+    }
+}
+
+/// FFI safe version of [`EvaluationType`].
+#[expect(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Clone)]
+pub enum FFI_EvaluationType {
+    Lazy,
+    Eager,
+}
+
+impl From<EvaluationType> for FFI_EvaluationType {
+    fn from(value: EvaluationType) -> Self {
+        match value {
+            EvaluationType::Lazy => Self::Lazy,
+            EvaluationType::Eager => Self::Eager,
+        }
+    }
+}
+
+impl From<FFI_EvaluationType> for EvaluationType {
+    fn from(value: FFI_EvaluationType) -> Self {
+        match value {
+            FFI_EvaluationType::Lazy => Self::Lazy,
+            FFI_EvaluationType::Eager => Self::Eager,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
@@ -315,6 +393,38 @@ mod tests {
 
         assert_eq!(format!("{foreign_props:?}"), format!("{original_props:?}"));
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_ffi_plan_properties_scheduling_round_trip() -> Result<()> {
+        for scheduling in [SchedulingType::NonCooperative, SchedulingType::Cooperative] {
+            for foreign in [false, true] {
+                let props = create_test_props()?.with_scheduling_type(scheduling);
+                let mut ffi_props = FFI_PlanProperties::from(&props);
+                if foreign {
+                    ffi_props.library_marker_id = crate::mock_foreign_marker_id;
+                }
+                let result = PlanProperties::try_from(ffi_props)?;
+                assert_eq!(result.scheduling_type, scheduling, "foreign={foreign}");
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_ffi_plan_properties_evaluation_round_trip() -> Result<()> {
+        for evaluation in [EvaluationType::Lazy, EvaluationType::Eager] {
+            for foreign in [false, true] {
+                let props = create_test_props()?.with_evaluation_type(evaluation);
+                let mut ffi_props = FFI_PlanProperties::from(&props);
+                if foreign {
+                    ffi_props.library_marker_id = crate::mock_foreign_marker_id;
+                }
+                let result = PlanProperties::try_from(ffi_props)?;
+                assert_eq!(result.evaluation_type, evaluation, "foreign={foreign}");
+            }
+        }
         Ok(())
     }
 

--- a/datafusion/ffi/src/tests/mod.rs
+++ b/datafusion/ffi/src/tests/mod.rs
@@ -31,6 +31,7 @@ use datafusion_common::{Result, ScalarValue, exec_err};
 use datafusion_expr::{Expr, TableType, col, lit};
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_plan::ExecutionPlan;
+use datafusion_physical_plan::execution_plan::{EvaluationType, SchedulingType};
 use sync_provider::create_sync_table_provider;
 use udf_udaf_udwf::{
     create_ffi_abs_func, create_ffi_first_value_func, create_ffi_random_func,
@@ -179,7 +180,12 @@ extern "C" fn construct_table_provider_factory(
 pub(crate) extern "C" fn create_empty_exec() -> FFI_ExecutionPlan {
     let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Float32, false)]));
 
-    let plan = Arc::new(EmptyExec::new(schema));
+    // Nondefault properties expose information lost when crossing the library boundary.
+    let plan = Arc::new(
+        EmptyExec::new(schema)
+            .with_scheduling_type(SchedulingType::Cooperative)
+            .with_evaluation_type(EvaluationType::Eager),
+    );
     FFI_ExecutionPlan::new(plan, None)
 }
 

--- a/datafusion/ffi/tests/ffi_execution_plan.rs
+++ b/datafusion/ffi/tests/ffi_execution_plan.rs
@@ -21,6 +21,7 @@ mod tests {
     use arrow::datatypes::Schema;
     use arrow_schema::DataType;
     use datafusion_common::DataFusionError;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_common::tree_node::TreeNodeRecursion;
     use datafusion_ffi::execution_plan::{
         ExecutionPlanPrivateData, FFI_ExecutionPlan, ForeignExecutionPlan,
@@ -28,11 +29,33 @@ mod tests {
     };
     use datafusion_ffi::tests::utils::{get_byte_metrics_exec, get_module};
     use datafusion_physical_expr_common::metrics::{MetricCategory, MetricValue};
+    use datafusion_physical_optimizer::{
+        PhysicalOptimizerRule, ensure_coop::EnsureCooperative,
+    };
     use datafusion_physical_plan::execution_plan::InvariantLevel;
+    use datafusion_physical_plan::execution_plan::{EvaluationType, SchedulingType};
     use datafusion_physical_plan::{
         ChildrenPropertiesMode, ExecutionPlan, ReplaceChildrenOptions,
     };
     use std::sync::Arc;
+
+    #[test]
+    fn test_ffi_execution_plan_properties_cross_library() -> Result<(), DataFusionError> {
+        let module = get_module()?;
+        let ffi_plan = (module.create_empty_exec)();
+        let plan: Arc<dyn ExecutionPlan> = (&ffi_plan).try_into()?;
+        assert!(plan.is::<ForeignExecutionPlan>());
+        assert_eq!(
+            plan.properties().scheduling_type,
+            SchedulingType::Cooperative
+        );
+        assert_eq!(plan.properties().evaluation_type, EvaluationType::Eager);
+
+        // An already cooperative foreign leaf must not gain a redundant wrapper.
+        let optimized = EnsureCooperative::new().optimize(plan, &ConfigOptions::new())?;
+        assert!(optimized.is::<ForeignExecutionPlan>());
+        Ok(())
+    }
 
     #[test]
     #[expect(deprecated)]


### PR DESCRIPTION
## Which issue does this PR close?

Closes #25153.

## Rationale for this change

A foreign execution plan loses its scheduling and evaluation properties when converted into native `PlanProperties`. A cooperative, eager producer becomes noncooperative and lazy on the consumer side, changing the metadata used by `EnsureCooperative`.

## What changes are included in this PR?

Add FFI enums and producer callbacks for `scheduling_type` and `evaluation_type`, and restore both values during foreign plan-property reconstruction. Preserve the existing local-marker shortcut and ownership/release paths.

This is AI-assisted work.

## What is the testing strategy for this PR?

Unit tests exercise every scheduling/evaluation variant through local and forced foreign conversions. A separate-library integration test checks both nondefault properties on a `ForeignExecutionPlan` and verifies that `EnsureCooperative` leaves the already cooperative leaf unwrapped. The foreign regressions fail on the baseline and pass with the fix.

Validation on Linux x86_64 with Rust 1.97.0:

- Workspace formatting and Clippy with all targets, all features, and warnings denied pass.
- Default FFI tests: 121 passed. FFI tests with `integration-tests`: 156 passed, including the separately loaded `.so` regression.
- The complete extended workspace test command from `AGENTS.md` passes, including the core fuzz and SQL logic suites.
- Workspace Rust documentation with warnings denied, documentation formatting, and workflow policy checks pass. License, spelling, and TOML checks also pass on the same patch.

The FFI integration suite also passes on Windows with a separately loaded DLL. Both sides use the same source/toolchain in each test; mixed-toolchain compatibility and a runtime speedup were not measured.

## Are there any user-facing changes?

Foreign execution plans retain their producer's scheduling and evaluation metadata. This changes the `FFI_PlanProperties` layout and requires downstream libraries to rebuild for the new major version. This PR targets `main` and must not be backported to a patch release. Please apply the `api change` label before merge.

