### PR TITLE
perf: keep the key in the hash entry of GroupValuesPrimitive

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/single_group_by/primitive.rs
@@ -103,13 +103,16 @@ hash_float!(f16, f32, f64);
 pub struct GroupValuesPrimitive<T: ArrowPrimitiveType> {
     /// The data type of the output array
     data_type: DataType,
-    /// Stores the `(group_index, hash)` based on the hash of its value
+    /// Stores `(group_index, value)` under the hash of the value.
     ///
-    /// We also store `hash` is for reducing cost of rehashing. Such cost
-    /// is obvious in high cardinality group by situation.
-    /// More details can see:
-    /// <https://github.com/apache/datafusion/issues/15961>
-    map: HashTable<(usize, u64)>,
+    /// The value is kept in the entry so a probe compares against the
+    /// bucket it already loaded and never reads `values`: one cache miss
+    /// per row less than looking the group's value up by index. Rehashing
+    /// recomputes hashes from the stored values, which for primitives is
+    /// cheaper than the wider entry a stored hash would need (see
+    /// <https://github.com/apache/datafusion/issues/15961> for why the hash
+    /// used to be stored).
+    map: HashTable<(usize, T::Native)>,
     /// The group index of the null value if any
     null_group: Option<usize>,
     /// The values for each group index
@@ -155,17 +158,15 @@ where
                     let hash = key.hash(state);
                     let insert = self.map.entry(
                         hash,
-                        |&(g, h)| unsafe {
-                            hash == h && self.values.get_unchecked(g).is_eq(key)
-                        },
-                        |&(_, h)| h,
+                        |&(_, k)| k.is_eq(key),
+                        |&(_, k)| k.hash(state),
                     );
 
                     match insert {
                         hashbrown::hash_table::Entry::Occupied(o) => o.get().0,
                         hashbrown::hash_table::Entry::Vacant(v) => {
                             let g = self.values.len();
-                            v.insert((g, hash));
+                            v.insert((g, key));
                             self.values.push(key);
                             g
                         }
@@ -178,7 +179,8 @@ where
     }
 
     fn size(&self) -> usize {
-        self.map.capacity() * size_of::<(usize, u64)>() + self.values.allocated_size()
+        self.map.capacity() * size_of::<(usize, T::Native)>()
+            + self.values.allocated_size()
     }
 
     fn is_empty(&self) -> bool {


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #24704 (first of three small PRs toward blocked group state; the plan and measurements are in the discussion there).

## Rationale for this change

`GroupValuesPrimitive` stores `(group_index, hash)` in its hash table and compares a probe against `values[group_index]`. At high cardinality that is two dependent cache misses per row: the bucket, then the value it points at.

Keeping the key in the entry instead — `(group_index, key)` — lets the probe compare against the bucket it already loaded and never touch `values`. The hash is recomputed on resize; for primitive keys that is cheaper than the wider entry a stored hash would need (#15961 stored the hash to make rehashing cheap while the compare still went through `values`; with the key in the entry the compare is free and the entry stays 16 bytes for 8-byte keys).

Standalone probe loop, random `i64` keys, ns/row including the table build (M4 Pro):

| groups | today `(g, hash)` + `values[g]` | `(g, key)` |
|---|---|---|
| 100k | 4.1 | **3.3 (0.80x)** |
| 1M | 14.3 | **11.0 (0.77x)** |
| 10M | 16.2 | **11.5 (0.71x)** |

End to end (`datafusion-cli`, TPC-H `lineitem`, 12 partitions, interleaved rounds, median): `GROUP BY l_partkey` SF1 (200k groups) **0.93x**, SF10 (2M groups) **0.90x**; `GROUP BY l_orderkey` (clustered, cache-hot probes) 0.98–1.03x. TPC-H SF10 total 0.98x (with the two follow-up PRs applied).

## What changes are included in this PR?

- `GroupValuesPrimitive::map` is `HashTable<(usize, T::Native)>`; the probe closure compares the stored key, the rehash closure recomputes its hash. `size()` accounts the new entry width.

No behavior change.

Trade-off for natives wider than 8 bytes (`i128`/Decimal128, `i256`, intervals): the entry grows from 16 to 32 bytes, so the hash index doubles — measured +13% process RSS on `GROUP BY <Decimal128>` with 10M groups, at unchanged time (1.01x). The alternative, keeping `(group_index, hash)` and comparing `values[group_index]` for those types, measured +14% time on the same query (the dependent value load on the probe path), so the wider entry is the better trade for a key type this rare; it still saves one cache miss per probe.

## What is the testing strategy for this PR?

Existing `GroupValuesPrimitive` unit tests and the aggregate sqllogictests cover the behavior (results are unchanged); `force_hash_collisions` still passes since the compare is by key.

## Are there any user-facing changes?

No.