### PR TITLE
ci: share workspace check artifacts with feature checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,11 +73,32 @@ jobs:
       - name: Rust Dependency Cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
         with:
-          shared-key: "amd-ci-check" # this job uses it's own cache becase check has a separate cache and we need it to be fast as it blocks other jobs
+          shared-key: "amd-ci-check" # Keep cargo check artifacts separate from test builds.
           save-if: ${{ github.ref_name == 'main' }}
       - name: Prepare cargo build
         # `--locked` asserts that Cargo.lock is up to date with the manifest.
         run: cargo xtask ci step check workspace
+      - name: Archive Cargo check artifacts
+        id: archive-check
+        continue-on-error: true
+        shell: bash
+        run: |
+          # Preserve source timestamps so Cargo can reuse workspace crates.
+          git ls-files -z | tar --null -T - -cf "$RUNNER_TEMP/check-workspace.tar" target
+          tar -cf "$RUNNER_TEMP/check-registry.tar" -C "$CARGO_HOME" registry
+      - name: Upload Cargo check artifacts
+        if: steps.archive-check.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cargo-check
+          path: |
+            ${{ runner.temp }}/check-workspace.tar
+            ${{ runner.temp }}/check-registry.tar
+          compression-level: 1
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
 
   # Check datafusion-common features
   #
@@ -111,6 +132,8 @@ jobs:
   linux-datafusion-substrait-features:
     name: cargo check datafusion-substrait features
     needs: linux-build-lib
+    env:
+      CARGO_INCREMENTAL: "0"
     runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion', github.run_id) || 'ubuntu-latest' }}
     container:
       image: amd64/rust
@@ -120,11 +143,18 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - name: Rust Dependency Cache
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+      - name: Download Cargo check artifacts
+        id: download-check
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          save-if: false # set in linux-test
-          shared-key: "amd-ci"
+          name: cargo-check
+          path: ${{ runner.temp }}/cargo-check
+      - name: Restore Cargo check artifacts
+        if: steps.download-check.outcome == 'success'
+        run: |
+          tar -xf "$RUNNER_TEMP/cargo-check/check-workspace.tar"
+          tar -xf "$RUNNER_TEMP/cargo-check/check-registry.tar" -C "$CARGO_HOME"
       - name: Check datafusion-substrait (default features)
         run: cargo xtask ci step check datafusion-substrait default
         #
@@ -200,6 +230,8 @@ jobs:
   linux-cargo-check-datafusion:
     name: cargo check datafusion features
     needs: linux-build-lib
+    env:
+      CARGO_INCREMENTAL: "0"
     runs-on: ${{ vars.USE_RUNS_ON == 'true' && format('runs-on={0},family=m8a+m7a+c8a,cpu=16,image=ubuntu24-full-x64,extras=s3-cache,disk=large,tag=datafusion', github.run_id) || 'ubuntu-latest' }}
     container:
       image: amd64/rust
@@ -210,11 +242,18 @@ jobs:
         uses: ./.github/actions/setup-builder
         with:
           rust-version: stable
-      - name: Rust Dependency Cache
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+      - name: Download Cargo check artifacts
+        id: download-check
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          save-if: false # set in linux-test
-          shared-key: "amd-ci"
+          name: cargo-check
+          path: ${{ runner.temp }}/cargo-check
+      - name: Restore Cargo check artifacts
+        if: steps.download-check.outcome == 'success'
+        run: |
+          tar -xf "$RUNNER_TEMP/cargo-check/check-workspace.tar"
+          tar -xf "$RUNNER_TEMP/cargo-check/check-registry.tar" -C "$CARGO_HOME"
       - name: Check datafusion (default features)
         run: cargo xtask ci step check datafusion default
       #

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,10 @@ jobs:
           mkdir -p "$RUNNER_TEMP/cargo-check"
           # Preserve source timestamps so Cargo can reuse workspace crates.
           git ls-files -z | tar --null -T - -cf "$RUNNER_TEMP/cargo-check/check-workspace.tar" target
-          tar -cf "$RUNNER_TEMP/cargo-check/check-registry.tar" -C "$CARGO_HOME" registry
+          # -C incremental=false creates per-crate caches named "false".
+          tar --anchored --no-wildcards-match-slash \
+            --exclude='registry/src/*/*/false' \
+            -cf "$RUNNER_TEMP/cargo-check/check-registry.tar" -C "$CARGO_HOME" registry
       - name: Upload Cargo check artifacts
         if: steps.archive-check.outcome == 'success'
         continue-on-error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,18 +83,17 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
+          mkdir -p "$RUNNER_TEMP/cargo-check"
           # Preserve source timestamps so Cargo can reuse workspace crates.
-          git ls-files -z | tar --null -T - -cf "$RUNNER_TEMP/check-workspace.tar" target
-          tar -cf "$RUNNER_TEMP/check-registry.tar" -C "$CARGO_HOME" registry
+          git ls-files -z | tar --null -T - -cf "$RUNNER_TEMP/cargo-check/check-workspace.tar" target
+          tar -cf "$RUNNER_TEMP/cargo-check/check-registry.tar" -C "$CARGO_HOME" registry
       - name: Upload Cargo check artifacts
         if: steps.archive-check.outcome == 'success'
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cargo-check
-          path: |
-            ${{ runner.temp }}/check-workspace.tar
-            ${{ runner.temp }}/check-registry.tar
+          path: ${{ runner.temp }}/cargo-check/
           compression-level: 1
           retention-days: 1
           if-no-files-found: error


### PR DESCRIPTION
## Which issue does this PR close?

Part of #25148.

As suggested by @comphead https://github.com/apache/datafusion/pull/25231#pullrequestreview-5187991348

## Rationale for this change

The DataFusion and Substrait feature checks wait for the workspace check, but start on separate runners and restore a cache intended for test builds. Sharing the workspace check's outputs can avoid repeating compatible compilation work within the same workflow run, including on a cold PR run.

## What changes are included in this PR?

- Upload the workspace build outputs and Cargo registry once from `linux-build-lib`, then restore them in the DataFusion and Substrait feature-check jobs.
- Include tracked source files in the archive to preserve timestamps, and use tar archives to preserve Cargo's hidden fingerprint files and executable permissions.
- Exclude generated incremental compiler caches from the Cargo registry archive.
- Keep the producer's dependency cache, retain artifacts for one day, support reruns, and run the checks normally if artifacts cannot be uploaded or downloaded.
- Preserve every existing check command, runner, trigger, job name, and job dependency.

## What is the testing strategy for this PR?

- The updated workspace producer and both feature-check jobs pass in [PR CI](https://github.com/apache/datafusion/actions/runs/34743091547). The affected jobs also pass actionlint.
- [Repacking the original artifact](https://github.com/kumarUjjawal/datafusion/actions/runs/34742695510) with the same compression reduced it from 2.34 GB to 577 MB (75%), while preserving the workspace archive. Excluded paths were checked against the dependency source manifests.
- [Three controlled comparisons per consumer](https://github.com/kumarUjjawal/datafusion/actions/runs/34743010860) use the same source, toolchain, container, and physical runner for each baseline/artifact pair, clear build data between variants, and reverse execution order in one sample. All twelve consumer executions pass.
- The two consumers together save 59–81 seconds, including restoration. Packaging/upload measured separately takes 19–23 seconds; using its 19-second median gives an estimated net saving of 40–62 runner-seconds per run. These fork measurements do not establish AWS cost savings or faster overall PR feedback.

## Are there any user-facing changes?

No.
